### PR TITLE
fixes(spring) add JsonProperty on setter

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/jackson_annotations.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/jackson_annotations.mustache
@@ -1,0 +1,7 @@
+  @JsonProperty("{{baseName}}")
+{{#withXml}}
+  @JacksonXmlProperty(localName = "{{items.xmlName}}{{^items.xmlName}}{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}{{/items.xmlName}}"{{#isXmlAttribute}}, isAttribute = true{{/isXmlAttribute}}{{#xmlNamespace}}, namespace = "{{.}}"{{/xmlNamespace}})
+  {{#isContainer}}
+  @JacksonXmlElementWrapper({{#isXmlWrapped}}localName = "{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}", {{#xmlNamespace}}namespace = "{{.}}", {{/xmlNamespace}}{{/isXmlWrapped}}useWrapping = {{isXmlWrapped}})
+  {{/isContainer}}
+{{/withXml}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/lombokAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/lombokAnnotation.mustache
@@ -23,14 +23,7 @@
   {{#swagger2AnnotationLibrary}}
   @Schema(name = "{{{baseName}}}"{{#isReadOnly}}, accessMode = Schema.AccessMode.READ_ONLY{{/isReadOnly}}{{#example}}, example = "{{{.}}}"{{/example}}{{#description}}, description = "{{{.}}}"{{/description}}{{#deprecated}}, deprecated = true{{/deprecated}}, requiredMode = {{#required}}Schema.RequiredMode.REQUIRED{{/required}}{{^required}}Schema.RequiredMode.NOT_REQUIRED{{/required}})
   {{/swagger2AnnotationLibrary}}
-  {{#jackson}}@JsonProperty("{{baseName}}")
-    {{#withXml}}
-      @JacksonXmlProperty(localName = "{{items.xmlName}}{{^items.xmlName}}{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}{{/items.xmlName}}"{{#isXmlAttribute}}, isAttribute = true{{/isXmlAttribute}}{{#xmlNamespace}}, namespace = "{{.}}"{{/xmlNamespace}})
-      {{#isContainer}}
-        @JacksonXmlElementWrapper({{#isXmlWrapped}}localName = "{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}", {{#xmlNamespace}}namespace = "{{.}}", {{/xmlNamespace}}{{/isXmlWrapped}}useWrapping = {{isXmlWrapped}})
-      {{/isContainer}}
-    {{/withXml}}
-  {{/jackson}}
+{{#jackson}}{{>jackson_annotations}}{{/jackson}}
 {{/lombok.Data}}
 {{#lombok.Builder}}
   {{#defaultValue}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
@@ -226,25 +226,10 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
   {{#swagger1AnnotationLibrary}}
   @ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}value = "{{{description}}}")
   {{/swagger1AnnotationLibrary}}
-  {{#jackson}}
-  @JsonProperty("{{baseName}}")
-  {{#withXml}}
-  @JacksonXmlProperty(localName = "{{items.xmlName}}{{^items.xmlName}}{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}{{/items.xmlName}}"{{#isXmlAttribute}}, isAttribute = true{{/isXmlAttribute}}{{#xmlNamespace}}, namespace = "{{.}}"{{/xmlNamespace}})
-    {{#isContainer}}
-  @JacksonXmlElementWrapper({{#isXmlWrapped}}localName = "{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}", {{#xmlNamespace}}namespace = "{{.}}", {{/xmlNamespace}}{{/isXmlWrapped}}useWrapping = {{isXmlWrapped}})
-    {{/isContainer}}
-  {{/withXml}}
-  {{/jackson}}
-  {{#withXml}}
-  @Xml{{#isXmlAttribute}}Attribute{{/isXmlAttribute}}{{^isXmlAttribute}}Element{{/isXmlAttribute}}(name = "{{items.xmlName}}{{^items.xmlName}}{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}{{/items.xmlName}}"{{#xmlNamespace}}, namespace = "{{.}}"{{/xmlNamespace}})
-    {{#isXmlWrapped}}
-  @XmlElementWrapper(name = "{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}"{{#xmlNamespace}}, namespace = "{{.}}"{{/xmlNamespace}})
-    {{/isXmlWrapped}}
-  {{/withXml}}
   {{#deprecated}}
   @Deprecated
   {{/deprecated}}
-  public {{>nullableAnnotation}}{{>nullableDataTypeBeanValidation}} {{getter}}() {
+{{#jackson}}{{>jackson_annotations}}{{/jackson}}{{#withXml}}{{>xmlAccessorAnnotation}}{{/withXml}}  public {{>nullableAnnotation}}{{>nullableDataTypeBeanValidation}} {{getter}}() {
     return {{name}};
   }
   {{/lombok.Getter}}
@@ -261,7 +246,7 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
   {{#deprecated}}
   @Deprecated
   {{/deprecated}}
-  public void {{setter}}({{>nullableAnnotation}}{{>nullableDataType}} {{name}}) {
+{{#jackson}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{>jackson_annotations}}{{/vendorExtensions.x-is-jackson-optional-nullable}}{{/jackson}}  public void {{setter}}({{>nullableAnnotation}}{{>nullableDataType}} {{name}}) {
     this.{{name}} = {{name}};
   }
   {{/lombok.Setter}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/xmlAccessorAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/xmlAccessorAnnotation.mustache
@@ -1,0 +1,4 @@
+  @Xml{{#isXmlAttribute}}Attribute{{/isXmlAttribute}}{{^isXmlAttribute}}Element{{/isXmlAttribute}}(name = "{{items.xmlName}}{{^items.xmlName}}{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}{{/items.xmlName}}"{{#xmlNamespace}}, namespace = "{{.}}"{{/xmlNamespace}})
+{{#isXmlWrapped}}
+  @XmlElementWrapper(name = "{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}"{{#xmlNamespace}}, namespace = "{{.}}"{{/xmlNamespace}})
+{{/isXmlWrapped}}

--- a/samples/client/petstore/spring-cloud-date-time/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud-date-time/src/main/java/org/openapitools/model/Pet.java
@@ -68,6 +68,7 @@ public class Pet {
     return atType;
   }
 
+  @JsonProperty("@type")
   public void setAtType(String atType) {
     this.atType = atType;
   }
@@ -88,6 +89,7 @@ public class Pet {
     return age;
   }
 
+  @JsonProperty("age")
   public void setAge(Integer age) {
     this.age = age;
   }
@@ -108,6 +110,7 @@ public class Pet {
     return happy;
   }
 
+  @JsonProperty("happy")
   public void setHappy(Boolean happy) {
     this.happy = happy;
   }
@@ -128,6 +131,7 @@ public class Pet {
     return price;
   }
 
+  @JsonProperty("price")
   public void setPrice(BigDecimal price) {
     this.price = price;
   }
@@ -148,6 +152,7 @@ public class Pet {
     return lastFeed;
   }
 
+  @JsonProperty("lastFeed")
   public void setLastFeed(OffsetDateTime lastFeed) {
     this.lastFeed = lastFeed;
   }
@@ -168,6 +173,7 @@ public class Pet {
     return dateOfBirth;
   }
 
+  @JsonProperty("dateOfBirth")
   public void setDateOfBirth(LocalDate dateOfBirth) {
     this.dateOfBirth = dateOfBirth;
   }

--- a/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/model/Category.java
+++ b/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/model/Category.java
@@ -43,6 +43,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -47,6 +47,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -67,6 +68,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -87,6 +89,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/model/Order.java
+++ b/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/model/Order.java
@@ -94,6 +94,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -114,6 +115,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -134,6 +136,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -154,6 +157,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -174,6 +178,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -194,6 +199,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/model/Pet.java
@@ -109,6 +109,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -129,6 +130,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -149,6 +151,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(JsonNullable<String> name) {
     this.name = name;
   }
@@ -173,8 +176,8 @@ public class Pet {
    */
   @NotNull 
   @Schema(name = "photoUrls", deprecated = true, requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("photoUrls")
   @Deprecated
+  @JsonProperty("photoUrls")
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
@@ -183,6 +186,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -211,6 +215,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -231,6 +236,7 @@ public class Pet {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/model/User.java
+++ b/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/model/User.java
@@ -55,6 +55,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -75,6 +76,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -95,6 +97,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -115,6 +118,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -135,6 +139,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -155,6 +160,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -175,6 +181,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -195,6 +202,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/model/Category.java
+++ b/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/model/Category.java
@@ -44,6 +44,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -64,6 +65,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -48,6 +48,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -68,6 +69,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -88,6 +90,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/model/Order.java
+++ b/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/model/Order.java
@@ -93,6 +93,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -113,6 +114,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -133,6 +135,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -153,6 +156,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -173,6 +177,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -193,6 +198,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/model/Pet.java
@@ -110,6 +110,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -130,6 +131,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -150,6 +152,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -178,6 +181,7 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -206,6 +210,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -222,8 +227,8 @@ public class Pet {
    */
   
   @ApiModelProperty(value = "pet status in the store")
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -232,6 +237,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/model/Tag.java
@@ -44,6 +44,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -64,6 +65,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/model/User.java
+++ b/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/model/User.java
@@ -56,6 +56,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -76,6 +77,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -96,6 +98,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -116,6 +119,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -136,6 +140,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -156,6 +161,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -176,6 +182,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -196,6 +203,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/spring-cloud-tags/src/main/java/org/openapitools/model/Category.java
+++ b/samples/client/petstore/spring-cloud-tags/src/main/java/org/openapitools/model/Category.java
@@ -44,6 +44,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -64,6 +65,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-cloud-tags/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/client/petstore/spring-cloud-tags/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -48,6 +48,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -68,6 +69,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -88,6 +90,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/client/petstore/spring-cloud-tags/src/main/java/org/openapitools/model/Order.java
+++ b/samples/client/petstore/spring-cloud-tags/src/main/java/org/openapitools/model/Order.java
@@ -93,6 +93,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -113,6 +114,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -133,6 +135,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -153,6 +156,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -173,6 +177,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -193,6 +198,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/spring-cloud-tags/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud-tags/src/main/java/org/openapitools/model/Pet.java
@@ -109,6 +109,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -129,6 +130,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -149,6 +151,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -177,6 +180,7 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -205,6 +209,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -225,6 +230,7 @@ public class Pet {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/spring-cloud-tags/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/client/petstore/spring-cloud-tags/src/main/java/org/openapitools/model/Tag.java
@@ -44,6 +44,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -64,6 +65,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-cloud-tags/src/main/java/org/openapitools/model/User.java
+++ b/samples/client/petstore/spring-cloud-tags/src/main/java/org/openapitools/model/User.java
@@ -56,6 +56,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -76,6 +77,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -96,6 +98,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -116,6 +119,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -136,6 +140,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -156,6 +161,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -176,6 +182,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -196,6 +203,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Category.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Category.java
@@ -44,6 +44,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -64,6 +65,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -48,6 +48,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -68,6 +69,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -88,6 +90,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Order.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Order.java
@@ -93,6 +93,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -113,6 +114,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -133,6 +135,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -153,6 +156,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -173,6 +177,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -193,6 +198,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
@@ -110,6 +110,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -130,6 +131,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -150,6 +152,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -178,6 +181,7 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -206,6 +210,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -222,8 +227,8 @@ public class Pet {
    */
   
   @ApiModelProperty(value = "pet status in the store")
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -232,6 +237,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Tag.java
@@ -44,6 +44,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -64,6 +65,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/User.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/User.java
@@ -56,6 +56,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -76,6 +77,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -96,6 +98,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -116,6 +119,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -136,6 +140,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -156,6 +161,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -176,6 +182,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -196,6 +203,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesAnyTypeDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesAnyTypeDto.java
@@ -43,6 +43,7 @@ public class AdditionalPropertiesAnyTypeDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesArrayDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesArrayDto.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesArrayDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesBooleanDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesBooleanDto.java
@@ -43,6 +43,7 @@ public class AdditionalPropertiesBooleanDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
@@ -82,6 +82,7 @@ public class AdditionalPropertiesClassDto {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -109,6 +110,7 @@ public class AdditionalPropertiesClassDto {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -136,6 +138,7 @@ public class AdditionalPropertiesClassDto {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -163,6 +166,7 @@ public class AdditionalPropertiesClassDto {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -190,6 +194,7 @@ public class AdditionalPropertiesClassDto {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -217,6 +222,7 @@ public class AdditionalPropertiesClassDto {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -244,6 +250,7 @@ public class AdditionalPropertiesClassDto {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -271,6 +278,7 @@ public class AdditionalPropertiesClassDto {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -290,6 +298,7 @@ public class AdditionalPropertiesClassDto {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(@Nullable Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -328,6 +337,7 @@ public class AdditionalPropertiesClassDto {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(@Nullable Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesIntegerDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesIntegerDto.java
@@ -43,6 +43,7 @@ public class AdditionalPropertiesIntegerDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesNumberDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesNumberDto.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesNumberDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesObjectDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesObjectDto.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesObjectDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesStringDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesStringDto.java
@@ -43,6 +43,7 @@ public class AdditionalPropertiesStringDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/AnimalDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/AnimalDto.java
@@ -58,6 +58,7 @@ public class AnimalDto {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -77,6 +78,7 @@ public class AnimalDto {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ApiResponseDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ApiResponseDto.java
@@ -43,6 +43,7 @@ public class ApiResponseDto {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -62,6 +63,7 @@ public class ApiResponseDto {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -81,6 +83,7 @@ public class ApiResponseDto {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnlyDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnlyDto.java
@@ -52,6 +52,7 @@ public class ArrayOfArrayOfNumberOnlyDto {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ArrayOfNumberOnlyDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ArrayOfNumberOnlyDto.java
@@ -52,6 +52,7 @@ public class ArrayOfNumberOnlyDto {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ArrayTestDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ArrayTestDto.java
@@ -58,6 +58,7 @@ public class ArrayTestDto {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -85,6 +86,7 @@ public class ArrayTestDto {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -112,6 +114,7 @@ public class ArrayTestDto {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<ReadOnlyFirstDto>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/BigCatDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/BigCatDto.java
@@ -88,6 +88,7 @@ public class BigCatDto extends CatDto {
     return kind;
   }
 
+  @JsonProperty("kind")
   public void setKind(@Nullable KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/CapitalizationDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/CapitalizationDto.java
@@ -49,6 +49,7 @@ public class CapitalizationDto {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -68,6 +69,7 @@ public class CapitalizationDto {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -87,6 +89,7 @@ public class CapitalizationDto {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -106,6 +109,7 @@ public class CapitalizationDto {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -125,6 +129,7 @@ public class CapitalizationDto {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -144,6 +149,7 @@ public class CapitalizationDto {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/CatDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/CatDto.java
@@ -55,6 +55,7 @@ public class CatDto extends AnimalDto {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/CategoryDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/CategoryDto.java
@@ -45,6 +45,7 @@ public class CategoryDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -64,6 +65,7 @@ public class CategoryDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ChildWithNullableDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ChildWithNullableDto.java
@@ -47,6 +47,7 @@ public class ChildWithNullableDto extends ParentWithNullableDto {
     return otherProperty;
   }
 
+  @JsonProperty("otherProperty")
   public void setOtherProperty(@Nullable String otherProperty) {
     this.otherProperty = otherProperty;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ClassModelDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ClassModelDto.java
@@ -39,6 +39,7 @@ public class ClassModelDto {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ClientDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ClientDto.java
@@ -39,6 +39,7 @@ public class ClientDto {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
@@ -93,6 +93,7 @@ public class ContainerDefaultValueDto {
     return nullableRequiredArray;
   }
 
+  @JsonProperty("nullable_required_array")
   public void setNullableRequiredArray(JsonNullable<List<String>> nullableRequiredArray) {
     this.nullableRequiredArray = nullableRequiredArray;
   }
@@ -120,6 +121,7 @@ public class ContainerDefaultValueDto {
     return requiredArray;
   }
 
+  @JsonProperty("required_array")
   public void setRequiredArray(List<String> requiredArray) {
     this.requiredArray = requiredArray;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/DogDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/DogDto.java
@@ -48,6 +48,7 @@ public class DogDto extends AnimalDto {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/EnumArraysDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/EnumArraysDto.java
@@ -116,6 +116,7 @@ public class EnumArraysDto {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -143,6 +144,7 @@ public class EnumArraysDto {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/EnumTestDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/EnumTestDto.java
@@ -197,6 +197,7 @@ public class EnumTestDto {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -216,6 +217,7 @@ public class EnumTestDto {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -235,6 +237,7 @@ public class EnumTestDto {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -254,6 +257,7 @@ public class EnumTestDto {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -273,6 +277,7 @@ public class EnumTestDto {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(@Nullable OuterEnumDto outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/FileDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/FileDto.java
@@ -39,6 +39,7 @@ public class FileDto {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/FileSchemaTestClassDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/FileSchemaTestClassDto.java
@@ -46,6 +46,7 @@ public class FileSchemaTestClassDto {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable FileDto file) {
     this.file = file;
   }
@@ -73,6 +74,7 @@ public class FileSchemaTestClassDto {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<FileDto> files) {
     this.files = files;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/FormatTestDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/FormatTestDto.java
@@ -79,6 +79,7 @@ public class FormatTestDto {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -100,6 +101,7 @@ public class FormatTestDto {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -119,6 +121,7 @@ public class FormatTestDto {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -140,6 +143,7 @@ public class FormatTestDto {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -161,6 +165,7 @@ public class FormatTestDto {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -182,6 +187,7 @@ public class FormatTestDto {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -201,6 +207,7 @@ public class FormatTestDto {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -220,6 +227,7 @@ public class FormatTestDto {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -239,6 +247,7 @@ public class FormatTestDto {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -258,6 +267,7 @@ public class FormatTestDto {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -277,6 +287,7 @@ public class FormatTestDto {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -296,6 +307,7 @@ public class FormatTestDto {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -315,6 +327,7 @@ public class FormatTestDto {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -334,6 +347,7 @@ public class FormatTestDto {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(@Nullable BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/HasOnlyReadOnlyDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/HasOnlyReadOnlyDto.java
@@ -41,6 +41,7 @@ public class HasOnlyReadOnlyDto {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -60,6 +61,7 @@ public class HasOnlyReadOnlyDto {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ListDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ListDto.java
@@ -39,6 +39,7 @@ public class ListDto {
     return _123list;
   }
 
+  @JsonProperty("123-list")
   public void set123list(@Nullable String _123list) {
     this._123list = _123list;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/MapTestDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/MapTestDto.java
@@ -95,6 +95,7 @@ public class MapTestDto {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -122,6 +123,7 @@ public class MapTestDto {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -149,6 +151,7 @@ public class MapTestDto {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -176,6 +179,7 @@ public class MapTestDto {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClassDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClassDto.java
@@ -51,6 +51,7 @@ public class MixedPropertiesAndAdditionalPropertiesClassDto {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -70,6 +71,7 @@ public class MixedPropertiesAndAdditionalPropertiesClassDto {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -97,6 +99,7 @@ public class MixedPropertiesAndAdditionalPropertiesClassDto {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, AnimalDto> map) {
     this.map = map;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/Model200ResponseDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/Model200ResponseDto.java
@@ -41,6 +41,7 @@ public class Model200ResponseDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -60,6 +61,7 @@ public class Model200ResponseDto {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/NameDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/NameDto.java
@@ -49,6 +49,7 @@ public class NameDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -68,6 +69,7 @@ public class NameDto {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -87,6 +89,7 @@ public class NameDto {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -106,6 +109,7 @@ public class NameDto {
     return _123number;
   }
 
+  @JsonProperty("123Number")
   public void set123number(@Nullable Integer _123number) {
     this._123number = _123number;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/NumberOnlyDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/NumberOnlyDto.java
@@ -40,6 +40,7 @@ public class NumberOnlyDto {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/OrderDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/OrderDto.java
@@ -90,6 +90,7 @@ public class OrderDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -109,6 +110,7 @@ public class OrderDto {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -128,6 +130,7 @@ public class OrderDto {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -147,6 +150,7 @@ public class OrderDto {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -166,6 +170,7 @@ public class OrderDto {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -185,6 +190,7 @@ public class OrderDto {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/OuterCompositeDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/OuterCompositeDto.java
@@ -44,6 +44,7 @@ public class OuterCompositeDto {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -63,6 +64,7 @@ public class OuterCompositeDto {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -82,6 +84,7 @@ public class OuterCompositeDto {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ParentWithNullableDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ParentWithNullableDto.java
@@ -89,6 +89,7 @@ public class ParentWithNullableDto {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable TypeEnum type) {
     this.type = type;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/PetDto.java
@@ -102,6 +102,7 @@ public class PetDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -121,6 +122,7 @@ public class PetDto {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable CategoryDto category) {
     this.category = category;
   }
@@ -140,6 +142,7 @@ public class PetDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -168,6 +171,7 @@ public class PetDto {
   }
 
   @JsonDeserialize(as = LinkedHashSet.class)
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -195,6 +199,7 @@ public class PetDto {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<TagDto> tags) {
     this.tags = tags;
   }
@@ -210,8 +215,8 @@ public class PetDto {
    * @deprecated
    */
   
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -220,6 +225,7 @@ public class PetDto {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ReadOnlyFirstDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ReadOnlyFirstDto.java
@@ -41,6 +41,7 @@ public class ReadOnlyFirstDto {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -60,6 +61,7 @@ public class ReadOnlyFirstDto {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNamesDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNamesDto.java
@@ -45,6 +45,7 @@ public class ResponseObjectWithDifferentFieldNamesDto {
     return normalPropertyName;
   }
 
+  @JsonProperty("normalPropertyName")
   public void setNormalPropertyName(@Nullable String normalPropertyName) {
     this.normalPropertyName = normalPropertyName;
   }
@@ -64,6 +65,7 @@ public class ResponseObjectWithDifferentFieldNamesDto {
     return UPPER_CASE_PROPERTY_SNAKE;
   }
 
+  @JsonProperty("UPPER_CASE_PROPERTY_SNAKE")
   public void setUPPERCASEPROPERTYSNAKE(@Nullable String UPPER_CASE_PROPERTY_SNAKE) {
     this.UPPER_CASE_PROPERTY_SNAKE = UPPER_CASE_PROPERTY_SNAKE;
   }
@@ -83,6 +85,7 @@ public class ResponseObjectWithDifferentFieldNamesDto {
     return lowerCasePropertyDashes;
   }
 
+  @JsonProperty("lower-case-property-dashes")
   public void setLowerCasePropertyDashes(@Nullable String lowerCasePropertyDashes) {
     this.lowerCasePropertyDashes = lowerCasePropertyDashes;
   }
@@ -102,6 +105,7 @@ public class ResponseObjectWithDifferentFieldNamesDto {
     return propertyNameWithSpaces;
   }
 
+  @JsonProperty("property name with spaces")
   public void setPropertyNameWithSpaces(@Nullable String propertyNameWithSpaces) {
     this.propertyNameWithSpaces = propertyNameWithSpaces;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ReturnDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ReturnDto.java
@@ -39,6 +39,7 @@ public class ReturnDto {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/SpecialModelNameDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/SpecialModelNameDto.java
@@ -39,6 +39,7 @@ public class SpecialModelNameDto {
     return $specialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/TagDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/TagDto.java
@@ -41,6 +41,7 @@ public class TagDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -60,6 +61,7 @@ public class TagDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/TypeHolderDefaultDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/TypeHolderDefaultDto.java
@@ -56,6 +56,7 @@ public class TypeHolderDefaultDto {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -75,6 +76,7 @@ public class TypeHolderDefaultDto {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -94,6 +96,7 @@ public class TypeHolderDefaultDto {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -113,6 +116,7 @@ public class TypeHolderDefaultDto {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -140,6 +144,7 @@ public class TypeHolderDefaultDto {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/TypeHolderExampleDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/TypeHolderExampleDto.java
@@ -58,6 +58,7 @@ public class TypeHolderExampleDto {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -77,6 +78,7 @@ public class TypeHolderExampleDto {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -96,6 +98,7 @@ public class TypeHolderExampleDto {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -115,6 +118,7 @@ public class TypeHolderExampleDto {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -134,6 +138,7 @@ public class TypeHolderExampleDto {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -161,6 +166,7 @@ public class TypeHolderExampleDto {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/UserDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/UserDto.java
@@ -53,6 +53,7 @@ public class UserDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -72,6 +73,7 @@ public class UserDto {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -91,6 +93,7 @@ public class UserDto {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -110,6 +113,7 @@ public class UserDto {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -129,6 +133,7 @@ public class UserDto {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -148,6 +153,7 @@ public class UserDto {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -167,6 +173,7 @@ public class UserDto {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -186,6 +193,7 @@ public class UserDto {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/XmlItemDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/XmlItemDto.java
@@ -108,6 +108,7 @@ public class XmlItemDto {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(@Nullable String attributeString) {
     this.attributeString = attributeString;
   }
@@ -127,6 +128,7 @@ public class XmlItemDto {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(@Nullable BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -146,6 +148,7 @@ public class XmlItemDto {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(@Nullable Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -165,6 +168,7 @@ public class XmlItemDto {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(@Nullable Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -192,6 +196,7 @@ public class XmlItemDto {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -211,6 +216,7 @@ public class XmlItemDto {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(@Nullable String nameString) {
     this.nameString = nameString;
   }
@@ -230,6 +236,7 @@ public class XmlItemDto {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(@Nullable BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -249,6 +256,7 @@ public class XmlItemDto {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(@Nullable Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -268,6 +276,7 @@ public class XmlItemDto {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(@Nullable Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -295,6 +304,7 @@ public class XmlItemDto {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -322,6 +332,7 @@ public class XmlItemDto {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -341,6 +352,7 @@ public class XmlItemDto {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(@Nullable String prefixString) {
     this.prefixString = prefixString;
   }
@@ -360,6 +372,7 @@ public class XmlItemDto {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(@Nullable BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -379,6 +392,7 @@ public class XmlItemDto {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(@Nullable Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -398,6 +412,7 @@ public class XmlItemDto {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(@Nullable Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -425,6 +440,7 @@ public class XmlItemDto {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -452,6 +468,7 @@ public class XmlItemDto {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -471,6 +488,7 @@ public class XmlItemDto {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(@Nullable String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -490,6 +508,7 @@ public class XmlItemDto {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(@Nullable BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -509,6 +528,7 @@ public class XmlItemDto {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(@Nullable Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -528,6 +548,7 @@ public class XmlItemDto {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(@Nullable Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -555,6 +576,7 @@ public class XmlItemDto {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -582,6 +604,7 @@ public class XmlItemDto {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -601,6 +624,7 @@ public class XmlItemDto {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(@Nullable String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -620,6 +644,7 @@ public class XmlItemDto {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(@Nullable BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -639,6 +664,7 @@ public class XmlItemDto {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(@Nullable Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -658,6 +684,7 @@ public class XmlItemDto {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(@Nullable Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -685,6 +712,7 @@ public class XmlItemDto {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -712,6 +740,7 @@ public class XmlItemDto {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesAnyType {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesArray {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesBoolean {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -80,6 +80,7 @@ public class AdditionalPropertiesClass {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -107,6 +108,7 @@ public class AdditionalPropertiesClass {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -134,6 +136,7 @@ public class AdditionalPropertiesClass {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -161,6 +164,7 @@ public class AdditionalPropertiesClass {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -188,6 +192,7 @@ public class AdditionalPropertiesClass {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -215,6 +220,7 @@ public class AdditionalPropertiesClass {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -242,6 +248,7 @@ public class AdditionalPropertiesClass {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -269,6 +276,7 @@ public class AdditionalPropertiesClass {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -288,6 +296,7 @@ public class AdditionalPropertiesClass {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(@Nullable Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -326,6 +335,7 @@ public class AdditionalPropertiesClass {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(@Nullable Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesInteger {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesNumber {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesObject {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesString {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Animal.java
@@ -64,6 +64,7 @@ public class Animal {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -83,6 +84,7 @@ public class Animal {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -50,6 +50,7 @@ public class ArrayOfArrayOfNumberOnly {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -50,6 +50,7 @@ public class ArrayOfNumberOnly {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ArrayTest.java
@@ -56,6 +56,7 @@ public class ArrayTest {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -83,6 +84,7 @@ public class ArrayTest {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -110,6 +112,7 @@ public class ArrayTest {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/BigCat.java
@@ -93,6 +93,7 @@ public class BigCat extends Cat {
     return kind;
   }
 
+  @JsonProperty("kind")
   public void setKind(@Nullable KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Capitalization.java
@@ -47,6 +47,7 @@ public class Capitalization {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -66,6 +67,7 @@ public class Capitalization {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -85,6 +87,7 @@ public class Capitalization {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -104,6 +107,7 @@ public class Capitalization {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -123,6 +127,7 @@ public class Capitalization {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -142,6 +147,7 @@ public class Capitalization {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Cat.java
@@ -61,6 +61,7 @@ public class Cat extends Animal {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Category.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Category.java
@@ -50,6 +50,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -69,6 +70,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ChildWithNullable.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ChildWithNullable.java
@@ -45,6 +45,7 @@ public class ChildWithNullable extends ParentWithNullable {
     return otherProperty;
   }
 
+  @JsonProperty("otherProperty")
   public void setOtherProperty(@Nullable String otherProperty) {
     this.otherProperty = otherProperty;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ClassModel.java
@@ -37,6 +37,7 @@ public class ClassModel {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Client.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Client.java
@@ -37,6 +37,7 @@ public class Client {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -99,6 +99,7 @@ public class ContainerDefaultValue {
     return nullableRequiredArray;
   }
 
+  @JsonProperty("nullable_required_array")
   public void setNullableRequiredArray(JsonNullable<List<String>> nullableRequiredArray) {
     this.nullableRequiredArray = nullableRequiredArray;
   }
@@ -126,6 +127,7 @@ public class ContainerDefaultValue {
     return requiredArray;
   }
 
+  @JsonProperty("required_array")
   public void setRequiredArray(List<String> requiredArray) {
     this.requiredArray = requiredArray;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Dog.java
@@ -53,6 +53,7 @@ public class Dog extends Animal {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/EnumArrays.java
@@ -114,6 +114,7 @@ public class EnumArrays {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -141,6 +142,7 @@ public class EnumArrays {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/EnumTest.java
@@ -204,6 +204,7 @@ public class EnumTest {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -223,6 +224,7 @@ public class EnumTest {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -242,6 +244,7 @@ public class EnumTest {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -261,6 +264,7 @@ public class EnumTest {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -280,6 +284,7 @@ public class EnumTest {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(@Nullable OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/File.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/File.java
@@ -37,6 +37,7 @@ public class File {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -44,6 +44,7 @@ public class FileSchemaTestClass {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable File file) {
     this.file = file;
   }
@@ -71,6 +72,7 @@ public class FileSchemaTestClass {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<File> files) {
     this.files = files;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/FormatTest.java
@@ -89,6 +89,7 @@ public class FormatTest {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -110,6 +111,7 @@ public class FormatTest {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -129,6 +131,7 @@ public class FormatTest {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -150,6 +153,7 @@ public class FormatTest {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -171,6 +175,7 @@ public class FormatTest {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -192,6 +197,7 @@ public class FormatTest {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -211,6 +217,7 @@ public class FormatTest {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -230,6 +237,7 @@ public class FormatTest {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -249,6 +257,7 @@ public class FormatTest {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -268,6 +277,7 @@ public class FormatTest {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -287,6 +297,7 @@ public class FormatTest {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -306,6 +317,7 @@ public class FormatTest {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -325,6 +337,7 @@ public class FormatTest {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -344,6 +357,7 @@ public class FormatTest {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(@Nullable BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -41,6 +41,7 @@ public class HasOnlyReadOnly {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -60,6 +61,7 @@ public class HasOnlyReadOnly {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/MapTest.java
@@ -93,6 +93,7 @@ public class MapTest {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -120,6 +121,7 @@ public class MapTest {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -147,6 +149,7 @@ public class MapTest {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -174,6 +177,7 @@ public class MapTest {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -49,6 +49,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -68,6 +69,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -95,6 +97,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Model200Response.java
@@ -41,6 +41,7 @@ public class Model200Response {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -60,6 +61,7 @@ public class Model200Response {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -43,6 +43,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -62,6 +63,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -81,6 +83,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ModelList.java
@@ -39,6 +39,7 @@ public class ModelList {
     return _123list;
   }
 
+  @JsonProperty("123-list")
   public void set123list(@Nullable String _123list) {
     this._123list = _123list;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ModelReturn.java
@@ -39,6 +39,7 @@ public class ModelReturn {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Name.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Name.java
@@ -54,6 +54,7 @@ public class Name {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -73,6 +74,7 @@ public class Name {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -92,6 +94,7 @@ public class Name {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -111,6 +114,7 @@ public class Name {
     return _123number;
   }
 
+  @JsonProperty("123Number")
   public void set123number(@Nullable Integer _123number) {
     this._123number = _123number;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/NumberOnly.java
@@ -38,6 +38,7 @@ public class NumberOnly {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Order.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Order.java
@@ -88,6 +88,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -107,6 +108,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -126,6 +128,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -145,6 +148,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -164,6 +168,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -183,6 +188,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/OuterComposite.java
@@ -42,6 +42,7 @@ public class OuterComposite {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -61,6 +62,7 @@ public class OuterComposite {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -80,6 +82,7 @@ public class OuterComposite {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -88,6 +88,7 @@ public class ParentWithNullable {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable TypeEnum type) {
     this.type = type;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Pet.java
@@ -108,6 +108,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -127,6 +128,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -146,6 +148,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -174,6 +177,7 @@ public class Pet {
   }
 
   @JsonDeserialize(as = LinkedHashSet.class)
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -201,6 +205,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -216,8 +221,8 @@ public class Pet {
    * @deprecated
    */
   
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -226,6 +231,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -39,6 +39,7 @@ public class ReadOnlyFirst {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -58,6 +59,7 @@ public class ReadOnlyFirst {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
@@ -43,6 +43,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return normalPropertyName;
   }
 
+  @JsonProperty("normalPropertyName")
   public void setNormalPropertyName(@Nullable String normalPropertyName) {
     this.normalPropertyName = normalPropertyName;
   }
@@ -62,6 +63,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return UPPER_CASE_PROPERTY_SNAKE;
   }
 
+  @JsonProperty("UPPER_CASE_PROPERTY_SNAKE")
   public void setUPPERCASEPROPERTYSNAKE(@Nullable String UPPER_CASE_PROPERTY_SNAKE) {
     this.UPPER_CASE_PROPERTY_SNAKE = UPPER_CASE_PROPERTY_SNAKE;
   }
@@ -81,6 +83,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return lowerCasePropertyDashes;
   }
 
+  @JsonProperty("lower-case-property-dashes")
   public void setLowerCasePropertyDashes(@Nullable String lowerCasePropertyDashes) {
     this.lowerCasePropertyDashes = lowerCasePropertyDashes;
   }
@@ -100,6 +103,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return propertyNameWithSpaces;
   }
 
+  @JsonProperty("property name with spaces")
   public void setPropertyNameWithSpaces(@Nullable String propertyNameWithSpaces) {
     this.propertyNameWithSpaces = propertyNameWithSpaces;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -39,6 +39,7 @@ public class SpecialModelName {
     return $specialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Tag.java
@@ -39,6 +39,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -58,6 +59,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -65,6 +65,7 @@ public class TypeHolderDefault {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -84,6 +85,7 @@ public class TypeHolderDefault {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -103,6 +105,7 @@ public class TypeHolderDefault {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -122,6 +125,7 @@ public class TypeHolderDefault {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -149,6 +153,7 @@ public class TypeHolderDefault {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -68,6 +68,7 @@ public class TypeHolderExample {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -87,6 +88,7 @@ public class TypeHolderExample {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -106,6 +108,7 @@ public class TypeHolderExample {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -125,6 +128,7 @@ public class TypeHolderExample {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -144,6 +148,7 @@ public class TypeHolderExample {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -171,6 +176,7 @@ public class TypeHolderExample {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/User.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/User.java
@@ -51,6 +51,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -70,6 +71,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -89,6 +91,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -108,6 +111,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -127,6 +131,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -146,6 +151,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -165,6 +171,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -184,6 +191,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/XmlItem.java
@@ -106,6 +106,7 @@ public class XmlItem {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(@Nullable String attributeString) {
     this.attributeString = attributeString;
   }
@@ -125,6 +126,7 @@ public class XmlItem {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(@Nullable BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -144,6 +146,7 @@ public class XmlItem {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(@Nullable Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -163,6 +166,7 @@ public class XmlItem {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(@Nullable Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -190,6 +194,7 @@ public class XmlItem {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -209,6 +214,7 @@ public class XmlItem {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(@Nullable String nameString) {
     this.nameString = nameString;
   }
@@ -228,6 +234,7 @@ public class XmlItem {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(@Nullable BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -247,6 +254,7 @@ public class XmlItem {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(@Nullable Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -266,6 +274,7 @@ public class XmlItem {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(@Nullable Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -293,6 +302,7 @@ public class XmlItem {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -320,6 +330,7 @@ public class XmlItem {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -339,6 +350,7 @@ public class XmlItem {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(@Nullable String prefixString) {
     this.prefixString = prefixString;
   }
@@ -358,6 +370,7 @@ public class XmlItem {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(@Nullable BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -377,6 +390,7 @@ public class XmlItem {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(@Nullable Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -396,6 +410,7 @@ public class XmlItem {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(@Nullable Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -423,6 +438,7 @@ public class XmlItem {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -450,6 +466,7 @@ public class XmlItem {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -469,6 +486,7 @@ public class XmlItem {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(@Nullable String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -488,6 +506,7 @@ public class XmlItem {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(@Nullable BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -507,6 +526,7 @@ public class XmlItem {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(@Nullable Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -526,6 +546,7 @@ public class XmlItem {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(@Nullable Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -553,6 +574,7 @@ public class XmlItem {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -580,6 +602,7 @@ public class XmlItem {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -599,6 +622,7 @@ public class XmlItem {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(@Nullable String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -618,6 +642,7 @@ public class XmlItem {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(@Nullable BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -637,6 +662,7 @@ public class XmlItem {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(@Nullable Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -656,6 +682,7 @@ public class XmlItem {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(@Nullable Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -683,6 +710,7 @@ public class XmlItem {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -710,6 +738,7 @@ public class XmlItem {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesAnyType {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesArray {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesBoolean {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -80,6 +80,7 @@ public class AdditionalPropertiesClass {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -107,6 +108,7 @@ public class AdditionalPropertiesClass {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -134,6 +136,7 @@ public class AdditionalPropertiesClass {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -161,6 +164,7 @@ public class AdditionalPropertiesClass {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -188,6 +192,7 @@ public class AdditionalPropertiesClass {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -215,6 +220,7 @@ public class AdditionalPropertiesClass {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -242,6 +248,7 @@ public class AdditionalPropertiesClass {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -269,6 +276,7 @@ public class AdditionalPropertiesClass {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -288,6 +296,7 @@ public class AdditionalPropertiesClass {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(@Nullable Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -326,6 +335,7 @@ public class AdditionalPropertiesClass {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(@Nullable Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesInteger {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesNumber {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesObject {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesString {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Animal.java
@@ -64,6 +64,7 @@ public class Animal {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -83,6 +84,7 @@ public class Animal {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -50,6 +50,7 @@ public class ArrayOfArrayOfNumberOnly {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -50,6 +50,7 @@ public class ArrayOfNumberOnly {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ArrayTest.java
@@ -56,6 +56,7 @@ public class ArrayTest {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -83,6 +84,7 @@ public class ArrayTest {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -110,6 +112,7 @@ public class ArrayTest {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/BigCat.java
@@ -93,6 +93,7 @@ public class BigCat extends Cat {
     return kind;
   }
 
+  @JsonProperty("kind")
   public void setKind(@Nullable KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Capitalization.java
@@ -47,6 +47,7 @@ public class Capitalization {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -66,6 +67,7 @@ public class Capitalization {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -85,6 +87,7 @@ public class Capitalization {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -104,6 +107,7 @@ public class Capitalization {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -123,6 +127,7 @@ public class Capitalization {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -142,6 +147,7 @@ public class Capitalization {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Cat.java
@@ -61,6 +61,7 @@ public class Cat extends Animal {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Category.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Category.java
@@ -50,6 +50,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -69,6 +70,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ChildWithNullable.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ChildWithNullable.java
@@ -45,6 +45,7 @@ public class ChildWithNullable extends ParentWithNullable {
     return otherProperty;
   }
 
+  @JsonProperty("otherProperty")
   public void setOtherProperty(@Nullable String otherProperty) {
     this.otherProperty = otherProperty;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ClassModel.java
@@ -37,6 +37,7 @@ public class ClassModel {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Client.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Client.java
@@ -37,6 +37,7 @@ public class Client {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -99,6 +99,7 @@ public class ContainerDefaultValue {
     return nullableRequiredArray;
   }
 
+  @JsonProperty("nullable_required_array")
   public void setNullableRequiredArray(JsonNullable<List<String>> nullableRequiredArray) {
     this.nullableRequiredArray = nullableRequiredArray;
   }
@@ -126,6 +127,7 @@ public class ContainerDefaultValue {
     return requiredArray;
   }
 
+  @JsonProperty("required_array")
   public void setRequiredArray(List<String> requiredArray) {
     this.requiredArray = requiredArray;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Dog.java
@@ -53,6 +53,7 @@ public class Dog extends Animal {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/EnumArrays.java
@@ -114,6 +114,7 @@ public class EnumArrays {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -141,6 +142,7 @@ public class EnumArrays {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/EnumTest.java
@@ -204,6 +204,7 @@ public class EnumTest {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -223,6 +224,7 @@ public class EnumTest {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -242,6 +244,7 @@ public class EnumTest {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -261,6 +264,7 @@ public class EnumTest {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -280,6 +284,7 @@ public class EnumTest {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(@Nullable OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/File.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/File.java
@@ -37,6 +37,7 @@ public class File {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -44,6 +44,7 @@ public class FileSchemaTestClass {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable File file) {
     this.file = file;
   }
@@ -71,6 +72,7 @@ public class FileSchemaTestClass {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<File> files) {
     this.files = files;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/FormatTest.java
@@ -89,6 +89,7 @@ public class FormatTest {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -110,6 +111,7 @@ public class FormatTest {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -129,6 +131,7 @@ public class FormatTest {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -150,6 +153,7 @@ public class FormatTest {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -171,6 +175,7 @@ public class FormatTest {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -192,6 +197,7 @@ public class FormatTest {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -211,6 +217,7 @@ public class FormatTest {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -230,6 +237,7 @@ public class FormatTest {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -249,6 +257,7 @@ public class FormatTest {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -268,6 +277,7 @@ public class FormatTest {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -287,6 +297,7 @@ public class FormatTest {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -306,6 +317,7 @@ public class FormatTest {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -325,6 +337,7 @@ public class FormatTest {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -344,6 +357,7 @@ public class FormatTest {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(@Nullable BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -41,6 +41,7 @@ public class HasOnlyReadOnly {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -60,6 +61,7 @@ public class HasOnlyReadOnly {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/MapTest.java
@@ -93,6 +93,7 @@ public class MapTest {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -120,6 +121,7 @@ public class MapTest {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -147,6 +149,7 @@ public class MapTest {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -174,6 +177,7 @@ public class MapTest {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -49,6 +49,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -68,6 +69,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -95,6 +97,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Model200Response.java
@@ -41,6 +41,7 @@ public class Model200Response {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -60,6 +61,7 @@ public class Model200Response {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -43,6 +43,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -62,6 +63,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -81,6 +83,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ModelList.java
@@ -39,6 +39,7 @@ public class ModelList {
     return _123list;
   }
 
+  @JsonProperty("123-list")
   public void set123list(@Nullable String _123list) {
     this._123list = _123list;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ModelReturn.java
@@ -39,6 +39,7 @@ public class ModelReturn {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Name.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Name.java
@@ -54,6 +54,7 @@ public class Name {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -73,6 +74,7 @@ public class Name {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -92,6 +94,7 @@ public class Name {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -111,6 +114,7 @@ public class Name {
     return _123number;
   }
 
+  @JsonProperty("123Number")
   public void set123number(@Nullable Integer _123number) {
     this._123number = _123number;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/NumberOnly.java
@@ -38,6 +38,7 @@ public class NumberOnly {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Order.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Order.java
@@ -88,6 +88,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -107,6 +108,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -126,6 +128,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -145,6 +148,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -164,6 +168,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -183,6 +188,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/OuterComposite.java
@@ -42,6 +42,7 @@ public class OuterComposite {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -61,6 +62,7 @@ public class OuterComposite {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -80,6 +82,7 @@ public class OuterComposite {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -88,6 +88,7 @@ public class ParentWithNullable {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable TypeEnum type) {
     this.type = type;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Pet.java
@@ -108,6 +108,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -127,6 +128,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -146,6 +148,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -174,6 +177,7 @@ public class Pet {
   }
 
   @JsonDeserialize(as = LinkedHashSet.class)
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -201,6 +205,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -216,8 +221,8 @@ public class Pet {
    * @deprecated
    */
   
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -226,6 +231,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -39,6 +39,7 @@ public class ReadOnlyFirst {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -58,6 +59,7 @@ public class ReadOnlyFirst {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
@@ -43,6 +43,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return normalPropertyName;
   }
 
+  @JsonProperty("normalPropertyName")
   public void setNormalPropertyName(@Nullable String normalPropertyName) {
     this.normalPropertyName = normalPropertyName;
   }
@@ -62,6 +63,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return UPPER_CASE_PROPERTY_SNAKE;
   }
 
+  @JsonProperty("UPPER_CASE_PROPERTY_SNAKE")
   public void setUPPERCASEPROPERTYSNAKE(@Nullable String UPPER_CASE_PROPERTY_SNAKE) {
     this.UPPER_CASE_PROPERTY_SNAKE = UPPER_CASE_PROPERTY_SNAKE;
   }
@@ -81,6 +83,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return lowerCasePropertyDashes;
   }
 
+  @JsonProperty("lower-case-property-dashes")
   public void setLowerCasePropertyDashes(@Nullable String lowerCasePropertyDashes) {
     this.lowerCasePropertyDashes = lowerCasePropertyDashes;
   }
@@ -100,6 +103,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return propertyNameWithSpaces;
   }
 
+  @JsonProperty("property name with spaces")
   public void setPropertyNameWithSpaces(@Nullable String propertyNameWithSpaces) {
     this.propertyNameWithSpaces = propertyNameWithSpaces;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -39,6 +39,7 @@ public class SpecialModelName {
     return $specialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Tag.java
@@ -39,6 +39,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -58,6 +59,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -65,6 +65,7 @@ public class TypeHolderDefault {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -84,6 +85,7 @@ public class TypeHolderDefault {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -103,6 +105,7 @@ public class TypeHolderDefault {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -122,6 +125,7 @@ public class TypeHolderDefault {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -149,6 +153,7 @@ public class TypeHolderDefault {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -68,6 +68,7 @@ public class TypeHolderExample {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -87,6 +88,7 @@ public class TypeHolderExample {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -106,6 +108,7 @@ public class TypeHolderExample {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -125,6 +128,7 @@ public class TypeHolderExample {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -144,6 +148,7 @@ public class TypeHolderExample {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -171,6 +176,7 @@ public class TypeHolderExample {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/User.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/User.java
@@ -51,6 +51,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -70,6 +71,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -89,6 +91,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -108,6 +111,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -127,6 +131,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -146,6 +151,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -165,6 +171,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -184,6 +191,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/XmlItem.java
@@ -106,6 +106,7 @@ public class XmlItem {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(@Nullable String attributeString) {
     this.attributeString = attributeString;
   }
@@ -125,6 +126,7 @@ public class XmlItem {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(@Nullable BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -144,6 +146,7 @@ public class XmlItem {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(@Nullable Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -163,6 +166,7 @@ public class XmlItem {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(@Nullable Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -190,6 +194,7 @@ public class XmlItem {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -209,6 +214,7 @@ public class XmlItem {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(@Nullable String nameString) {
     this.nameString = nameString;
   }
@@ -228,6 +234,7 @@ public class XmlItem {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(@Nullable BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -247,6 +254,7 @@ public class XmlItem {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(@Nullable Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -266,6 +274,7 @@ public class XmlItem {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(@Nullable Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -293,6 +302,7 @@ public class XmlItem {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -320,6 +330,7 @@ public class XmlItem {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -339,6 +350,7 @@ public class XmlItem {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(@Nullable String prefixString) {
     this.prefixString = prefixString;
   }
@@ -358,6 +370,7 @@ public class XmlItem {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(@Nullable BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -377,6 +390,7 @@ public class XmlItem {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(@Nullable Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -396,6 +410,7 @@ public class XmlItem {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(@Nullable Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -423,6 +438,7 @@ public class XmlItem {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -450,6 +466,7 @@ public class XmlItem {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -469,6 +486,7 @@ public class XmlItem {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(@Nullable String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -488,6 +506,7 @@ public class XmlItem {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(@Nullable BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -507,6 +526,7 @@ public class XmlItem {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(@Nullable Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -526,6 +546,7 @@ public class XmlItem {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(@Nullable Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -553,6 +574,7 @@ public class XmlItem {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -580,6 +602,7 @@ public class XmlItem {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -599,6 +622,7 @@ public class XmlItem {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(@Nullable String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -618,6 +642,7 @@ public class XmlItem {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(@Nullable BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -637,6 +662,7 @@ public class XmlItem {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(@Nullable Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -656,6 +682,7 @@ public class XmlItem {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(@Nullable Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -683,6 +710,7 @@ public class XmlItem {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -710,6 +738,7 @@ public class XmlItem {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/AdditionalPropertiesAnyTypeDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/AdditionalPropertiesAnyTypeDto.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesAnyTypeDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/AdditionalPropertiesArrayDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/AdditionalPropertiesArrayDto.java
@@ -43,6 +43,7 @@ public class AdditionalPropertiesArrayDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/AdditionalPropertiesBooleanDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/AdditionalPropertiesBooleanDto.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesBooleanDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
@@ -78,6 +78,7 @@ public class AdditionalPropertiesClassDto {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -105,6 +106,7 @@ public class AdditionalPropertiesClassDto {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -132,6 +134,7 @@ public class AdditionalPropertiesClassDto {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -159,6 +162,7 @@ public class AdditionalPropertiesClassDto {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -186,6 +190,7 @@ public class AdditionalPropertiesClassDto {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -213,6 +218,7 @@ public class AdditionalPropertiesClassDto {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -240,6 +246,7 @@ public class AdditionalPropertiesClassDto {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -267,6 +274,7 @@ public class AdditionalPropertiesClassDto {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -286,6 +294,7 @@ public class AdditionalPropertiesClassDto {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(@Nullable Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -305,6 +314,7 @@ public class AdditionalPropertiesClassDto {
     return anytype2;
   }
 
+  @JsonProperty("anytype_2")
   public void setAnytype2(@Nullable Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -324,6 +334,7 @@ public class AdditionalPropertiesClassDto {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(@Nullable Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/AdditionalPropertiesIntegerDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/AdditionalPropertiesIntegerDto.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesIntegerDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/AdditionalPropertiesNumberDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/AdditionalPropertiesNumberDto.java
@@ -43,6 +43,7 @@ public class AdditionalPropertiesNumberDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/AdditionalPropertiesObjectDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/AdditionalPropertiesObjectDto.java
@@ -43,6 +43,7 @@ public class AdditionalPropertiesObjectDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/AdditionalPropertiesStringDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/AdditionalPropertiesStringDto.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesStringDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/AnimalDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/AnimalDto.java
@@ -57,6 +57,7 @@ public class AnimalDto {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -76,6 +77,7 @@ public class AnimalDto {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ApiResponseDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ApiResponseDto.java
@@ -42,6 +42,7 @@ public class ApiResponseDto {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -61,6 +62,7 @@ public class ApiResponseDto {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -80,6 +82,7 @@ public class ApiResponseDto {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnlyDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnlyDto.java
@@ -51,6 +51,7 @@ public class ArrayOfArrayOfNumberOnlyDto {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ArrayOfNumberOnlyDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ArrayOfNumberOnlyDto.java
@@ -51,6 +51,7 @@ public class ArrayOfNumberOnlyDto {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ArrayTestDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ArrayTestDto.java
@@ -57,6 +57,7 @@ public class ArrayTestDto {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -84,6 +85,7 @@ public class ArrayTestDto {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -111,6 +113,7 @@ public class ArrayTestDto {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<ReadOnlyFirstDto>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/BigCatDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/BigCatDto.java
@@ -87,6 +87,7 @@ public class BigCatDto extends CatDto {
     return kind;
   }
 
+  @JsonProperty("kind")
   public void setKind(@Nullable KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/CapitalizationDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/CapitalizationDto.java
@@ -48,6 +48,7 @@ public class CapitalizationDto {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -67,6 +68,7 @@ public class CapitalizationDto {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -86,6 +88,7 @@ public class CapitalizationDto {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -105,6 +108,7 @@ public class CapitalizationDto {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -124,6 +128,7 @@ public class CapitalizationDto {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -143,6 +148,7 @@ public class CapitalizationDto {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/CatDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/CatDto.java
@@ -54,6 +54,7 @@ public class CatDto extends AnimalDto {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/CategoryDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/CategoryDto.java
@@ -44,6 +44,7 @@ public class CategoryDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class CategoryDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ChildWithNullableDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ChildWithNullableDto.java
@@ -44,6 +44,7 @@ public class ChildWithNullableDto extends ParentWithNullableDto {
     return otherProperty;
   }
 
+  @JsonProperty("otherProperty")
   public void setOtherProperty(@Nullable String otherProperty) {
     this.otherProperty = otherProperty;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ClassModelDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ClassModelDto.java
@@ -38,6 +38,7 @@ public class ClassModelDto {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ClientDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ClientDto.java
@@ -38,6 +38,7 @@ public class ClientDto {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
@@ -63,6 +63,7 @@ public class ContainerDefaultValueDto {
     return nullableArray;
   }
 
+  @JsonProperty("nullable_array")
   public void setNullableArray(@Nullable List<String> nullableArray) {
     this.nullableArray = nullableArray;
   }
@@ -90,6 +91,7 @@ public class ContainerDefaultValueDto {
     return nullableRequiredArray;
   }
 
+  @JsonProperty("nullable_required_array")
   public void setNullableRequiredArray(List<String> nullableRequiredArray) {
     this.nullableRequiredArray = nullableRequiredArray;
   }
@@ -117,6 +119,7 @@ public class ContainerDefaultValueDto {
     return requiredArray;
   }
 
+  @JsonProperty("required_array")
   public void setRequiredArray(List<String> requiredArray) {
     this.requiredArray = requiredArray;
   }
@@ -144,6 +147,7 @@ public class ContainerDefaultValueDto {
     return nullableArrayWithDefault;
   }
 
+  @JsonProperty("nullable_array_with_default")
   public void setNullableArrayWithDefault(@Nullable List<String> nullableArrayWithDefault) {
     this.nullableArrayWithDefault = nullableArrayWithDefault;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/DogDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/DogDto.java
@@ -47,6 +47,7 @@ public class DogDto extends AnimalDto {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/EnumArraysDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/EnumArraysDto.java
@@ -115,6 +115,7 @@ public class EnumArraysDto {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -142,6 +143,7 @@ public class EnumArraysDto {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/EnumTestDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/EnumTestDto.java
@@ -196,6 +196,7 @@ public class EnumTestDto {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -215,6 +216,7 @@ public class EnumTestDto {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -234,6 +236,7 @@ public class EnumTestDto {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -253,6 +256,7 @@ public class EnumTestDto {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -272,6 +276,7 @@ public class EnumTestDto {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(@Nullable OuterEnumDto outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/FileDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/FileDto.java
@@ -38,6 +38,7 @@ public class FileDto {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/FileSchemaTestClassDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/FileSchemaTestClassDto.java
@@ -45,6 +45,7 @@ public class FileSchemaTestClassDto {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable FileDto file) {
     this.file = file;
   }
@@ -72,6 +73,7 @@ public class FileSchemaTestClassDto {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<FileDto> files) {
     this.files = files;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/FormatTestDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/FormatTestDto.java
@@ -78,6 +78,7 @@ public class FormatTestDto {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -99,6 +100,7 @@ public class FormatTestDto {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -118,6 +120,7 @@ public class FormatTestDto {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -139,6 +142,7 @@ public class FormatTestDto {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -160,6 +164,7 @@ public class FormatTestDto {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -181,6 +186,7 @@ public class FormatTestDto {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -200,6 +206,7 @@ public class FormatTestDto {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -219,6 +226,7 @@ public class FormatTestDto {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -238,6 +246,7 @@ public class FormatTestDto {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -257,6 +266,7 @@ public class FormatTestDto {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -276,6 +286,7 @@ public class FormatTestDto {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -295,6 +306,7 @@ public class FormatTestDto {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -314,6 +326,7 @@ public class FormatTestDto {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -333,6 +346,7 @@ public class FormatTestDto {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(@Nullable BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/HasOnlyReadOnlyDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/HasOnlyReadOnlyDto.java
@@ -40,6 +40,7 @@ public class HasOnlyReadOnlyDto {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -59,6 +60,7 @@ public class HasOnlyReadOnlyDto {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ListDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ListDto.java
@@ -38,6 +38,7 @@ public class ListDto {
     return _123list;
   }
 
+  @JsonProperty("123-list")
   public void set123list(@Nullable String _123list) {
     this._123list = _123list;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/MapTestDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/MapTestDto.java
@@ -94,6 +94,7 @@ public class MapTestDto {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -121,6 +122,7 @@ public class MapTestDto {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -148,6 +150,7 @@ public class MapTestDto {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -175,6 +178,7 @@ public class MapTestDto {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClassDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClassDto.java
@@ -50,6 +50,7 @@ public class MixedPropertiesAndAdditionalPropertiesClassDto {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -69,6 +70,7 @@ public class MixedPropertiesAndAdditionalPropertiesClassDto {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -96,6 +98,7 @@ public class MixedPropertiesAndAdditionalPropertiesClassDto {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, AnimalDto> map) {
     this.map = map;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/Model200ResponseDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/Model200ResponseDto.java
@@ -40,6 +40,7 @@ public class Model200ResponseDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -59,6 +60,7 @@ public class Model200ResponseDto {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/NameDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/NameDto.java
@@ -48,6 +48,7 @@ public class NameDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -67,6 +68,7 @@ public class NameDto {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -86,6 +88,7 @@ public class NameDto {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -105,6 +108,7 @@ public class NameDto {
     return _123number;
   }
 
+  @JsonProperty("123Number")
   public void set123number(@Nullable Integer _123number) {
     this._123number = _123number;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
@@ -49,6 +49,7 @@ public class NullableMapPropertyDto {
     return languageValues;
   }
 
+  @JsonProperty("languageValues")
   public void setLanguageValues(@Nullable Map<String, String> languageValues) {
     this.languageValues = languageValues;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/NumberOnlyDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/NumberOnlyDto.java
@@ -39,6 +39,7 @@ public class NumberOnlyDto {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/OrderDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/OrderDto.java
@@ -89,6 +89,7 @@ public class OrderDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -108,6 +109,7 @@ public class OrderDto {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -127,6 +129,7 @@ public class OrderDto {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -146,6 +149,7 @@ public class OrderDto {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -165,6 +169,7 @@ public class OrderDto {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -184,6 +189,7 @@ public class OrderDto {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/OuterCompositeDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/OuterCompositeDto.java
@@ -43,6 +43,7 @@ public class OuterCompositeDto {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -62,6 +63,7 @@ public class OuterCompositeDto {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -81,6 +83,7 @@ public class OuterCompositeDto {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ParentWithNullableDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ParentWithNullableDto.java
@@ -85,6 +85,7 @@ public class ParentWithNullableDto {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable TypeEnum type) {
     this.type = type;
   }
@@ -104,6 +105,7 @@ public class ParentWithNullableDto {
     return nullableProperty;
   }
 
+  @JsonProperty("nullableProperty")
   public void setNullableProperty(@Nullable String nullableProperty) {
     this.nullableProperty = nullableProperty;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/PetDto.java
@@ -101,6 +101,7 @@ public class PetDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -120,6 +121,7 @@ public class PetDto {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable CategoryDto category) {
     this.category = category;
   }
@@ -139,6 +141,7 @@ public class PetDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -167,6 +170,7 @@ public class PetDto {
   }
 
   @JsonDeserialize(as = LinkedHashSet.class)
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -194,6 +198,7 @@ public class PetDto {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<TagDto> tags) {
     this.tags = tags;
   }
@@ -209,8 +214,8 @@ public class PetDto {
    * @deprecated
    */
   
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -219,6 +224,7 @@ public class PetDto {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ReadOnlyFirstDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ReadOnlyFirstDto.java
@@ -40,6 +40,7 @@ public class ReadOnlyFirstDto {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -59,6 +60,7 @@ public class ReadOnlyFirstDto {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNamesDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNamesDto.java
@@ -44,6 +44,7 @@ public class ResponseObjectWithDifferentFieldNamesDto {
     return normalPropertyName;
   }
 
+  @JsonProperty("normalPropertyName")
   public void setNormalPropertyName(@Nullable String normalPropertyName) {
     this.normalPropertyName = normalPropertyName;
   }
@@ -63,6 +64,7 @@ public class ResponseObjectWithDifferentFieldNamesDto {
     return UPPER_CASE_PROPERTY_SNAKE;
   }
 
+  @JsonProperty("UPPER_CASE_PROPERTY_SNAKE")
   public void setUPPERCASEPROPERTYSNAKE(@Nullable String UPPER_CASE_PROPERTY_SNAKE) {
     this.UPPER_CASE_PROPERTY_SNAKE = UPPER_CASE_PROPERTY_SNAKE;
   }
@@ -82,6 +84,7 @@ public class ResponseObjectWithDifferentFieldNamesDto {
     return lowerCasePropertyDashes;
   }
 
+  @JsonProperty("lower-case-property-dashes")
   public void setLowerCasePropertyDashes(@Nullable String lowerCasePropertyDashes) {
     this.lowerCasePropertyDashes = lowerCasePropertyDashes;
   }
@@ -101,6 +104,7 @@ public class ResponseObjectWithDifferentFieldNamesDto {
     return propertyNameWithSpaces;
   }
 
+  @JsonProperty("property name with spaces")
   public void setPropertyNameWithSpaces(@Nullable String propertyNameWithSpaces) {
     this.propertyNameWithSpaces = propertyNameWithSpaces;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ReturnDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ReturnDto.java
@@ -38,6 +38,7 @@ public class ReturnDto {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/SpecialModelNameDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/SpecialModelNameDto.java
@@ -38,6 +38,7 @@ public class SpecialModelNameDto {
     return $specialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/TagDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/TagDto.java
@@ -40,6 +40,7 @@ public class TagDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -59,6 +60,7 @@ public class TagDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/TypeHolderDefaultDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/TypeHolderDefaultDto.java
@@ -55,6 +55,7 @@ public class TypeHolderDefaultDto {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -74,6 +75,7 @@ public class TypeHolderDefaultDto {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -93,6 +95,7 @@ public class TypeHolderDefaultDto {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -112,6 +115,7 @@ public class TypeHolderDefaultDto {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -139,6 +143,7 @@ public class TypeHolderDefaultDto {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/TypeHolderExampleDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/TypeHolderExampleDto.java
@@ -57,6 +57,7 @@ public class TypeHolderExampleDto {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -76,6 +77,7 @@ public class TypeHolderExampleDto {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -95,6 +97,7 @@ public class TypeHolderExampleDto {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -114,6 +117,7 @@ public class TypeHolderExampleDto {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -133,6 +137,7 @@ public class TypeHolderExampleDto {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -160,6 +165,7 @@ public class TypeHolderExampleDto {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/UserDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/UserDto.java
@@ -52,6 +52,7 @@ public class UserDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -71,6 +72,7 @@ public class UserDto {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -90,6 +92,7 @@ public class UserDto {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -109,6 +112,7 @@ public class UserDto {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -128,6 +132,7 @@ public class UserDto {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -147,6 +152,7 @@ public class UserDto {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -166,6 +172,7 @@ public class UserDto {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -185,6 +192,7 @@ public class UserDto {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/XmlItemDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/XmlItemDto.java
@@ -107,6 +107,7 @@ public class XmlItemDto {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(@Nullable String attributeString) {
     this.attributeString = attributeString;
   }
@@ -126,6 +127,7 @@ public class XmlItemDto {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(@Nullable BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -145,6 +147,7 @@ public class XmlItemDto {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(@Nullable Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -164,6 +167,7 @@ public class XmlItemDto {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(@Nullable Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -191,6 +195,7 @@ public class XmlItemDto {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -210,6 +215,7 @@ public class XmlItemDto {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(@Nullable String nameString) {
     this.nameString = nameString;
   }
@@ -229,6 +235,7 @@ public class XmlItemDto {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(@Nullable BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -248,6 +255,7 @@ public class XmlItemDto {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(@Nullable Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -267,6 +275,7 @@ public class XmlItemDto {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(@Nullable Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -294,6 +303,7 @@ public class XmlItemDto {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -321,6 +331,7 @@ public class XmlItemDto {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -340,6 +351,7 @@ public class XmlItemDto {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(@Nullable String prefixString) {
     this.prefixString = prefixString;
   }
@@ -359,6 +371,7 @@ public class XmlItemDto {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(@Nullable BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -378,6 +391,7 @@ public class XmlItemDto {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(@Nullable Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -397,6 +411,7 @@ public class XmlItemDto {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(@Nullable Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -424,6 +439,7 @@ public class XmlItemDto {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -451,6 +467,7 @@ public class XmlItemDto {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -470,6 +487,7 @@ public class XmlItemDto {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(@Nullable String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -489,6 +507,7 @@ public class XmlItemDto {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(@Nullable BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -508,6 +527,7 @@ public class XmlItemDto {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(@Nullable Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -527,6 +547,7 @@ public class XmlItemDto {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(@Nullable Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -554,6 +575,7 @@ public class XmlItemDto {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -581,6 +603,7 @@ public class XmlItemDto {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -600,6 +623,7 @@ public class XmlItemDto {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(@Nullable String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -619,6 +643,7 @@ public class XmlItemDto {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(@Nullable BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -638,6 +663,7 @@ public class XmlItemDto {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(@Nullable Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -657,6 +683,7 @@ public class XmlItemDto {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(@Nullable Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -684,6 +711,7 @@ public class XmlItemDto {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -711,6 +739,7 @@ public class XmlItemDto {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/AdditionalPropertiesAnyTypeDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/AdditionalPropertiesAnyTypeDto.java
@@ -43,6 +43,7 @@ public class AdditionalPropertiesAnyTypeDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/AdditionalPropertiesArrayDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/AdditionalPropertiesArrayDto.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesArrayDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/AdditionalPropertiesBooleanDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/AdditionalPropertiesBooleanDto.java
@@ -43,6 +43,7 @@ public class AdditionalPropertiesBooleanDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
@@ -82,6 +82,7 @@ public class AdditionalPropertiesClassDto {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -109,6 +110,7 @@ public class AdditionalPropertiesClassDto {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -136,6 +138,7 @@ public class AdditionalPropertiesClassDto {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -163,6 +166,7 @@ public class AdditionalPropertiesClassDto {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -190,6 +194,7 @@ public class AdditionalPropertiesClassDto {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -217,6 +222,7 @@ public class AdditionalPropertiesClassDto {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -244,6 +250,7 @@ public class AdditionalPropertiesClassDto {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -271,6 +278,7 @@ public class AdditionalPropertiesClassDto {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -290,6 +298,7 @@ public class AdditionalPropertiesClassDto {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(@Nullable Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -328,6 +337,7 @@ public class AdditionalPropertiesClassDto {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(@Nullable Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/AdditionalPropertiesIntegerDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/AdditionalPropertiesIntegerDto.java
@@ -43,6 +43,7 @@ public class AdditionalPropertiesIntegerDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/AdditionalPropertiesNumberDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/AdditionalPropertiesNumberDto.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesNumberDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/AdditionalPropertiesObjectDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/AdditionalPropertiesObjectDto.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesObjectDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/AdditionalPropertiesStringDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/AdditionalPropertiesStringDto.java
@@ -43,6 +43,7 @@ public class AdditionalPropertiesStringDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/AnimalDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/AnimalDto.java
@@ -58,6 +58,7 @@ public class AnimalDto {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -77,6 +78,7 @@ public class AnimalDto {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ApiResponseDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ApiResponseDto.java
@@ -43,6 +43,7 @@ public class ApiResponseDto {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -62,6 +63,7 @@ public class ApiResponseDto {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -81,6 +83,7 @@ public class ApiResponseDto {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnlyDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnlyDto.java
@@ -52,6 +52,7 @@ public class ArrayOfArrayOfNumberOnlyDto {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ArrayOfNumberOnlyDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ArrayOfNumberOnlyDto.java
@@ -52,6 +52,7 @@ public class ArrayOfNumberOnlyDto {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ArrayTestDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ArrayTestDto.java
@@ -58,6 +58,7 @@ public class ArrayTestDto {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -85,6 +86,7 @@ public class ArrayTestDto {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -112,6 +114,7 @@ public class ArrayTestDto {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<ReadOnlyFirstDto>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/BigCatDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/BigCatDto.java
@@ -88,6 +88,7 @@ public class BigCatDto extends CatDto {
     return kind;
   }
 
+  @JsonProperty("kind")
   public void setKind(@Nullable KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/CapitalizationDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/CapitalizationDto.java
@@ -49,6 +49,7 @@ public class CapitalizationDto {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -68,6 +69,7 @@ public class CapitalizationDto {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -87,6 +89,7 @@ public class CapitalizationDto {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -106,6 +109,7 @@ public class CapitalizationDto {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -125,6 +129,7 @@ public class CapitalizationDto {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -144,6 +149,7 @@ public class CapitalizationDto {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/CatDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/CatDto.java
@@ -55,6 +55,7 @@ public class CatDto extends AnimalDto {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/CategoryDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/CategoryDto.java
@@ -45,6 +45,7 @@ public class CategoryDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -64,6 +65,7 @@ public class CategoryDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ChildWithNullableDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ChildWithNullableDto.java
@@ -47,6 +47,7 @@ public class ChildWithNullableDto extends ParentWithNullableDto {
     return otherProperty;
   }
 
+  @JsonProperty("otherProperty")
   public void setOtherProperty(@Nullable String otherProperty) {
     this.otherProperty = otherProperty;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ClassModelDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ClassModelDto.java
@@ -39,6 +39,7 @@ public class ClassModelDto {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ClientDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ClientDto.java
@@ -39,6 +39,7 @@ public class ClientDto {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
@@ -93,6 +93,7 @@ public class ContainerDefaultValueDto {
     return nullableRequiredArray;
   }
 
+  @JsonProperty("nullable_required_array")
   public void setNullableRequiredArray(JsonNullable<List<String>> nullableRequiredArray) {
     this.nullableRequiredArray = nullableRequiredArray;
   }
@@ -120,6 +121,7 @@ public class ContainerDefaultValueDto {
     return requiredArray;
   }
 
+  @JsonProperty("required_array")
   public void setRequiredArray(List<String> requiredArray) {
     this.requiredArray = requiredArray;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/DogDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/DogDto.java
@@ -48,6 +48,7 @@ public class DogDto extends AnimalDto {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/EnumArraysDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/EnumArraysDto.java
@@ -116,6 +116,7 @@ public class EnumArraysDto {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -143,6 +144,7 @@ public class EnumArraysDto {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/EnumTestDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/EnumTestDto.java
@@ -197,6 +197,7 @@ public class EnumTestDto {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -216,6 +217,7 @@ public class EnumTestDto {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -235,6 +237,7 @@ public class EnumTestDto {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -254,6 +257,7 @@ public class EnumTestDto {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -273,6 +277,7 @@ public class EnumTestDto {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(@Nullable OuterEnumDto outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/FileDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/FileDto.java
@@ -39,6 +39,7 @@ public class FileDto {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/FileSchemaTestClassDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/FileSchemaTestClassDto.java
@@ -46,6 +46,7 @@ public class FileSchemaTestClassDto {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable FileDto file) {
     this.file = file;
   }
@@ -73,6 +74,7 @@ public class FileSchemaTestClassDto {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<FileDto> files) {
     this.files = files;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/FormatTestDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/FormatTestDto.java
@@ -79,6 +79,7 @@ public class FormatTestDto {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -100,6 +101,7 @@ public class FormatTestDto {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -119,6 +121,7 @@ public class FormatTestDto {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -140,6 +143,7 @@ public class FormatTestDto {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -161,6 +165,7 @@ public class FormatTestDto {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -182,6 +187,7 @@ public class FormatTestDto {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -201,6 +207,7 @@ public class FormatTestDto {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -220,6 +227,7 @@ public class FormatTestDto {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -239,6 +247,7 @@ public class FormatTestDto {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -258,6 +267,7 @@ public class FormatTestDto {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -277,6 +287,7 @@ public class FormatTestDto {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -296,6 +307,7 @@ public class FormatTestDto {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -315,6 +327,7 @@ public class FormatTestDto {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -334,6 +347,7 @@ public class FormatTestDto {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(@Nullable BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/HasOnlyReadOnlyDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/HasOnlyReadOnlyDto.java
@@ -41,6 +41,7 @@ public class HasOnlyReadOnlyDto {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -60,6 +61,7 @@ public class HasOnlyReadOnlyDto {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ListDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ListDto.java
@@ -39,6 +39,7 @@ public class ListDto {
     return _123list;
   }
 
+  @JsonProperty("123-list")
   public void set123list(@Nullable String _123list) {
     this._123list = _123list;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/MapTestDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/MapTestDto.java
@@ -95,6 +95,7 @@ public class MapTestDto {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -122,6 +123,7 @@ public class MapTestDto {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -149,6 +151,7 @@ public class MapTestDto {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -176,6 +179,7 @@ public class MapTestDto {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClassDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClassDto.java
@@ -51,6 +51,7 @@ public class MixedPropertiesAndAdditionalPropertiesClassDto {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -70,6 +71,7 @@ public class MixedPropertiesAndAdditionalPropertiesClassDto {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -97,6 +99,7 @@ public class MixedPropertiesAndAdditionalPropertiesClassDto {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, AnimalDto> map) {
     this.map = map;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/Model200ResponseDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/Model200ResponseDto.java
@@ -41,6 +41,7 @@ public class Model200ResponseDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -60,6 +61,7 @@ public class Model200ResponseDto {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/NameDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/NameDto.java
@@ -49,6 +49,7 @@ public class NameDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -68,6 +69,7 @@ public class NameDto {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -87,6 +89,7 @@ public class NameDto {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -106,6 +109,7 @@ public class NameDto {
     return _123number;
   }
 
+  @JsonProperty("123Number")
   public void set123number(@Nullable Integer _123number) {
     this._123number = _123number;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/NumberOnlyDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/NumberOnlyDto.java
@@ -40,6 +40,7 @@ public class NumberOnlyDto {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/OrderDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/OrderDto.java
@@ -90,6 +90,7 @@ public class OrderDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -109,6 +110,7 @@ public class OrderDto {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -128,6 +130,7 @@ public class OrderDto {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -147,6 +150,7 @@ public class OrderDto {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -166,6 +170,7 @@ public class OrderDto {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -185,6 +190,7 @@ public class OrderDto {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/OuterCompositeDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/OuterCompositeDto.java
@@ -44,6 +44,7 @@ public class OuterCompositeDto {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -63,6 +64,7 @@ public class OuterCompositeDto {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -82,6 +84,7 @@ public class OuterCompositeDto {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ParentWithNullableDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ParentWithNullableDto.java
@@ -89,6 +89,7 @@ public class ParentWithNullableDto {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable TypeEnum type) {
     this.type = type;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/PetDto.java
@@ -102,6 +102,7 @@ public class PetDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -121,6 +122,7 @@ public class PetDto {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable CategoryDto category) {
     this.category = category;
   }
@@ -140,6 +142,7 @@ public class PetDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -168,6 +171,7 @@ public class PetDto {
   }
 
   @JsonDeserialize(as = LinkedHashSet.class)
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -195,6 +199,7 @@ public class PetDto {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<TagDto> tags) {
     this.tags = tags;
   }
@@ -210,8 +215,8 @@ public class PetDto {
    * @deprecated
    */
   
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -220,6 +225,7 @@ public class PetDto {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ReadOnlyFirstDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ReadOnlyFirstDto.java
@@ -41,6 +41,7 @@ public class ReadOnlyFirstDto {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -60,6 +61,7 @@ public class ReadOnlyFirstDto {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNamesDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNamesDto.java
@@ -45,6 +45,7 @@ public class ResponseObjectWithDifferentFieldNamesDto {
     return normalPropertyName;
   }
 
+  @JsonProperty("normalPropertyName")
   public void setNormalPropertyName(@Nullable String normalPropertyName) {
     this.normalPropertyName = normalPropertyName;
   }
@@ -64,6 +65,7 @@ public class ResponseObjectWithDifferentFieldNamesDto {
     return UPPER_CASE_PROPERTY_SNAKE;
   }
 
+  @JsonProperty("UPPER_CASE_PROPERTY_SNAKE")
   public void setUPPERCASEPROPERTYSNAKE(@Nullable String UPPER_CASE_PROPERTY_SNAKE) {
     this.UPPER_CASE_PROPERTY_SNAKE = UPPER_CASE_PROPERTY_SNAKE;
   }
@@ -83,6 +85,7 @@ public class ResponseObjectWithDifferentFieldNamesDto {
     return lowerCasePropertyDashes;
   }
 
+  @JsonProperty("lower-case-property-dashes")
   public void setLowerCasePropertyDashes(@Nullable String lowerCasePropertyDashes) {
     this.lowerCasePropertyDashes = lowerCasePropertyDashes;
   }
@@ -102,6 +105,7 @@ public class ResponseObjectWithDifferentFieldNamesDto {
     return propertyNameWithSpaces;
   }
 
+  @JsonProperty("property name with spaces")
   public void setPropertyNameWithSpaces(@Nullable String propertyNameWithSpaces) {
     this.propertyNameWithSpaces = propertyNameWithSpaces;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ReturnDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ReturnDto.java
@@ -39,6 +39,7 @@ public class ReturnDto {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/SpecialModelNameDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/SpecialModelNameDto.java
@@ -39,6 +39,7 @@ public class SpecialModelNameDto {
     return $specialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/TagDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/TagDto.java
@@ -41,6 +41,7 @@ public class TagDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -60,6 +61,7 @@ public class TagDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/TypeHolderDefaultDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/TypeHolderDefaultDto.java
@@ -56,6 +56,7 @@ public class TypeHolderDefaultDto {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -75,6 +76,7 @@ public class TypeHolderDefaultDto {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -94,6 +96,7 @@ public class TypeHolderDefaultDto {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -113,6 +116,7 @@ public class TypeHolderDefaultDto {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -140,6 +144,7 @@ public class TypeHolderDefaultDto {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/TypeHolderExampleDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/TypeHolderExampleDto.java
@@ -58,6 +58,7 @@ public class TypeHolderExampleDto {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -77,6 +78,7 @@ public class TypeHolderExampleDto {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -96,6 +98,7 @@ public class TypeHolderExampleDto {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -115,6 +118,7 @@ public class TypeHolderExampleDto {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -134,6 +138,7 @@ public class TypeHolderExampleDto {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -161,6 +166,7 @@ public class TypeHolderExampleDto {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/UserDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/UserDto.java
@@ -53,6 +53,7 @@ public class UserDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -72,6 +73,7 @@ public class UserDto {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -91,6 +93,7 @@ public class UserDto {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -110,6 +113,7 @@ public class UserDto {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -129,6 +133,7 @@ public class UserDto {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -148,6 +153,7 @@ public class UserDto {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -167,6 +173,7 @@ public class UserDto {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -186,6 +193,7 @@ public class UserDto {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/XmlItemDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/XmlItemDto.java
@@ -108,6 +108,7 @@ public class XmlItemDto {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(@Nullable String attributeString) {
     this.attributeString = attributeString;
   }
@@ -127,6 +128,7 @@ public class XmlItemDto {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(@Nullable BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -146,6 +148,7 @@ public class XmlItemDto {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(@Nullable Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -165,6 +168,7 @@ public class XmlItemDto {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(@Nullable Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -192,6 +196,7 @@ public class XmlItemDto {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -211,6 +216,7 @@ public class XmlItemDto {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(@Nullable String nameString) {
     this.nameString = nameString;
   }
@@ -230,6 +236,7 @@ public class XmlItemDto {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(@Nullable BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -249,6 +256,7 @@ public class XmlItemDto {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(@Nullable Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -268,6 +276,7 @@ public class XmlItemDto {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(@Nullable Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -295,6 +304,7 @@ public class XmlItemDto {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -322,6 +332,7 @@ public class XmlItemDto {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -341,6 +352,7 @@ public class XmlItemDto {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(@Nullable String prefixString) {
     this.prefixString = prefixString;
   }
@@ -360,6 +372,7 @@ public class XmlItemDto {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(@Nullable BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -379,6 +392,7 @@ public class XmlItemDto {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(@Nullable Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -398,6 +412,7 @@ public class XmlItemDto {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(@Nullable Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -425,6 +440,7 @@ public class XmlItemDto {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -452,6 +468,7 @@ public class XmlItemDto {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -471,6 +488,7 @@ public class XmlItemDto {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(@Nullable String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -490,6 +508,7 @@ public class XmlItemDto {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(@Nullable BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -509,6 +528,7 @@ public class XmlItemDto {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(@Nullable Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -528,6 +548,7 @@ public class XmlItemDto {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(@Nullable Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -555,6 +576,7 @@ public class XmlItemDto {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -582,6 +604,7 @@ public class XmlItemDto {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -601,6 +624,7 @@ public class XmlItemDto {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(@Nullable String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -620,6 +644,7 @@ public class XmlItemDto {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(@Nullable BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -639,6 +664,7 @@ public class XmlItemDto {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(@Nullable Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -658,6 +684,7 @@ public class XmlItemDto {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(@Nullable Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -685,6 +712,7 @@ public class XmlItemDto {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -712,6 +740,7 @@ public class XmlItemDto {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Category.java
@@ -40,6 +40,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(Optional<Long> id) {
     this.id = id;
   }
@@ -59,6 +60,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Optional<String> name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -44,6 +44,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(Optional<Integer> code) {
     this.code = code;
   }
@@ -63,6 +64,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(Optional<String> type) {
     this.type = type;
   }
@@ -82,6 +84,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(Optional<String> message) {
     this.message = message;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Order.java
@@ -89,6 +89,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(Optional<Long> id) {
     this.id = id;
   }
@@ -108,6 +109,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(Optional<Long> petId) {
     this.petId = petId;
   }
@@ -127,6 +129,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(Optional<Integer> quantity) {
     this.quantity = quantity;
   }
@@ -146,6 +149,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(Optional<OffsetDateTime> shipDate) {
     this.shipDate = shipDate;
   }
@@ -165,6 +169,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(Optional<StatusEnum> status) {
     this.status = status;
   }
@@ -184,6 +189,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Optional<Boolean> complete) {
     this.complete = complete;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Pet.java
@@ -106,6 +106,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(Optional<Long> id) {
     this.id = id;
   }
@@ -125,6 +126,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(Optional<Category> category) {
     this.category = category;
   }
@@ -144,6 +146,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -171,6 +174,7 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -198,6 +202,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -213,8 +218,8 @@ public class Pet {
    * @deprecated
    */
   
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public Optional<StatusEnum> getStatus() {
     return status;
   }
@@ -223,6 +228,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(Optional<StatusEnum> status) {
     this.status = status;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/Tag.java
@@ -40,6 +40,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(Optional<Long> id) {
     this.id = id;
   }
@@ -59,6 +60,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Optional<String> name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/model/User.java
@@ -52,6 +52,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(Optional<Long> id) {
     this.id = id;
   }
@@ -71,6 +72,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(Optional<String> username) {
     this.username = username;
   }
@@ -90,6 +92,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(Optional<String> firstName) {
     this.firstName = firstName;
   }
@@ -109,6 +112,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(Optional<String> lastName) {
     this.lastName = lastName;
   }
@@ -128,6 +132,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(Optional<String> email) {
     this.email = email;
   }
@@ -147,6 +152,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(Optional<String> password) {
     this.password = password;
   }
@@ -166,6 +172,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(Optional<String> phone) {
     this.phone = phone;
   }
@@ -185,6 +192,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(Optional<Integer> userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Category.java
@@ -43,6 +43,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -47,6 +47,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -67,6 +68,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -87,6 +89,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Order.java
@@ -92,6 +92,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -112,6 +113,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -132,6 +134,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -152,6 +155,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -172,6 +176,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -192,6 +197,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Pet.java
@@ -109,6 +109,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -129,6 +130,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -149,6 +151,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -177,6 +180,7 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -205,6 +209,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -221,8 +226,8 @@ public class Pet {
    */
   
   @Schema(name = "status", description = "pet status in the store", deprecated = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -231,6 +236,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/User.java
@@ -55,6 +55,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -75,6 +76,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -95,6 +97,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -115,6 +118,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -135,6 +139,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -155,6 +160,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -175,6 +181,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -195,6 +202,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/Category.java
@@ -39,6 +39,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(Long id) {
     this.id = id;
   }
@@ -58,6 +59,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -43,6 +43,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -62,6 +63,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(String type) {
     this.type = type;
   }
@@ -81,6 +83,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(String message) {
     this.message = message;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/Order.java
@@ -88,6 +88,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(Long id) {
     this.id = id;
   }
@@ -107,6 +108,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(Long petId) {
     this.petId = petId;
   }
@@ -126,6 +128,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -145,6 +148,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -164,6 +168,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -183,6 +188,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/Pet.java
@@ -105,6 +105,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(Long id) {
     this.id = id;
   }
@@ -124,6 +125,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -143,6 +145,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -170,6 +173,7 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -197,6 +201,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -212,8 +217,8 @@ public class Pet {
    * @deprecated
    */
   
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public StatusEnum getStatus() {
     return status;
   }
@@ -222,6 +227,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(StatusEnum status) {
     this.status = status;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/Tag.java
@@ -39,6 +39,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(Long id) {
     this.id = id;
   }
@@ -58,6 +59,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/client/petstore/spring-cloud-4-with-optional/src/main/java/org/openapitools/model/User.java
@@ -51,6 +51,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(Long id) {
     this.id = id;
   }
@@ -70,6 +71,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(String username) {
     this.username = username;
   }
@@ -89,6 +91,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -108,6 +111,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
@@ -127,6 +131,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(String email) {
     this.email = email;
   }
@@ -146,6 +151,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -165,6 +171,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -184,6 +191,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Category.java
@@ -43,6 +43,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -47,6 +47,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -67,6 +68,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -87,6 +89,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Order.java
@@ -92,6 +92,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -112,6 +113,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -132,6 +134,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -152,6 +155,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -172,6 +176,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -192,6 +197,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Pet.java
@@ -109,6 +109,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -129,6 +130,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -149,6 +151,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -177,6 +180,7 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -205,6 +209,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -221,8 +226,8 @@ public class Pet {
    */
   
   @Schema(name = "status", description = "pet status in the store", deprecated = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -231,6 +236,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/User.java
@@ -55,6 +55,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -75,6 +76,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -95,6 +97,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -115,6 +118,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -135,6 +139,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -155,6 +160,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -175,6 +181,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -195,6 +202,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-date-time/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-date-time/src/main/java/org/openapitools/model/Pet.java
@@ -67,6 +67,7 @@ public class Pet {
     return atType;
   }
 
+  @JsonProperty("@type")
   public void setAtType(String atType) {
     this.atType = atType;
   }
@@ -87,6 +88,7 @@ public class Pet {
     return age;
   }
 
+  @JsonProperty("age")
   public void setAge(Integer age) {
     this.age = age;
   }
@@ -107,6 +109,7 @@ public class Pet {
     return happy;
   }
 
+  @JsonProperty("happy")
   public void setHappy(Boolean happy) {
     this.happy = happy;
   }
@@ -127,6 +130,7 @@ public class Pet {
     return price;
   }
 
+  @JsonProperty("price")
   public void setPrice(BigDecimal price) {
     this.price = price;
   }
@@ -147,6 +151,7 @@ public class Pet {
     return lastFeed;
   }
 
+  @JsonProperty("lastFeed")
   public void setLastFeed(OffsetDateTime lastFeed) {
     this.lastFeed = lastFeed;
   }
@@ -167,6 +172,7 @@ public class Pet {
     return dateOfBirth;
   }
 
+  @JsonProperty("dateOfBirth")
   public void setDateOfBirth(LocalDate dateOfBirth) {
     this.dateOfBirth = dateOfBirth;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-http-basic/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/client/petstore/spring-cloud-http-basic/src/main/java/org/openapitools/model/Category.java
@@ -43,6 +43,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-http-basic/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-http-basic/src/main/java/org/openapitools/model/Pet.java
@@ -109,6 +109,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -129,6 +130,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -149,6 +151,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -177,6 +180,7 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -205,6 +209,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -221,8 +226,8 @@ public class Pet {
    */
   
   @Schema(name = "status", description = "pet status in the store", deprecated = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -231,6 +236,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-http-basic/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/client/petstore/spring-cloud-http-basic/src/main/java/org/openapitools/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesAnyType {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesArray {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesBoolean {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -83,6 +83,7 @@ public class AdditionalPropertiesClass {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -111,6 +112,7 @@ public class AdditionalPropertiesClass {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -139,6 +141,7 @@ public class AdditionalPropertiesClass {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -167,6 +170,7 @@ public class AdditionalPropertiesClass {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -195,6 +199,7 @@ public class AdditionalPropertiesClass {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -223,6 +228,7 @@ public class AdditionalPropertiesClass {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -251,6 +257,7 @@ public class AdditionalPropertiesClass {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -279,6 +286,7 @@ public class AdditionalPropertiesClass {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -299,6 +307,7 @@ public class AdditionalPropertiesClass {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(@Nullable Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -339,6 +348,7 @@ public class AdditionalPropertiesClass {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(@Nullable Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesInteger {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesNumber {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesObject {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesString {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Animal.java
@@ -60,6 +60,7 @@ public class Animal {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -80,6 +81,7 @@ public class Animal {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -53,6 +53,7 @@ public class ArrayOfArrayOfNumberOnly {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -53,6 +53,7 @@ public class ArrayOfNumberOnly {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ArrayTest.java
@@ -59,6 +59,7 @@ public class ArrayTest {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -87,6 +88,7 @@ public class ArrayTest {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -115,6 +117,7 @@ public class ArrayTest {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/BigCat.java
@@ -89,6 +89,7 @@ public class BigCat extends Cat {
     return kind;
   }
 
+  @JsonProperty("kind")
   public void setKind(@Nullable KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Capitalization.java
@@ -50,6 +50,7 @@ public class Capitalization {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -70,6 +71,7 @@ public class Capitalization {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -90,6 +92,7 @@ public class Capitalization {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -110,6 +113,7 @@ public class Capitalization {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -130,6 +134,7 @@ public class Capitalization {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -150,6 +155,7 @@ public class Capitalization {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Cat.java
@@ -57,6 +57,7 @@ public class Cat extends Animal {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Category.java
@@ -46,6 +46,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -66,6 +67,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ChildWithNullable.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ChildWithNullable.java
@@ -48,6 +48,7 @@ public class ChildWithNullable extends ParentWithNullable {
     return otherProperty;
   }
 
+  @JsonProperty("otherProperty")
   public void setOtherProperty(@Nullable String otherProperty) {
     this.otherProperty = otherProperty;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ClassModel.java
@@ -41,6 +41,7 @@ public class ClassModel {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Client.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Client.java
@@ -40,6 +40,7 @@ public class Client {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -95,6 +95,7 @@ public class ContainerDefaultValue {
     return nullableRequiredArray;
   }
 
+  @JsonProperty("nullable_required_array")
   public void setNullableRequiredArray(JsonNullable<List<String>> nullableRequiredArray) {
     this.nullableRequiredArray = nullableRequiredArray;
   }
@@ -123,6 +124,7 @@ public class ContainerDefaultValue {
     return requiredArray;
   }
 
+  @JsonProperty("required_array")
   public void setRequiredArray(List<String> requiredArray) {
     this.requiredArray = requiredArray;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Dog.java
@@ -49,6 +49,7 @@ public class Dog extends Animal {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/EnumArrays.java
@@ -117,6 +117,7 @@ public class EnumArrays {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -145,6 +146,7 @@ public class EnumArrays {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/EnumTest.java
@@ -200,6 +200,7 @@ public class EnumTest {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -220,6 +221,7 @@ public class EnumTest {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -240,6 +242,7 @@ public class EnumTest {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -260,6 +263,7 @@ public class EnumTest {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -280,6 +284,7 @@ public class EnumTest {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(@Nullable OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/File.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/File.java
@@ -41,6 +41,7 @@ public class File {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -47,6 +47,7 @@ public class FileSchemaTestClass {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable File file) {
     this.file = file;
   }
@@ -75,6 +76,7 @@ public class FileSchemaTestClass {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<@Valid File> files) {
     this.files = files;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/FormatTest.java
@@ -82,6 +82,7 @@ public class FormatTest {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -104,6 +105,7 @@ public class FormatTest {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -124,6 +126,7 @@ public class FormatTest {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -146,6 +149,7 @@ public class FormatTest {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -168,6 +172,7 @@ public class FormatTest {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -190,6 +195,7 @@ public class FormatTest {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -210,6 +216,7 @@ public class FormatTest {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -230,6 +237,7 @@ public class FormatTest {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -250,6 +258,7 @@ public class FormatTest {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -270,6 +279,7 @@ public class FormatTest {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -290,6 +300,7 @@ public class FormatTest {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -310,6 +321,7 @@ public class FormatTest {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -330,6 +342,7 @@ public class FormatTest {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -350,6 +363,7 @@ public class FormatTest {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(@Nullable BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -44,6 +44,7 @@ public class HasOnlyReadOnly {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -64,6 +65,7 @@ public class HasOnlyReadOnly {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/MapTest.java
@@ -96,6 +96,7 @@ public class MapTest {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -124,6 +125,7 @@ public class MapTest {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -152,6 +154,7 @@ public class MapTest {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -180,6 +183,7 @@ public class MapTest {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -52,6 +52,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -72,6 +73,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -100,6 +102,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Model200Response.java
@@ -45,6 +45,7 @@ public class Model200Response {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -65,6 +66,7 @@ public class Model200Response {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -46,6 +46,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -66,6 +67,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -86,6 +88,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ModelList.java
@@ -42,6 +42,7 @@ public class ModelList {
     return _123list;
   }
 
+  @JsonProperty("123-list")
   public void set123list(@Nullable String _123list) {
     this._123list = _123list;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ModelReturn.java
@@ -43,6 +43,7 @@ public class ModelReturn {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Name.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Name.java
@@ -51,6 +51,7 @@ public class Name {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -71,6 +72,7 @@ public class Name {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -91,6 +93,7 @@ public class Name {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -111,6 +114,7 @@ public class Name {
     return _123number;
   }
 
+  @JsonProperty("123Number")
   public void set123number(@Nullable Integer _123number) {
     this._123number = _123number;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/NumberOnly.java
@@ -41,6 +41,7 @@ public class NumberOnly {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Order.java
@@ -91,6 +91,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -111,6 +112,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -131,6 +133,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -151,6 +154,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -171,6 +175,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -191,6 +196,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/OuterComposite.java
@@ -45,6 +45,7 @@ public class OuterComposite {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -65,6 +66,7 @@ public class OuterComposite {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -85,6 +87,7 @@ public class OuterComposite {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -91,6 +91,7 @@ public class ParentWithNullable {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable TypeEnum type) {
     this.type = type;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Pet.java
@@ -103,6 +103,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -123,6 +124,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -143,6 +145,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -172,6 +175,7 @@ public class Pet {
   }
 
   @JsonDeserialize(as = LinkedHashSet.class)
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -200,6 +204,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -216,8 +221,8 @@ public class Pet {
    */
   
   @Schema(name = "status", description = "pet status in the store", deprecated = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -226,6 +231,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -42,6 +42,7 @@ public class ReadOnlyFirst {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -62,6 +63,7 @@ public class ReadOnlyFirst {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
@@ -46,6 +46,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return normalPropertyName;
   }
 
+  @JsonProperty("normalPropertyName")
   public void setNormalPropertyName(@Nullable String normalPropertyName) {
     this.normalPropertyName = normalPropertyName;
   }
@@ -66,6 +67,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return UPPER_CASE_PROPERTY_SNAKE;
   }
 
+  @JsonProperty("UPPER_CASE_PROPERTY_SNAKE")
   public void setUPPERCASEPROPERTYSNAKE(@Nullable String UPPER_CASE_PROPERTY_SNAKE) {
     this.UPPER_CASE_PROPERTY_SNAKE = UPPER_CASE_PROPERTY_SNAKE;
   }
@@ -86,6 +88,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return lowerCasePropertyDashes;
   }
 
+  @JsonProperty("lower-case-property-dashes")
   public void setLowerCasePropertyDashes(@Nullable String lowerCasePropertyDashes) {
     this.lowerCasePropertyDashes = lowerCasePropertyDashes;
   }
@@ -106,6 +109,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return propertyNameWithSpaces;
   }
 
+  @JsonProperty("property name with spaces")
   public void setPropertyNameWithSpaces(@Nullable String propertyNameWithSpaces) {
     this.propertyNameWithSpaces = propertyNameWithSpaces;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -42,6 +42,7 @@ public class SpecialModelName {
     return $specialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Tag.java
@@ -42,6 +42,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -62,6 +63,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -57,6 +57,7 @@ public class TypeHolderDefault {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -77,6 +78,7 @@ public class TypeHolderDefault {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -97,6 +99,7 @@ public class TypeHolderDefault {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -117,6 +120,7 @@ public class TypeHolderDefault {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -145,6 +149,7 @@ public class TypeHolderDefault {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -59,6 +59,7 @@ public class TypeHolderExample {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -79,6 +80,7 @@ public class TypeHolderExample {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -99,6 +101,7 @@ public class TypeHolderExample {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -119,6 +122,7 @@ public class TypeHolderExample {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -139,6 +143,7 @@ public class TypeHolderExample {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -167,6 +172,7 @@ public class TypeHolderExample {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/User.java
@@ -54,6 +54,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -74,6 +75,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -94,6 +96,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -114,6 +117,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -134,6 +138,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -154,6 +159,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -174,6 +180,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -194,6 +201,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/XmlItem.java
@@ -109,6 +109,7 @@ public class XmlItem {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(@Nullable String attributeString) {
     this.attributeString = attributeString;
   }
@@ -129,6 +130,7 @@ public class XmlItem {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(@Nullable BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -149,6 +151,7 @@ public class XmlItem {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(@Nullable Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -169,6 +172,7 @@ public class XmlItem {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(@Nullable Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -197,6 +201,7 @@ public class XmlItem {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -217,6 +222,7 @@ public class XmlItem {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(@Nullable String nameString) {
     this.nameString = nameString;
   }
@@ -237,6 +243,7 @@ public class XmlItem {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(@Nullable BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -257,6 +264,7 @@ public class XmlItem {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(@Nullable Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -277,6 +285,7 @@ public class XmlItem {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(@Nullable Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -305,6 +314,7 @@ public class XmlItem {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -333,6 +343,7 @@ public class XmlItem {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -353,6 +364,7 @@ public class XmlItem {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(@Nullable String prefixString) {
     this.prefixString = prefixString;
   }
@@ -373,6 +385,7 @@ public class XmlItem {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(@Nullable BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -393,6 +406,7 @@ public class XmlItem {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(@Nullable Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -413,6 +427,7 @@ public class XmlItem {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(@Nullable Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -441,6 +456,7 @@ public class XmlItem {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -469,6 +485,7 @@ public class XmlItem {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -489,6 +506,7 @@ public class XmlItem {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(@Nullable String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -509,6 +527,7 @@ public class XmlItem {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(@Nullable BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -529,6 +548,7 @@ public class XmlItem {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(@Nullable Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -549,6 +569,7 @@ public class XmlItem {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(@Nullable Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -577,6 +598,7 @@ public class XmlItem {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -605,6 +627,7 @@ public class XmlItem {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -625,6 +648,7 @@ public class XmlItem {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(@Nullable String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -645,6 +669,7 @@ public class XmlItem {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(@Nullable BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -665,6 +690,7 @@ public class XmlItem {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(@Nullable Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -685,6 +711,7 @@ public class XmlItem {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(@Nullable Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -713,6 +740,7 @@ public class XmlItem {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -741,6 +769,7 @@ public class XmlItem {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/Category.java
@@ -43,6 +43,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -47,6 +47,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -67,6 +68,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -87,6 +89,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/Order.java
@@ -92,6 +92,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -112,6 +113,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -132,6 +134,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -152,6 +155,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -172,6 +176,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -192,6 +197,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/Pet.java
@@ -108,6 +108,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -128,6 +129,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -148,6 +150,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -176,6 +179,7 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -204,6 +208,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -224,6 +229,7 @@ public class Pet {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/User.java
@@ -55,6 +55,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -75,6 +76,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -95,6 +97,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -115,6 +118,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -135,6 +139,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -155,6 +160,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -175,6 +181,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -195,6 +202,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Category.java
@@ -43,6 +43,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -47,6 +47,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -67,6 +68,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -87,6 +89,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Order.java
@@ -92,6 +92,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -112,6 +113,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -132,6 +134,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -152,6 +155,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -172,6 +176,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -192,6 +197,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
@@ -109,6 +109,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -129,6 +130,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -149,6 +151,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -177,6 +180,7 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -205,6 +209,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -221,8 +226,8 @@ public class Pet {
    */
   
   @Schema(name = "status", description = "pet status in the store", deprecated = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -231,6 +236,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/User.java
@@ -55,6 +55,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -75,6 +76,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -95,6 +97,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -115,6 +118,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -135,6 +139,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -155,6 +160,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -175,6 +181,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -195,6 +202,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Category.java
@@ -43,6 +43,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -47,6 +47,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -67,6 +68,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -87,6 +89,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Order.java
@@ -92,6 +92,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -112,6 +113,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -132,6 +134,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -152,6 +155,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -172,6 +176,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -192,6 +197,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Pet.java
@@ -109,6 +109,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -129,6 +130,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -149,6 +151,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -177,6 +180,7 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -205,6 +209,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -221,8 +226,8 @@ public class Pet {
    */
   
   @Schema(name = "status", description = "pet status in the store", deprecated = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -231,6 +236,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/User.java
@@ -55,6 +55,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -75,6 +76,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -95,6 +97,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -115,6 +118,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -135,6 +139,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -155,6 +160,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -175,6 +181,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -195,6 +202,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Category.java
@@ -43,6 +43,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -47,6 +47,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -67,6 +68,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -87,6 +89,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Order.java
@@ -92,6 +92,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -112,6 +113,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -132,6 +134,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -152,6 +155,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -172,6 +176,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -192,6 +197,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Pet.java
@@ -109,6 +109,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -129,6 +130,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -149,6 +151,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -177,6 +180,7 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -205,6 +209,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -221,8 +226,8 @@ public class Pet {
    */
   
   @Schema(name = "status", description = "pet status in the store", deprecated = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -231,6 +236,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/User.java
@@ -55,6 +55,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -75,6 +76,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -95,6 +97,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -115,6 +118,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -135,6 +139,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -155,6 +160,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -175,6 +181,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -195,6 +202,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/Addressable.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/Addressable.java
@@ -43,6 +43,7 @@ public class Addressable {
     return href;
   }
 
+  @JsonProperty("href")
   public void setHref(@Nullable String href) {
     this.href = href;
   }
@@ -63,6 +64,7 @@ public class Addressable {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable String id) {
     this.id = id;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/Apple.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/Apple.java
@@ -58,6 +58,7 @@ public class Apple implements Fruit {
     return seeds;
   }
 
+  @JsonProperty("seeds")
   public void setSeeds(Integer seeds) {
     this.seeds = seeds;
   }
@@ -78,6 +79,7 @@ public class Apple implements Fruit {
     return fruitType;
   }
 
+  @JsonProperty("fruitType")
   public void setFruitType(FruitType fruitType) {
     this.fruitType = fruitType;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/Banana.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/Banana.java
@@ -58,6 +58,7 @@ public class Banana implements Fruit {
     return length;
   }
 
+  @JsonProperty("length")
   public void setLength(Integer length) {
     this.length = length;
   }
@@ -78,6 +79,7 @@ public class Banana implements Fruit {
     return fruitType;
   }
 
+  @JsonProperty("fruitType")
   public void setFruitType(FruitType fruitType) {
     this.fruitType = fruitType;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/Bar.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/Bar.java
@@ -64,6 +64,7 @@ public class Bar extends Entity implements BarRefOrValue {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(String id) {
     this.id = id;
   }
@@ -84,6 +85,7 @@ public class Bar extends Entity implements BarRefOrValue {
     return barPropA;
   }
 
+  @JsonProperty("barPropA")
   public void setBarPropA(@Nullable String barPropA) {
     this.barPropA = barPropA;
   }
@@ -104,6 +106,7 @@ public class Bar extends Entity implements BarRefOrValue {
     return fooPropB;
   }
 
+  @JsonProperty("fooPropB")
   public void setFooPropB(@Nullable String fooPropB) {
     this.fooPropB = fooPropB;
   }
@@ -124,6 +127,7 @@ public class Bar extends Entity implements BarRefOrValue {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable FooRefOrValue foo) {
     this.foo = foo;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/BarCreate.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/BarCreate.java
@@ -63,6 +63,7 @@ public class BarCreate extends Entity {
     return barPropA;
   }
 
+  @JsonProperty("barPropA")
   public void setBarPropA(@Nullable String barPropA) {
     this.barPropA = barPropA;
   }
@@ -83,6 +84,7 @@ public class BarCreate extends Entity {
     return fooPropB;
   }
 
+  @JsonProperty("fooPropB")
   public void setFooPropB(@Nullable String fooPropB) {
     this.fooPropB = fooPropB;
   }
@@ -103,6 +105,7 @@ public class BarCreate extends Entity {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable FooRefOrValue foo) {
     this.foo = foo;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/Cat.java
@@ -40,6 +40,7 @@ public class Cat implements Animal {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/Dog.java
@@ -40,6 +40,7 @@ public class Dog implements Animal {
     return bark;
   }
 
+  @JsonProperty("bark")
   public void setBark(@Nullable Boolean bark) {
     this.bark = bark;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/Entity.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/Entity.java
@@ -76,6 +76,7 @@ public class Entity {
     return href;
   }
 
+  @JsonProperty("href")
   public void setHref(@Nullable String href) {
     this.href = href;
   }
@@ -96,6 +97,7 @@ public class Entity {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable String id) {
     this.id = id;
   }
@@ -116,6 +118,7 @@ public class Entity {
     return atSchemaLocation;
   }
 
+  @JsonProperty("@schemaLocation")
   public void setAtSchemaLocation(@Nullable String atSchemaLocation) {
     this.atSchemaLocation = atSchemaLocation;
   }
@@ -136,6 +139,7 @@ public class Entity {
     return atBaseType;
   }
 
+  @JsonProperty("@baseType")
   public void setAtBaseType(@Nullable String atBaseType) {
     this.atBaseType = atBaseType;
   }
@@ -156,6 +160,7 @@ public class Entity {
     return atType;
   }
 
+  @JsonProperty("@type")
   public void setAtType(String atType) {
     this.atType = atType;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/EntityRef.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/EntityRef.java
@@ -76,6 +76,7 @@ public class EntityRef {
     return href;
   }
 
+  @JsonProperty("href")
   public void setHref(@Nullable String href) {
     this.href = href;
   }
@@ -96,6 +97,7 @@ public class EntityRef {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable String id) {
     this.id = id;
   }
@@ -116,6 +118,7 @@ public class EntityRef {
     return atSchemaLocation;
   }
 
+  @JsonProperty("@schemaLocation")
   public void setAtSchemaLocation(@Nullable String atSchemaLocation) {
     this.atSchemaLocation = atSchemaLocation;
   }
@@ -136,6 +139,7 @@ public class EntityRef {
     return atBaseType;
   }
 
+  @JsonProperty("@baseType")
   public void setAtBaseType(@Nullable String atBaseType) {
     this.atBaseType = atBaseType;
   }
@@ -156,6 +160,7 @@ public class EntityRef {
     return atType;
   }
 
+  @JsonProperty("@type")
   public void setAtType(String atType) {
     this.atType = atType;
   }
@@ -176,6 +181,7 @@ public class EntityRef {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }
@@ -196,6 +202,7 @@ public class EntityRef {
     return atReferredType;
   }
 
+  @JsonProperty("@referredType")
   public void setAtReferredType(@Nullable String atReferredType) {
     this.atReferredType = atReferredType;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/Extensible.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/Extensible.java
@@ -55,6 +55,7 @@ public class Extensible {
     return atSchemaLocation;
   }
 
+  @JsonProperty("@schemaLocation")
   public void setAtSchemaLocation(@Nullable String atSchemaLocation) {
     this.atSchemaLocation = atSchemaLocation;
   }
@@ -75,6 +76,7 @@ public class Extensible {
     return atBaseType;
   }
 
+  @JsonProperty("@baseType")
   public void setAtBaseType(@Nullable String atBaseType) {
     this.atBaseType = atBaseType;
   }
@@ -95,6 +97,7 @@ public class Extensible {
     return atType;
   }
 
+  @JsonProperty("@type")
   public void setAtType(String atType) {
     this.atType = atType;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/Foo.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/Foo.java
@@ -58,6 +58,7 @@ public class Foo extends Entity implements FooRefOrValue {
     return fooPropA;
   }
 
+  @JsonProperty("fooPropA")
   public void setFooPropA(@Nullable String fooPropA) {
     this.fooPropA = fooPropA;
   }
@@ -78,6 +79,7 @@ public class Foo extends Entity implements FooRefOrValue {
     return fooPropB;
   }
 
+  @JsonProperty("fooPropB")
   public void setFooPropB(@Nullable String fooPropB) {
     this.fooPropB = fooPropB;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/FooRef.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/FooRef.java
@@ -56,6 +56,7 @@ public class FooRef extends EntityRef implements FooRefOrValue {
     return foorefPropA;
   }
 
+  @JsonProperty("foorefPropA")
   public void setFoorefPropA(@Nullable String foorefPropA) {
     this.foorefPropA = foorefPropA;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/Pasta.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/Pasta.java
@@ -56,6 +56,7 @@ public class Pasta extends Entity {
     return vendor;
   }
 
+  @JsonProperty("vendor")
   public void setVendor(@Nullable String vendor) {
     this.vendor = vendor;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/Pizza.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/Pizza.java
@@ -65,6 +65,7 @@ public class Pizza extends Entity {
     return pizzaSize;
   }
 
+  @JsonProperty("pizzaSize")
   public void setPizzaSize(@Nullable BigDecimal pizzaSize) {
     this.pizzaSize = pizzaSize;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/PizzaSpeziale.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/model/PizzaSpeziale.java
@@ -57,6 +57,7 @@ public class PizzaSpeziale extends Pizza {
     return toppings;
   }
 
+  @JsonProperty("toppings")
   public void setToppings(@Nullable String toppings) {
     this.toppings = toppings;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/Addressable.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/Addressable.java
@@ -43,6 +43,7 @@ public final class Addressable {
     return href;
   }
 
+  @JsonProperty("href")
   public void setHref(@Nullable String href) {
     this.href = href;
   }
@@ -63,6 +64,7 @@ public final class Addressable {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable String id) {
     this.id = id;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/Apple.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/Apple.java
@@ -58,6 +58,7 @@ public final class Apple implements Fruit {
     return seeds;
   }
 
+  @JsonProperty("seeds")
   public void setSeeds(Integer seeds) {
     this.seeds = seeds;
   }
@@ -78,6 +79,7 @@ public final class Apple implements Fruit {
     return fruitType;
   }
 
+  @JsonProperty("fruitType")
   public void setFruitType(FruitType fruitType) {
     this.fruitType = fruitType;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/Banana.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/Banana.java
@@ -58,6 +58,7 @@ public final class Banana implements Fruit {
     return length;
   }
 
+  @JsonProperty("length")
   public void setLength(Integer length) {
     this.length = length;
   }
@@ -78,6 +79,7 @@ public final class Banana implements Fruit {
     return fruitType;
   }
 
+  @JsonProperty("fruitType")
   public void setFruitType(FruitType fruitType) {
     this.fruitType = fruitType;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/Bar.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/Bar.java
@@ -64,6 +64,7 @@ public final class Bar extends Entity implements BarRefOrValue {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(String id) {
     this.id = id;
   }
@@ -84,6 +85,7 @@ public final class Bar extends Entity implements BarRefOrValue {
     return barPropA;
   }
 
+  @JsonProperty("barPropA")
   public void setBarPropA(@Nullable String barPropA) {
     this.barPropA = barPropA;
   }
@@ -104,6 +106,7 @@ public final class Bar extends Entity implements BarRefOrValue {
     return fooPropB;
   }
 
+  @JsonProperty("fooPropB")
   public void setFooPropB(@Nullable String fooPropB) {
     this.fooPropB = fooPropB;
   }
@@ -124,6 +127,7 @@ public final class Bar extends Entity implements BarRefOrValue {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable FooRefOrValue foo) {
     this.foo = foo;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/BarCreate.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/BarCreate.java
@@ -63,6 +63,7 @@ public final class BarCreate extends Entity {
     return barPropA;
   }
 
+  @JsonProperty("barPropA")
   public void setBarPropA(@Nullable String barPropA) {
     this.barPropA = barPropA;
   }
@@ -83,6 +84,7 @@ public final class BarCreate extends Entity {
     return fooPropB;
   }
 
+  @JsonProperty("fooPropB")
   public void setFooPropB(@Nullable String fooPropB) {
     this.fooPropB = fooPropB;
   }
@@ -103,6 +105,7 @@ public final class BarCreate extends Entity {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable FooRefOrValue foo) {
     this.foo = foo;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/Cat.java
@@ -40,6 +40,7 @@ public final class Cat implements Animal {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/Dog.java
@@ -40,6 +40,7 @@ public final class Dog implements Animal {
     return bark;
   }
 
+  @JsonProperty("bark")
   public void setBark(@Nullable Boolean bark) {
     this.bark = bark;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/Entity.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/Entity.java
@@ -76,6 +76,7 @@ public sealed class Entity permits Bar, BarCreate, Foo, Pasta, Pizza {
     return href;
   }
 
+  @JsonProperty("href")
   public void setHref(@Nullable String href) {
     this.href = href;
   }
@@ -96,6 +97,7 @@ public sealed class Entity permits Bar, BarCreate, Foo, Pasta, Pizza {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable String id) {
     this.id = id;
   }
@@ -116,6 +118,7 @@ public sealed class Entity permits Bar, BarCreate, Foo, Pasta, Pizza {
     return atSchemaLocation;
   }
 
+  @JsonProperty("@schemaLocation")
   public void setAtSchemaLocation(@Nullable String atSchemaLocation) {
     this.atSchemaLocation = atSchemaLocation;
   }
@@ -136,6 +139,7 @@ public sealed class Entity permits Bar, BarCreate, Foo, Pasta, Pizza {
     return atBaseType;
   }
 
+  @JsonProperty("@baseType")
   public void setAtBaseType(@Nullable String atBaseType) {
     this.atBaseType = atBaseType;
   }
@@ -156,6 +160,7 @@ public sealed class Entity permits Bar, BarCreate, Foo, Pasta, Pizza {
     return atType;
   }
 
+  @JsonProperty("@type")
   public void setAtType(String atType) {
     this.atType = atType;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/EntityRef.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/EntityRef.java
@@ -76,6 +76,7 @@ public sealed class EntityRef permits BarRef, FooRef {
     return href;
   }
 
+  @JsonProperty("href")
   public void setHref(@Nullable String href) {
     this.href = href;
   }
@@ -96,6 +97,7 @@ public sealed class EntityRef permits BarRef, FooRef {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable String id) {
     this.id = id;
   }
@@ -116,6 +118,7 @@ public sealed class EntityRef permits BarRef, FooRef {
     return atSchemaLocation;
   }
 
+  @JsonProperty("@schemaLocation")
   public void setAtSchemaLocation(@Nullable String atSchemaLocation) {
     this.atSchemaLocation = atSchemaLocation;
   }
@@ -136,6 +139,7 @@ public sealed class EntityRef permits BarRef, FooRef {
     return atBaseType;
   }
 
+  @JsonProperty("@baseType")
   public void setAtBaseType(@Nullable String atBaseType) {
     this.atBaseType = atBaseType;
   }
@@ -156,6 +160,7 @@ public sealed class EntityRef permits BarRef, FooRef {
     return atType;
   }
 
+  @JsonProperty("@type")
   public void setAtType(String atType) {
     this.atType = atType;
   }
@@ -176,6 +181,7 @@ public sealed class EntityRef permits BarRef, FooRef {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }
@@ -196,6 +202,7 @@ public sealed class EntityRef permits BarRef, FooRef {
     return atReferredType;
   }
 
+  @JsonProperty("@referredType")
   public void setAtReferredType(@Nullable String atReferredType) {
     this.atReferredType = atReferredType;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/Extensible.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/Extensible.java
@@ -55,6 +55,7 @@ public final class Extensible {
     return atSchemaLocation;
   }
 
+  @JsonProperty("@schemaLocation")
   public void setAtSchemaLocation(@Nullable String atSchemaLocation) {
     this.atSchemaLocation = atSchemaLocation;
   }
@@ -75,6 +76,7 @@ public final class Extensible {
     return atBaseType;
   }
 
+  @JsonProperty("@baseType")
   public void setAtBaseType(@Nullable String atBaseType) {
     this.atBaseType = atBaseType;
   }
@@ -95,6 +97,7 @@ public final class Extensible {
     return atType;
   }
 
+  @JsonProperty("@type")
   public void setAtType(String atType) {
     this.atType = atType;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/Foo.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/Foo.java
@@ -58,6 +58,7 @@ public final class Foo extends Entity implements FooRefOrValue {
     return fooPropA;
   }
 
+  @JsonProperty("fooPropA")
   public void setFooPropA(@Nullable String fooPropA) {
     this.fooPropA = fooPropA;
   }
@@ -78,6 +79,7 @@ public final class Foo extends Entity implements FooRefOrValue {
     return fooPropB;
   }
 
+  @JsonProperty("fooPropB")
   public void setFooPropB(@Nullable String fooPropB) {
     this.fooPropB = fooPropB;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/FooRef.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/FooRef.java
@@ -56,6 +56,7 @@ public final class FooRef extends EntityRef implements FooRefOrValue {
     return foorefPropA;
   }
 
+  @JsonProperty("foorefPropA")
   public void setFoorefPropA(@Nullable String foorefPropA) {
     this.foorefPropA = foorefPropA;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/Pasta.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/Pasta.java
@@ -56,6 +56,7 @@ public final class Pasta extends Entity {
     return vendor;
   }
 
+  @JsonProperty("vendor")
   public void setVendor(@Nullable String vendor) {
     this.vendor = vendor;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/Pizza.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/Pizza.java
@@ -65,6 +65,7 @@ public sealed class Pizza extends Entity permits PizzaSpeziale {
     return pizzaSize;
   }
 
+  @JsonProperty("pizzaSize")
   public void setPizzaSize(@Nullable BigDecimal pizzaSize) {
     this.pizzaSize = pizzaSize;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/PizzaSpeziale.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/model/PizzaSpeziale.java
@@ -57,6 +57,7 @@ public final class PizzaSpeziale extends Pizza {
     return toppings;
   }
 
+  @JsonProperty("toppings")
   public void setToppings(@Nullable String toppings) {
     this.toppings = toppings;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Addressable.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Addressable.java
@@ -43,6 +43,7 @@ public class Addressable {
     return href;
   }
 
+  @JsonProperty("href")
   public void setHref(@Nullable String href) {
     this.href = href;
   }
@@ -63,6 +64,7 @@ public class Addressable {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable String id) {
     this.id = id;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Apple.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Apple.java
@@ -58,6 +58,7 @@ public class Apple implements Fruit {
     return seeds;
   }
 
+  @JsonProperty("seeds")
   public void setSeeds(Integer seeds) {
     this.seeds = seeds;
   }
@@ -78,6 +79,7 @@ public class Apple implements Fruit {
     return fruitType;
   }
 
+  @JsonProperty("fruitType")
   public void setFruitType(FruitType fruitType) {
     this.fruitType = fruitType;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Banana.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Banana.java
@@ -58,6 +58,7 @@ public class Banana implements Fruit {
     return length;
   }
 
+  @JsonProperty("length")
   public void setLength(Integer length) {
     this.length = length;
   }
@@ -78,6 +79,7 @@ public class Banana implements Fruit {
     return fruitType;
   }
 
+  @JsonProperty("fruitType")
   public void setFruitType(FruitType fruitType) {
     this.fruitType = fruitType;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Bar.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Bar.java
@@ -64,6 +64,7 @@ public class Bar extends Entity implements BarRefOrValue {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(String id) {
     this.id = id;
   }
@@ -84,6 +85,7 @@ public class Bar extends Entity implements BarRefOrValue {
     return barPropA;
   }
 
+  @JsonProperty("barPropA")
   public void setBarPropA(@Nullable String barPropA) {
     this.barPropA = barPropA;
   }
@@ -104,6 +106,7 @@ public class Bar extends Entity implements BarRefOrValue {
     return fooPropB;
   }
 
+  @JsonProperty("fooPropB")
   public void setFooPropB(@Nullable String fooPropB) {
     this.fooPropB = fooPropB;
   }
@@ -124,6 +127,7 @@ public class Bar extends Entity implements BarRefOrValue {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable FooRefOrValue foo) {
     this.foo = foo;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/BarCreate.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/BarCreate.java
@@ -63,6 +63,7 @@ public class BarCreate extends Entity {
     return barPropA;
   }
 
+  @JsonProperty("barPropA")
   public void setBarPropA(@Nullable String barPropA) {
     this.barPropA = barPropA;
   }
@@ -83,6 +84,7 @@ public class BarCreate extends Entity {
     return fooPropB;
   }
 
+  @JsonProperty("fooPropB")
   public void setFooPropB(@Nullable String fooPropB) {
     this.fooPropB = fooPropB;
   }
@@ -103,6 +105,7 @@ public class BarCreate extends Entity {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable FooRefOrValue foo) {
     this.foo = foo;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Cat.java
@@ -40,6 +40,7 @@ public class Cat implements Animal {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Dog.java
@@ -40,6 +40,7 @@ public class Dog implements Animal {
     return bark;
   }
 
+  @JsonProperty("bark")
   public void setBark(@Nullable Boolean bark) {
     this.bark = bark;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Entity.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Entity.java
@@ -76,6 +76,7 @@ public class Entity {
     return href;
   }
 
+  @JsonProperty("href")
   public void setHref(@Nullable String href) {
     this.href = href;
   }
@@ -96,6 +97,7 @@ public class Entity {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable String id) {
     this.id = id;
   }
@@ -116,6 +118,7 @@ public class Entity {
     return atSchemaLocation;
   }
 
+  @JsonProperty("@schemaLocation")
   public void setAtSchemaLocation(@Nullable String atSchemaLocation) {
     this.atSchemaLocation = atSchemaLocation;
   }
@@ -136,6 +139,7 @@ public class Entity {
     return atBaseType;
   }
 
+  @JsonProperty("@baseType")
   public void setAtBaseType(@Nullable String atBaseType) {
     this.atBaseType = atBaseType;
   }
@@ -156,6 +160,7 @@ public class Entity {
     return atType;
   }
 
+  @JsonProperty("@type")
   public void setAtType(String atType) {
     this.atType = atType;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/EntityRef.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/EntityRef.java
@@ -76,6 +76,7 @@ public class EntityRef {
     return href;
   }
 
+  @JsonProperty("href")
   public void setHref(@Nullable String href) {
     this.href = href;
   }
@@ -96,6 +97,7 @@ public class EntityRef {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable String id) {
     this.id = id;
   }
@@ -116,6 +118,7 @@ public class EntityRef {
     return atSchemaLocation;
   }
 
+  @JsonProperty("@schemaLocation")
   public void setAtSchemaLocation(@Nullable String atSchemaLocation) {
     this.atSchemaLocation = atSchemaLocation;
   }
@@ -136,6 +139,7 @@ public class EntityRef {
     return atBaseType;
   }
 
+  @JsonProperty("@baseType")
   public void setAtBaseType(@Nullable String atBaseType) {
     this.atBaseType = atBaseType;
   }
@@ -156,6 +160,7 @@ public class EntityRef {
     return atType;
   }
 
+  @JsonProperty("@type")
   public void setAtType(String atType) {
     this.atType = atType;
   }
@@ -176,6 +181,7 @@ public class EntityRef {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }
@@ -196,6 +202,7 @@ public class EntityRef {
     return atReferredType;
   }
 
+  @JsonProperty("@referredType")
   public void setAtReferredType(@Nullable String atReferredType) {
     this.atReferredType = atReferredType;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Extensible.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Extensible.java
@@ -55,6 +55,7 @@ public class Extensible {
     return atSchemaLocation;
   }
 
+  @JsonProperty("@schemaLocation")
   public void setAtSchemaLocation(@Nullable String atSchemaLocation) {
     this.atSchemaLocation = atSchemaLocation;
   }
@@ -75,6 +76,7 @@ public class Extensible {
     return atBaseType;
   }
 
+  @JsonProperty("@baseType")
   public void setAtBaseType(@Nullable String atBaseType) {
     this.atBaseType = atBaseType;
   }
@@ -95,6 +97,7 @@ public class Extensible {
     return atType;
   }
 
+  @JsonProperty("@type")
   public void setAtType(String atType) {
     this.atType = atType;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Foo.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Foo.java
@@ -58,6 +58,7 @@ public class Foo extends Entity implements FooRefOrValue {
     return fooPropA;
   }
 
+  @JsonProperty("fooPropA")
   public void setFooPropA(@Nullable String fooPropA) {
     this.fooPropA = fooPropA;
   }
@@ -78,6 +79,7 @@ public class Foo extends Entity implements FooRefOrValue {
     return fooPropB;
   }
 
+  @JsonProperty("fooPropB")
   public void setFooPropB(@Nullable String fooPropB) {
     this.fooPropB = fooPropB;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/FooRef.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/FooRef.java
@@ -56,6 +56,7 @@ public class FooRef extends EntityRef implements FooRefOrValue {
     return foorefPropA;
   }
 
+  @JsonProperty("foorefPropA")
   public void setFoorefPropA(@Nullable String foorefPropA) {
     this.foorefPropA = foorefPropA;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Pasta.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Pasta.java
@@ -56,6 +56,7 @@ public class Pasta extends Entity {
     return vendor;
   }
 
+  @JsonProperty("vendor")
   public void setVendor(@Nullable String vendor) {
     this.vendor = vendor;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Pizza.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Pizza.java
@@ -65,6 +65,7 @@ public class Pizza extends Entity {
     return pizzaSize;
   }
 
+  @JsonProperty("pizzaSize")
   public void setPizzaSize(@Nullable BigDecimal pizzaSize) {
     this.pizzaSize = pizzaSize;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/PizzaSpeziale.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/PizzaSpeziale.java
@@ -57,6 +57,7 @@ public class PizzaSpeziale extends Pizza {
     return toppings;
   }
 
+  @JsonProperty("toppings")
   public void setToppings(@Nullable String toppings) {
     this.toppings = toppings;
   }

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Category.java
@@ -43,6 +43,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -47,6 +47,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -67,6 +68,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -87,6 +89,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Order.java
@@ -92,6 +92,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -112,6 +113,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -132,6 +134,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -152,6 +155,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -172,6 +176,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -192,6 +197,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Pet.java
@@ -109,6 +109,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -129,6 +130,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -149,6 +151,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -177,6 +180,7 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -205,6 +209,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -221,8 +226,8 @@ public class Pet {
    */
   
   @Schema(name = "status", description = "pet status in the store", deprecated = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -231,6 +236,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/User.java
@@ -55,6 +55,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -75,6 +76,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -95,6 +97,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -115,6 +118,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -135,6 +139,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -155,6 +160,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -175,6 +181,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -195,6 +202,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/openapi3/server/petstore/springboot-3-include-http-request-context/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/server/petstore/springboot-3-include-http-request-context/src/main/java/org/openapitools/model/Category.java
@@ -64,6 +64,8 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
+  @JacksonXmlProperty(localName = "id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -86,6 +88,8 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
+  @JacksonXmlProperty(localName = "name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-3-include-http-request-context/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/server/petstore/springboot-3-include-http-request-context/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -69,6 +69,8 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
+  @JacksonXmlProperty(localName = "code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -91,6 +93,8 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
+  @JacksonXmlProperty(localName = "type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -113,6 +117,8 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
+  @JacksonXmlProperty(localName = "message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/openapi3/server/petstore/springboot-3-include-http-request-context/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/springboot-3-include-http-request-context/src/main/java/org/openapitools/model/Order.java
@@ -117,6 +117,8 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
+  @JacksonXmlProperty(localName = "id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -139,6 +141,8 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
+  @JacksonXmlProperty(localName = "petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -161,6 +165,8 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
+  @JacksonXmlProperty(localName = "quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -183,6 +189,8 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
+  @JacksonXmlProperty(localName = "shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -205,6 +213,8 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
+  @JacksonXmlProperty(localName = "status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -227,6 +237,8 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
+  @JacksonXmlProperty(localName = "complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/openapi3/server/petstore/springboot-3-include-http-request-context/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-3-include-http-request-context/src/main/java/org/openapitools/model/Pet.java
@@ -130,6 +130,8 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
+  @JacksonXmlProperty(localName = "id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -152,6 +154,8 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
+  @JacksonXmlProperty(localName = "Category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -174,6 +178,8 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
+  @JacksonXmlProperty(localName = "name")
   public void setName(String name) {
     this.name = name;
   }
@@ -206,6 +212,9 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
+  @JacksonXmlProperty(localName = "photoUrl")
+  @JacksonXmlElementWrapper(localName = "photoUrl", useWrapping = true)
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -238,6 +247,9 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
+  @JacksonXmlProperty(localName = "Tag")
+  @JacksonXmlElementWrapper(localName = "tag", useWrapping = true)
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -254,10 +266,10 @@ public class Pet {
    */
   
   @Schema(name = "status", description = "pet status in the store", deprecated = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @Deprecated
   @JsonProperty("status")
   @JacksonXmlProperty(localName = "status")
   @XmlElement(name = "status")
-  @Deprecated
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -266,6 +278,8 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
+  @JacksonXmlProperty(localName = "status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/openapi3/server/petstore/springboot-3-include-http-request-context/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/server/petstore/springboot-3-include-http-request-context/src/main/java/org/openapitools/model/Tag.java
@@ -64,6 +64,8 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
+  @JacksonXmlProperty(localName = "id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -86,6 +88,8 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
+  @JacksonXmlProperty(localName = "name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-3-include-http-request-context/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/server/petstore/springboot-3-include-http-request-context/src/main/java/org/openapitools/model/User.java
@@ -82,6 +82,8 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
+  @JacksonXmlProperty(localName = "id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -104,6 +106,8 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
+  @JacksonXmlProperty(localName = "username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -126,6 +130,8 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
+  @JacksonXmlProperty(localName = "firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -148,6 +154,8 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
+  @JacksonXmlProperty(localName = "lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -170,6 +178,8 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
+  @JacksonXmlProperty(localName = "email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -192,6 +202,8 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
+  @JacksonXmlProperty(localName = "password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -214,6 +226,8 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
+  @JacksonXmlProperty(localName = "phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -236,6 +250,8 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
+  @JacksonXmlProperty(localName = "userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Category.java
@@ -64,6 +64,8 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
+  @JacksonXmlProperty(localName = "id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -86,6 +88,8 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
+  @JacksonXmlProperty(localName = "name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -69,6 +69,8 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
+  @JacksonXmlProperty(localName = "code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -91,6 +93,8 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
+  @JacksonXmlProperty(localName = "type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -113,6 +117,8 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
+  @JacksonXmlProperty(localName = "message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Order.java
@@ -117,6 +117,8 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
+  @JacksonXmlProperty(localName = "id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -139,6 +141,8 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
+  @JacksonXmlProperty(localName = "petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -161,6 +165,8 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
+  @JacksonXmlProperty(localName = "quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -183,6 +189,8 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
+  @JacksonXmlProperty(localName = "shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -205,6 +213,8 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
+  @JacksonXmlProperty(localName = "status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -227,6 +237,8 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
+  @JacksonXmlProperty(localName = "complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Pet.java
@@ -130,6 +130,8 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
+  @JacksonXmlProperty(localName = "id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -152,6 +154,8 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
+  @JacksonXmlProperty(localName = "Category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -174,6 +178,8 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
+  @JacksonXmlProperty(localName = "name")
   public void setName(String name) {
     this.name = name;
   }
@@ -206,6 +212,9 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
+  @JacksonXmlProperty(localName = "photoUrl")
+  @JacksonXmlElementWrapper(localName = "photoUrl", useWrapping = true)
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -238,6 +247,9 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
+  @JacksonXmlProperty(localName = "Tag")
+  @JacksonXmlElementWrapper(localName = "tag", useWrapping = true)
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -254,10 +266,10 @@ public class Pet {
    */
   
   @Schema(name = "status", description = "pet status in the store", deprecated = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @Deprecated
   @JsonProperty("status")
   @JacksonXmlProperty(localName = "status")
   @XmlElement(name = "status")
-  @Deprecated
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -266,6 +278,8 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
+  @JacksonXmlProperty(localName = "status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Tag.java
@@ -64,6 +64,8 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
+  @JacksonXmlProperty(localName = "id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -86,6 +88,8 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
+  @JacksonXmlProperty(localName = "name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/User.java
@@ -82,6 +82,8 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
+  @JacksonXmlProperty(localName = "id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -104,6 +106,8 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
+  @JacksonXmlProperty(localName = "username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -126,6 +130,8 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
+  @JacksonXmlProperty(localName = "firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -148,6 +154,8 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
+  @JacksonXmlProperty(localName = "lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -170,6 +178,8 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
+  @JacksonXmlProperty(localName = "email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -192,6 +202,8 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
+  @JacksonXmlProperty(localName = "password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -214,6 +226,8 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
+  @JacksonXmlProperty(localName = "phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -236,6 +250,8 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
+  @JacksonXmlProperty(localName = "userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/openapi3/server/petstore/springboot-4/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/server/petstore/springboot-4/src/main/java/org/openapitools/model/Category.java
@@ -63,6 +63,8 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
+  @JacksonXmlProperty(localName = "id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -85,6 +87,8 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
+  @JacksonXmlProperty(localName = "name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-4/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/server/petstore/springboot-4/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -68,6 +68,8 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
+  @JacksonXmlProperty(localName = "code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -90,6 +92,8 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
+  @JacksonXmlProperty(localName = "type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -112,6 +116,8 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
+  @JacksonXmlProperty(localName = "message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/openapi3/server/petstore/springboot-4/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/springboot-4/src/main/java/org/openapitools/model/Order.java
@@ -116,6 +116,8 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
+  @JacksonXmlProperty(localName = "id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -138,6 +140,8 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
+  @JacksonXmlProperty(localName = "petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -160,6 +164,8 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
+  @JacksonXmlProperty(localName = "quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -182,6 +188,8 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
+  @JacksonXmlProperty(localName = "shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -204,6 +212,8 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
+  @JacksonXmlProperty(localName = "status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -226,6 +236,8 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
+  @JacksonXmlProperty(localName = "complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/openapi3/server/petstore/springboot-4/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-4/src/main/java/org/openapitools/model/Pet.java
@@ -129,6 +129,8 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
+  @JacksonXmlProperty(localName = "id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -151,6 +153,8 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
+  @JacksonXmlProperty(localName = "Category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -173,6 +177,8 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
+  @JacksonXmlProperty(localName = "name")
   public void setName(String name) {
     this.name = name;
   }
@@ -205,6 +211,9 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
+  @JacksonXmlProperty(localName = "photoUrl")
+  @JacksonXmlElementWrapper(localName = "photoUrl", useWrapping = true)
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -237,6 +246,9 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
+  @JacksonXmlProperty(localName = "Tag")
+  @JacksonXmlElementWrapper(localName = "tag", useWrapping = true)
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -253,10 +265,10 @@ public class Pet {
    */
   
   @Schema(name = "status", description = "pet status in the store", deprecated = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @Deprecated
   @JsonProperty("status")
   @JacksonXmlProperty(localName = "status")
   @XmlElement(name = "status")
-  @Deprecated
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -265,6 +277,8 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
+  @JacksonXmlProperty(localName = "status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/openapi3/server/petstore/springboot-4/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/server/petstore/springboot-4/src/main/java/org/openapitools/model/Tag.java
@@ -63,6 +63,8 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
+  @JacksonXmlProperty(localName = "id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -85,6 +87,8 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
+  @JacksonXmlProperty(localName = "name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-4/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/server/petstore/springboot-4/src/main/java/org/openapitools/model/User.java
@@ -81,6 +81,8 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
+  @JacksonXmlProperty(localName = "id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -103,6 +105,8 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
+  @JacksonXmlProperty(localName = "username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -125,6 +129,8 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
+  @JacksonXmlProperty(localName = "firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -147,6 +153,8 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
+  @JacksonXmlProperty(localName = "lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -169,6 +177,8 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
+  @JacksonXmlProperty(localName = "email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -191,6 +201,8 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
+  @JacksonXmlProperty(localName = "password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -213,6 +225,8 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
+  @JacksonXmlProperty(localName = "phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -235,6 +249,8 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
+  @JacksonXmlProperty(localName = "userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesAnyType {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesArray {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesBoolean {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -83,6 +83,7 @@ public class AdditionalPropertiesClass {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -111,6 +112,7 @@ public class AdditionalPropertiesClass {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -139,6 +141,7 @@ public class AdditionalPropertiesClass {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -167,6 +170,7 @@ public class AdditionalPropertiesClass {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -195,6 +199,7 @@ public class AdditionalPropertiesClass {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -223,6 +228,7 @@ public class AdditionalPropertiesClass {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -251,6 +257,7 @@ public class AdditionalPropertiesClass {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -279,6 +286,7 @@ public class AdditionalPropertiesClass {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -299,6 +307,7 @@ public class AdditionalPropertiesClass {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(@Nullable Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -339,6 +348,7 @@ public class AdditionalPropertiesClass {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(@Nullable Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesInteger {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesNumber {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesObject {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesString {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Animal.java
@@ -67,6 +67,7 @@ public class Animal {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -87,6 +88,7 @@ public class Animal {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -53,6 +53,7 @@ public class ArrayOfArrayOfNumberOnly {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -53,6 +53,7 @@ public class ArrayOfNumberOnly {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ArrayTest.java
@@ -59,6 +59,7 @@ public class ArrayTest {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -87,6 +88,7 @@ public class ArrayTest {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -115,6 +117,7 @@ public class ArrayTest {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/BigCat.java
@@ -96,6 +96,7 @@ public class BigCat extends Cat {
     return kind;
   }
 
+  @JsonProperty("kind")
   public void setKind(@Nullable KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Capitalization.java
@@ -50,6 +50,7 @@ public class Capitalization {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -70,6 +71,7 @@ public class Capitalization {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -90,6 +92,7 @@ public class Capitalization {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -110,6 +113,7 @@ public class Capitalization {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -130,6 +134,7 @@ public class Capitalization {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -150,6 +155,7 @@ public class Capitalization {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Cat.java
@@ -64,6 +64,7 @@ public class Cat extends Animal {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Category.java
@@ -53,6 +53,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -73,6 +74,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ChildWithNullable.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ChildWithNullable.java
@@ -48,6 +48,7 @@ public class ChildWithNullable extends ParentWithNullable {
     return otherProperty;
   }
 
+  @JsonProperty("otherProperty")
   public void setOtherProperty(@Nullable String otherProperty) {
     this.otherProperty = otherProperty;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ClassModel.java
@@ -41,6 +41,7 @@ public class ClassModel {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Client.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Client.java
@@ -40,6 +40,7 @@ public class Client {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -103,6 +103,7 @@ public class ContainerDefaultValue {
     return nullableRequiredArray;
   }
 
+  @JsonProperty("nullable_required_array")
   public void setNullableRequiredArray(JsonNullable<List<String>> nullableRequiredArray) {
     this.nullableRequiredArray = nullableRequiredArray;
   }
@@ -131,6 +132,7 @@ public class ContainerDefaultValue {
     return requiredArray;
   }
 
+  @JsonProperty("required_array")
   public void setRequiredArray(List<String> requiredArray) {
     this.requiredArray = requiredArray;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Dog.java
@@ -56,6 +56,7 @@ public class Dog extends Animal {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumArrays.java
@@ -117,6 +117,7 @@ public class EnumArrays {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -145,6 +146,7 @@ public class EnumArrays {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumTest.java
@@ -207,6 +207,7 @@ public class EnumTest {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -227,6 +228,7 @@ public class EnumTest {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -247,6 +249,7 @@ public class EnumTest {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -267,6 +270,7 @@ public class EnumTest {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -287,6 +291,7 @@ public class EnumTest {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(@Nullable OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/File.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/File.java
@@ -41,6 +41,7 @@ public class File {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -47,6 +47,7 @@ public class FileSchemaTestClass {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable File file) {
     this.file = file;
   }
@@ -75,6 +76,7 @@ public class FileSchemaTestClass {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<@Valid File> files) {
     this.files = files;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/FormatTest.java
@@ -92,6 +92,7 @@ public class FormatTest {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -114,6 +115,7 @@ public class FormatTest {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -134,6 +136,7 @@ public class FormatTest {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -156,6 +159,7 @@ public class FormatTest {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -178,6 +182,7 @@ public class FormatTest {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -200,6 +205,7 @@ public class FormatTest {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -220,6 +226,7 @@ public class FormatTest {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -240,6 +247,7 @@ public class FormatTest {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -260,6 +268,7 @@ public class FormatTest {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -280,6 +289,7 @@ public class FormatTest {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -300,6 +310,7 @@ public class FormatTest {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -320,6 +331,7 @@ public class FormatTest {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -340,6 +352,7 @@ public class FormatTest {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -360,6 +373,7 @@ public class FormatTest {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(@Nullable BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -44,6 +44,7 @@ public class HasOnlyReadOnly {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -64,6 +65,7 @@ public class HasOnlyReadOnly {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/MapTest.java
@@ -96,6 +96,7 @@ public class MapTest {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -124,6 +125,7 @@ public class MapTest {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -152,6 +154,7 @@ public class MapTest {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -180,6 +183,7 @@ public class MapTest {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -52,6 +52,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -72,6 +73,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -100,6 +102,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Model200Response.java
@@ -45,6 +45,7 @@ public class Model200Response {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -65,6 +66,7 @@ public class Model200Response {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -46,6 +46,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -66,6 +67,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -86,6 +88,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ModelList.java
@@ -42,6 +42,7 @@ public class ModelList {
     return _123list;
   }
 
+  @JsonProperty("123-list")
   public void set123list(@Nullable String _123list) {
     this._123list = _123list;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ModelReturn.java
@@ -43,6 +43,7 @@ public class ModelReturn {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Name.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Name.java
@@ -58,6 +58,7 @@ public class Name {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -78,6 +79,7 @@ public class Name {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -98,6 +100,7 @@ public class Name {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -118,6 +121,7 @@ public class Name {
     return _123number;
   }
 
+  @JsonProperty("123Number")
   public void set123number(@Nullable Integer _123number) {
     this._123number = _123number;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/NumberOnly.java
@@ -41,6 +41,7 @@ public class NumberOnly {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Order.java
@@ -91,6 +91,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -111,6 +112,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -131,6 +133,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -151,6 +154,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -171,6 +175,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -191,6 +196,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/OuterComposite.java
@@ -45,6 +45,7 @@ public class OuterComposite {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -65,6 +66,7 @@ public class OuterComposite {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -85,6 +87,7 @@ public class OuterComposite {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -91,6 +91,7 @@ public class ParentWithNullable {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable TypeEnum type) {
     this.type = type;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
@@ -111,6 +111,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -131,6 +132,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -151,6 +153,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -180,6 +183,7 @@ public class Pet {
   }
 
   @JsonDeserialize(as = LinkedHashSet.class)
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -208,6 +212,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -224,8 +229,8 @@ public class Pet {
    */
   
   @Schema(name = "status", description = "pet status in the store", deprecated = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -234,6 +239,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -42,6 +42,7 @@ public class ReadOnlyFirst {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -62,6 +63,7 @@ public class ReadOnlyFirst {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
@@ -46,6 +46,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return normalPropertyName;
   }
 
+  @JsonProperty("normalPropertyName")
   public void setNormalPropertyName(@Nullable String normalPropertyName) {
     this.normalPropertyName = normalPropertyName;
   }
@@ -66,6 +67,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return UPPER_CASE_PROPERTY_SNAKE;
   }
 
+  @JsonProperty("UPPER_CASE_PROPERTY_SNAKE")
   public void setUPPERCASEPROPERTYSNAKE(@Nullable String UPPER_CASE_PROPERTY_SNAKE) {
     this.UPPER_CASE_PROPERTY_SNAKE = UPPER_CASE_PROPERTY_SNAKE;
   }
@@ -86,6 +88,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return lowerCasePropertyDashes;
   }
 
+  @JsonProperty("lower-case-property-dashes")
   public void setLowerCasePropertyDashes(@Nullable String lowerCasePropertyDashes) {
     this.lowerCasePropertyDashes = lowerCasePropertyDashes;
   }
@@ -106,6 +109,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return propertyNameWithSpaces;
   }
 
+  @JsonProperty("property name with spaces")
   public void setPropertyNameWithSpaces(@Nullable String propertyNameWithSpaces) {
     this.propertyNameWithSpaces = propertyNameWithSpaces;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -42,6 +42,7 @@ public class SpecialModelName {
     return $specialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Tag.java
@@ -42,6 +42,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -62,6 +63,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -68,6 +68,7 @@ public class TypeHolderDefault {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -88,6 +89,7 @@ public class TypeHolderDefault {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -108,6 +110,7 @@ public class TypeHolderDefault {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -128,6 +131,7 @@ public class TypeHolderDefault {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -156,6 +160,7 @@ public class TypeHolderDefault {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -71,6 +71,7 @@ public class TypeHolderExample {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -91,6 +92,7 @@ public class TypeHolderExample {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -111,6 +113,7 @@ public class TypeHolderExample {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -131,6 +134,7 @@ public class TypeHolderExample {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -151,6 +155,7 @@ public class TypeHolderExample {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -179,6 +184,7 @@ public class TypeHolderExample {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/User.java
@@ -54,6 +54,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -74,6 +75,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -94,6 +96,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -114,6 +117,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -134,6 +138,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -154,6 +159,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -174,6 +180,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -194,6 +201,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/XmlItem.java
@@ -109,6 +109,7 @@ public class XmlItem {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(@Nullable String attributeString) {
     this.attributeString = attributeString;
   }
@@ -129,6 +130,7 @@ public class XmlItem {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(@Nullable BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -149,6 +151,7 @@ public class XmlItem {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(@Nullable Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -169,6 +172,7 @@ public class XmlItem {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(@Nullable Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -197,6 +201,7 @@ public class XmlItem {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -217,6 +222,7 @@ public class XmlItem {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(@Nullable String nameString) {
     this.nameString = nameString;
   }
@@ -237,6 +243,7 @@ public class XmlItem {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(@Nullable BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -257,6 +264,7 @@ public class XmlItem {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(@Nullable Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -277,6 +285,7 @@ public class XmlItem {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(@Nullable Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -305,6 +314,7 @@ public class XmlItem {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -333,6 +343,7 @@ public class XmlItem {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -353,6 +364,7 @@ public class XmlItem {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(@Nullable String prefixString) {
     this.prefixString = prefixString;
   }
@@ -373,6 +385,7 @@ public class XmlItem {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(@Nullable BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -393,6 +406,7 @@ public class XmlItem {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(@Nullable Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -413,6 +427,7 @@ public class XmlItem {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(@Nullable Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -441,6 +456,7 @@ public class XmlItem {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -469,6 +485,7 @@ public class XmlItem {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -489,6 +506,7 @@ public class XmlItem {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(@Nullable String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -509,6 +527,7 @@ public class XmlItem {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(@Nullable BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -529,6 +548,7 @@ public class XmlItem {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(@Nullable Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -549,6 +569,7 @@ public class XmlItem {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(@Nullable Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -577,6 +598,7 @@ public class XmlItem {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -605,6 +627,7 @@ public class XmlItem {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -625,6 +648,7 @@ public class XmlItem {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(@Nullable String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -645,6 +669,7 @@ public class XmlItem {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(@Nullable BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -665,6 +690,7 @@ public class XmlItem {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(@Nullable Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -685,6 +711,7 @@ public class XmlItem {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(@Nullable Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -713,6 +740,7 @@ public class XmlItem {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -741,6 +769,7 @@ public class XmlItem {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesAnyType {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesArray {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesBoolean {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -83,6 +83,7 @@ public class AdditionalPropertiesClass {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -111,6 +112,7 @@ public class AdditionalPropertiesClass {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -139,6 +141,7 @@ public class AdditionalPropertiesClass {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -167,6 +170,7 @@ public class AdditionalPropertiesClass {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -195,6 +199,7 @@ public class AdditionalPropertiesClass {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -223,6 +228,7 @@ public class AdditionalPropertiesClass {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -251,6 +257,7 @@ public class AdditionalPropertiesClass {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -279,6 +286,7 @@ public class AdditionalPropertiesClass {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -299,6 +307,7 @@ public class AdditionalPropertiesClass {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(@Nullable Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -339,6 +348,7 @@ public class AdditionalPropertiesClass {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(@Nullable Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesInteger {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesNumber {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesObject {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesString {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Animal.java
@@ -67,6 +67,7 @@ public class Animal {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -87,6 +88,7 @@ public class Animal {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -53,6 +53,7 @@ public class ArrayOfArrayOfNumberOnly {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -53,6 +53,7 @@ public class ArrayOfNumberOnly {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ArrayTest.java
@@ -59,6 +59,7 @@ public class ArrayTest {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -87,6 +88,7 @@ public class ArrayTest {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -115,6 +117,7 @@ public class ArrayTest {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/BigCat.java
@@ -96,6 +96,7 @@ public class BigCat extends Cat {
     return kind;
   }
 
+  @JsonProperty("kind")
   public void setKind(@Nullable KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Capitalization.java
@@ -50,6 +50,7 @@ public class Capitalization {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -70,6 +71,7 @@ public class Capitalization {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -90,6 +92,7 @@ public class Capitalization {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -110,6 +113,7 @@ public class Capitalization {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -130,6 +134,7 @@ public class Capitalization {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -150,6 +155,7 @@ public class Capitalization {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Cat.java
@@ -64,6 +64,7 @@ public class Cat extends Animal {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Category.java
@@ -53,6 +53,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -73,6 +74,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ChildWithNullable.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ChildWithNullable.java
@@ -48,6 +48,7 @@ public class ChildWithNullable extends ParentWithNullable {
     return otherProperty;
   }
 
+  @JsonProperty("otherProperty")
   public void setOtherProperty(@Nullable String otherProperty) {
     this.otherProperty = otherProperty;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ClassModel.java
@@ -41,6 +41,7 @@ public class ClassModel {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Client.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Client.java
@@ -40,6 +40,7 @@ public class Client {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -103,6 +103,7 @@ public class ContainerDefaultValue {
     return nullableRequiredArray;
   }
 
+  @JsonProperty("nullable_required_array")
   public void setNullableRequiredArray(JsonNullable<List<String>> nullableRequiredArray) {
     this.nullableRequiredArray = nullableRequiredArray;
   }
@@ -131,6 +132,7 @@ public class ContainerDefaultValue {
     return requiredArray;
   }
 
+  @JsonProperty("required_array")
   public void setRequiredArray(List<String> requiredArray) {
     this.requiredArray = requiredArray;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Dog.java
@@ -56,6 +56,7 @@ public class Dog extends Animal {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumArrays.java
@@ -117,6 +117,7 @@ public class EnumArrays {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -145,6 +146,7 @@ public class EnumArrays {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumTest.java
@@ -207,6 +207,7 @@ public class EnumTest {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -227,6 +228,7 @@ public class EnumTest {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -247,6 +249,7 @@ public class EnumTest {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -267,6 +270,7 @@ public class EnumTest {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -287,6 +291,7 @@ public class EnumTest {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(@Nullable OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/File.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/File.java
@@ -41,6 +41,7 @@ public class File {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -47,6 +47,7 @@ public class FileSchemaTestClass {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable File file) {
     this.file = file;
   }
@@ -75,6 +76,7 @@ public class FileSchemaTestClass {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<@Valid File> files) {
     this.files = files;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/FormatTest.java
@@ -92,6 +92,7 @@ public class FormatTest {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -114,6 +115,7 @@ public class FormatTest {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -134,6 +136,7 @@ public class FormatTest {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -156,6 +159,7 @@ public class FormatTest {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -178,6 +182,7 @@ public class FormatTest {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -200,6 +205,7 @@ public class FormatTest {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -220,6 +226,7 @@ public class FormatTest {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -240,6 +247,7 @@ public class FormatTest {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -260,6 +268,7 @@ public class FormatTest {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -280,6 +289,7 @@ public class FormatTest {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -300,6 +310,7 @@ public class FormatTest {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -320,6 +331,7 @@ public class FormatTest {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -340,6 +352,7 @@ public class FormatTest {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -360,6 +373,7 @@ public class FormatTest {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(@Nullable BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -44,6 +44,7 @@ public class HasOnlyReadOnly {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -64,6 +65,7 @@ public class HasOnlyReadOnly {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/MapTest.java
@@ -96,6 +96,7 @@ public class MapTest {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -124,6 +125,7 @@ public class MapTest {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -152,6 +154,7 @@ public class MapTest {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -180,6 +183,7 @@ public class MapTest {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -52,6 +52,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -72,6 +73,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -100,6 +102,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Model200Response.java
@@ -45,6 +45,7 @@ public class Model200Response {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -65,6 +66,7 @@ public class Model200Response {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -46,6 +46,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -66,6 +67,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -86,6 +88,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ModelList.java
@@ -42,6 +42,7 @@ public class ModelList {
     return _123list;
   }
 
+  @JsonProperty("123-list")
   public void set123list(@Nullable String _123list) {
     this._123list = _123list;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ModelReturn.java
@@ -43,6 +43,7 @@ public class ModelReturn {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Name.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Name.java
@@ -58,6 +58,7 @@ public class Name {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -78,6 +79,7 @@ public class Name {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -98,6 +100,7 @@ public class Name {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -118,6 +121,7 @@ public class Name {
     return _123number;
   }
 
+  @JsonProperty("123Number")
   public void set123number(@Nullable Integer _123number) {
     this._123number = _123number;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/NumberOnly.java
@@ -41,6 +41,7 @@ public class NumberOnly {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Order.java
@@ -91,6 +91,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -111,6 +112,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -131,6 +133,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -151,6 +154,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -171,6 +175,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -191,6 +196,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/OuterComposite.java
@@ -45,6 +45,7 @@ public class OuterComposite {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -65,6 +66,7 @@ public class OuterComposite {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -85,6 +87,7 @@ public class OuterComposite {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -91,6 +91,7 @@ public class ParentWithNullable {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable TypeEnum type) {
     this.type = type;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
@@ -111,6 +111,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -131,6 +132,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -151,6 +153,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -180,6 +183,7 @@ public class Pet {
   }
 
   @JsonDeserialize(as = LinkedHashSet.class)
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -208,6 +212,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -224,8 +229,8 @@ public class Pet {
    */
   
   @Schema(name = "status", description = "pet status in the store", deprecated = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -234,6 +239,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -42,6 +42,7 @@ public class ReadOnlyFirst {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -62,6 +63,7 @@ public class ReadOnlyFirst {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
@@ -46,6 +46,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return normalPropertyName;
   }
 
+  @JsonProperty("normalPropertyName")
   public void setNormalPropertyName(@Nullable String normalPropertyName) {
     this.normalPropertyName = normalPropertyName;
   }
@@ -66,6 +67,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return UPPER_CASE_PROPERTY_SNAKE;
   }
 
+  @JsonProperty("UPPER_CASE_PROPERTY_SNAKE")
   public void setUPPERCASEPROPERTYSNAKE(@Nullable String UPPER_CASE_PROPERTY_SNAKE) {
     this.UPPER_CASE_PROPERTY_SNAKE = UPPER_CASE_PROPERTY_SNAKE;
   }
@@ -86,6 +88,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return lowerCasePropertyDashes;
   }
 
+  @JsonProperty("lower-case-property-dashes")
   public void setLowerCasePropertyDashes(@Nullable String lowerCasePropertyDashes) {
     this.lowerCasePropertyDashes = lowerCasePropertyDashes;
   }
@@ -106,6 +109,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return propertyNameWithSpaces;
   }
 
+  @JsonProperty("property name with spaces")
   public void setPropertyNameWithSpaces(@Nullable String propertyNameWithSpaces) {
     this.propertyNameWithSpaces = propertyNameWithSpaces;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -42,6 +42,7 @@ public class SpecialModelName {
     return $specialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Tag.java
@@ -42,6 +42,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -62,6 +63,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -68,6 +68,7 @@ public class TypeHolderDefault {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -88,6 +89,7 @@ public class TypeHolderDefault {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -108,6 +110,7 @@ public class TypeHolderDefault {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -128,6 +131,7 @@ public class TypeHolderDefault {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -156,6 +160,7 @@ public class TypeHolderDefault {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -71,6 +71,7 @@ public class TypeHolderExample {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -91,6 +92,7 @@ public class TypeHolderExample {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -111,6 +113,7 @@ public class TypeHolderExample {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -131,6 +134,7 @@ public class TypeHolderExample {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -151,6 +155,7 @@ public class TypeHolderExample {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -179,6 +184,7 @@ public class TypeHolderExample {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/User.java
@@ -54,6 +54,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -74,6 +75,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -94,6 +96,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -114,6 +117,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -134,6 +138,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -154,6 +159,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -174,6 +180,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -194,6 +201,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/XmlItem.java
@@ -109,6 +109,7 @@ public class XmlItem {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(@Nullable String attributeString) {
     this.attributeString = attributeString;
   }
@@ -129,6 +130,7 @@ public class XmlItem {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(@Nullable BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -149,6 +151,7 @@ public class XmlItem {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(@Nullable Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -169,6 +172,7 @@ public class XmlItem {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(@Nullable Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -197,6 +201,7 @@ public class XmlItem {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -217,6 +222,7 @@ public class XmlItem {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(@Nullable String nameString) {
     this.nameString = nameString;
   }
@@ -237,6 +243,7 @@ public class XmlItem {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(@Nullable BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -257,6 +264,7 @@ public class XmlItem {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(@Nullable Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -277,6 +285,7 @@ public class XmlItem {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(@Nullable Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -305,6 +314,7 @@ public class XmlItem {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -333,6 +343,7 @@ public class XmlItem {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -353,6 +364,7 @@ public class XmlItem {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(@Nullable String prefixString) {
     this.prefixString = prefixString;
   }
@@ -373,6 +385,7 @@ public class XmlItem {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(@Nullable BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -393,6 +406,7 @@ public class XmlItem {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(@Nullable Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -413,6 +427,7 @@ public class XmlItem {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(@Nullable Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -441,6 +456,7 @@ public class XmlItem {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -469,6 +485,7 @@ public class XmlItem {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -489,6 +506,7 @@ public class XmlItem {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(@Nullable String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -509,6 +527,7 @@ public class XmlItem {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(@Nullable BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -529,6 +548,7 @@ public class XmlItem {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(@Nullable Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -549,6 +569,7 @@ public class XmlItem {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(@Nullable Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -577,6 +598,7 @@ public class XmlItem {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -605,6 +627,7 @@ public class XmlItem {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -625,6 +648,7 @@ public class XmlItem {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(@Nullable String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -645,6 +669,7 @@ public class XmlItem {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(@Nullable BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -665,6 +690,7 @@ public class XmlItem {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(@Nullable Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -685,6 +711,7 @@ public class XmlItem {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(@Nullable Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -713,6 +740,7 @@ public class XmlItem {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -741,6 +769,7 @@ public class XmlItem {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/model/Category.java
@@ -40,6 +40,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -59,6 +60,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -44,6 +44,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -63,6 +64,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -82,6 +84,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/model/Order.java
@@ -89,6 +89,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -108,6 +109,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -127,6 +129,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -146,6 +149,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -165,6 +169,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -184,6 +189,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/model/Pet.java
@@ -106,6 +106,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -125,6 +126,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -144,6 +146,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -171,6 +174,7 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -198,6 +202,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -213,8 +218,8 @@ public class Pet {
    * @deprecated
    */
   
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -223,6 +228,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/model/Tag.java
@@ -40,6 +40,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -59,6 +60,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/model/User.java
@@ -52,6 +52,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -71,6 +72,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -90,6 +92,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -109,6 +112,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -128,6 +132,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -147,6 +152,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -166,6 +172,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -185,6 +192,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Category.java
@@ -43,6 +43,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -47,6 +47,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -67,6 +68,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -87,6 +89,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Order.java
@@ -92,6 +92,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -112,6 +113,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -132,6 +134,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -152,6 +155,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -172,6 +176,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -192,6 +197,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Pet.java
@@ -109,6 +109,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -129,6 +130,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -149,6 +151,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -177,6 +180,7 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -205,6 +209,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -221,8 +226,8 @@ public class Pet {
    */
   
   @Schema(name = "status", description = "pet status in the store", deprecated = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -231,6 +236,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/User.java
@@ -55,6 +55,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -75,6 +76,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -95,6 +97,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -115,6 +118,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -135,6 +139,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -155,6 +160,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -175,6 +181,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -195,6 +202,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesAnyType {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesArray {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesBoolean {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -83,6 +83,7 @@ public class AdditionalPropertiesClass {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -111,6 +112,7 @@ public class AdditionalPropertiesClass {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -139,6 +141,7 @@ public class AdditionalPropertiesClass {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -167,6 +170,7 @@ public class AdditionalPropertiesClass {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -195,6 +199,7 @@ public class AdditionalPropertiesClass {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -223,6 +228,7 @@ public class AdditionalPropertiesClass {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -251,6 +257,7 @@ public class AdditionalPropertiesClass {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -279,6 +286,7 @@ public class AdditionalPropertiesClass {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -299,6 +307,7 @@ public class AdditionalPropertiesClass {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(@Nullable Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -339,6 +348,7 @@ public class AdditionalPropertiesClass {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(@Nullable Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesInteger {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesNumber {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesObject {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesString {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Animal.java
@@ -67,6 +67,7 @@ public class Animal {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -87,6 +88,7 @@ public class Animal {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -53,6 +53,7 @@ public class ArrayOfArrayOfNumberOnly {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -53,6 +53,7 @@ public class ArrayOfNumberOnly {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ArrayTest.java
@@ -59,6 +59,7 @@ public class ArrayTest {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -87,6 +88,7 @@ public class ArrayTest {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -115,6 +117,7 @@ public class ArrayTest {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/BigCat.java
@@ -96,6 +96,7 @@ public class BigCat extends Cat {
     return kind;
   }
 
+  @JsonProperty("kind")
   public void setKind(@Nullable KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Capitalization.java
@@ -50,6 +50,7 @@ public class Capitalization {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -70,6 +71,7 @@ public class Capitalization {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -90,6 +92,7 @@ public class Capitalization {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -110,6 +113,7 @@ public class Capitalization {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -130,6 +134,7 @@ public class Capitalization {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -150,6 +155,7 @@ public class Capitalization {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Cat.java
@@ -64,6 +64,7 @@ public class Cat extends Animal {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Category.java
@@ -53,6 +53,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -73,6 +74,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ChildWithNullable.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ChildWithNullable.java
@@ -48,6 +48,7 @@ public class ChildWithNullable extends ParentWithNullable {
     return otherProperty;
   }
 
+  @JsonProperty("otherProperty")
   public void setOtherProperty(@Nullable String otherProperty) {
     this.otherProperty = otherProperty;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ClassModel.java
@@ -41,6 +41,7 @@ public class ClassModel {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Client.java
@@ -40,6 +40,7 @@ public class Client {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -103,6 +103,7 @@ public class ContainerDefaultValue {
     return nullableRequiredArray;
   }
 
+  @JsonProperty("nullable_required_array")
   public void setNullableRequiredArray(JsonNullable<List<String>> nullableRequiredArray) {
     this.nullableRequiredArray = nullableRequiredArray;
   }
@@ -131,6 +132,7 @@ public class ContainerDefaultValue {
     return requiredArray;
   }
 
+  @JsonProperty("required_array")
   public void setRequiredArray(List<String> requiredArray) {
     this.requiredArray = requiredArray;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Dog.java
@@ -56,6 +56,7 @@ public class Dog extends Animal {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/EnumArrays.java
@@ -117,6 +117,7 @@ public class EnumArrays {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -145,6 +146,7 @@ public class EnumArrays {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/EnumTest.java
@@ -207,6 +207,7 @@ public class EnumTest {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -227,6 +228,7 @@ public class EnumTest {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -247,6 +249,7 @@ public class EnumTest {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -267,6 +270,7 @@ public class EnumTest {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -287,6 +291,7 @@ public class EnumTest {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(@Nullable OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/File.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/File.java
@@ -41,6 +41,7 @@ public class File {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -47,6 +47,7 @@ public class FileSchemaTestClass {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable File file) {
     this.file = file;
   }
@@ -75,6 +76,7 @@ public class FileSchemaTestClass {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<@Valid File> files) {
     this.files = files;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/FormatTest.java
@@ -92,6 +92,7 @@ public class FormatTest {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -114,6 +115,7 @@ public class FormatTest {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -134,6 +136,7 @@ public class FormatTest {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -156,6 +159,7 @@ public class FormatTest {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -178,6 +182,7 @@ public class FormatTest {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -200,6 +205,7 @@ public class FormatTest {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -220,6 +226,7 @@ public class FormatTest {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -240,6 +247,7 @@ public class FormatTest {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -260,6 +268,7 @@ public class FormatTest {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -280,6 +289,7 @@ public class FormatTest {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -300,6 +310,7 @@ public class FormatTest {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -320,6 +331,7 @@ public class FormatTest {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -340,6 +352,7 @@ public class FormatTest {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -360,6 +373,7 @@ public class FormatTest {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(@Nullable BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -44,6 +44,7 @@ public class HasOnlyReadOnly {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -64,6 +65,7 @@ public class HasOnlyReadOnly {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/MapTest.java
@@ -96,6 +96,7 @@ public class MapTest {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -124,6 +125,7 @@ public class MapTest {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -152,6 +154,7 @@ public class MapTest {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -180,6 +183,7 @@ public class MapTest {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -52,6 +52,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -72,6 +73,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -100,6 +102,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Model200Response.java
@@ -45,6 +45,7 @@ public class Model200Response {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -65,6 +66,7 @@ public class Model200Response {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -46,6 +46,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -66,6 +67,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -86,6 +88,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ModelList.java
@@ -42,6 +42,7 @@ public class ModelList {
     return _123list;
   }
 
+  @JsonProperty("123-list")
   public void set123list(@Nullable String _123list) {
     this._123list = _123list;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ModelReturn.java
@@ -43,6 +43,7 @@ public class ModelReturn {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Name.java
@@ -58,6 +58,7 @@ public class Name {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -78,6 +79,7 @@ public class Name {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -98,6 +100,7 @@ public class Name {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -118,6 +121,7 @@ public class Name {
     return _123number;
   }
 
+  @JsonProperty("123Number")
   public void set123number(@Nullable Integer _123number) {
     this._123number = _123number;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/NumberOnly.java
@@ -41,6 +41,7 @@ public class NumberOnly {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Order.java
@@ -91,6 +91,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -111,6 +112,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -131,6 +133,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -151,6 +154,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -171,6 +175,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -191,6 +196,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/OuterComposite.java
@@ -45,6 +45,7 @@ public class OuterComposite {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -65,6 +66,7 @@ public class OuterComposite {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -85,6 +87,7 @@ public class OuterComposite {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -91,6 +91,7 @@ public class ParentWithNullable {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable TypeEnum type) {
     this.type = type;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Pet.java
@@ -111,6 +111,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -131,6 +132,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -151,6 +153,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -180,6 +183,7 @@ public class Pet {
   }
 
   @JsonDeserialize(as = LinkedHashSet.class)
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -208,6 +212,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -224,8 +229,8 @@ public class Pet {
    */
   
   @Schema(name = "status", description = "pet status in the store", deprecated = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -234,6 +239,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -42,6 +42,7 @@ public class ReadOnlyFirst {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -62,6 +63,7 @@ public class ReadOnlyFirst {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
@@ -46,6 +46,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return normalPropertyName;
   }
 
+  @JsonProperty("normalPropertyName")
   public void setNormalPropertyName(@Nullable String normalPropertyName) {
     this.normalPropertyName = normalPropertyName;
   }
@@ -66,6 +67,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return UPPER_CASE_PROPERTY_SNAKE;
   }
 
+  @JsonProperty("UPPER_CASE_PROPERTY_SNAKE")
   public void setUPPERCASEPROPERTYSNAKE(@Nullable String UPPER_CASE_PROPERTY_SNAKE) {
     this.UPPER_CASE_PROPERTY_SNAKE = UPPER_CASE_PROPERTY_SNAKE;
   }
@@ -86,6 +88,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return lowerCasePropertyDashes;
   }
 
+  @JsonProperty("lower-case-property-dashes")
   public void setLowerCasePropertyDashes(@Nullable String lowerCasePropertyDashes) {
     this.lowerCasePropertyDashes = lowerCasePropertyDashes;
   }
@@ -106,6 +109,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return propertyNameWithSpaces;
   }
 
+  @JsonProperty("property name with spaces")
   public void setPropertyNameWithSpaces(@Nullable String propertyNameWithSpaces) {
     this.propertyNameWithSpaces = propertyNameWithSpaces;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -42,6 +42,7 @@ public class SpecialModelName {
     return $specialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/Tag.java
@@ -42,6 +42,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -62,6 +63,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -68,6 +68,7 @@ public class TypeHolderDefault {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -88,6 +89,7 @@ public class TypeHolderDefault {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -108,6 +110,7 @@ public class TypeHolderDefault {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -128,6 +131,7 @@ public class TypeHolderDefault {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -156,6 +160,7 @@ public class TypeHolderDefault {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -71,6 +71,7 @@ public class TypeHolderExample {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -91,6 +92,7 @@ public class TypeHolderExample {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -111,6 +113,7 @@ public class TypeHolderExample {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -131,6 +134,7 @@ public class TypeHolderExample {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -151,6 +155,7 @@ public class TypeHolderExample {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -179,6 +184,7 @@ public class TypeHolderExample {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/User.java
@@ -54,6 +54,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -74,6 +75,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -94,6 +96,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -114,6 +117,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -134,6 +138,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -154,6 +159,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -174,6 +180,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -194,6 +201,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/XmlItem.java
@@ -109,6 +109,7 @@ public class XmlItem {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(@Nullable String attributeString) {
     this.attributeString = attributeString;
   }
@@ -129,6 +130,7 @@ public class XmlItem {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(@Nullable BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -149,6 +151,7 @@ public class XmlItem {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(@Nullable Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -169,6 +172,7 @@ public class XmlItem {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(@Nullable Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -197,6 +201,7 @@ public class XmlItem {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -217,6 +222,7 @@ public class XmlItem {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(@Nullable String nameString) {
     this.nameString = nameString;
   }
@@ -237,6 +243,7 @@ public class XmlItem {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(@Nullable BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -257,6 +264,7 @@ public class XmlItem {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(@Nullable Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -277,6 +285,7 @@ public class XmlItem {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(@Nullable Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -305,6 +314,7 @@ public class XmlItem {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -333,6 +343,7 @@ public class XmlItem {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -353,6 +364,7 @@ public class XmlItem {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(@Nullable String prefixString) {
     this.prefixString = prefixString;
   }
@@ -373,6 +385,7 @@ public class XmlItem {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(@Nullable BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -393,6 +406,7 @@ public class XmlItem {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(@Nullable Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -413,6 +427,7 @@ public class XmlItem {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(@Nullable Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -441,6 +456,7 @@ public class XmlItem {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -469,6 +485,7 @@ public class XmlItem {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -489,6 +506,7 @@ public class XmlItem {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(@Nullable String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -509,6 +527,7 @@ public class XmlItem {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(@Nullable BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -529,6 +548,7 @@ public class XmlItem {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(@Nullable Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -549,6 +569,7 @@ public class XmlItem {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(@Nullable Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -577,6 +598,7 @@ public class XmlItem {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -605,6 +627,7 @@ public class XmlItem {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -625,6 +648,7 @@ public class XmlItem {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(@Nullable String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -645,6 +669,7 @@ public class XmlItem {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(@Nullable BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -665,6 +690,7 @@ public class XmlItem {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(@Nullable Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -685,6 +711,7 @@ public class XmlItem {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(@Nullable Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -713,6 +740,7 @@ public class XmlItem {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -741,6 +769,7 @@ public class XmlItem {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/server/petstore/spring-boot-nullable-set/src/main/java/org/openapitools/model/ObjectWithUniqueItems.java
+++ b/samples/server/petstore/spring-boot-nullable-set/src/main/java/org/openapitools/model/ObjectWithUniqueItems.java
@@ -103,6 +103,7 @@ public class ObjectWithUniqueItems {
   }
 
   @JsonDeserialize(as = LinkedHashSet.class)
+  @JsonProperty("notNullSet")
   public void setNotNullSet(Set<String> notNullSet) {
     this.notNullSet = notNullSet;
   }
@@ -159,6 +160,7 @@ public class ObjectWithUniqueItems {
     return notNullList;
   }
 
+  @JsonProperty("notNullList")
   public void setNotNullList(List<String> notNullList) {
     this.notNullList = notNullList;
   }
@@ -179,6 +181,7 @@ public class ObjectWithUniqueItems {
     return notNullDateField;
   }
 
+  @JsonProperty("notNullDateField")
   public void setNotNullDateField(@Nullable OffsetDateTime notNullDateField) {
     this.notNullDateField = notNullDateField;
   }
@@ -199,6 +202,7 @@ public class ObjectWithUniqueItems {
     return nullDateField;
   }
 
+  @JsonProperty("nullDateField")
   public void setNullDateField(@Nullable OffsetDateTime nullDateField) {
     this.nullDateField = nullDateField;
   }

--- a/samples/server/petstore/springboot-api-response-examples/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot-api-response-examples/src/main/java/org/openapitools/model/Dog.java
@@ -42,6 +42,7 @@ public class Dog {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }
@@ -63,6 +64,7 @@ public class Dog {
     return age;
   }
 
+  @JsonProperty("age")
   public void setAge(@Nullable Integer age) {
     this.age = age;
   }

--- a/samples/server/petstore/springboot-api-response-examples/src/main/java/org/openapitools/model/Error.java
+++ b/samples/server/petstore/springboot-api-response-examples/src/main/java/org/openapitools/model/Error.java
@@ -42,6 +42,7 @@ public class Error {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -62,6 +63,7 @@ public class Error {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesAnyType {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesArray {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesBoolean {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -80,6 +80,7 @@ public class AdditionalPropertiesClass {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -108,6 +109,7 @@ public class AdditionalPropertiesClass {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -136,6 +138,7 @@ public class AdditionalPropertiesClass {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -164,6 +167,7 @@ public class AdditionalPropertiesClass {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -192,6 +196,7 @@ public class AdditionalPropertiesClass {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -220,6 +225,7 @@ public class AdditionalPropertiesClass {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -248,6 +254,7 @@ public class AdditionalPropertiesClass {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -276,6 +283,7 @@ public class AdditionalPropertiesClass {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -296,6 +304,7 @@ public class AdditionalPropertiesClass {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(@Nullable Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -316,6 +325,7 @@ public class AdditionalPropertiesClass {
     return anytype2;
   }
 
+  @JsonProperty("anytype_2")
   public void setAnytype2(@Nullable Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -336,6 +346,7 @@ public class AdditionalPropertiesClass {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(@Nullable Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesInteger {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesNumber {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesObject {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesString {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Animal.java
@@ -67,6 +67,7 @@ public class Animal {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -87,6 +88,7 @@ public class Animal {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -53,6 +53,7 @@ public class ArrayOfArrayOfNumberOnly {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -53,6 +53,7 @@ public class ArrayOfNumberOnly {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ArrayTest.java
@@ -59,6 +59,7 @@ public class ArrayTest {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -87,6 +88,7 @@ public class ArrayTest {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -115,6 +117,7 @@ public class ArrayTest {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/BigCat.java
@@ -96,6 +96,7 @@ public class BigCat extends Cat {
     return kind;
   }
 
+  @JsonProperty("kind")
   public void setKind(@Nullable KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Capitalization.java
@@ -50,6 +50,7 @@ public class Capitalization {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -70,6 +71,7 @@ public class Capitalization {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -90,6 +92,7 @@ public class Capitalization {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -110,6 +113,7 @@ public class Capitalization {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -130,6 +134,7 @@ public class Capitalization {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -150,6 +155,7 @@ public class Capitalization {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Cat.java
@@ -64,6 +64,7 @@ public class Cat extends Animal {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Category.java
@@ -53,6 +53,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -73,6 +74,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ChildWithNullable.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ChildWithNullable.java
@@ -46,6 +46,7 @@ public class ChildWithNullable extends ParentWithNullable {
     return otherProperty;
   }
 
+  @JsonProperty("otherProperty")
   public void setOtherProperty(@Nullable String otherProperty) {
     this.otherProperty = otherProperty;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ClassModel.java
@@ -41,6 +41,7 @@ public class ClassModel {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Client.java
@@ -40,6 +40,7 @@ public class Client {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -73,6 +73,7 @@ public class ContainerDefaultValue {
     return nullableArray;
   }
 
+  @JsonProperty("nullable_array")
   public void setNullableArray(@Nullable List<String> nullableArray) {
     this.nullableArray = nullableArray;
   }
@@ -101,6 +102,7 @@ public class ContainerDefaultValue {
     return nullableRequiredArray;
   }
 
+  @JsonProperty("nullable_required_array")
   public void setNullableRequiredArray(List<String> nullableRequiredArray) {
     this.nullableRequiredArray = nullableRequiredArray;
   }
@@ -129,6 +131,7 @@ public class ContainerDefaultValue {
     return requiredArray;
   }
 
+  @JsonProperty("required_array")
   public void setRequiredArray(List<String> requiredArray) {
     this.requiredArray = requiredArray;
   }
@@ -157,6 +160,7 @@ public class ContainerDefaultValue {
     return nullableArrayWithDefault;
   }
 
+  @JsonProperty("nullable_array_with_default")
   public void setNullableArrayWithDefault(@Nullable List<String> nullableArrayWithDefault) {
     this.nullableArrayWithDefault = nullableArrayWithDefault;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Dog.java
@@ -56,6 +56,7 @@ public class Dog extends Animal {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/EnumArrays.java
@@ -117,6 +117,7 @@ public class EnumArrays {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -145,6 +146,7 @@ public class EnumArrays {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/EnumTest.java
@@ -207,6 +207,7 @@ public class EnumTest {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -227,6 +228,7 @@ public class EnumTest {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -247,6 +249,7 @@ public class EnumTest {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -267,6 +270,7 @@ public class EnumTest {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -287,6 +291,7 @@ public class EnumTest {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(@Nullable OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/File.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/File.java
@@ -41,6 +41,7 @@ public class File {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -47,6 +47,7 @@ public class FileSchemaTestClass {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable File file) {
     this.file = file;
   }
@@ -75,6 +76,7 @@ public class FileSchemaTestClass {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<@Valid File> files) {
     this.files = files;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/FormatTest.java
@@ -92,6 +92,7 @@ public class FormatTest {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -114,6 +115,7 @@ public class FormatTest {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -134,6 +136,7 @@ public class FormatTest {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -156,6 +159,7 @@ public class FormatTest {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -178,6 +182,7 @@ public class FormatTest {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -200,6 +205,7 @@ public class FormatTest {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -220,6 +226,7 @@ public class FormatTest {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -240,6 +247,7 @@ public class FormatTest {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -260,6 +268,7 @@ public class FormatTest {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -280,6 +289,7 @@ public class FormatTest {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -300,6 +310,7 @@ public class FormatTest {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -320,6 +331,7 @@ public class FormatTest {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -340,6 +352,7 @@ public class FormatTest {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -360,6 +373,7 @@ public class FormatTest {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(@Nullable BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -44,6 +44,7 @@ public class HasOnlyReadOnly {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -64,6 +65,7 @@ public class HasOnlyReadOnly {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/MapTest.java
@@ -96,6 +96,7 @@ public class MapTest {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -124,6 +125,7 @@ public class MapTest {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -152,6 +154,7 @@ public class MapTest {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -180,6 +183,7 @@ public class MapTest {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -52,6 +52,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -72,6 +73,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -100,6 +102,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Model200Response.java
@@ -45,6 +45,7 @@ public class Model200Response {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -65,6 +66,7 @@ public class Model200Response {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -46,6 +46,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -66,6 +67,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -86,6 +88,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ModelList.java
@@ -42,6 +42,7 @@ public class ModelList {
     return _123list;
   }
 
+  @JsonProperty("123-list")
   public void set123list(@Nullable String _123list) {
     this._123list = _123list;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ModelReturn.java
@@ -43,6 +43,7 @@ public class ModelReturn {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Name.java
@@ -58,6 +58,7 @@ public class Name {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -78,6 +79,7 @@ public class Name {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -98,6 +100,7 @@ public class Name {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -118,6 +121,7 @@ public class Name {
     return _123number;
   }
 
+  @JsonProperty("123Number")
   public void set123number(@Nullable Integer _123number) {
     this._123number = _123number;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -51,6 +51,7 @@ public class NullableMapProperty {
     return languageValues;
   }
 
+  @JsonProperty("languageValues")
   public void setLanguageValues(@Nullable Map<String, String> languageValues) {
     this.languageValues = languageValues;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/NumberOnly.java
@@ -41,6 +41,7 @@ public class NumberOnly {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Order.java
@@ -91,6 +91,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -111,6 +112,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -131,6 +133,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -151,6 +154,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -171,6 +175,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -191,6 +196,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/OuterComposite.java
@@ -45,6 +45,7 @@ public class OuterComposite {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -65,6 +66,7 @@ public class OuterComposite {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -85,6 +87,7 @@ public class OuterComposite {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -88,6 +88,7 @@ public class ParentWithNullable {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable TypeEnum type) {
     this.type = type;
   }
@@ -108,6 +109,7 @@ public class ParentWithNullable {
     return nullableProperty;
   }
 
+  @JsonProperty("nullableProperty")
   public void setNullableProperty(@Nullable String nullableProperty) {
     this.nullableProperty = nullableProperty;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Pet.java
@@ -111,6 +111,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -131,6 +132,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -151,6 +153,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -180,6 +183,7 @@ public class Pet {
   }
 
   @JsonDeserialize(as = LinkedHashSet.class)
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -208,6 +212,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -224,8 +229,8 @@ public class Pet {
    */
   
   @ApiModelProperty(value = "pet status in the store")
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -234,6 +239,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -42,6 +42,7 @@ public class ReadOnlyFirst {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -62,6 +63,7 @@ public class ReadOnlyFirst {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
@@ -46,6 +46,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return normalPropertyName;
   }
 
+  @JsonProperty("normalPropertyName")
   public void setNormalPropertyName(@Nullable String normalPropertyName) {
     this.normalPropertyName = normalPropertyName;
   }
@@ -66,6 +67,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return UPPER_CASE_PROPERTY_SNAKE;
   }
 
+  @JsonProperty("UPPER_CASE_PROPERTY_SNAKE")
   public void setUPPERCASEPROPERTYSNAKE(@Nullable String UPPER_CASE_PROPERTY_SNAKE) {
     this.UPPER_CASE_PROPERTY_SNAKE = UPPER_CASE_PROPERTY_SNAKE;
   }
@@ -86,6 +88,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return lowerCasePropertyDashes;
   }
 
+  @JsonProperty("lower-case-property-dashes")
   public void setLowerCasePropertyDashes(@Nullable String lowerCasePropertyDashes) {
     this.lowerCasePropertyDashes = lowerCasePropertyDashes;
   }
@@ -106,6 +109,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return propertyNameWithSpaces;
   }
 
+  @JsonProperty("property name with spaces")
   public void setPropertyNameWithSpaces(@Nullable String propertyNameWithSpaces) {
     this.propertyNameWithSpaces = propertyNameWithSpaces;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -42,6 +42,7 @@ public class SpecialModelName {
     return $specialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Tag.java
@@ -42,6 +42,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -62,6 +63,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -68,6 +68,7 @@ public class TypeHolderDefault {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -88,6 +89,7 @@ public class TypeHolderDefault {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -108,6 +110,7 @@ public class TypeHolderDefault {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -128,6 +131,7 @@ public class TypeHolderDefault {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -156,6 +160,7 @@ public class TypeHolderDefault {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -71,6 +71,7 @@ public class TypeHolderExample {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -91,6 +92,7 @@ public class TypeHolderExample {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -111,6 +113,7 @@ public class TypeHolderExample {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -131,6 +134,7 @@ public class TypeHolderExample {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -151,6 +155,7 @@ public class TypeHolderExample {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -179,6 +184,7 @@ public class TypeHolderExample {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/User.java
@@ -54,6 +54,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -74,6 +75,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -94,6 +96,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -114,6 +117,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -134,6 +138,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -154,6 +159,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -174,6 +180,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -194,6 +201,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/XmlItem.java
@@ -109,6 +109,7 @@ public class XmlItem {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(@Nullable String attributeString) {
     this.attributeString = attributeString;
   }
@@ -129,6 +130,7 @@ public class XmlItem {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(@Nullable BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -149,6 +151,7 @@ public class XmlItem {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(@Nullable Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -169,6 +172,7 @@ public class XmlItem {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(@Nullable Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -197,6 +201,7 @@ public class XmlItem {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -217,6 +222,7 @@ public class XmlItem {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(@Nullable String nameString) {
     this.nameString = nameString;
   }
@@ -237,6 +243,7 @@ public class XmlItem {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(@Nullable BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -257,6 +264,7 @@ public class XmlItem {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(@Nullable Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -277,6 +285,7 @@ public class XmlItem {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(@Nullable Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -305,6 +314,7 @@ public class XmlItem {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -333,6 +343,7 @@ public class XmlItem {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -353,6 +364,7 @@ public class XmlItem {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(@Nullable String prefixString) {
     this.prefixString = prefixString;
   }
@@ -373,6 +385,7 @@ public class XmlItem {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(@Nullable BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -393,6 +406,7 @@ public class XmlItem {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(@Nullable Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -413,6 +427,7 @@ public class XmlItem {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(@Nullable Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -441,6 +456,7 @@ public class XmlItem {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -469,6 +485,7 @@ public class XmlItem {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -489,6 +506,7 @@ public class XmlItem {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(@Nullable String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -509,6 +527,7 @@ public class XmlItem {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(@Nullable BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -529,6 +548,7 @@ public class XmlItem {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(@Nullable Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -549,6 +569,7 @@ public class XmlItem {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(@Nullable Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -577,6 +598,7 @@ public class XmlItem {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -605,6 +627,7 @@ public class XmlItem {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -625,6 +648,7 @@ public class XmlItem {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(@Nullable String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -645,6 +669,7 @@ public class XmlItem {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(@Nullable BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -665,6 +690,7 @@ public class XmlItem {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(@Nullable Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -685,6 +711,7 @@ public class XmlItem {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(@Nullable Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -713,6 +740,7 @@ public class XmlItem {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -741,6 +769,7 @@ public class XmlItem {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesAnyType {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesArray {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesBoolean {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -84,6 +84,7 @@ public class AdditionalPropertiesClass {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -112,6 +113,7 @@ public class AdditionalPropertiesClass {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -140,6 +142,7 @@ public class AdditionalPropertiesClass {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -168,6 +171,7 @@ public class AdditionalPropertiesClass {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -196,6 +200,7 @@ public class AdditionalPropertiesClass {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -224,6 +229,7 @@ public class AdditionalPropertiesClass {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -252,6 +258,7 @@ public class AdditionalPropertiesClass {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -280,6 +287,7 @@ public class AdditionalPropertiesClass {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -300,6 +308,7 @@ public class AdditionalPropertiesClass {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(@Nullable Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -340,6 +349,7 @@ public class AdditionalPropertiesClass {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(@Nullable Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesInteger {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesNumber {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesObject {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesString {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Animal.java
@@ -68,6 +68,7 @@ public class Animal {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -88,6 +89,7 @@ public class Animal {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -54,6 +54,7 @@ public class ArrayOfArrayOfNumberOnly {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -54,6 +54,7 @@ public class ArrayOfNumberOnly {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ArrayTest.java
@@ -60,6 +60,7 @@ public class ArrayTest {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -88,6 +89,7 @@ public class ArrayTest {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -116,6 +118,7 @@ public class ArrayTest {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/BigCat.java
@@ -97,6 +97,7 @@ public class BigCat extends Cat {
     return kind;
   }
 
+  @JsonProperty("kind")
   public void setKind(@Nullable KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Capitalization.java
@@ -51,6 +51,7 @@ public class Capitalization {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -71,6 +72,7 @@ public class Capitalization {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -91,6 +93,7 @@ public class Capitalization {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -111,6 +114,7 @@ public class Capitalization {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -131,6 +135,7 @@ public class Capitalization {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -151,6 +156,7 @@ public class Capitalization {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Cat.java
@@ -65,6 +65,7 @@ public class Cat extends Animal {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Category.java
@@ -54,6 +54,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -74,6 +75,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ChildWithNullable.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ChildWithNullable.java
@@ -49,6 +49,7 @@ public class ChildWithNullable extends ParentWithNullable {
     return otherProperty;
   }
 
+  @JsonProperty("otherProperty")
   public void setOtherProperty(@Nullable String otherProperty) {
     this.otherProperty = otherProperty;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ClassModel.java
@@ -42,6 +42,7 @@ public class ClassModel {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Client.java
@@ -41,6 +41,7 @@ public class Client {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -104,6 +104,7 @@ public class ContainerDefaultValue {
     return nullableRequiredArray;
   }
 
+  @JsonProperty("nullable_required_array")
   public void setNullableRequiredArray(JsonNullable<List<String>> nullableRequiredArray) {
     this.nullableRequiredArray = nullableRequiredArray;
   }
@@ -132,6 +133,7 @@ public class ContainerDefaultValue {
     return requiredArray;
   }
 
+  @JsonProperty("required_array")
   public void setRequiredArray(List<String> requiredArray) {
     this.requiredArray = requiredArray;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Dog.java
@@ -57,6 +57,7 @@ public class Dog extends Animal {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumArrays.java
@@ -118,6 +118,7 @@ public class EnumArrays {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -146,6 +147,7 @@ public class EnumArrays {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumTest.java
@@ -208,6 +208,7 @@ public class EnumTest {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -228,6 +229,7 @@ public class EnumTest {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -248,6 +250,7 @@ public class EnumTest {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -268,6 +271,7 @@ public class EnumTest {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -288,6 +292,7 @@ public class EnumTest {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(@Nullable OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/File.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/File.java
@@ -42,6 +42,7 @@ public class File {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -48,6 +48,7 @@ public class FileSchemaTestClass {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable File file) {
     this.file = file;
   }
@@ -76,6 +77,7 @@ public class FileSchemaTestClass {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<@Valid File> files) {
     this.files = files;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/FormatTest.java
@@ -93,6 +93,7 @@ public class FormatTest {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -115,6 +116,7 @@ public class FormatTest {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -135,6 +137,7 @@ public class FormatTest {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -157,6 +160,7 @@ public class FormatTest {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -179,6 +183,7 @@ public class FormatTest {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -201,6 +206,7 @@ public class FormatTest {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -221,6 +227,7 @@ public class FormatTest {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -241,6 +248,7 @@ public class FormatTest {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -261,6 +269,7 @@ public class FormatTest {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -281,6 +290,7 @@ public class FormatTest {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -301,6 +311,7 @@ public class FormatTest {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -321,6 +332,7 @@ public class FormatTest {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -341,6 +353,7 @@ public class FormatTest {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -361,6 +374,7 @@ public class FormatTest {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(@Nullable BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -45,6 +45,7 @@ public class HasOnlyReadOnly {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -65,6 +66,7 @@ public class HasOnlyReadOnly {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/MapTest.java
@@ -97,6 +97,7 @@ public class MapTest {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -125,6 +126,7 @@ public class MapTest {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -153,6 +155,7 @@ public class MapTest {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -181,6 +184,7 @@ public class MapTest {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -53,6 +53,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -73,6 +74,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -101,6 +103,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Model200Response.java
@@ -46,6 +46,7 @@ public class Model200Response {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -66,6 +67,7 @@ public class Model200Response {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -47,6 +47,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -67,6 +68,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -87,6 +89,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ModelList.java
@@ -43,6 +43,7 @@ public class ModelList {
     return _123list;
   }
 
+  @JsonProperty("123-list")
   public void set123list(@Nullable String _123list) {
     this._123list = _123list;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ModelReturn.java
@@ -44,6 +44,7 @@ public class ModelReturn {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Name.java
@@ -59,6 +59,7 @@ public class Name {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -79,6 +80,7 @@ public class Name {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -99,6 +101,7 @@ public class Name {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -119,6 +122,7 @@ public class Name {
     return _123number;
   }
 
+  @JsonProperty("123Number")
   public void set123number(@Nullable Integer _123number) {
     this._123number = _123number;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/NumberOnly.java
@@ -42,6 +42,7 @@ public class NumberOnly {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Order.java
@@ -92,6 +92,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -112,6 +113,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -132,6 +134,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -152,6 +155,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -172,6 +176,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -192,6 +197,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/OuterComposite.java
@@ -46,6 +46,7 @@ public class OuterComposite {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -66,6 +67,7 @@ public class OuterComposite {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -86,6 +88,7 @@ public class OuterComposite {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -92,6 +92,7 @@ public class ParentWithNullable {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable TypeEnum type) {
     this.type = type;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Pet.java
@@ -112,6 +112,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -132,6 +133,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -152,6 +154,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -181,6 +184,7 @@ public class Pet {
   }
 
   @JsonDeserialize(as = LinkedHashSet.class)
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -209,6 +213,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -225,8 +230,8 @@ public class Pet {
    */
   
   @ApiModelProperty(value = "pet status in the store")
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -235,6 +240,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -43,6 +43,7 @@ public class ReadOnlyFirst {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -63,6 +64,7 @@ public class ReadOnlyFirst {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
@@ -47,6 +47,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return normalPropertyName;
   }
 
+  @JsonProperty("normalPropertyName")
   public void setNormalPropertyName(@Nullable String normalPropertyName) {
     this.normalPropertyName = normalPropertyName;
   }
@@ -67,6 +68,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return UPPER_CASE_PROPERTY_SNAKE;
   }
 
+  @JsonProperty("UPPER_CASE_PROPERTY_SNAKE")
   public void setUPPERCASEPROPERTYSNAKE(@Nullable String UPPER_CASE_PROPERTY_SNAKE) {
     this.UPPER_CASE_PROPERTY_SNAKE = UPPER_CASE_PROPERTY_SNAKE;
   }
@@ -87,6 +89,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return lowerCasePropertyDashes;
   }
 
+  @JsonProperty("lower-case-property-dashes")
   public void setLowerCasePropertyDashes(@Nullable String lowerCasePropertyDashes) {
     this.lowerCasePropertyDashes = lowerCasePropertyDashes;
   }
@@ -107,6 +110,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return propertyNameWithSpaces;
   }
 
+  @JsonProperty("property name with spaces")
   public void setPropertyNameWithSpaces(@Nullable String propertyNameWithSpaces) {
     this.propertyNameWithSpaces = propertyNameWithSpaces;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -43,6 +43,7 @@ public class SpecialModelName {
     return $specialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -69,6 +69,7 @@ public class TypeHolderDefault {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -89,6 +90,7 @@ public class TypeHolderDefault {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -109,6 +111,7 @@ public class TypeHolderDefault {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -129,6 +132,7 @@ public class TypeHolderDefault {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -157,6 +161,7 @@ public class TypeHolderDefault {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -72,6 +72,7 @@ public class TypeHolderExample {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -92,6 +93,7 @@ public class TypeHolderExample {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -112,6 +114,7 @@ public class TypeHolderExample {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -132,6 +135,7 @@ public class TypeHolderExample {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -152,6 +156,7 @@ public class TypeHolderExample {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -180,6 +185,7 @@ public class TypeHolderExample {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/User.java
@@ -55,6 +55,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -75,6 +76,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -95,6 +97,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -115,6 +118,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -135,6 +139,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -155,6 +160,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -175,6 +181,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -195,6 +202,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/XmlItem.java
@@ -110,6 +110,7 @@ public class XmlItem {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(@Nullable String attributeString) {
     this.attributeString = attributeString;
   }
@@ -130,6 +131,7 @@ public class XmlItem {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(@Nullable BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -150,6 +152,7 @@ public class XmlItem {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(@Nullable Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -170,6 +173,7 @@ public class XmlItem {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(@Nullable Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -198,6 +202,7 @@ public class XmlItem {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -218,6 +223,7 @@ public class XmlItem {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(@Nullable String nameString) {
     this.nameString = nameString;
   }
@@ -238,6 +244,7 @@ public class XmlItem {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(@Nullable BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -258,6 +265,7 @@ public class XmlItem {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(@Nullable Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -278,6 +286,7 @@ public class XmlItem {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(@Nullable Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -306,6 +315,7 @@ public class XmlItem {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -334,6 +344,7 @@ public class XmlItem {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -354,6 +365,7 @@ public class XmlItem {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(@Nullable String prefixString) {
     this.prefixString = prefixString;
   }
@@ -374,6 +386,7 @@ public class XmlItem {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(@Nullable BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -394,6 +407,7 @@ public class XmlItem {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(@Nullable Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -414,6 +428,7 @@ public class XmlItem {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(@Nullable Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -442,6 +457,7 @@ public class XmlItem {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -470,6 +486,7 @@ public class XmlItem {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -490,6 +507,7 @@ public class XmlItem {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(@Nullable String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -510,6 +528,7 @@ public class XmlItem {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(@Nullable BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -530,6 +549,7 @@ public class XmlItem {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(@Nullable Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -550,6 +570,7 @@ public class XmlItem {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(@Nullable Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -578,6 +599,7 @@ public class XmlItem {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -606,6 +628,7 @@ public class XmlItem {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -626,6 +649,7 @@ public class XmlItem {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(@Nullable String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -646,6 +670,7 @@ public class XmlItem {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(@Nullable BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -666,6 +691,7 @@ public class XmlItem {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(@Nullable Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -686,6 +712,7 @@ public class XmlItem {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(@Nullable Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -714,6 +741,7 @@ public class XmlItem {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -742,6 +770,7 @@ public class XmlItem {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesAnyType {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesArray {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesBoolean {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -84,6 +84,7 @@ public class AdditionalPropertiesClass {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -112,6 +113,7 @@ public class AdditionalPropertiesClass {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -140,6 +142,7 @@ public class AdditionalPropertiesClass {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -168,6 +171,7 @@ public class AdditionalPropertiesClass {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -196,6 +200,7 @@ public class AdditionalPropertiesClass {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -224,6 +229,7 @@ public class AdditionalPropertiesClass {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -252,6 +258,7 @@ public class AdditionalPropertiesClass {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -280,6 +287,7 @@ public class AdditionalPropertiesClass {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -300,6 +308,7 @@ public class AdditionalPropertiesClass {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(@Nullable Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -340,6 +349,7 @@ public class AdditionalPropertiesClass {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(@Nullable Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesInteger {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesNumber {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesObject {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesString {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Animal.java
@@ -68,6 +68,7 @@ public class Animal {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -88,6 +89,7 @@ public class Animal {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -54,6 +54,7 @@ public class ArrayOfArrayOfNumberOnly {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -54,6 +54,7 @@ public class ArrayOfNumberOnly {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ArrayTest.java
@@ -60,6 +60,7 @@ public class ArrayTest {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -88,6 +89,7 @@ public class ArrayTest {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -116,6 +118,7 @@ public class ArrayTest {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/BigCat.java
@@ -97,6 +97,7 @@ public class BigCat extends Cat {
     return kind;
   }
 
+  @JsonProperty("kind")
   public void setKind(@Nullable KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Capitalization.java
@@ -51,6 +51,7 @@ public class Capitalization {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -71,6 +72,7 @@ public class Capitalization {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -91,6 +93,7 @@ public class Capitalization {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -111,6 +114,7 @@ public class Capitalization {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -131,6 +135,7 @@ public class Capitalization {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -151,6 +156,7 @@ public class Capitalization {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Cat.java
@@ -65,6 +65,7 @@ public class Cat extends Animal {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Category.java
@@ -54,6 +54,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -74,6 +75,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ChildWithNullable.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ChildWithNullable.java
@@ -49,6 +49,7 @@ public class ChildWithNullable extends ParentWithNullable {
     return otherProperty;
   }
 
+  @JsonProperty("otherProperty")
   public void setOtherProperty(@Nullable String otherProperty) {
     this.otherProperty = otherProperty;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ClassModel.java
@@ -42,6 +42,7 @@ public class ClassModel {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Client.java
@@ -41,6 +41,7 @@ public class Client {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -104,6 +104,7 @@ public class ContainerDefaultValue {
     return nullableRequiredArray;
   }
 
+  @JsonProperty("nullable_required_array")
   public void setNullableRequiredArray(JsonNullable<List<String>> nullableRequiredArray) {
     this.nullableRequiredArray = nullableRequiredArray;
   }
@@ -132,6 +133,7 @@ public class ContainerDefaultValue {
     return requiredArray;
   }
 
+  @JsonProperty("required_array")
   public void setRequiredArray(List<String> requiredArray) {
     this.requiredArray = requiredArray;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Dog.java
@@ -57,6 +57,7 @@ public class Dog extends Animal {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/EnumArrays.java
@@ -118,6 +118,7 @@ public class EnumArrays {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -146,6 +147,7 @@ public class EnumArrays {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/EnumTest.java
@@ -208,6 +208,7 @@ public class EnumTest {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -228,6 +229,7 @@ public class EnumTest {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -248,6 +250,7 @@ public class EnumTest {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -268,6 +271,7 @@ public class EnumTest {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -288,6 +292,7 @@ public class EnumTest {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(@Nullable OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/File.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/File.java
@@ -42,6 +42,7 @@ public class File {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -48,6 +48,7 @@ public class FileSchemaTestClass {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable File file) {
     this.file = file;
   }
@@ -76,6 +77,7 @@ public class FileSchemaTestClass {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<@Valid File> files) {
     this.files = files;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/FormatTest.java
@@ -93,6 +93,7 @@ public class FormatTest {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -115,6 +116,7 @@ public class FormatTest {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -135,6 +137,7 @@ public class FormatTest {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -157,6 +160,7 @@ public class FormatTest {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -179,6 +183,7 @@ public class FormatTest {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -201,6 +206,7 @@ public class FormatTest {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -221,6 +227,7 @@ public class FormatTest {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -241,6 +248,7 @@ public class FormatTest {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -261,6 +269,7 @@ public class FormatTest {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -281,6 +290,7 @@ public class FormatTest {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -301,6 +311,7 @@ public class FormatTest {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -321,6 +332,7 @@ public class FormatTest {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -341,6 +353,7 @@ public class FormatTest {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -361,6 +374,7 @@ public class FormatTest {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(@Nullable BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -45,6 +45,7 @@ public class HasOnlyReadOnly {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -65,6 +66,7 @@ public class HasOnlyReadOnly {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/MapTest.java
@@ -97,6 +97,7 @@ public class MapTest {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -125,6 +126,7 @@ public class MapTest {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -153,6 +155,7 @@ public class MapTest {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -181,6 +184,7 @@ public class MapTest {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -53,6 +53,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -73,6 +74,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -101,6 +103,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Model200Response.java
@@ -46,6 +46,7 @@ public class Model200Response {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -66,6 +67,7 @@ public class Model200Response {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -47,6 +47,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -67,6 +68,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -87,6 +89,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ModelList.java
@@ -43,6 +43,7 @@ public class ModelList {
     return _123list;
   }
 
+  @JsonProperty("123-list")
   public void set123list(@Nullable String _123list) {
     this._123list = _123list;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ModelReturn.java
@@ -44,6 +44,7 @@ public class ModelReturn {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Name.java
@@ -59,6 +59,7 @@ public class Name {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -79,6 +80,7 @@ public class Name {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -99,6 +101,7 @@ public class Name {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -119,6 +122,7 @@ public class Name {
     return _123number;
   }
 
+  @JsonProperty("123Number")
   public void set123number(@Nullable Integer _123number) {
     this._123number = _123number;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/NumberOnly.java
@@ -42,6 +42,7 @@ public class NumberOnly {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Order.java
@@ -92,6 +92,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -112,6 +113,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -132,6 +134,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -152,6 +155,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -172,6 +176,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -192,6 +197,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/OuterComposite.java
@@ -46,6 +46,7 @@ public class OuterComposite {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -66,6 +67,7 @@ public class OuterComposite {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -86,6 +88,7 @@ public class OuterComposite {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -92,6 +92,7 @@ public class ParentWithNullable {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable TypeEnum type) {
     this.type = type;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Pet.java
@@ -112,6 +112,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -132,6 +133,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -152,6 +154,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -181,6 +184,7 @@ public class Pet {
   }
 
   @JsonDeserialize(as = LinkedHashSet.class)
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -209,6 +213,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -225,8 +230,8 @@ public class Pet {
    */
   
   @ApiModelProperty(value = "pet status in the store")
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -235,6 +240,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -43,6 +43,7 @@ public class ReadOnlyFirst {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -63,6 +64,7 @@ public class ReadOnlyFirst {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
@@ -47,6 +47,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return normalPropertyName;
   }
 
+  @JsonProperty("normalPropertyName")
   public void setNormalPropertyName(@Nullable String normalPropertyName) {
     this.normalPropertyName = normalPropertyName;
   }
@@ -67,6 +68,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return UPPER_CASE_PROPERTY_SNAKE;
   }
 
+  @JsonProperty("UPPER_CASE_PROPERTY_SNAKE")
   public void setUPPERCASEPROPERTYSNAKE(@Nullable String UPPER_CASE_PROPERTY_SNAKE) {
     this.UPPER_CASE_PROPERTY_SNAKE = UPPER_CASE_PROPERTY_SNAKE;
   }
@@ -87,6 +89,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return lowerCasePropertyDashes;
   }
 
+  @JsonProperty("lower-case-property-dashes")
   public void setLowerCasePropertyDashes(@Nullable String lowerCasePropertyDashes) {
     this.lowerCasePropertyDashes = lowerCasePropertyDashes;
   }
@@ -107,6 +110,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return propertyNameWithSpaces;
   }
 
+  @JsonProperty("property name with spaces")
   public void setPropertyNameWithSpaces(@Nullable String propertyNameWithSpaces) {
     this.propertyNameWithSpaces = propertyNameWithSpaces;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -43,6 +43,7 @@ public class SpecialModelName {
     return $specialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -69,6 +69,7 @@ public class TypeHolderDefault {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -89,6 +90,7 @@ public class TypeHolderDefault {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -109,6 +111,7 @@ public class TypeHolderDefault {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -129,6 +132,7 @@ public class TypeHolderDefault {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -157,6 +161,7 @@ public class TypeHolderDefault {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -72,6 +72,7 @@ public class TypeHolderExample {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -92,6 +93,7 @@ public class TypeHolderExample {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -112,6 +114,7 @@ public class TypeHolderExample {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -132,6 +135,7 @@ public class TypeHolderExample {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -152,6 +156,7 @@ public class TypeHolderExample {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -180,6 +185,7 @@ public class TypeHolderExample {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/User.java
@@ -55,6 +55,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -75,6 +76,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -95,6 +97,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -115,6 +118,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -135,6 +139,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -155,6 +160,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -175,6 +181,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -195,6 +202,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/XmlItem.java
@@ -110,6 +110,7 @@ public class XmlItem {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(@Nullable String attributeString) {
     this.attributeString = attributeString;
   }
@@ -130,6 +131,7 @@ public class XmlItem {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(@Nullable BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -150,6 +152,7 @@ public class XmlItem {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(@Nullable Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -170,6 +173,7 @@ public class XmlItem {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(@Nullable Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -198,6 +202,7 @@ public class XmlItem {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -218,6 +223,7 @@ public class XmlItem {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(@Nullable String nameString) {
     this.nameString = nameString;
   }
@@ -238,6 +244,7 @@ public class XmlItem {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(@Nullable BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -258,6 +265,7 @@ public class XmlItem {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(@Nullable Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -278,6 +286,7 @@ public class XmlItem {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(@Nullable Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -306,6 +315,7 @@ public class XmlItem {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -334,6 +344,7 @@ public class XmlItem {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -354,6 +365,7 @@ public class XmlItem {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(@Nullable String prefixString) {
     this.prefixString = prefixString;
   }
@@ -374,6 +386,7 @@ public class XmlItem {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(@Nullable BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -394,6 +407,7 @@ public class XmlItem {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(@Nullable Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -414,6 +428,7 @@ public class XmlItem {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(@Nullable Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -442,6 +457,7 @@ public class XmlItem {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -470,6 +486,7 @@ public class XmlItem {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -490,6 +507,7 @@ public class XmlItem {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(@Nullable String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -510,6 +528,7 @@ public class XmlItem {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(@Nullable BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -530,6 +549,7 @@ public class XmlItem {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(@Nullable Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -550,6 +570,7 @@ public class XmlItem {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(@Nullable Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -578,6 +599,7 @@ public class XmlItem {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -606,6 +628,7 @@ public class XmlItem {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -626,6 +649,7 @@ public class XmlItem {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(@Nullable String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -646,6 +670,7 @@ public class XmlItem {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(@Nullable BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -666,6 +691,7 @@ public class XmlItem {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(@Nullable Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -686,6 +712,7 @@ public class XmlItem {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(@Nullable Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -714,6 +741,7 @@ public class XmlItem {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -742,6 +770,7 @@ public class XmlItem {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesAnyType {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesArray {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesBoolean {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -84,6 +84,7 @@ public class AdditionalPropertiesClass {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -112,6 +113,7 @@ public class AdditionalPropertiesClass {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -140,6 +142,7 @@ public class AdditionalPropertiesClass {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -168,6 +171,7 @@ public class AdditionalPropertiesClass {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -196,6 +200,7 @@ public class AdditionalPropertiesClass {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -224,6 +229,7 @@ public class AdditionalPropertiesClass {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -252,6 +258,7 @@ public class AdditionalPropertiesClass {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -280,6 +287,7 @@ public class AdditionalPropertiesClass {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -300,6 +308,7 @@ public class AdditionalPropertiesClass {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(@Nullable Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -340,6 +349,7 @@ public class AdditionalPropertiesClass {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(@Nullable Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesInteger {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesNumber {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesObject {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesString {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Animal.java
@@ -68,6 +68,7 @@ public class Animal {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -88,6 +89,7 @@ public class Animal {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -54,6 +54,7 @@ public class ArrayOfArrayOfNumberOnly {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -54,6 +54,7 @@ public class ArrayOfNumberOnly {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ArrayTest.java
@@ -60,6 +60,7 @@ public class ArrayTest {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -88,6 +89,7 @@ public class ArrayTest {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -116,6 +118,7 @@ public class ArrayTest {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/BigCat.java
@@ -97,6 +97,7 @@ public class BigCat extends Cat {
     return kind;
   }
 
+  @JsonProperty("kind")
   public void setKind(@Nullable KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Capitalization.java
@@ -51,6 +51,7 @@ public class Capitalization {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -71,6 +72,7 @@ public class Capitalization {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -91,6 +93,7 @@ public class Capitalization {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -111,6 +114,7 @@ public class Capitalization {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -131,6 +135,7 @@ public class Capitalization {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -151,6 +156,7 @@ public class Capitalization {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Cat.java
@@ -65,6 +65,7 @@ public class Cat extends Animal {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Category.java
@@ -54,6 +54,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -74,6 +75,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ChildWithNullable.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ChildWithNullable.java
@@ -49,6 +49,7 @@ public class ChildWithNullable extends ParentWithNullable {
     return otherProperty;
   }
 
+  @JsonProperty("otherProperty")
   public void setOtherProperty(@Nullable String otherProperty) {
     this.otherProperty = otherProperty;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ClassModel.java
@@ -42,6 +42,7 @@ public class ClassModel {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Client.java
@@ -41,6 +41,7 @@ public class Client {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -104,6 +104,7 @@ public class ContainerDefaultValue {
     return nullableRequiredArray;
   }
 
+  @JsonProperty("nullable_required_array")
   public void setNullableRequiredArray(JsonNullable<List<String>> nullableRequiredArray) {
     this.nullableRequiredArray = nullableRequiredArray;
   }
@@ -132,6 +133,7 @@ public class ContainerDefaultValue {
     return requiredArray;
   }
 
+  @JsonProperty("required_array")
   public void setRequiredArray(List<String> requiredArray) {
     this.requiredArray = requiredArray;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Dog.java
@@ -57,6 +57,7 @@ public class Dog extends Animal {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/EnumArrays.java
@@ -118,6 +118,7 @@ public class EnumArrays {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -146,6 +147,7 @@ public class EnumArrays {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/EnumTest.java
@@ -208,6 +208,7 @@ public class EnumTest {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -228,6 +229,7 @@ public class EnumTest {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -248,6 +250,7 @@ public class EnumTest {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -268,6 +271,7 @@ public class EnumTest {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -288,6 +292,7 @@ public class EnumTest {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(@Nullable OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/File.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/File.java
@@ -42,6 +42,7 @@ public class File {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -48,6 +48,7 @@ public class FileSchemaTestClass {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable File file) {
     this.file = file;
   }
@@ -76,6 +77,7 @@ public class FileSchemaTestClass {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<@Valid File> files) {
     this.files = files;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/FormatTest.java
@@ -93,6 +93,7 @@ public class FormatTest {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -115,6 +116,7 @@ public class FormatTest {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -135,6 +137,7 @@ public class FormatTest {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -157,6 +160,7 @@ public class FormatTest {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -179,6 +183,7 @@ public class FormatTest {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -201,6 +206,7 @@ public class FormatTest {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -221,6 +227,7 @@ public class FormatTest {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -241,6 +248,7 @@ public class FormatTest {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -261,6 +269,7 @@ public class FormatTest {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -281,6 +290,7 @@ public class FormatTest {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -301,6 +311,7 @@ public class FormatTest {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -321,6 +332,7 @@ public class FormatTest {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -341,6 +353,7 @@ public class FormatTest {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -361,6 +374,7 @@ public class FormatTest {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(@Nullable BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -45,6 +45,7 @@ public class HasOnlyReadOnly {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -65,6 +66,7 @@ public class HasOnlyReadOnly {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/MapTest.java
@@ -97,6 +97,7 @@ public class MapTest {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -125,6 +126,7 @@ public class MapTest {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -153,6 +155,7 @@ public class MapTest {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -181,6 +184,7 @@ public class MapTest {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -53,6 +53,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -73,6 +74,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -101,6 +103,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Model200Response.java
@@ -46,6 +46,7 @@ public class Model200Response {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -66,6 +67,7 @@ public class Model200Response {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -47,6 +47,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -67,6 +68,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -87,6 +89,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ModelList.java
@@ -43,6 +43,7 @@ public class ModelList {
     return _123list;
   }
 
+  @JsonProperty("123-list")
   public void set123list(@Nullable String _123list) {
     this._123list = _123list;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ModelReturn.java
@@ -44,6 +44,7 @@ public class ModelReturn {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Name.java
@@ -59,6 +59,7 @@ public class Name {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -79,6 +80,7 @@ public class Name {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -99,6 +101,7 @@ public class Name {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -119,6 +122,7 @@ public class Name {
     return _123number;
   }
 
+  @JsonProperty("123Number")
   public void set123number(@Nullable Integer _123number) {
     this._123number = _123number;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/NumberOnly.java
@@ -42,6 +42,7 @@ public class NumberOnly {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Order.java
@@ -92,6 +92,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -112,6 +113,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -132,6 +134,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -152,6 +155,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -172,6 +176,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -192,6 +197,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/OuterComposite.java
@@ -46,6 +46,7 @@ public class OuterComposite {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -66,6 +67,7 @@ public class OuterComposite {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -86,6 +88,7 @@ public class OuterComposite {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -92,6 +92,7 @@ public class ParentWithNullable {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable TypeEnum type) {
     this.type = type;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Pet.java
@@ -112,6 +112,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -132,6 +133,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -152,6 +154,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -181,6 +184,7 @@ public class Pet {
   }
 
   @JsonDeserialize(as = LinkedHashSet.class)
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -209,6 +213,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -225,8 +230,8 @@ public class Pet {
    */
   
   @ApiModelProperty(value = "pet status in the store")
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -235,6 +240,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -43,6 +43,7 @@ public class ReadOnlyFirst {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -63,6 +64,7 @@ public class ReadOnlyFirst {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
@@ -47,6 +47,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return normalPropertyName;
   }
 
+  @JsonProperty("normalPropertyName")
   public void setNormalPropertyName(@Nullable String normalPropertyName) {
     this.normalPropertyName = normalPropertyName;
   }
@@ -67,6 +68,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return UPPER_CASE_PROPERTY_SNAKE;
   }
 
+  @JsonProperty("UPPER_CASE_PROPERTY_SNAKE")
   public void setUPPERCASEPROPERTYSNAKE(@Nullable String UPPER_CASE_PROPERTY_SNAKE) {
     this.UPPER_CASE_PROPERTY_SNAKE = UPPER_CASE_PROPERTY_SNAKE;
   }
@@ -87,6 +89,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return lowerCasePropertyDashes;
   }
 
+  @JsonProperty("lower-case-property-dashes")
   public void setLowerCasePropertyDashes(@Nullable String lowerCasePropertyDashes) {
     this.lowerCasePropertyDashes = lowerCasePropertyDashes;
   }
@@ -107,6 +110,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return propertyNameWithSpaces;
   }
 
+  @JsonProperty("property name with spaces")
   public void setPropertyNameWithSpaces(@Nullable String propertyNameWithSpaces) {
     this.propertyNameWithSpaces = propertyNameWithSpaces;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -43,6 +43,7 @@ public class SpecialModelName {
     return $specialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -69,6 +69,7 @@ public class TypeHolderDefault {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -89,6 +90,7 @@ public class TypeHolderDefault {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -109,6 +111,7 @@ public class TypeHolderDefault {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -129,6 +132,7 @@ public class TypeHolderDefault {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -157,6 +161,7 @@ public class TypeHolderDefault {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -72,6 +72,7 @@ public class TypeHolderExample {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -92,6 +93,7 @@ public class TypeHolderExample {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -112,6 +114,7 @@ public class TypeHolderExample {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -132,6 +135,7 @@ public class TypeHolderExample {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -152,6 +156,7 @@ public class TypeHolderExample {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -180,6 +185,7 @@ public class TypeHolderExample {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/User.java
@@ -55,6 +55,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -75,6 +76,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -95,6 +97,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -115,6 +118,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -135,6 +139,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -155,6 +160,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -175,6 +181,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -195,6 +202,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/XmlItem.java
@@ -110,6 +110,7 @@ public class XmlItem {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(@Nullable String attributeString) {
     this.attributeString = attributeString;
   }
@@ -130,6 +131,7 @@ public class XmlItem {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(@Nullable BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -150,6 +152,7 @@ public class XmlItem {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(@Nullable Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -170,6 +173,7 @@ public class XmlItem {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(@Nullable Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -198,6 +202,7 @@ public class XmlItem {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -218,6 +223,7 @@ public class XmlItem {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(@Nullable String nameString) {
     this.nameString = nameString;
   }
@@ -238,6 +244,7 @@ public class XmlItem {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(@Nullable BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -258,6 +265,7 @@ public class XmlItem {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(@Nullable Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -278,6 +286,7 @@ public class XmlItem {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(@Nullable Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -306,6 +315,7 @@ public class XmlItem {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -334,6 +344,7 @@ public class XmlItem {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -354,6 +365,7 @@ public class XmlItem {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(@Nullable String prefixString) {
     this.prefixString = prefixString;
   }
@@ -374,6 +386,7 @@ public class XmlItem {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(@Nullable BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -394,6 +407,7 @@ public class XmlItem {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(@Nullable Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -414,6 +428,7 @@ public class XmlItem {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(@Nullable Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -442,6 +457,7 @@ public class XmlItem {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -470,6 +486,7 @@ public class XmlItem {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -490,6 +507,7 @@ public class XmlItem {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(@Nullable String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -510,6 +528,7 @@ public class XmlItem {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(@Nullable BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -530,6 +549,7 @@ public class XmlItem {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(@Nullable Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -550,6 +570,7 @@ public class XmlItem {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(@Nullable Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -578,6 +599,7 @@ public class XmlItem {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -606,6 +628,7 @@ public class XmlItem {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -626,6 +649,7 @@ public class XmlItem {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(@Nullable String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -646,6 +670,7 @@ public class XmlItem {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(@Nullable BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -666,6 +691,7 @@ public class XmlItem {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(@Nullable Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -686,6 +712,7 @@ public class XmlItem {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(@Nullable Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -714,6 +741,7 @@ public class XmlItem {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -742,6 +770,7 @@ public class XmlItem {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/server/petstore/springboot-delegate-no-response-entity/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-delegate-no-response-entity/src/main/java/org/openapitools/model/Category.java
@@ -44,6 +44,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -64,6 +65,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-delegate-no-response-entity/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-delegate-no-response-entity/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -48,6 +48,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -68,6 +69,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -88,6 +90,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/server/petstore/springboot-delegate-no-response-entity/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-delegate-no-response-entity/src/main/java/org/openapitools/model/Order.java
@@ -93,6 +93,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -113,6 +114,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -133,6 +135,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -153,6 +156,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -173,6 +177,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -193,6 +198,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/server/petstore/springboot-delegate-no-response-entity/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-delegate-no-response-entity/src/main/java/org/openapitools/model/Pet.java
@@ -110,6 +110,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -130,6 +131,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -150,6 +152,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -178,6 +181,7 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -206,6 +210,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -222,8 +227,8 @@ public class Pet {
    */
   
   @ApiModelProperty(value = "pet status in the store")
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -232,6 +237,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/server/petstore/springboot-delegate-no-response-entity/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-delegate-no-response-entity/src/main/java/org/openapitools/model/Tag.java
@@ -44,6 +44,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -64,6 +65,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-delegate-no-response-entity/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-delegate-no-response-entity/src/main/java/org/openapitools/model/User.java
@@ -56,6 +56,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -76,6 +77,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -96,6 +98,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -116,6 +119,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -136,6 +140,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -156,6 +161,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -176,6 +182,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -196,6 +203,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -56,6 +56,7 @@ public class AdditionalPropertiesAnyType {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -57,6 +57,7 @@ public class AdditionalPropertiesArray {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -56,6 +56,7 @@ public class AdditionalPropertiesBoolean {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -105,6 +105,7 @@ public class AdditionalPropertiesClass {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -133,6 +134,7 @@ public class AdditionalPropertiesClass {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -161,6 +163,7 @@ public class AdditionalPropertiesClass {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -189,6 +192,7 @@ public class AdditionalPropertiesClass {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -217,6 +221,7 @@ public class AdditionalPropertiesClass {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -245,6 +250,7 @@ public class AdditionalPropertiesClass {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -273,6 +279,7 @@ public class AdditionalPropertiesClass {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -301,6 +308,7 @@ public class AdditionalPropertiesClass {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -321,6 +329,7 @@ public class AdditionalPropertiesClass {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(@Nullable Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -361,6 +370,7 @@ public class AdditionalPropertiesClass {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(@Nullable Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -56,6 +56,7 @@ public class AdditionalPropertiesInteger {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -57,6 +57,7 @@ public class AdditionalPropertiesNumber {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -57,6 +57,7 @@ public class AdditionalPropertiesObject {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -56,6 +56,7 @@ public class AdditionalPropertiesString {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Animal.java
@@ -76,6 +76,7 @@ public class Animal {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -96,6 +97,7 @@ public class Animal {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -65,6 +65,7 @@ public class ArrayOfArrayOfNumberOnly {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -65,6 +65,7 @@ public class ArrayOfNumberOnly {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ArrayTest.java
@@ -73,6 +73,7 @@ public class ArrayTest {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -101,6 +102,7 @@ public class ArrayTest {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -129,6 +131,7 @@ public class ArrayTest {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/BigCat.java
@@ -105,6 +105,7 @@ public class BigCat extends Cat {
     return kind;
   }
 
+  @JsonProperty("kind")
   public void setKind(@Nullable KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Capitalization.java
@@ -67,6 +67,7 @@ public class Capitalization {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -87,6 +88,7 @@ public class Capitalization {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -107,6 +109,7 @@ public class Capitalization {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -127,6 +130,7 @@ public class Capitalization {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -147,6 +151,7 @@ public class Capitalization {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -167,6 +172,7 @@ public class Capitalization {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Cat.java
@@ -73,6 +73,7 @@ public class Cat extends Animal {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Category.java
@@ -62,6 +62,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -82,6 +83,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ChildWithNullable.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ChildWithNullable.java
@@ -61,6 +61,7 @@ public class ChildWithNullable extends ParentWithNullable {
     return otherProperty;
   }
 
+  @JsonProperty("otherProperty")
   public void setOtherProperty(@Nullable String otherProperty) {
     this.otherProperty = otherProperty;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ClassModel.java
@@ -53,6 +53,7 @@ public class ClassModel {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Client.java
@@ -52,6 +52,7 @@ public class Client {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -114,6 +114,7 @@ public class ContainerDefaultValue {
     return nullableRequiredArray;
   }
 
+  @JsonProperty("nullable_required_array")
   public void setNullableRequiredArray(JsonNullable<List<String>> nullableRequiredArray) {
     this.nullableRequiredArray = nullableRequiredArray;
   }
@@ -142,6 +143,7 @@ public class ContainerDefaultValue {
     return requiredArray;
   }
 
+  @JsonProperty("required_array")
   public void setRequiredArray(List<String> requiredArray) {
     this.requiredArray = requiredArray;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Dog.java
@@ -65,6 +65,7 @@ public class Dog extends Animal {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumArrays.java
@@ -130,6 +130,7 @@ public class EnumArrays {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -158,6 +159,7 @@ public class EnumArrays {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumTest.java
@@ -219,6 +219,7 @@ public class EnumTest {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -239,6 +240,7 @@ public class EnumTest {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -259,6 +261,7 @@ public class EnumTest {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -279,6 +282,7 @@ public class EnumTest {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -299,6 +303,7 @@ public class EnumTest {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(@Nullable OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/File.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/File.java
@@ -53,6 +53,7 @@ public class File {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -60,6 +60,7 @@ public class FileSchemaTestClass {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable File file) {
     this.file = file;
   }
@@ -88,6 +89,7 @@ public class FileSchemaTestClass {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<@Valid File> files) {
     this.files = files;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/FormatTest.java
@@ -113,6 +113,7 @@ public class FormatTest {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -135,6 +136,7 @@ public class FormatTest {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -155,6 +157,7 @@ public class FormatTest {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -177,6 +180,7 @@ public class FormatTest {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -199,6 +203,7 @@ public class FormatTest {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -221,6 +226,7 @@ public class FormatTest {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -241,6 +247,7 @@ public class FormatTest {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -261,6 +268,7 @@ public class FormatTest {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -281,6 +289,7 @@ public class FormatTest {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -301,6 +310,7 @@ public class FormatTest {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -321,6 +331,7 @@ public class FormatTest {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -341,6 +352,7 @@ public class FormatTest {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -361,6 +373,7 @@ public class FormatTest {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -381,6 +394,7 @@ public class FormatTest {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(@Nullable BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -57,6 +57,7 @@ public class HasOnlyReadOnly {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -77,6 +78,7 @@ public class HasOnlyReadOnly {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/MapTest.java
@@ -111,6 +111,7 @@ public class MapTest {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -139,6 +140,7 @@ public class MapTest {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -167,6 +169,7 @@ public class MapTest {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -195,6 +198,7 @@ public class MapTest {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -66,6 +66,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -86,6 +87,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -114,6 +116,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Model200Response.java
@@ -58,6 +58,7 @@ public class Model200Response {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -78,6 +79,7 @@ public class Model200Response {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -60,6 +60,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -80,6 +81,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -100,6 +102,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ModelList.java
@@ -54,6 +54,7 @@ public class ModelList {
     return _123list;
   }
 
+  @JsonProperty("123-list")
   public void set123list(@Nullable String _123list) {
     this._123list = _123list;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ModelReturn.java
@@ -55,6 +55,7 @@ public class ModelReturn {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Name.java
@@ -69,6 +69,7 @@ public class Name {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -89,6 +90,7 @@ public class Name {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -109,6 +111,7 @@ public class Name {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -129,6 +132,7 @@ public class Name {
     return _123number;
   }
 
+  @JsonProperty("123Number")
   public void set123number(@Nullable Integer _123number) {
     this._123number = _123number;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/NumberOnly.java
@@ -53,6 +53,7 @@ public class NumberOnly {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Order.java
@@ -108,6 +108,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -128,6 +129,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -148,6 +150,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -168,6 +171,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -188,6 +192,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -208,6 +213,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/OuterComposite.java
@@ -59,6 +59,7 @@ public class OuterComposite {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -79,6 +80,7 @@ public class OuterComposite {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -99,6 +101,7 @@ public class OuterComposite {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -104,6 +104,7 @@ public class ParentWithNullable {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable TypeEnum type) {
     this.type = type;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
@@ -124,6 +124,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -144,6 +145,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -164,6 +166,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -193,6 +196,7 @@ public class Pet {
   }
 
   @JsonDeserialize(as = LinkedHashSet.class)
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -221,6 +225,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -237,8 +242,8 @@ public class Pet {
    */
   
   @ApiModelProperty(value = "pet status in the store")
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -247,6 +252,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -55,6 +55,7 @@ public class ReadOnlyFirst {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -75,6 +76,7 @@ public class ReadOnlyFirst {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
@@ -61,6 +61,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return normalPropertyName;
   }
 
+  @JsonProperty("normalPropertyName")
   public void setNormalPropertyName(@Nullable String normalPropertyName) {
     this.normalPropertyName = normalPropertyName;
   }
@@ -81,6 +82,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return UPPER_CASE_PROPERTY_SNAKE;
   }
 
+  @JsonProperty("UPPER_CASE_PROPERTY_SNAKE")
   public void setUPPERCASEPROPERTYSNAKE(@Nullable String UPPER_CASE_PROPERTY_SNAKE) {
     this.UPPER_CASE_PROPERTY_SNAKE = UPPER_CASE_PROPERTY_SNAKE;
   }
@@ -101,6 +103,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return lowerCasePropertyDashes;
   }
 
+  @JsonProperty("lower-case-property-dashes")
   public void setLowerCasePropertyDashes(@Nullable String lowerCasePropertyDashes) {
     this.lowerCasePropertyDashes = lowerCasePropertyDashes;
   }
@@ -121,6 +124,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return propertyNameWithSpaces;
   }
 
+  @JsonProperty("property name with spaces")
   public void setPropertyNameWithSpaces(@Nullable String propertyNameWithSpaces) {
     this.propertyNameWithSpaces = propertyNameWithSpaces;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -54,6 +54,7 @@ public class SpecialModelName {
     return $specialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Tag.java
@@ -55,6 +55,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -75,6 +76,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -69,6 +69,7 @@ public class TypeHolderDefault {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -89,6 +90,7 @@ public class TypeHolderDefault {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -109,6 +111,7 @@ public class TypeHolderDefault {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -129,6 +132,7 @@ public class TypeHolderDefault {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -157,6 +161,7 @@ public class TypeHolderDefault {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -72,6 +72,7 @@ public class TypeHolderExample {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -92,6 +93,7 @@ public class TypeHolderExample {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -112,6 +114,7 @@ public class TypeHolderExample {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -132,6 +135,7 @@ public class TypeHolderExample {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -152,6 +156,7 @@ public class TypeHolderExample {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -180,6 +185,7 @@ public class TypeHolderExample {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/User.java
@@ -73,6 +73,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -93,6 +94,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -113,6 +115,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -133,6 +136,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -153,6 +157,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -173,6 +178,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -193,6 +199,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -213,6 +220,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/XmlItem.java
@@ -149,6 +149,7 @@ public class XmlItem {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(@Nullable String attributeString) {
     this.attributeString = attributeString;
   }
@@ -169,6 +170,7 @@ public class XmlItem {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(@Nullable BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -189,6 +191,7 @@ public class XmlItem {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(@Nullable Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -209,6 +212,7 @@ public class XmlItem {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(@Nullable Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -237,6 +241,7 @@ public class XmlItem {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -257,6 +262,7 @@ public class XmlItem {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(@Nullable String nameString) {
     this.nameString = nameString;
   }
@@ -277,6 +283,7 @@ public class XmlItem {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(@Nullable BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -297,6 +304,7 @@ public class XmlItem {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(@Nullable Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -317,6 +325,7 @@ public class XmlItem {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(@Nullable Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -345,6 +354,7 @@ public class XmlItem {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -373,6 +383,7 @@ public class XmlItem {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -393,6 +404,7 @@ public class XmlItem {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(@Nullable String prefixString) {
     this.prefixString = prefixString;
   }
@@ -413,6 +425,7 @@ public class XmlItem {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(@Nullable BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -433,6 +446,7 @@ public class XmlItem {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(@Nullable Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -453,6 +467,7 @@ public class XmlItem {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(@Nullable Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -481,6 +496,7 @@ public class XmlItem {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -509,6 +525,7 @@ public class XmlItem {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -529,6 +546,7 @@ public class XmlItem {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(@Nullable String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -549,6 +567,7 @@ public class XmlItem {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(@Nullable BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -569,6 +588,7 @@ public class XmlItem {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(@Nullable Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -589,6 +609,7 @@ public class XmlItem {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(@Nullable Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -617,6 +638,7 @@ public class XmlItem {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -645,6 +667,7 @@ public class XmlItem {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -665,6 +688,7 @@ public class XmlItem {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(@Nullable String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -685,6 +709,7 @@ public class XmlItem {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(@Nullable BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -705,6 +730,7 @@ public class XmlItem {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(@Nullable Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -725,6 +751,7 @@ public class XmlItem {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(@Nullable Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -753,6 +780,7 @@ public class XmlItem {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -781,6 +809,7 @@ public class XmlItem {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/model/Category.java
@@ -40,6 +40,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -59,6 +60,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -44,6 +44,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -63,6 +64,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -82,6 +84,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/model/Order.java
@@ -89,6 +89,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -108,6 +109,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -127,6 +129,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -146,6 +149,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -165,6 +169,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -184,6 +189,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/model/Pet.java
@@ -106,6 +106,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -125,6 +126,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -144,6 +146,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -171,6 +174,7 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -198,6 +202,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -213,8 +218,8 @@ public class Pet {
    * @deprecated
    */
   
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -223,6 +228,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/model/Tag.java
@@ -40,6 +40,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -59,6 +60,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/model/User.java
@@ -52,6 +52,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -71,6 +72,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -90,6 +92,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -109,6 +112,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -128,6 +132,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -147,6 +152,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -166,6 +172,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -185,6 +192,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesAnyType {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesArray {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesBoolean {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -84,6 +84,7 @@ public class AdditionalPropertiesClass {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -112,6 +113,7 @@ public class AdditionalPropertiesClass {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -140,6 +142,7 @@ public class AdditionalPropertiesClass {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -168,6 +171,7 @@ public class AdditionalPropertiesClass {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -196,6 +200,7 @@ public class AdditionalPropertiesClass {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -224,6 +229,7 @@ public class AdditionalPropertiesClass {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -252,6 +258,7 @@ public class AdditionalPropertiesClass {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -280,6 +287,7 @@ public class AdditionalPropertiesClass {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -300,6 +308,7 @@ public class AdditionalPropertiesClass {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(@Nullable Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -340,6 +349,7 @@ public class AdditionalPropertiesClass {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(@Nullable Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesInteger {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesNumber {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesObject {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesString {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Animal.java
@@ -68,6 +68,7 @@ public class Animal {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -88,6 +89,7 @@ public class Animal {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -54,6 +54,7 @@ public class ArrayOfArrayOfNumberOnly {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -54,6 +54,7 @@ public class ArrayOfNumberOnly {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ArrayTest.java
@@ -60,6 +60,7 @@ public class ArrayTest {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -88,6 +89,7 @@ public class ArrayTest {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -116,6 +118,7 @@ public class ArrayTest {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/BigCat.java
@@ -97,6 +97,7 @@ public class BigCat extends Cat {
     return kind;
   }
 
+  @JsonProperty("kind")
   public void setKind(@Nullable KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Capitalization.java
@@ -51,6 +51,7 @@ public class Capitalization {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -71,6 +72,7 @@ public class Capitalization {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -91,6 +93,7 @@ public class Capitalization {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -111,6 +114,7 @@ public class Capitalization {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -131,6 +135,7 @@ public class Capitalization {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -151,6 +156,7 @@ public class Capitalization {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Cat.java
@@ -65,6 +65,7 @@ public class Cat extends Animal {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Category.java
@@ -54,6 +54,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -74,6 +75,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ChildWithNullable.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ChildWithNullable.java
@@ -49,6 +49,7 @@ public class ChildWithNullable extends ParentWithNullable {
     return otherProperty;
   }
 
+  @JsonProperty("otherProperty")
   public void setOtherProperty(@Nullable String otherProperty) {
     this.otherProperty = otherProperty;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ClassModel.java
@@ -42,6 +42,7 @@ public class ClassModel {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Client.java
@@ -41,6 +41,7 @@ public class Client {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -104,6 +104,7 @@ public class ContainerDefaultValue {
     return nullableRequiredArray;
   }
 
+  @JsonProperty("nullable_required_array")
   public void setNullableRequiredArray(JsonNullable<List<String>> nullableRequiredArray) {
     this.nullableRequiredArray = nullableRequiredArray;
   }
@@ -132,6 +133,7 @@ public class ContainerDefaultValue {
     return requiredArray;
   }
 
+  @JsonProperty("required_array")
   public void setRequiredArray(List<String> requiredArray) {
     this.requiredArray = requiredArray;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Dog.java
@@ -57,6 +57,7 @@ public class Dog extends Animal {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumArrays.java
@@ -118,6 +118,7 @@ public class EnumArrays {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -146,6 +147,7 @@ public class EnumArrays {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumTest.java
@@ -208,6 +208,7 @@ public class EnumTest {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -228,6 +229,7 @@ public class EnumTest {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -248,6 +250,7 @@ public class EnumTest {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -268,6 +271,7 @@ public class EnumTest {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -288,6 +292,7 @@ public class EnumTest {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(@Nullable OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/File.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/File.java
@@ -42,6 +42,7 @@ public class File {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -48,6 +48,7 @@ public class FileSchemaTestClass {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable File file) {
     this.file = file;
   }
@@ -76,6 +77,7 @@ public class FileSchemaTestClass {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<@Valid File> files) {
     this.files = files;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/FormatTest.java
@@ -93,6 +93,7 @@ public class FormatTest {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -115,6 +116,7 @@ public class FormatTest {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -135,6 +137,7 @@ public class FormatTest {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -157,6 +160,7 @@ public class FormatTest {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -179,6 +183,7 @@ public class FormatTest {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -201,6 +206,7 @@ public class FormatTest {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -221,6 +227,7 @@ public class FormatTest {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -241,6 +248,7 @@ public class FormatTest {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -261,6 +269,7 @@ public class FormatTest {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -281,6 +290,7 @@ public class FormatTest {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -301,6 +311,7 @@ public class FormatTest {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -321,6 +332,7 @@ public class FormatTest {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -341,6 +353,7 @@ public class FormatTest {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -361,6 +374,7 @@ public class FormatTest {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(@Nullable BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -45,6 +45,7 @@ public class HasOnlyReadOnly {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -65,6 +66,7 @@ public class HasOnlyReadOnly {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/MapTest.java
@@ -97,6 +97,7 @@ public class MapTest {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -125,6 +126,7 @@ public class MapTest {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -153,6 +155,7 @@ public class MapTest {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -181,6 +184,7 @@ public class MapTest {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -53,6 +53,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -73,6 +74,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -101,6 +103,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Model200Response.java
@@ -46,6 +46,7 @@ public class Model200Response {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -66,6 +67,7 @@ public class Model200Response {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -47,6 +47,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -67,6 +68,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -87,6 +89,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ModelList.java
@@ -43,6 +43,7 @@ public class ModelList {
     return _123list;
   }
 
+  @JsonProperty("123-list")
   public void set123list(@Nullable String _123list) {
     this._123list = _123list;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ModelReturn.java
@@ -44,6 +44,7 @@ public class ModelReturn {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Name.java
@@ -59,6 +59,7 @@ public class Name {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -79,6 +80,7 @@ public class Name {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -99,6 +101,7 @@ public class Name {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -119,6 +122,7 @@ public class Name {
     return _123number;
   }
 
+  @JsonProperty("123Number")
   public void set123number(@Nullable Integer _123number) {
     this._123number = _123number;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/NumberOnly.java
@@ -42,6 +42,7 @@ public class NumberOnly {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Order.java
@@ -92,6 +92,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -112,6 +113,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -132,6 +134,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -152,6 +155,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -172,6 +176,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -192,6 +197,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/OuterComposite.java
@@ -46,6 +46,7 @@ public class OuterComposite {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -66,6 +67,7 @@ public class OuterComposite {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -86,6 +88,7 @@ public class OuterComposite {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -92,6 +92,7 @@ public class ParentWithNullable {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable TypeEnum type) {
     this.type = type;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
@@ -112,6 +112,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -132,6 +133,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -152,6 +154,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -181,6 +184,7 @@ public class Pet {
   }
 
   @JsonDeserialize(as = LinkedHashSet.class)
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -209,6 +213,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -225,8 +230,8 @@ public class Pet {
    */
   
   @ApiModelProperty(value = "pet status in the store")
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -235,6 +240,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -43,6 +43,7 @@ public class ReadOnlyFirst {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -63,6 +64,7 @@ public class ReadOnlyFirst {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
@@ -47,6 +47,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return normalPropertyName;
   }
 
+  @JsonProperty("normalPropertyName")
   public void setNormalPropertyName(@Nullable String normalPropertyName) {
     this.normalPropertyName = normalPropertyName;
   }
@@ -67,6 +68,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return UPPER_CASE_PROPERTY_SNAKE;
   }
 
+  @JsonProperty("UPPER_CASE_PROPERTY_SNAKE")
   public void setUPPERCASEPROPERTYSNAKE(@Nullable String UPPER_CASE_PROPERTY_SNAKE) {
     this.UPPER_CASE_PROPERTY_SNAKE = UPPER_CASE_PROPERTY_SNAKE;
   }
@@ -87,6 +89,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return lowerCasePropertyDashes;
   }
 
+  @JsonProperty("lower-case-property-dashes")
   public void setLowerCasePropertyDashes(@Nullable String lowerCasePropertyDashes) {
     this.lowerCasePropertyDashes = lowerCasePropertyDashes;
   }
@@ -107,6 +110,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return propertyNameWithSpaces;
   }
 
+  @JsonProperty("property name with spaces")
   public void setPropertyNameWithSpaces(@Nullable String propertyNameWithSpaces) {
     this.propertyNameWithSpaces = propertyNameWithSpaces;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -43,6 +43,7 @@ public class SpecialModelName {
     return $specialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -69,6 +69,7 @@ public class TypeHolderDefault {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -89,6 +90,7 @@ public class TypeHolderDefault {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -109,6 +111,7 @@ public class TypeHolderDefault {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -129,6 +132,7 @@ public class TypeHolderDefault {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -157,6 +161,7 @@ public class TypeHolderDefault {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -72,6 +72,7 @@ public class TypeHolderExample {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -92,6 +93,7 @@ public class TypeHolderExample {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -112,6 +114,7 @@ public class TypeHolderExample {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -132,6 +135,7 @@ public class TypeHolderExample {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -152,6 +156,7 @@ public class TypeHolderExample {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -180,6 +185,7 @@ public class TypeHolderExample {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/User.java
@@ -55,6 +55,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -75,6 +76,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -95,6 +97,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -115,6 +118,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -135,6 +139,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -155,6 +160,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -175,6 +181,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -195,6 +202,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/XmlItem.java
@@ -110,6 +110,7 @@ public class XmlItem {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(@Nullable String attributeString) {
     this.attributeString = attributeString;
   }
@@ -130,6 +131,7 @@ public class XmlItem {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(@Nullable BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -150,6 +152,7 @@ public class XmlItem {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(@Nullable Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -170,6 +173,7 @@ public class XmlItem {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(@Nullable Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -198,6 +202,7 @@ public class XmlItem {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -218,6 +223,7 @@ public class XmlItem {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(@Nullable String nameString) {
     this.nameString = nameString;
   }
@@ -238,6 +244,7 @@ public class XmlItem {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(@Nullable BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -258,6 +265,7 @@ public class XmlItem {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(@Nullable Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -278,6 +286,7 @@ public class XmlItem {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(@Nullable Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -306,6 +315,7 @@ public class XmlItem {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -334,6 +344,7 @@ public class XmlItem {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -354,6 +365,7 @@ public class XmlItem {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(@Nullable String prefixString) {
     this.prefixString = prefixString;
   }
@@ -374,6 +386,7 @@ public class XmlItem {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(@Nullable BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -394,6 +407,7 @@ public class XmlItem {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(@Nullable Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -414,6 +428,7 @@ public class XmlItem {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(@Nullable Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -442,6 +457,7 @@ public class XmlItem {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -470,6 +486,7 @@ public class XmlItem {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -490,6 +507,7 @@ public class XmlItem {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(@Nullable String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -510,6 +528,7 @@ public class XmlItem {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(@Nullable BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -530,6 +549,7 @@ public class XmlItem {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(@Nullable Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -550,6 +570,7 @@ public class XmlItem {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(@Nullable Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -578,6 +599,7 @@ public class XmlItem {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -606,6 +628,7 @@ public class XmlItem {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -626,6 +649,7 @@ public class XmlItem {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(@Nullable String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -646,6 +670,7 @@ public class XmlItem {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(@Nullable BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -666,6 +691,7 @@ public class XmlItem {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(@Nullable Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -686,6 +712,7 @@ public class XmlItem {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(@Nullable Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -714,6 +741,7 @@ public class XmlItem {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -742,6 +770,7 @@ public class XmlItem {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/AdditionalPropertiesAnyTypeDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/AdditionalPropertiesAnyTypeDto.java
@@ -47,6 +47,7 @@ public class AdditionalPropertiesAnyTypeDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/AdditionalPropertiesArrayDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/AdditionalPropertiesArrayDto.java
@@ -48,6 +48,7 @@ public class AdditionalPropertiesArrayDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/AdditionalPropertiesBooleanDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/AdditionalPropertiesBooleanDto.java
@@ -47,6 +47,7 @@ public class AdditionalPropertiesBooleanDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
@@ -86,6 +86,7 @@ public class AdditionalPropertiesClassDto {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -114,6 +115,7 @@ public class AdditionalPropertiesClassDto {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -142,6 +144,7 @@ public class AdditionalPropertiesClassDto {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -170,6 +173,7 @@ public class AdditionalPropertiesClassDto {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -198,6 +202,7 @@ public class AdditionalPropertiesClassDto {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -226,6 +231,7 @@ public class AdditionalPropertiesClassDto {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -254,6 +260,7 @@ public class AdditionalPropertiesClassDto {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -282,6 +289,7 @@ public class AdditionalPropertiesClassDto {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -302,6 +310,7 @@ public class AdditionalPropertiesClassDto {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(@Nullable Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -342,6 +351,7 @@ public class AdditionalPropertiesClassDto {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(@Nullable Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/AdditionalPropertiesIntegerDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/AdditionalPropertiesIntegerDto.java
@@ -47,6 +47,7 @@ public class AdditionalPropertiesIntegerDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/AdditionalPropertiesNumberDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/AdditionalPropertiesNumberDto.java
@@ -48,6 +48,7 @@ public class AdditionalPropertiesNumberDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/AdditionalPropertiesObjectDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/AdditionalPropertiesObjectDto.java
@@ -48,6 +48,7 @@ public class AdditionalPropertiesObjectDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/AdditionalPropertiesStringDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/AdditionalPropertiesStringDto.java
@@ -47,6 +47,7 @@ public class AdditionalPropertiesStringDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/AnimalDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/AnimalDto.java
@@ -69,6 +69,7 @@ public class AnimalDto {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -89,6 +90,7 @@ public class AnimalDto {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ApiResponseDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ApiResponseDto.java
@@ -47,6 +47,7 @@ public class ApiResponseDto {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -67,6 +68,7 @@ public class ApiResponseDto {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -87,6 +89,7 @@ public class ApiResponseDto {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnlyDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnlyDto.java
@@ -56,6 +56,7 @@ public class ArrayOfArrayOfNumberOnlyDto {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ArrayOfNumberOnlyDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ArrayOfNumberOnlyDto.java
@@ -56,6 +56,7 @@ public class ArrayOfNumberOnlyDto {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ArrayTestDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ArrayTestDto.java
@@ -62,6 +62,7 @@ public class ArrayTestDto {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -90,6 +91,7 @@ public class ArrayTestDto {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -118,6 +120,7 @@ public class ArrayTestDto {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirstDto>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/BigCatDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/BigCatDto.java
@@ -99,6 +99,7 @@ public class BigCatDto extends CatDto {
     return kind;
   }
 
+  @JsonProperty("kind")
   public void setKind(@Nullable KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/CapitalizationDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/CapitalizationDto.java
@@ -53,6 +53,7 @@ public class CapitalizationDto {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -73,6 +74,7 @@ public class CapitalizationDto {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -93,6 +95,7 @@ public class CapitalizationDto {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -113,6 +116,7 @@ public class CapitalizationDto {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -133,6 +137,7 @@ public class CapitalizationDto {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -153,6 +158,7 @@ public class CapitalizationDto {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/CatDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/CatDto.java
@@ -66,6 +66,7 @@ public class CatDto extends AnimalDto {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/CategoryDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/CategoryDto.java
@@ -56,6 +56,7 @@ public class CategoryDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -76,6 +77,7 @@ public class CategoryDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ChildWithNullableDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ChildWithNullableDto.java
@@ -51,6 +51,7 @@ public class ChildWithNullableDto extends ParentWithNullableDto {
     return otherProperty;
   }
 
+  @JsonProperty("otherProperty")
   public void setOtherProperty(@Nullable String otherProperty) {
     this.otherProperty = otherProperty;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ClassModelDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ClassModelDto.java
@@ -44,6 +44,7 @@ public class ClassModelDto {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ClientDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ClientDto.java
@@ -43,6 +43,7 @@ public class ClientDto {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
@@ -106,6 +106,7 @@ public class ContainerDefaultValueDto {
     return nullableRequiredArray;
   }
 
+  @JsonProperty("nullable_required_array")
   public void setNullableRequiredArray(JsonNullable<List<String>> nullableRequiredArray) {
     this.nullableRequiredArray = nullableRequiredArray;
   }
@@ -134,6 +135,7 @@ public class ContainerDefaultValueDto {
     return requiredArray;
   }
 
+  @JsonProperty("required_array")
   public void setRequiredArray(List<String> requiredArray) {
     this.requiredArray = requiredArray;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/DogDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/DogDto.java
@@ -59,6 +59,7 @@ public class DogDto extends AnimalDto {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/EnumArraysDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/EnumArraysDto.java
@@ -120,6 +120,7 @@ public class EnumArraysDto {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -148,6 +149,7 @@ public class EnumArraysDto {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/EnumTestDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/EnumTestDto.java
@@ -208,6 +208,7 @@ public class EnumTestDto {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -228,6 +229,7 @@ public class EnumTestDto {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -248,6 +250,7 @@ public class EnumTestDto {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -268,6 +271,7 @@ public class EnumTestDto {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -288,6 +292,7 @@ public class EnumTestDto {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(@Nullable OuterEnumDto outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/FileDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/FileDto.java
@@ -44,6 +44,7 @@ public class FileDto {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/FileSchemaTestClassDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/FileSchemaTestClassDto.java
@@ -50,6 +50,7 @@ public class FileSchemaTestClassDto {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable FileDto file) {
     this.file = file;
   }
@@ -78,6 +79,7 @@ public class FileSchemaTestClassDto {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<@Valid FileDto> files) {
     this.files = files;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/FormatTestDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/FormatTestDto.java
@@ -93,6 +93,7 @@ public class FormatTestDto {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -115,6 +116,7 @@ public class FormatTestDto {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -135,6 +137,7 @@ public class FormatTestDto {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -157,6 +160,7 @@ public class FormatTestDto {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -179,6 +183,7 @@ public class FormatTestDto {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -201,6 +206,7 @@ public class FormatTestDto {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -221,6 +227,7 @@ public class FormatTestDto {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -241,6 +248,7 @@ public class FormatTestDto {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -261,6 +269,7 @@ public class FormatTestDto {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -281,6 +290,7 @@ public class FormatTestDto {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -301,6 +311,7 @@ public class FormatTestDto {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -321,6 +332,7 @@ public class FormatTestDto {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -341,6 +353,7 @@ public class FormatTestDto {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -361,6 +374,7 @@ public class FormatTestDto {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(@Nullable BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/HasOnlyReadOnlyDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/HasOnlyReadOnlyDto.java
@@ -45,6 +45,7 @@ public class HasOnlyReadOnlyDto {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -65,6 +66,7 @@ public class HasOnlyReadOnlyDto {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ListDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ListDto.java
@@ -43,6 +43,7 @@ public class ListDto {
     return _123List;
   }
 
+  @JsonProperty("123-list")
   public void set123List(@Nullable String _123List) {
     this._123List = _123List;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/MapTestDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/MapTestDto.java
@@ -99,6 +99,7 @@ public class MapTestDto {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -127,6 +128,7 @@ public class MapTestDto {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -155,6 +157,7 @@ public class MapTestDto {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -183,6 +186,7 @@ public class MapTestDto {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClassDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClassDto.java
@@ -55,6 +55,7 @@ public class MixedPropertiesAndAdditionalPropertiesClassDto {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -75,6 +76,7 @@ public class MixedPropertiesAndAdditionalPropertiesClassDto {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -103,6 +105,7 @@ public class MixedPropertiesAndAdditionalPropertiesClassDto {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, AnimalDto> map) {
     this.map = map;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/Model200ResponseDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/Model200ResponseDto.java
@@ -46,6 +46,7 @@ public class Model200ResponseDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -66,6 +67,7 @@ public class Model200ResponseDto {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/NameDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/NameDto.java
@@ -61,6 +61,7 @@ public class NameDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -81,6 +82,7 @@ public class NameDto {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -101,6 +103,7 @@ public class NameDto {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -121,6 +124,7 @@ public class NameDto {
     return _123Number;
   }
 
+  @JsonProperty("123Number")
   public void set123Number(@Nullable Integer _123Number) {
     this._123Number = _123Number;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/NumberOnlyDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/NumberOnlyDto.java
@@ -44,6 +44,7 @@ public class NumberOnlyDto {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/OrderDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/OrderDto.java
@@ -94,6 +94,7 @@ public class OrderDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -114,6 +115,7 @@ public class OrderDto {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -134,6 +136,7 @@ public class OrderDto {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -154,6 +157,7 @@ public class OrderDto {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -174,6 +178,7 @@ public class OrderDto {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -194,6 +199,7 @@ public class OrderDto {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/OuterCompositeDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/OuterCompositeDto.java
@@ -48,6 +48,7 @@ public class OuterCompositeDto {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -68,6 +69,7 @@ public class OuterCompositeDto {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -88,6 +90,7 @@ public class OuterCompositeDto {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ParentWithNullableDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ParentWithNullableDto.java
@@ -93,6 +93,7 @@ public class ParentWithNullableDto {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable TypeEnum type) {
     this.type = type;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/PetDto.java
@@ -114,6 +114,7 @@ public class PetDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -134,6 +135,7 @@ public class PetDto {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable CategoryDto category) {
     this.category = category;
   }
@@ -154,6 +156,7 @@ public class PetDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -183,6 +186,7 @@ public class PetDto {
   }
 
   @JsonDeserialize(as = LinkedHashSet.class)
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -211,6 +215,7 @@ public class PetDto {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid TagDto> tags) {
     this.tags = tags;
   }
@@ -227,8 +232,8 @@ public class PetDto {
    */
   
   @ApiModelProperty(value = "pet status in the store")
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -237,6 +242,7 @@ public class PetDto {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ReadOnlyFirstDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ReadOnlyFirstDto.java
@@ -45,6 +45,7 @@ public class ReadOnlyFirstDto {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -65,6 +66,7 @@ public class ReadOnlyFirstDto {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNamesDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNamesDto.java
@@ -49,6 +49,7 @@ public class ResponseObjectWithDifferentFieldNamesDto {
     return normalPropertyName;
   }
 
+  @JsonProperty("normalPropertyName")
   public void setNormalPropertyName(@Nullable String normalPropertyName) {
     this.normalPropertyName = normalPropertyName;
   }
@@ -69,6 +70,7 @@ public class ResponseObjectWithDifferentFieldNamesDto {
     return UPPER_CASE_PROPERTY_SNAKE;
   }
 
+  @JsonProperty("UPPER_CASE_PROPERTY_SNAKE")
   public void setUPPERCASEPROPERTYSNAKE(@Nullable String UPPER_CASE_PROPERTY_SNAKE) {
     this.UPPER_CASE_PROPERTY_SNAKE = UPPER_CASE_PROPERTY_SNAKE;
   }
@@ -89,6 +91,7 @@ public class ResponseObjectWithDifferentFieldNamesDto {
     return lowerCasePropertyDashes;
   }
 
+  @JsonProperty("lower-case-property-dashes")
   public void setLowerCasePropertyDashes(@Nullable String lowerCasePropertyDashes) {
     this.lowerCasePropertyDashes = lowerCasePropertyDashes;
   }
@@ -109,6 +112,7 @@ public class ResponseObjectWithDifferentFieldNamesDto {
     return propertyNameWithSpaces;
   }
 
+  @JsonProperty("property name with spaces")
   public void setPropertyNameWithSpaces(@Nullable String propertyNameWithSpaces) {
     this.propertyNameWithSpaces = propertyNameWithSpaces;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ReturnDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ReturnDto.java
@@ -44,6 +44,7 @@ public class ReturnDto {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/SpecialModelNameDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/SpecialModelNameDto.java
@@ -43,6 +43,7 @@ public class SpecialModelNameDto {
     return $SpecialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $SpecialPropertyName) {
     this.$SpecialPropertyName = $SpecialPropertyName;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/TagDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/TagDto.java
@@ -45,6 +45,7 @@ public class TagDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -65,6 +66,7 @@ public class TagDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/TypeHolderDefaultDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/TypeHolderDefaultDto.java
@@ -71,6 +71,7 @@ public class TypeHolderDefaultDto {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -91,6 +92,7 @@ public class TypeHolderDefaultDto {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -111,6 +113,7 @@ public class TypeHolderDefaultDto {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -131,6 +134,7 @@ public class TypeHolderDefaultDto {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -159,6 +163,7 @@ public class TypeHolderDefaultDto {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/TypeHolderExampleDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/TypeHolderExampleDto.java
@@ -74,6 +74,7 @@ public class TypeHolderExampleDto {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -94,6 +95,7 @@ public class TypeHolderExampleDto {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -114,6 +116,7 @@ public class TypeHolderExampleDto {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -134,6 +137,7 @@ public class TypeHolderExampleDto {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -154,6 +158,7 @@ public class TypeHolderExampleDto {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -182,6 +187,7 @@ public class TypeHolderExampleDto {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/UserDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/UserDto.java
@@ -57,6 +57,7 @@ public class UserDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -77,6 +78,7 @@ public class UserDto {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -97,6 +99,7 @@ public class UserDto {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -117,6 +120,7 @@ public class UserDto {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -137,6 +141,7 @@ public class UserDto {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -157,6 +162,7 @@ public class UserDto {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -177,6 +183,7 @@ public class UserDto {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -197,6 +204,7 @@ public class UserDto {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/XmlItemDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/XmlItemDto.java
@@ -112,6 +112,7 @@ public class XmlItemDto {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(@Nullable String attributeString) {
     this.attributeString = attributeString;
   }
@@ -132,6 +133,7 @@ public class XmlItemDto {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(@Nullable BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -152,6 +154,7 @@ public class XmlItemDto {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(@Nullable Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -172,6 +175,7 @@ public class XmlItemDto {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(@Nullable Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -200,6 +204,7 @@ public class XmlItemDto {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -220,6 +225,7 @@ public class XmlItemDto {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(@Nullable String nameString) {
     this.nameString = nameString;
   }
@@ -240,6 +246,7 @@ public class XmlItemDto {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(@Nullable BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -260,6 +267,7 @@ public class XmlItemDto {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(@Nullable Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -280,6 +288,7 @@ public class XmlItemDto {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(@Nullable Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -308,6 +317,7 @@ public class XmlItemDto {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -336,6 +346,7 @@ public class XmlItemDto {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -356,6 +367,7 @@ public class XmlItemDto {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(@Nullable String prefixString) {
     this.prefixString = prefixString;
   }
@@ -376,6 +388,7 @@ public class XmlItemDto {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(@Nullable BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -396,6 +409,7 @@ public class XmlItemDto {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(@Nullable Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -416,6 +430,7 @@ public class XmlItemDto {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(@Nullable Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -444,6 +459,7 @@ public class XmlItemDto {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -472,6 +488,7 @@ public class XmlItemDto {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -492,6 +509,7 @@ public class XmlItemDto {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(@Nullable String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -512,6 +530,7 @@ public class XmlItemDto {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(@Nullable BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -532,6 +551,7 @@ public class XmlItemDto {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(@Nullable Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -552,6 +572,7 @@ public class XmlItemDto {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(@Nullable Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -580,6 +601,7 @@ public class XmlItemDto {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -608,6 +630,7 @@ public class XmlItemDto {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -628,6 +651,7 @@ public class XmlItemDto {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(@Nullable String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -648,6 +672,7 @@ public class XmlItemDto {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(@Nullable BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -668,6 +693,7 @@ public class XmlItemDto {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(@Nullable Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -688,6 +714,7 @@ public class XmlItemDto {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(@Nullable Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -716,6 +743,7 @@ public class XmlItemDto {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -744,6 +772,7 @@ public class XmlItemDto {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/server/petstore/springboot-lombok-data/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-lombok-data/src/main/java/org/openapitools/model/Category.java
@@ -30,11 +30,13 @@ public class Category {
   
   @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("id")
+
   private @Nullable Long id;
 
   @Pattern(regexp = "^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$") 
   @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("name")
+
   private @Nullable String name;
 
 }

--- a/samples/server/petstore/springboot-lombok-data/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-lombok-data/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -32,16 +32,19 @@ public class ModelApiResponse {
   
   @Schema(name = "code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("code")
+
   private @Nullable Integer code;
 
   
   @Schema(name = "type", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("type")
+
   private @Nullable String type;
 
   
   @Schema(name = "message", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("message")
+
   private @Nullable String message;
 
 }

--- a/samples/server/petstore/springboot-lombok-data/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-lombok-data/src/main/java/org/openapitools/model/Order.java
@@ -33,21 +33,25 @@ public class Order {
   
   @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("id")
+
   private @Nullable Long id;
 
   
   @Schema(name = "petId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("petId")
+
   private @Nullable Long petId;
 
   
   @Schema(name = "quantity", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("quantity")
+
   private @Nullable Integer quantity;
 
   @Valid 
   @Schema(name = "shipDate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("shipDate")
+
   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
   private @Nullable OffsetDateTime shipDate;
 
@@ -91,11 +95,13 @@ public class Order {
   
   @Schema(name = "status", description = "Order Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("status")
+
   private @Nullable StatusEnum status;
 
   
   @Schema(name = "complete", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("complete")
+
   @lombok.Builder.Default
   private Boolean complete = false;
 

--- a/samples/server/petstore/springboot-lombok-data/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-lombok-data/src/main/java/org/openapitools/model/Pet.java
@@ -36,21 +36,25 @@ public class Pet {
   
   @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("id")
+
   private @Nullable Long id;
 
   @Valid 
   @Schema(name = "category", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("category")
+
   private @Nullable Category category;
 
   @NotNull 
   @Schema(name = "name", example = "doggie", requiredMode = Schema.RequiredMode.REQUIRED)
   @JsonProperty("name")
+
   private String name;
 
   
   @Schema(name = "photoUrls", requiredMode = Schema.RequiredMode.REQUIRED)
   @JsonProperty("photoUrls")
+
   @lombok.Builder.Default
   @Valid
   private List<String> photoUrls = new ArrayList<>();
@@ -58,6 +62,7 @@ public class Pet {
   
   @Schema(name = "tags", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("tags")
+
   @lombok.Builder.Default
   @Valid
   private List<@Valid Tag> tags = new ArrayList<>();
@@ -102,6 +107,7 @@ public class Pet {
   
   @Schema(name = "status", description = "pet status in the store", deprecated = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("status")
+
   @Deprecated
   private @Nullable StatusEnum status;
 

--- a/samples/server/petstore/springboot-lombok-data/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-lombok-data/src/main/java/org/openapitools/model/Tag.java
@@ -30,11 +30,13 @@ public class Tag {
   
   @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("id")
+
   private @Nullable Long id;
 
   
   @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("name")
+
   private @Nullable String name;
 
 }

--- a/samples/server/petstore/springboot-lombok-data/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-lombok-data/src/main/java/org/openapitools/model/User.java
@@ -30,41 +30,49 @@ public class User {
   
   @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("id")
+
   private @Nullable Long id;
 
   
   @Schema(name = "username", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("username")
+
   private @Nullable String username;
 
   
   @Schema(name = "firstName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("firstName")
+
   private @Nullable String firstName;
 
   
   @Schema(name = "lastName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("lastName")
+
   private @Nullable String lastName;
 
   
   @Schema(name = "email", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("email")
+
   private @Nullable String email;
 
   
   @Schema(name = "password", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("password")
+
   private @Nullable String password;
 
   
   @Schema(name = "phone", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("phone")
+
   private @Nullable String phone;
 
   
   @Schema(name = "userStatus", description = "User Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("userStatus")
+
   private @Nullable Integer userStatus;
 
 }

--- a/samples/server/petstore/springboot-petstore-with-api-response-examples/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-petstore-with-api-response-examples/src/main/java/org/openapitools/model/Category.java
@@ -43,6 +43,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-petstore-with-api-response-examples/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-petstore-with-api-response-examples/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -47,6 +47,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -67,6 +68,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -87,6 +89,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/server/petstore/springboot-petstore-with-api-response-examples/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-petstore-with-api-response-examples/src/main/java/org/openapitools/model/Order.java
@@ -92,6 +92,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -112,6 +113,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -132,6 +134,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -152,6 +155,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -172,6 +176,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -192,6 +197,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/server/petstore/springboot-petstore-with-api-response-examples/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-petstore-with-api-response-examples/src/main/java/org/openapitools/model/Pet.java
@@ -109,6 +109,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -129,6 +130,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -149,6 +151,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -177,6 +180,7 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -205,6 +209,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -221,8 +226,8 @@ public class Pet {
    */
   
   @Schema(name = "status", description = "pet status in the store", deprecated = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -231,6 +236,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/server/petstore/springboot-petstore-with-api-response-examples/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-petstore-with-api-response-examples/src/main/java/org/openapitools/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-petstore-with-api-response-examples/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-petstore-with-api-response-examples/src/main/java/org/openapitools/model/User.java
@@ -55,6 +55,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -75,6 +76,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -95,6 +97,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -115,6 +118,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -135,6 +139,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -155,6 +160,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -175,6 +181,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -195,6 +202,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesAnyType {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesArray {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesBoolean {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -84,6 +84,7 @@ public class AdditionalPropertiesClass {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -112,6 +113,7 @@ public class AdditionalPropertiesClass {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -140,6 +142,7 @@ public class AdditionalPropertiesClass {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -168,6 +171,7 @@ public class AdditionalPropertiesClass {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -196,6 +200,7 @@ public class AdditionalPropertiesClass {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -224,6 +229,7 @@ public class AdditionalPropertiesClass {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -252,6 +258,7 @@ public class AdditionalPropertiesClass {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -280,6 +287,7 @@ public class AdditionalPropertiesClass {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -300,6 +308,7 @@ public class AdditionalPropertiesClass {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(@Nullable Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -340,6 +349,7 @@ public class AdditionalPropertiesClass {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(@Nullable Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesInteger {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesNumber {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesObject {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesString {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Animal.java
@@ -68,6 +68,7 @@ public class Animal {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -88,6 +89,7 @@ public class Animal {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -54,6 +54,7 @@ public class ArrayOfArrayOfNumberOnly {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -54,6 +54,7 @@ public class ArrayOfNumberOnly {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ArrayTest.java
@@ -60,6 +60,7 @@ public class ArrayTest {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -88,6 +89,7 @@ public class ArrayTest {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -116,6 +118,7 @@ public class ArrayTest {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/BigCat.java
@@ -97,6 +97,7 @@ public class BigCat extends Cat {
     return kind;
   }
 
+  @JsonProperty("kind")
   public void setKind(@Nullable KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Capitalization.java
@@ -51,6 +51,7 @@ public class Capitalization {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -71,6 +72,7 @@ public class Capitalization {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -91,6 +93,7 @@ public class Capitalization {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -111,6 +114,7 @@ public class Capitalization {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -131,6 +135,7 @@ public class Capitalization {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -151,6 +156,7 @@ public class Capitalization {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Cat.java
@@ -65,6 +65,7 @@ public class Cat extends Animal {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Category.java
@@ -54,6 +54,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -74,6 +75,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ChildWithNullable.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ChildWithNullable.java
@@ -49,6 +49,7 @@ public class ChildWithNullable extends ParentWithNullable {
     return otherProperty;
   }
 
+  @JsonProperty("otherProperty")
   public void setOtherProperty(@Nullable String otherProperty) {
     this.otherProperty = otherProperty;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ClassModel.java
@@ -42,6 +42,7 @@ public class ClassModel {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Client.java
@@ -41,6 +41,7 @@ public class Client {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -104,6 +104,7 @@ public class ContainerDefaultValue {
     return nullableRequiredArray;
   }
 
+  @JsonProperty("nullable_required_array")
   public void setNullableRequiredArray(JsonNullable<List<String>> nullableRequiredArray) {
     this.nullableRequiredArray = nullableRequiredArray;
   }
@@ -132,6 +133,7 @@ public class ContainerDefaultValue {
     return requiredArray;
   }
 
+  @JsonProperty("required_array")
   public void setRequiredArray(List<String> requiredArray) {
     this.requiredArray = requiredArray;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Dog.java
@@ -57,6 +57,7 @@ public class Dog extends Animal {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/EnumArrays.java
@@ -118,6 +118,7 @@ public class EnumArrays {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -146,6 +147,7 @@ public class EnumArrays {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/EnumTest.java
@@ -208,6 +208,7 @@ public class EnumTest {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -228,6 +229,7 @@ public class EnumTest {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -248,6 +250,7 @@ public class EnumTest {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -268,6 +271,7 @@ public class EnumTest {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -288,6 +292,7 @@ public class EnumTest {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(@Nullable OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/File.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/File.java
@@ -42,6 +42,7 @@ public class File {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -48,6 +48,7 @@ public class FileSchemaTestClass {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable File file) {
     this.file = file;
   }
@@ -76,6 +77,7 @@ public class FileSchemaTestClass {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<@Valid File> files) {
     this.files = files;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/FormatTest.java
@@ -93,6 +93,7 @@ public class FormatTest {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -115,6 +116,7 @@ public class FormatTest {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -135,6 +137,7 @@ public class FormatTest {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -157,6 +160,7 @@ public class FormatTest {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -179,6 +183,7 @@ public class FormatTest {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -201,6 +206,7 @@ public class FormatTest {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -221,6 +227,7 @@ public class FormatTest {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -241,6 +248,7 @@ public class FormatTest {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -261,6 +269,7 @@ public class FormatTest {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -281,6 +290,7 @@ public class FormatTest {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -301,6 +311,7 @@ public class FormatTest {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -321,6 +332,7 @@ public class FormatTest {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -341,6 +353,7 @@ public class FormatTest {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -361,6 +374,7 @@ public class FormatTest {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(@Nullable BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -45,6 +45,7 @@ public class HasOnlyReadOnly {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -65,6 +66,7 @@ public class HasOnlyReadOnly {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/MapTest.java
@@ -97,6 +97,7 @@ public class MapTest {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -125,6 +126,7 @@ public class MapTest {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -153,6 +155,7 @@ public class MapTest {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -181,6 +184,7 @@ public class MapTest {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -53,6 +53,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -73,6 +74,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -101,6 +103,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Model200Response.java
@@ -46,6 +46,7 @@ public class Model200Response {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -66,6 +67,7 @@ public class Model200Response {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -47,6 +47,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -67,6 +68,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -87,6 +89,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ModelList.java
@@ -43,6 +43,7 @@ public class ModelList {
     return _123list;
   }
 
+  @JsonProperty("123-list")
   public void set123list(@Nullable String _123list) {
     this._123list = _123list;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ModelReturn.java
@@ -44,6 +44,7 @@ public class ModelReturn {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Name.java
@@ -59,6 +59,7 @@ public class Name {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -79,6 +80,7 @@ public class Name {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -99,6 +101,7 @@ public class Name {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -119,6 +122,7 @@ public class Name {
     return _123number;
   }
 
+  @JsonProperty("123Number")
   public void set123number(@Nullable Integer _123number) {
     this._123number = _123number;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/NumberOnly.java
@@ -42,6 +42,7 @@ public class NumberOnly {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Order.java
@@ -92,6 +92,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -112,6 +113,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -132,6 +134,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -152,6 +155,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -172,6 +176,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -192,6 +197,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/OuterComposite.java
@@ -46,6 +46,7 @@ public class OuterComposite {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -66,6 +67,7 @@ public class OuterComposite {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -86,6 +88,7 @@ public class OuterComposite {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -92,6 +92,7 @@ public class ParentWithNullable {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable TypeEnum type) {
     this.type = type;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Pet.java
@@ -112,6 +112,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -132,6 +133,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -152,6 +154,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -181,6 +184,7 @@ public class Pet {
   }
 
   @JsonDeserialize(as = LinkedHashSet.class)
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -209,6 +213,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -225,8 +230,8 @@ public class Pet {
    */
   
   @ApiModelProperty(value = "pet status in the store")
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -235,6 +240,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -43,6 +43,7 @@ public class ReadOnlyFirst {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -63,6 +64,7 @@ public class ReadOnlyFirst {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
@@ -47,6 +47,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return normalPropertyName;
   }
 
+  @JsonProperty("normalPropertyName")
   public void setNormalPropertyName(@Nullable String normalPropertyName) {
     this.normalPropertyName = normalPropertyName;
   }
@@ -67,6 +68,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return UPPER_CASE_PROPERTY_SNAKE;
   }
 
+  @JsonProperty("UPPER_CASE_PROPERTY_SNAKE")
   public void setUPPERCASEPROPERTYSNAKE(@Nullable String UPPER_CASE_PROPERTY_SNAKE) {
     this.UPPER_CASE_PROPERTY_SNAKE = UPPER_CASE_PROPERTY_SNAKE;
   }
@@ -87,6 +89,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return lowerCasePropertyDashes;
   }
 
+  @JsonProperty("lower-case-property-dashes")
   public void setLowerCasePropertyDashes(@Nullable String lowerCasePropertyDashes) {
     this.lowerCasePropertyDashes = lowerCasePropertyDashes;
   }
@@ -107,6 +110,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return propertyNameWithSpaces;
   }
 
+  @JsonProperty("property name with spaces")
   public void setPropertyNameWithSpaces(@Nullable String propertyNameWithSpaces) {
     this.propertyNameWithSpaces = propertyNameWithSpaces;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -43,6 +43,7 @@ public class SpecialModelName {
     return $specialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -69,6 +69,7 @@ public class TypeHolderDefault {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -89,6 +90,7 @@ public class TypeHolderDefault {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -109,6 +111,7 @@ public class TypeHolderDefault {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -129,6 +132,7 @@ public class TypeHolderDefault {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -157,6 +161,7 @@ public class TypeHolderDefault {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -72,6 +72,7 @@ public class TypeHolderExample {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -92,6 +93,7 @@ public class TypeHolderExample {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -112,6 +114,7 @@ public class TypeHolderExample {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -132,6 +135,7 @@ public class TypeHolderExample {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -152,6 +156,7 @@ public class TypeHolderExample {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -180,6 +185,7 @@ public class TypeHolderExample {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/User.java
@@ -55,6 +55,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -75,6 +76,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -95,6 +97,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -115,6 +118,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -135,6 +139,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -155,6 +160,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -175,6 +181,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -195,6 +202,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/XmlItem.java
@@ -110,6 +110,7 @@ public class XmlItem {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(@Nullable String attributeString) {
     this.attributeString = attributeString;
   }
@@ -130,6 +131,7 @@ public class XmlItem {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(@Nullable BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -150,6 +152,7 @@ public class XmlItem {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(@Nullable Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -170,6 +173,7 @@ public class XmlItem {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(@Nullable Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -198,6 +202,7 @@ public class XmlItem {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -218,6 +223,7 @@ public class XmlItem {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(@Nullable String nameString) {
     this.nameString = nameString;
   }
@@ -238,6 +244,7 @@ public class XmlItem {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(@Nullable BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -258,6 +265,7 @@ public class XmlItem {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(@Nullable Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -278,6 +286,7 @@ public class XmlItem {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(@Nullable Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -306,6 +315,7 @@ public class XmlItem {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -334,6 +344,7 @@ public class XmlItem {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -354,6 +365,7 @@ public class XmlItem {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(@Nullable String prefixString) {
     this.prefixString = prefixString;
   }
@@ -374,6 +386,7 @@ public class XmlItem {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(@Nullable BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -394,6 +407,7 @@ public class XmlItem {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(@Nullable Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -414,6 +428,7 @@ public class XmlItem {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(@Nullable Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -442,6 +457,7 @@ public class XmlItem {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -470,6 +486,7 @@ public class XmlItem {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -490,6 +507,7 @@ public class XmlItem {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(@Nullable String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -510,6 +528,7 @@ public class XmlItem {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(@Nullable BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -530,6 +549,7 @@ public class XmlItem {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(@Nullable Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -550,6 +570,7 @@ public class XmlItem {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(@Nullable Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -578,6 +599,7 @@ public class XmlItem {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -606,6 +628,7 @@ public class XmlItem {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -626,6 +649,7 @@ public class XmlItem {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(@Nullable String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -646,6 +670,7 @@ public class XmlItem {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(@Nullable BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -666,6 +691,7 @@ public class XmlItem {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(@Nullable Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -686,6 +712,7 @@ public class XmlItem {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(@Nullable Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -714,6 +741,7 @@ public class XmlItem {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -742,6 +770,7 @@ public class XmlItem {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesAnyType {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesArray {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesBoolean {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -84,6 +84,7 @@ public class AdditionalPropertiesClass {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -112,6 +113,7 @@ public class AdditionalPropertiesClass {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -140,6 +142,7 @@ public class AdditionalPropertiesClass {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -168,6 +171,7 @@ public class AdditionalPropertiesClass {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -196,6 +200,7 @@ public class AdditionalPropertiesClass {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -224,6 +229,7 @@ public class AdditionalPropertiesClass {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -252,6 +258,7 @@ public class AdditionalPropertiesClass {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -280,6 +287,7 @@ public class AdditionalPropertiesClass {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -300,6 +308,7 @@ public class AdditionalPropertiesClass {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(@Nullable Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -340,6 +349,7 @@ public class AdditionalPropertiesClass {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(@Nullable Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesInteger {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesNumber {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesObject {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesString {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Animal.java
@@ -68,6 +68,7 @@ public class Animal {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -88,6 +89,7 @@ public class Animal {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -54,6 +54,7 @@ public class ArrayOfArrayOfNumberOnly {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -54,6 +54,7 @@ public class ArrayOfNumberOnly {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ArrayTest.java
@@ -60,6 +60,7 @@ public class ArrayTest {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -88,6 +89,7 @@ public class ArrayTest {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -116,6 +118,7 @@ public class ArrayTest {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/BigCat.java
@@ -97,6 +97,7 @@ public class BigCat extends Cat {
     return kind;
   }
 
+  @JsonProperty("kind")
   public void setKind(@Nullable KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Capitalization.java
@@ -51,6 +51,7 @@ public class Capitalization {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -71,6 +72,7 @@ public class Capitalization {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -91,6 +93,7 @@ public class Capitalization {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -111,6 +114,7 @@ public class Capitalization {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -131,6 +135,7 @@ public class Capitalization {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -151,6 +156,7 @@ public class Capitalization {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Cat.java
@@ -65,6 +65,7 @@ public class Cat extends Animal {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Category.java
@@ -54,6 +54,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -74,6 +75,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ChildWithNullable.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ChildWithNullable.java
@@ -49,6 +49,7 @@ public class ChildWithNullable extends ParentWithNullable {
     return otherProperty;
   }
 
+  @JsonProperty("otherProperty")
   public void setOtherProperty(@Nullable String otherProperty) {
     this.otherProperty = otherProperty;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ClassModel.java
@@ -42,6 +42,7 @@ public class ClassModel {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Client.java
@@ -41,6 +41,7 @@ public class Client {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -104,6 +104,7 @@ public class ContainerDefaultValue {
     return nullableRequiredArray;
   }
 
+  @JsonProperty("nullable_required_array")
   public void setNullableRequiredArray(JsonNullable<List<String>> nullableRequiredArray) {
     this.nullableRequiredArray = nullableRequiredArray;
   }
@@ -132,6 +133,7 @@ public class ContainerDefaultValue {
     return requiredArray;
   }
 
+  @JsonProperty("required_array")
   public void setRequiredArray(List<String> requiredArray) {
     this.requiredArray = requiredArray;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Dog.java
@@ -57,6 +57,7 @@ public class Dog extends Animal {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumArrays.java
@@ -118,6 +118,7 @@ public class EnumArrays {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -146,6 +147,7 @@ public class EnumArrays {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumTest.java
@@ -208,6 +208,7 @@ public class EnumTest {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -228,6 +229,7 @@ public class EnumTest {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -248,6 +250,7 @@ public class EnumTest {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -268,6 +271,7 @@ public class EnumTest {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -288,6 +292,7 @@ public class EnumTest {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(@Nullable OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/File.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/File.java
@@ -42,6 +42,7 @@ public class File {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -48,6 +48,7 @@ public class FileSchemaTestClass {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable File file) {
     this.file = file;
   }
@@ -76,6 +77,7 @@ public class FileSchemaTestClass {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<@Valid File> files) {
     this.files = files;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/FormatTest.java
@@ -93,6 +93,7 @@ public class FormatTest {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -115,6 +116,7 @@ public class FormatTest {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -135,6 +137,7 @@ public class FormatTest {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -157,6 +160,7 @@ public class FormatTest {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -179,6 +183,7 @@ public class FormatTest {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -201,6 +206,7 @@ public class FormatTest {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -221,6 +227,7 @@ public class FormatTest {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -241,6 +248,7 @@ public class FormatTest {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -261,6 +269,7 @@ public class FormatTest {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -281,6 +290,7 @@ public class FormatTest {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -301,6 +311,7 @@ public class FormatTest {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -321,6 +332,7 @@ public class FormatTest {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -341,6 +353,7 @@ public class FormatTest {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -361,6 +374,7 @@ public class FormatTest {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(@Nullable BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -45,6 +45,7 @@ public class HasOnlyReadOnly {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -65,6 +66,7 @@ public class HasOnlyReadOnly {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/MapTest.java
@@ -97,6 +97,7 @@ public class MapTest {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -125,6 +126,7 @@ public class MapTest {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -153,6 +155,7 @@ public class MapTest {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -181,6 +184,7 @@ public class MapTest {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -53,6 +53,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -73,6 +74,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -101,6 +103,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Model200Response.java
@@ -46,6 +46,7 @@ public class Model200Response {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -66,6 +67,7 @@ public class Model200Response {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -47,6 +47,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -67,6 +68,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -87,6 +89,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ModelList.java
@@ -43,6 +43,7 @@ public class ModelList {
     return _123list;
   }
 
+  @JsonProperty("123-list")
   public void set123list(@Nullable String _123list) {
     this._123list = _123list;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ModelReturn.java
@@ -44,6 +44,7 @@ public class ModelReturn {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Name.java
@@ -59,6 +59,7 @@ public class Name {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -79,6 +80,7 @@ public class Name {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -99,6 +101,7 @@ public class Name {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -119,6 +122,7 @@ public class Name {
     return _123number;
   }
 
+  @JsonProperty("123Number")
   public void set123number(@Nullable Integer _123number) {
     this._123number = _123number;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/NumberOnly.java
@@ -42,6 +42,7 @@ public class NumberOnly {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Order.java
@@ -92,6 +92,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -112,6 +113,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -132,6 +134,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -152,6 +155,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -172,6 +176,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -192,6 +197,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/OuterComposite.java
@@ -46,6 +46,7 @@ public class OuterComposite {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -66,6 +67,7 @@ public class OuterComposite {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -86,6 +88,7 @@ public class OuterComposite {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -92,6 +92,7 @@ public class ParentWithNullable {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable TypeEnum type) {
     this.type = type;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Pet.java
@@ -112,6 +112,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -132,6 +133,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -152,6 +154,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -181,6 +184,7 @@ public class Pet {
   }
 
   @JsonDeserialize(as = LinkedHashSet.class)
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -209,6 +213,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -225,8 +230,8 @@ public class Pet {
    */
   
   @ApiModelProperty(value = "pet status in the store")
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -235,6 +240,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -43,6 +43,7 @@ public class ReadOnlyFirst {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -63,6 +64,7 @@ public class ReadOnlyFirst {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
@@ -47,6 +47,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return normalPropertyName;
   }
 
+  @JsonProperty("normalPropertyName")
   public void setNormalPropertyName(@Nullable String normalPropertyName) {
     this.normalPropertyName = normalPropertyName;
   }
@@ -67,6 +68,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return UPPER_CASE_PROPERTY_SNAKE;
   }
 
+  @JsonProperty("UPPER_CASE_PROPERTY_SNAKE")
   public void setUPPERCASEPROPERTYSNAKE(@Nullable String UPPER_CASE_PROPERTY_SNAKE) {
     this.UPPER_CASE_PROPERTY_SNAKE = UPPER_CASE_PROPERTY_SNAKE;
   }
@@ -87,6 +89,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return lowerCasePropertyDashes;
   }
 
+  @JsonProperty("lower-case-property-dashes")
   public void setLowerCasePropertyDashes(@Nullable String lowerCasePropertyDashes) {
     this.lowerCasePropertyDashes = lowerCasePropertyDashes;
   }
@@ -107,6 +110,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return propertyNameWithSpaces;
   }
 
+  @JsonProperty("property name with spaces")
   public void setPropertyNameWithSpaces(@Nullable String propertyNameWithSpaces) {
     this.propertyNameWithSpaces = propertyNameWithSpaces;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -43,6 +43,7 @@ public class SpecialModelName {
     return $specialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -69,6 +69,7 @@ public class TypeHolderDefault {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -89,6 +90,7 @@ public class TypeHolderDefault {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -109,6 +111,7 @@ public class TypeHolderDefault {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -129,6 +132,7 @@ public class TypeHolderDefault {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -157,6 +161,7 @@ public class TypeHolderDefault {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -72,6 +72,7 @@ public class TypeHolderExample {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -92,6 +93,7 @@ public class TypeHolderExample {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -112,6 +114,7 @@ public class TypeHolderExample {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -132,6 +135,7 @@ public class TypeHolderExample {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -152,6 +156,7 @@ public class TypeHolderExample {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -180,6 +185,7 @@ public class TypeHolderExample {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/User.java
@@ -55,6 +55,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -75,6 +76,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -95,6 +97,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -115,6 +118,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -135,6 +139,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -155,6 +160,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -175,6 +181,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -195,6 +202,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/XmlItem.java
@@ -110,6 +110,7 @@ public class XmlItem {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(@Nullable String attributeString) {
     this.attributeString = attributeString;
   }
@@ -130,6 +131,7 @@ public class XmlItem {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(@Nullable BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -150,6 +152,7 @@ public class XmlItem {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(@Nullable Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -170,6 +173,7 @@ public class XmlItem {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(@Nullable Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -198,6 +202,7 @@ public class XmlItem {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -218,6 +223,7 @@ public class XmlItem {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(@Nullable String nameString) {
     this.nameString = nameString;
   }
@@ -238,6 +244,7 @@ public class XmlItem {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(@Nullable BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -258,6 +265,7 @@ public class XmlItem {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(@Nullable Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -278,6 +286,7 @@ public class XmlItem {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(@Nullable Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -306,6 +315,7 @@ public class XmlItem {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -334,6 +344,7 @@ public class XmlItem {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -354,6 +365,7 @@ public class XmlItem {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(@Nullable String prefixString) {
     this.prefixString = prefixString;
   }
@@ -374,6 +386,7 @@ public class XmlItem {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(@Nullable BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -394,6 +407,7 @@ public class XmlItem {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(@Nullable Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -414,6 +428,7 @@ public class XmlItem {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(@Nullable Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -442,6 +457,7 @@ public class XmlItem {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -470,6 +486,7 @@ public class XmlItem {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -490,6 +507,7 @@ public class XmlItem {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(@Nullable String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -510,6 +528,7 @@ public class XmlItem {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(@Nullable BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -530,6 +549,7 @@ public class XmlItem {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(@Nullable Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -550,6 +570,7 @@ public class XmlItem {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(@Nullable Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -578,6 +599,7 @@ public class XmlItem {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -606,6 +628,7 @@ public class XmlItem {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -626,6 +649,7 @@ public class XmlItem {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(@Nullable String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -646,6 +670,7 @@ public class XmlItem {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(@Nullable BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -666,6 +691,7 @@ public class XmlItem {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(@Nullable Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -686,6 +712,7 @@ public class XmlItem {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(@Nullable Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -714,6 +741,7 @@ public class XmlItem {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -742,6 +770,7 @@ public class XmlItem {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesAnyType {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesArray {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesBoolean {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -81,6 +81,7 @@ public class AdditionalPropertiesClass {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -109,6 +110,7 @@ public class AdditionalPropertiesClass {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -137,6 +139,7 @@ public class AdditionalPropertiesClass {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -165,6 +168,7 @@ public class AdditionalPropertiesClass {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -193,6 +197,7 @@ public class AdditionalPropertiesClass {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -221,6 +226,7 @@ public class AdditionalPropertiesClass {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -249,6 +255,7 @@ public class AdditionalPropertiesClass {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -277,6 +284,7 @@ public class AdditionalPropertiesClass {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -297,6 +305,7 @@ public class AdditionalPropertiesClass {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(@Nullable Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -317,6 +326,7 @@ public class AdditionalPropertiesClass {
     return anytype2;
   }
 
+  @JsonProperty("anytype_2")
   public void setAnytype2(@Nullable Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -337,6 +347,7 @@ public class AdditionalPropertiesClass {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(@Nullable Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesInteger {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesNumber {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesObject {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesString {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Animal.java
@@ -67,6 +67,7 @@ public class Animal {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -87,6 +88,7 @@ public class Animal {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -54,6 +54,7 @@ public class ArrayOfArrayOfNumberOnly {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -54,6 +54,7 @@ public class ArrayOfNumberOnly {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/ArrayTest.java
@@ -60,6 +60,7 @@ public class ArrayTest {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -88,6 +89,7 @@ public class ArrayTest {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -116,6 +118,7 @@ public class ArrayTest {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Capitalization.java
@@ -51,6 +51,7 @@ public class Capitalization {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -71,6 +72,7 @@ public class Capitalization {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -91,6 +93,7 @@ public class Capitalization {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -111,6 +114,7 @@ public class Capitalization {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -131,6 +135,7 @@ public class Capitalization {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -151,6 +156,7 @@ public class Capitalization {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Cat.java
@@ -57,6 +57,7 @@ public class Cat extends Animal {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Category.java
@@ -54,6 +54,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -74,6 +75,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/ClassModel.java
@@ -42,6 +42,7 @@ public class ClassModel {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Client.java
@@ -41,6 +41,7 @@ public class Client {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Dog.java
@@ -57,6 +57,7 @@ public class Dog extends Animal {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/EnumArrays.java
@@ -118,6 +118,7 @@ public class EnumArrays {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -146,6 +147,7 @@ public class EnumArrays {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/EnumTest.java
@@ -208,6 +208,7 @@ public class EnumTest {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -228,6 +229,7 @@ public class EnumTest {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -248,6 +250,7 @@ public class EnumTest {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -268,6 +271,7 @@ public class EnumTest {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -288,6 +292,7 @@ public class EnumTest {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(@Nullable OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/File.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/File.java
@@ -42,6 +42,7 @@ public class File {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -48,6 +48,7 @@ public class FileSchemaTestClass {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable File file) {
     this.file = file;
   }
@@ -76,6 +77,7 @@ public class FileSchemaTestClass {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<@Valid File> files) {
     this.files = files;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/FormatTest.java
@@ -93,6 +93,7 @@ public class FormatTest {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -115,6 +116,7 @@ public class FormatTest {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -135,6 +137,7 @@ public class FormatTest {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -157,6 +160,7 @@ public class FormatTest {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -179,6 +183,7 @@ public class FormatTest {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -201,6 +206,7 @@ public class FormatTest {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -221,6 +227,7 @@ public class FormatTest {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -241,6 +248,7 @@ public class FormatTest {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -261,6 +269,7 @@ public class FormatTest {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -281,6 +290,7 @@ public class FormatTest {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -301,6 +311,7 @@ public class FormatTest {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -321,6 +332,7 @@ public class FormatTest {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -341,6 +353,7 @@ public class FormatTest {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -361,6 +374,7 @@ public class FormatTest {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(@Nullable BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -45,6 +45,7 @@ public class HasOnlyReadOnly {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -65,6 +66,7 @@ public class HasOnlyReadOnly {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/MapTest.java
@@ -97,6 +97,7 @@ public class MapTest {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -125,6 +126,7 @@ public class MapTest {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -153,6 +155,7 @@ public class MapTest {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -181,6 +184,7 @@ public class MapTest {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -53,6 +53,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -73,6 +74,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -101,6 +103,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Model200Response.java
@@ -46,6 +46,7 @@ public class Model200Response {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -66,6 +67,7 @@ public class Model200Response {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -47,6 +47,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -67,6 +68,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -87,6 +89,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/ModelList.java
@@ -43,6 +43,7 @@ public class ModelList {
     return _123list;
   }
 
+  @JsonProperty("123-list")
   public void set123list(@Nullable String _123list) {
     this._123list = _123list;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/ModelReturn.java
@@ -44,6 +44,7 @@ public class ModelReturn {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Name.java
@@ -59,6 +59,7 @@ public class Name {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -79,6 +80,7 @@ public class Name {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -99,6 +101,7 @@ public class Name {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -119,6 +122,7 @@ public class Name {
     return _123number;
   }
 
+  @JsonProperty("123Number")
   public void set123number(@Nullable Integer _123number) {
     this._123number = _123number;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/NumberOnly.java
@@ -42,6 +42,7 @@ public class NumberOnly {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Order.java
@@ -92,6 +92,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -112,6 +113,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -132,6 +134,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -152,6 +155,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -172,6 +176,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -192,6 +197,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/OuterComposite.java
@@ -46,6 +46,7 @@ public class OuterComposite {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -66,6 +67,7 @@ public class OuterComposite {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -86,6 +88,7 @@ public class OuterComposite {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Pet.java
@@ -108,6 +108,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -128,6 +129,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -148,6 +150,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -176,6 +179,7 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -204,6 +208,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -224,6 +229,7 @@ public class Pet {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -43,6 +43,7 @@ public class ReadOnlyFirst {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -63,6 +64,7 @@ public class ReadOnlyFirst {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -43,6 +43,7 @@ public class SpecialModelName {
     return $specialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -69,6 +69,7 @@ public class TypeHolderDefault {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -89,6 +90,7 @@ public class TypeHolderDefault {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -109,6 +111,7 @@ public class TypeHolderDefault {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -129,6 +132,7 @@ public class TypeHolderDefault {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -157,6 +161,7 @@ public class TypeHolderDefault {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -72,6 +72,7 @@ public class TypeHolderExample {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -92,6 +93,7 @@ public class TypeHolderExample {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -112,6 +114,7 @@ public class TypeHolderExample {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -132,6 +135,7 @@ public class TypeHolderExample {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -152,6 +156,7 @@ public class TypeHolderExample {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -180,6 +185,7 @@ public class TypeHolderExample {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/User.java
@@ -55,6 +55,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -75,6 +76,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -95,6 +97,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -115,6 +118,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -135,6 +139,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -155,6 +160,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -175,6 +181,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -195,6 +202,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/XmlItem.java
@@ -110,6 +110,7 @@ public class XmlItem {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(@Nullable String attributeString) {
     this.attributeString = attributeString;
   }
@@ -130,6 +131,7 @@ public class XmlItem {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(@Nullable BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -150,6 +152,7 @@ public class XmlItem {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(@Nullable Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -170,6 +173,7 @@ public class XmlItem {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(@Nullable Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -198,6 +202,7 @@ public class XmlItem {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -218,6 +223,7 @@ public class XmlItem {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(@Nullable String nameString) {
     this.nameString = nameString;
   }
@@ -238,6 +244,7 @@ public class XmlItem {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(@Nullable BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -258,6 +265,7 @@ public class XmlItem {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(@Nullable Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -278,6 +286,7 @@ public class XmlItem {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(@Nullable Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -306,6 +315,7 @@ public class XmlItem {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -334,6 +344,7 @@ public class XmlItem {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -354,6 +365,7 @@ public class XmlItem {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(@Nullable String prefixString) {
     this.prefixString = prefixString;
   }
@@ -374,6 +386,7 @@ public class XmlItem {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(@Nullable BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -394,6 +407,7 @@ public class XmlItem {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(@Nullable Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -414,6 +428,7 @@ public class XmlItem {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(@Nullable Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -442,6 +457,7 @@ public class XmlItem {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -470,6 +486,7 @@ public class XmlItem {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -490,6 +507,7 @@ public class XmlItem {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(@Nullable String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -510,6 +528,7 @@ public class XmlItem {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(@Nullable BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -530,6 +549,7 @@ public class XmlItem {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(@Nullable Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -550,6 +570,7 @@ public class XmlItem {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(@Nullable Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -578,6 +599,7 @@ public class XmlItem {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -606,6 +628,7 @@ public class XmlItem {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -626,6 +649,7 @@ public class XmlItem {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(@Nullable String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -646,6 +670,7 @@ public class XmlItem {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(@Nullable BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -666,6 +691,7 @@ public class XmlItem {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(@Nullable Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -686,6 +712,7 @@ public class XmlItem {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(@Nullable Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -714,6 +741,7 @@ public class XmlItem {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -742,6 +770,7 @@ public class XmlItem {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesAnyType {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesArray {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesBoolean {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -81,6 +81,7 @@ public class AdditionalPropertiesClass {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -109,6 +110,7 @@ public class AdditionalPropertiesClass {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -137,6 +139,7 @@ public class AdditionalPropertiesClass {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -165,6 +168,7 @@ public class AdditionalPropertiesClass {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -193,6 +197,7 @@ public class AdditionalPropertiesClass {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -221,6 +226,7 @@ public class AdditionalPropertiesClass {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -249,6 +255,7 @@ public class AdditionalPropertiesClass {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -277,6 +284,7 @@ public class AdditionalPropertiesClass {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -297,6 +305,7 @@ public class AdditionalPropertiesClass {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(@Nullable Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -317,6 +326,7 @@ public class AdditionalPropertiesClass {
     return anytype2;
   }
 
+  @JsonProperty("anytype_2")
   public void setAnytype2(@Nullable Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -337,6 +347,7 @@ public class AdditionalPropertiesClass {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(@Nullable Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesInteger {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesNumber {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesObject {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesString {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Animal.java
@@ -67,6 +67,7 @@ public class Animal {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -87,6 +88,7 @@ public class Animal {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -54,6 +54,7 @@ public class ArrayOfArrayOfNumberOnly {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -54,6 +54,7 @@ public class ArrayOfNumberOnly {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/ArrayTest.java
@@ -60,6 +60,7 @@ public class ArrayTest {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -88,6 +89,7 @@ public class ArrayTest {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -116,6 +118,7 @@ public class ArrayTest {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Capitalization.java
@@ -51,6 +51,7 @@ public class Capitalization {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -71,6 +72,7 @@ public class Capitalization {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -91,6 +93,7 @@ public class Capitalization {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -111,6 +114,7 @@ public class Capitalization {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -131,6 +135,7 @@ public class Capitalization {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -151,6 +156,7 @@ public class Capitalization {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Cat.java
@@ -57,6 +57,7 @@ public class Cat extends Animal {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Category.java
@@ -54,6 +54,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -74,6 +75,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/ClassModel.java
@@ -42,6 +42,7 @@ public class ClassModel {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Client.java
@@ -41,6 +41,7 @@ public class Client {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Dog.java
@@ -57,6 +57,7 @@ public class Dog extends Animal {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/EnumArrays.java
@@ -118,6 +118,7 @@ public class EnumArrays {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -146,6 +147,7 @@ public class EnumArrays {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/EnumTest.java
@@ -208,6 +208,7 @@ public class EnumTest {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -228,6 +229,7 @@ public class EnumTest {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -248,6 +250,7 @@ public class EnumTest {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -268,6 +271,7 @@ public class EnumTest {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -288,6 +292,7 @@ public class EnumTest {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(@Nullable OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/File.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/File.java
@@ -42,6 +42,7 @@ public class File {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -48,6 +48,7 @@ public class FileSchemaTestClass {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable File file) {
     this.file = file;
   }
@@ -76,6 +77,7 @@ public class FileSchemaTestClass {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<@Valid File> files) {
     this.files = files;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/FormatTest.java
@@ -93,6 +93,7 @@ public class FormatTest {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -115,6 +116,7 @@ public class FormatTest {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -135,6 +137,7 @@ public class FormatTest {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -157,6 +160,7 @@ public class FormatTest {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -179,6 +183,7 @@ public class FormatTest {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -201,6 +206,7 @@ public class FormatTest {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -221,6 +227,7 @@ public class FormatTest {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -241,6 +248,7 @@ public class FormatTest {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -261,6 +269,7 @@ public class FormatTest {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -281,6 +290,7 @@ public class FormatTest {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -301,6 +311,7 @@ public class FormatTest {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -321,6 +332,7 @@ public class FormatTest {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -341,6 +353,7 @@ public class FormatTest {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -361,6 +374,7 @@ public class FormatTest {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(@Nullable BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -45,6 +45,7 @@ public class HasOnlyReadOnly {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -65,6 +66,7 @@ public class HasOnlyReadOnly {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/MapTest.java
@@ -97,6 +97,7 @@ public class MapTest {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -125,6 +126,7 @@ public class MapTest {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -153,6 +155,7 @@ public class MapTest {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -181,6 +184,7 @@ public class MapTest {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -53,6 +53,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -73,6 +74,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -101,6 +103,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Model200Response.java
@@ -46,6 +46,7 @@ public class Model200Response {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -66,6 +67,7 @@ public class Model200Response {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -47,6 +47,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -67,6 +68,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -87,6 +89,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/ModelList.java
@@ -43,6 +43,7 @@ public class ModelList {
     return _123list;
   }
 
+  @JsonProperty("123-list")
   public void set123list(@Nullable String _123list) {
     this._123list = _123list;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/ModelReturn.java
@@ -44,6 +44,7 @@ public class ModelReturn {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Name.java
@@ -59,6 +59,7 @@ public class Name {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -79,6 +80,7 @@ public class Name {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -99,6 +101,7 @@ public class Name {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -119,6 +122,7 @@ public class Name {
     return _123number;
   }
 
+  @JsonProperty("123Number")
   public void set123number(@Nullable Integer _123number) {
     this._123number = _123number;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/NumberOnly.java
@@ -42,6 +42,7 @@ public class NumberOnly {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Order.java
@@ -92,6 +92,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -112,6 +113,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -132,6 +134,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -152,6 +155,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -172,6 +176,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -192,6 +197,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/OuterComposite.java
@@ -46,6 +46,7 @@ public class OuterComposite {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -66,6 +67,7 @@ public class OuterComposite {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -86,6 +88,7 @@ public class OuterComposite {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Pet.java
@@ -108,6 +108,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -128,6 +129,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -148,6 +150,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -176,6 +179,7 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -204,6 +208,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -224,6 +229,7 @@ public class Pet {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -43,6 +43,7 @@ public class ReadOnlyFirst {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -63,6 +64,7 @@ public class ReadOnlyFirst {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -43,6 +43,7 @@ public class SpecialModelName {
     return $specialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -69,6 +69,7 @@ public class TypeHolderDefault {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -89,6 +90,7 @@ public class TypeHolderDefault {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -109,6 +111,7 @@ public class TypeHolderDefault {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -129,6 +132,7 @@ public class TypeHolderDefault {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -157,6 +161,7 @@ public class TypeHolderDefault {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -72,6 +72,7 @@ public class TypeHolderExample {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -92,6 +93,7 @@ public class TypeHolderExample {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -112,6 +114,7 @@ public class TypeHolderExample {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -132,6 +135,7 @@ public class TypeHolderExample {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -152,6 +156,7 @@ public class TypeHolderExample {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -180,6 +185,7 @@ public class TypeHolderExample {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/User.java
@@ -55,6 +55,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -75,6 +76,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -95,6 +97,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -115,6 +118,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -135,6 +139,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -155,6 +160,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -175,6 +181,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -195,6 +202,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/XmlItem.java
@@ -110,6 +110,7 @@ public class XmlItem {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(@Nullable String attributeString) {
     this.attributeString = attributeString;
   }
@@ -130,6 +131,7 @@ public class XmlItem {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(@Nullable BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -150,6 +152,7 @@ public class XmlItem {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(@Nullable Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -170,6 +173,7 @@ public class XmlItem {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(@Nullable Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -198,6 +202,7 @@ public class XmlItem {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -218,6 +223,7 @@ public class XmlItem {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(@Nullable String nameString) {
     this.nameString = nameString;
   }
@@ -238,6 +244,7 @@ public class XmlItem {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(@Nullable BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -258,6 +265,7 @@ public class XmlItem {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(@Nullable Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -278,6 +286,7 @@ public class XmlItem {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(@Nullable Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -306,6 +315,7 @@ public class XmlItem {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -334,6 +344,7 @@ public class XmlItem {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -354,6 +365,7 @@ public class XmlItem {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(@Nullable String prefixString) {
     this.prefixString = prefixString;
   }
@@ -374,6 +386,7 @@ public class XmlItem {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(@Nullable BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -394,6 +407,7 @@ public class XmlItem {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(@Nullable Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -414,6 +428,7 @@ public class XmlItem {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(@Nullable Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -442,6 +457,7 @@ public class XmlItem {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -470,6 +486,7 @@ public class XmlItem {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -490,6 +507,7 @@ public class XmlItem {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(@Nullable String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -510,6 +528,7 @@ public class XmlItem {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(@Nullable BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -530,6 +549,7 @@ public class XmlItem {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(@Nullable Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -550,6 +570,7 @@ public class XmlItem {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(@Nullable Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -578,6 +599,7 @@ public class XmlItem {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -606,6 +628,7 @@ public class XmlItem {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -626,6 +649,7 @@ public class XmlItem {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(@Nullable String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -646,6 +670,7 @@ public class XmlItem {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(@Nullable BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -666,6 +691,7 @@ public class XmlItem {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(@Nullable Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -686,6 +712,7 @@ public class XmlItem {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(@Nullable Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -714,6 +741,7 @@ public class XmlItem {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -742,6 +770,7 @@ public class XmlItem {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesAnyType {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesArray {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesBoolean {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -81,6 +81,7 @@ public class AdditionalPropertiesClass {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -109,6 +110,7 @@ public class AdditionalPropertiesClass {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -137,6 +139,7 @@ public class AdditionalPropertiesClass {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -165,6 +168,7 @@ public class AdditionalPropertiesClass {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -193,6 +197,7 @@ public class AdditionalPropertiesClass {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -221,6 +226,7 @@ public class AdditionalPropertiesClass {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -249,6 +255,7 @@ public class AdditionalPropertiesClass {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -277,6 +284,7 @@ public class AdditionalPropertiesClass {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -297,6 +305,7 @@ public class AdditionalPropertiesClass {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(@Nullable Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -317,6 +326,7 @@ public class AdditionalPropertiesClass {
     return anytype2;
   }
 
+  @JsonProperty("anytype_2")
   public void setAnytype2(@Nullable Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -337,6 +347,7 @@ public class AdditionalPropertiesClass {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(@Nullable Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesInteger {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesNumber {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesObject {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesString {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Animal.java
@@ -67,6 +67,7 @@ public class Animal {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -87,6 +88,7 @@ public class Animal {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -54,6 +54,7 @@ public class ArrayOfArrayOfNumberOnly {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -54,6 +54,7 @@ public class ArrayOfNumberOnly {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/ArrayTest.java
@@ -60,6 +60,7 @@ public class ArrayTest {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -88,6 +89,7 @@ public class ArrayTest {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -116,6 +118,7 @@ public class ArrayTest {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Capitalization.java
@@ -51,6 +51,7 @@ public class Capitalization {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -71,6 +72,7 @@ public class Capitalization {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -91,6 +93,7 @@ public class Capitalization {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -111,6 +114,7 @@ public class Capitalization {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -131,6 +135,7 @@ public class Capitalization {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -151,6 +156,7 @@ public class Capitalization {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Cat.java
@@ -57,6 +57,7 @@ public class Cat extends Animal {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Category.java
@@ -54,6 +54,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -74,6 +75,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/ClassModel.java
@@ -42,6 +42,7 @@ public class ClassModel {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Client.java
@@ -41,6 +41,7 @@ public class Client {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Dog.java
@@ -57,6 +57,7 @@ public class Dog extends Animal {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/EnumArrays.java
@@ -118,6 +118,7 @@ public class EnumArrays {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -146,6 +147,7 @@ public class EnumArrays {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/EnumTest.java
@@ -208,6 +208,7 @@ public class EnumTest {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -228,6 +229,7 @@ public class EnumTest {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -248,6 +250,7 @@ public class EnumTest {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -268,6 +271,7 @@ public class EnumTest {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -288,6 +292,7 @@ public class EnumTest {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(@Nullable OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/File.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/File.java
@@ -42,6 +42,7 @@ public class File {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -48,6 +48,7 @@ public class FileSchemaTestClass {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable File file) {
     this.file = file;
   }
@@ -76,6 +77,7 @@ public class FileSchemaTestClass {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<@Valid File> files) {
     this.files = files;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/FormatTest.java
@@ -93,6 +93,7 @@ public class FormatTest {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -115,6 +116,7 @@ public class FormatTest {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -135,6 +137,7 @@ public class FormatTest {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -157,6 +160,7 @@ public class FormatTest {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -179,6 +183,7 @@ public class FormatTest {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -201,6 +206,7 @@ public class FormatTest {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -221,6 +227,7 @@ public class FormatTest {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -241,6 +248,7 @@ public class FormatTest {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -261,6 +269,7 @@ public class FormatTest {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -281,6 +290,7 @@ public class FormatTest {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -301,6 +311,7 @@ public class FormatTest {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -321,6 +332,7 @@ public class FormatTest {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -341,6 +353,7 @@ public class FormatTest {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -361,6 +374,7 @@ public class FormatTest {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(@Nullable BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -45,6 +45,7 @@ public class HasOnlyReadOnly {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -65,6 +66,7 @@ public class HasOnlyReadOnly {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/MapTest.java
@@ -97,6 +97,7 @@ public class MapTest {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -125,6 +126,7 @@ public class MapTest {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -153,6 +155,7 @@ public class MapTest {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -181,6 +184,7 @@ public class MapTest {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -53,6 +53,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -73,6 +74,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -101,6 +103,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Model200Response.java
@@ -46,6 +46,7 @@ public class Model200Response {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -66,6 +67,7 @@ public class Model200Response {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -47,6 +47,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -67,6 +68,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -87,6 +89,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/ModelList.java
@@ -43,6 +43,7 @@ public class ModelList {
     return _123list;
   }
 
+  @JsonProperty("123-list")
   public void set123list(@Nullable String _123list) {
     this._123list = _123list;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/ModelReturn.java
@@ -44,6 +44,7 @@ public class ModelReturn {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Name.java
@@ -59,6 +59,7 @@ public class Name {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -79,6 +80,7 @@ public class Name {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -99,6 +101,7 @@ public class Name {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -119,6 +122,7 @@ public class Name {
     return _123number;
   }
 
+  @JsonProperty("123Number")
   public void set123number(@Nullable Integer _123number) {
     this._123number = _123number;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/NumberOnly.java
@@ -42,6 +42,7 @@ public class NumberOnly {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Order.java
@@ -92,6 +92,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -112,6 +113,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -132,6 +134,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -152,6 +155,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -172,6 +176,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -192,6 +197,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/OuterComposite.java
@@ -46,6 +46,7 @@ public class OuterComposite {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -66,6 +67,7 @@ public class OuterComposite {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -86,6 +88,7 @@ public class OuterComposite {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Pet.java
@@ -108,6 +108,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -128,6 +129,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -148,6 +150,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -176,6 +179,7 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -204,6 +208,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -224,6 +229,7 @@ public class Pet {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -43,6 +43,7 @@ public class ReadOnlyFirst {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -63,6 +64,7 @@ public class ReadOnlyFirst {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -43,6 +43,7 @@ public class SpecialModelName {
     return $specialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -69,6 +69,7 @@ public class TypeHolderDefault {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -89,6 +90,7 @@ public class TypeHolderDefault {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -109,6 +111,7 @@ public class TypeHolderDefault {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -129,6 +132,7 @@ public class TypeHolderDefault {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -157,6 +161,7 @@ public class TypeHolderDefault {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -72,6 +72,7 @@ public class TypeHolderExample {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -92,6 +93,7 @@ public class TypeHolderExample {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -112,6 +114,7 @@ public class TypeHolderExample {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -132,6 +135,7 @@ public class TypeHolderExample {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -152,6 +156,7 @@ public class TypeHolderExample {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -180,6 +185,7 @@ public class TypeHolderExample {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/User.java
@@ -55,6 +55,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -75,6 +76,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -95,6 +97,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -115,6 +118,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -135,6 +139,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -155,6 +160,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -175,6 +181,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -195,6 +202,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/XmlItem.java
@@ -110,6 +110,7 @@ public class XmlItem {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(@Nullable String attributeString) {
     this.attributeString = attributeString;
   }
@@ -130,6 +131,7 @@ public class XmlItem {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(@Nullable BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -150,6 +152,7 @@ public class XmlItem {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(@Nullable Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -170,6 +173,7 @@ public class XmlItem {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(@Nullable Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -198,6 +202,7 @@ public class XmlItem {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -218,6 +223,7 @@ public class XmlItem {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(@Nullable String nameString) {
     this.nameString = nameString;
   }
@@ -238,6 +244,7 @@ public class XmlItem {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(@Nullable BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -258,6 +265,7 @@ public class XmlItem {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(@Nullable Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -278,6 +286,7 @@ public class XmlItem {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(@Nullable Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -306,6 +315,7 @@ public class XmlItem {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -334,6 +344,7 @@ public class XmlItem {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -354,6 +365,7 @@ public class XmlItem {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(@Nullable String prefixString) {
     this.prefixString = prefixString;
   }
@@ -374,6 +386,7 @@ public class XmlItem {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(@Nullable BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -394,6 +407,7 @@ public class XmlItem {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(@Nullable Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -414,6 +428,7 @@ public class XmlItem {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(@Nullable Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -442,6 +457,7 @@ public class XmlItem {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -470,6 +486,7 @@ public class XmlItem {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -490,6 +507,7 @@ public class XmlItem {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(@Nullable String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -510,6 +528,7 @@ public class XmlItem {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(@Nullable BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -530,6 +549,7 @@ public class XmlItem {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(@Nullable Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -550,6 +570,7 @@ public class XmlItem {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(@Nullable Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -578,6 +599,7 @@ public class XmlItem {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -606,6 +628,7 @@ public class XmlItem {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -626,6 +649,7 @@ public class XmlItem {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(@Nullable String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -646,6 +670,7 @@ public class XmlItem {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(@Nullable BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -666,6 +691,7 @@ public class XmlItem {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(@Nullable Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -686,6 +712,7 @@ public class XmlItem {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(@Nullable Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -714,6 +741,7 @@ public class XmlItem {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -742,6 +770,7 @@ public class XmlItem {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesAnyType {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesArray {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesBoolean {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -81,6 +81,7 @@ public class AdditionalPropertiesClass {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -109,6 +110,7 @@ public class AdditionalPropertiesClass {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -137,6 +139,7 @@ public class AdditionalPropertiesClass {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -165,6 +168,7 @@ public class AdditionalPropertiesClass {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -193,6 +197,7 @@ public class AdditionalPropertiesClass {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -221,6 +226,7 @@ public class AdditionalPropertiesClass {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -249,6 +255,7 @@ public class AdditionalPropertiesClass {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -277,6 +284,7 @@ public class AdditionalPropertiesClass {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -297,6 +305,7 @@ public class AdditionalPropertiesClass {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(@Nullable Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -317,6 +326,7 @@ public class AdditionalPropertiesClass {
     return anytype2;
   }
 
+  @JsonProperty("anytype_2")
   public void setAnytype2(@Nullable Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -337,6 +347,7 @@ public class AdditionalPropertiesClass {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(@Nullable Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesInteger {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesNumber {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesObject {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesString {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Animal.java
@@ -67,6 +67,7 @@ public class Animal {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -87,6 +88,7 @@ public class Animal {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -54,6 +54,7 @@ public class ArrayOfArrayOfNumberOnly {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -54,6 +54,7 @@ public class ArrayOfNumberOnly {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/ArrayTest.java
@@ -60,6 +60,7 @@ public class ArrayTest {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -88,6 +89,7 @@ public class ArrayTest {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -116,6 +118,7 @@ public class ArrayTest {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Capitalization.java
@@ -51,6 +51,7 @@ public class Capitalization {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -71,6 +72,7 @@ public class Capitalization {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -91,6 +93,7 @@ public class Capitalization {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -111,6 +114,7 @@ public class Capitalization {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -131,6 +135,7 @@ public class Capitalization {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -151,6 +156,7 @@ public class Capitalization {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Cat.java
@@ -57,6 +57,7 @@ public class Cat extends Animal {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Category.java
@@ -54,6 +54,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -74,6 +75,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/ClassModel.java
@@ -42,6 +42,7 @@ public class ClassModel {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Client.java
@@ -41,6 +41,7 @@ public class Client {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Dog.java
@@ -57,6 +57,7 @@ public class Dog extends Animal {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/EnumArrays.java
@@ -118,6 +118,7 @@ public class EnumArrays {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -146,6 +147,7 @@ public class EnumArrays {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/EnumTest.java
@@ -208,6 +208,7 @@ public class EnumTest {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -228,6 +229,7 @@ public class EnumTest {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -248,6 +250,7 @@ public class EnumTest {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -268,6 +271,7 @@ public class EnumTest {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -288,6 +292,7 @@ public class EnumTest {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(@Nullable OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/File.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/File.java
@@ -42,6 +42,7 @@ public class File {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -48,6 +48,7 @@ public class FileSchemaTestClass {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable File file) {
     this.file = file;
   }
@@ -76,6 +77,7 @@ public class FileSchemaTestClass {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<@Valid File> files) {
     this.files = files;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/FormatTest.java
@@ -93,6 +93,7 @@ public class FormatTest {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -115,6 +116,7 @@ public class FormatTest {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -135,6 +137,7 @@ public class FormatTest {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -157,6 +160,7 @@ public class FormatTest {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -179,6 +183,7 @@ public class FormatTest {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -201,6 +206,7 @@ public class FormatTest {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -221,6 +227,7 @@ public class FormatTest {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -241,6 +248,7 @@ public class FormatTest {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -261,6 +269,7 @@ public class FormatTest {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -281,6 +290,7 @@ public class FormatTest {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -301,6 +311,7 @@ public class FormatTest {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -321,6 +332,7 @@ public class FormatTest {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -341,6 +353,7 @@ public class FormatTest {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -361,6 +374,7 @@ public class FormatTest {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(@Nullable BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -45,6 +45,7 @@ public class HasOnlyReadOnly {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -65,6 +66,7 @@ public class HasOnlyReadOnly {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/MapTest.java
@@ -97,6 +97,7 @@ public class MapTest {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -125,6 +126,7 @@ public class MapTest {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -153,6 +155,7 @@ public class MapTest {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -181,6 +184,7 @@ public class MapTest {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -53,6 +53,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -73,6 +74,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -101,6 +103,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Model200Response.java
@@ -46,6 +46,7 @@ public class Model200Response {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -66,6 +67,7 @@ public class Model200Response {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -47,6 +47,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -67,6 +68,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -87,6 +89,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/ModelList.java
@@ -43,6 +43,7 @@ public class ModelList {
     return _123list;
   }
 
+  @JsonProperty("123-list")
   public void set123list(@Nullable String _123list) {
     this._123list = _123list;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/ModelReturn.java
@@ -44,6 +44,7 @@ public class ModelReturn {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Name.java
@@ -59,6 +59,7 @@ public class Name {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -79,6 +80,7 @@ public class Name {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -99,6 +101,7 @@ public class Name {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -119,6 +122,7 @@ public class Name {
     return _123number;
   }
 
+  @JsonProperty("123Number")
   public void set123number(@Nullable Integer _123number) {
     this._123number = _123number;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/NumberOnly.java
@@ -42,6 +42,7 @@ public class NumberOnly {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Order.java
@@ -92,6 +92,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -112,6 +113,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -132,6 +134,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -152,6 +155,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -172,6 +176,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -192,6 +197,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/OuterComposite.java
@@ -46,6 +46,7 @@ public class OuterComposite {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -66,6 +67,7 @@ public class OuterComposite {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -86,6 +88,7 @@ public class OuterComposite {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Pet.java
@@ -108,6 +108,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -128,6 +129,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -148,6 +150,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -176,6 +179,7 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -204,6 +208,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -224,6 +229,7 @@ public class Pet {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -43,6 +43,7 @@ public class ReadOnlyFirst {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -63,6 +64,7 @@ public class ReadOnlyFirst {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -43,6 +43,7 @@ public class SpecialModelName {
     return $specialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -69,6 +69,7 @@ public class TypeHolderDefault {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -89,6 +90,7 @@ public class TypeHolderDefault {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -109,6 +111,7 @@ public class TypeHolderDefault {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -129,6 +132,7 @@ public class TypeHolderDefault {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -157,6 +161,7 @@ public class TypeHolderDefault {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -72,6 +72,7 @@ public class TypeHolderExample {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -92,6 +93,7 @@ public class TypeHolderExample {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -112,6 +114,7 @@ public class TypeHolderExample {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -132,6 +135,7 @@ public class TypeHolderExample {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -152,6 +156,7 @@ public class TypeHolderExample {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -180,6 +185,7 @@ public class TypeHolderExample {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/User.java
@@ -55,6 +55,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -75,6 +76,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -95,6 +97,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -115,6 +118,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -135,6 +139,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -155,6 +160,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -175,6 +181,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -195,6 +202,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/XmlItem.java
@@ -110,6 +110,7 @@ public class XmlItem {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(@Nullable String attributeString) {
     this.attributeString = attributeString;
   }
@@ -130,6 +131,7 @@ public class XmlItem {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(@Nullable BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -150,6 +152,7 @@ public class XmlItem {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(@Nullable Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -170,6 +173,7 @@ public class XmlItem {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(@Nullable Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -198,6 +202,7 @@ public class XmlItem {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -218,6 +223,7 @@ public class XmlItem {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(@Nullable String nameString) {
     this.nameString = nameString;
   }
@@ -238,6 +244,7 @@ public class XmlItem {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(@Nullable BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -258,6 +265,7 @@ public class XmlItem {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(@Nullable Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -278,6 +286,7 @@ public class XmlItem {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(@Nullable Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -306,6 +315,7 @@ public class XmlItem {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -334,6 +344,7 @@ public class XmlItem {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -354,6 +365,7 @@ public class XmlItem {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(@Nullable String prefixString) {
     this.prefixString = prefixString;
   }
@@ -374,6 +386,7 @@ public class XmlItem {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(@Nullable BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -394,6 +407,7 @@ public class XmlItem {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(@Nullable Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -414,6 +428,7 @@ public class XmlItem {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(@Nullable Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -442,6 +457,7 @@ public class XmlItem {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -470,6 +486,7 @@ public class XmlItem {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -490,6 +507,7 @@ public class XmlItem {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(@Nullable String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -510,6 +528,7 @@ public class XmlItem {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(@Nullable BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -530,6 +549,7 @@ public class XmlItem {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(@Nullable Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -550,6 +570,7 @@ public class XmlItem {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(@Nullable Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -578,6 +599,7 @@ public class XmlItem {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -606,6 +628,7 @@ public class XmlItem {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -626,6 +649,7 @@ public class XmlItem {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(@Nullable String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -646,6 +670,7 @@ public class XmlItem {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(@Nullable BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -666,6 +691,7 @@ public class XmlItem {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(@Nullable Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -686,6 +712,7 @@ public class XmlItem {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(@Nullable Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -714,6 +741,7 @@ public class XmlItem {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -742,6 +770,7 @@ public class XmlItem {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/server/petstore/springboot-spring-provide-args/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-spring-provide-args/src/main/java/org/openapitools/model/Category.java
@@ -42,6 +42,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -62,6 +63,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-provide-args/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-spring-provide-args/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -46,6 +46,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -66,6 +67,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -86,6 +88,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/server/petstore/springboot-spring-provide-args/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-spring-provide-args/src/main/java/org/openapitools/model/Order.java
@@ -91,6 +91,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -111,6 +112,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -131,6 +133,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -151,6 +154,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -171,6 +175,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -191,6 +196,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(@Nullable Boolean complete) {
     this.complete = complete;
   }

--- a/samples/server/petstore/springboot-spring-provide-args/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-spring-provide-args/src/main/java/org/openapitools/model/Pet.java
@@ -107,6 +107,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -127,6 +128,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -147,6 +149,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -175,6 +178,7 @@ public class Pet {
     return photoUrls;
   }
 
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -203,6 +207,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -223,6 +228,7 @@ public class Pet {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/server/petstore/springboot-spring-provide-args/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-spring-provide-args/src/main/java/org/openapitools/model/Tag.java
@@ -42,6 +42,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -62,6 +63,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-spring-provide-args/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-spring-provide-args/src/main/java/org/openapitools/model/User.java
@@ -54,6 +54,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -74,6 +75,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -94,6 +96,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -114,6 +117,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -134,6 +138,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -154,6 +159,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -174,6 +180,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -194,6 +201,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesAnyType {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Optional<String> name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesArray {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Optional<String> name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesBoolean {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Optional<String> name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -84,6 +84,7 @@ public class AdditionalPropertiesClass {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -112,6 +113,7 @@ public class AdditionalPropertiesClass {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -140,6 +142,7 @@ public class AdditionalPropertiesClass {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -168,6 +171,7 @@ public class AdditionalPropertiesClass {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -196,6 +200,7 @@ public class AdditionalPropertiesClass {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -224,6 +229,7 @@ public class AdditionalPropertiesClass {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -252,6 +258,7 @@ public class AdditionalPropertiesClass {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -280,6 +287,7 @@ public class AdditionalPropertiesClass {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -300,6 +308,7 @@ public class AdditionalPropertiesClass {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(Optional<Object> anytype1) {
     this.anytype1 = anytype1;
   }
@@ -340,6 +349,7 @@ public class AdditionalPropertiesClass {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(Optional<Object> anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesInteger {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Optional<String> name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesNumber {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Optional<String> name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -46,6 +46,7 @@ public class AdditionalPropertiesObject {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Optional<String> name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesString {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Optional<String> name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Animal.java
@@ -68,6 +68,7 @@ public class Animal {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -88,6 +89,7 @@ public class Animal {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(Optional<String> color) {
     this.color = color;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -54,6 +54,7 @@ public class ArrayOfArrayOfNumberOnly {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -54,6 +54,7 @@ public class ArrayOfNumberOnly {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ArrayTest.java
@@ -60,6 +60,7 @@ public class ArrayTest {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -88,6 +89,7 @@ public class ArrayTest {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -116,6 +118,7 @@ public class ArrayTest {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/BigCat.java
@@ -97,6 +97,7 @@ public class BigCat extends Cat {
     return kind;
   }
 
+  @JsonProperty("kind")
   public void setKind(Optional<KindEnum> kind) {
     this.kind = kind;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Capitalization.java
@@ -51,6 +51,7 @@ public class Capitalization {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(Optional<String> smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -71,6 +72,7 @@ public class Capitalization {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(Optional<String> capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -91,6 +93,7 @@ public class Capitalization {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(Optional<String> smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -111,6 +114,7 @@ public class Capitalization {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(Optional<String> capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -131,6 +135,7 @@ public class Capitalization {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(Optional<String> scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -151,6 +156,7 @@ public class Capitalization {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(Optional<String> ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Cat.java
@@ -65,6 +65,7 @@ public class Cat extends Animal {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(Optional<Boolean> declawed) {
     this.declawed = declawed;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Category.java
@@ -54,6 +54,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(Optional<Long> id) {
     this.id = id;
   }
@@ -74,6 +75,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ChildWithNullable.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ChildWithNullable.java
@@ -49,6 +49,7 @@ public class ChildWithNullable extends ParentWithNullable {
     return otherProperty;
   }
 
+  @JsonProperty("otherProperty")
   public void setOtherProperty(Optional<String> otherProperty) {
     this.otherProperty = otherProperty;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ClassModel.java
@@ -42,6 +42,7 @@ public class ClassModel {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(Optional<String> propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Client.java
@@ -41,6 +41,7 @@ public class Client {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(Optional<String> client) {
     this.client = client;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -104,6 +104,7 @@ public class ContainerDefaultValue {
     return nullableRequiredArray;
   }
 
+  @JsonProperty("nullable_required_array")
   public void setNullableRequiredArray(JsonNullable<List<String>> nullableRequiredArray) {
     this.nullableRequiredArray = nullableRequiredArray;
   }
@@ -132,6 +133,7 @@ public class ContainerDefaultValue {
     return requiredArray;
   }
 
+  @JsonProperty("required_array")
   public void setRequiredArray(List<String> requiredArray) {
     this.requiredArray = requiredArray;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Dog.java
@@ -57,6 +57,7 @@ public class Dog extends Animal {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(Optional<String> breed) {
     this.breed = breed;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumArrays.java
@@ -118,6 +118,7 @@ public class EnumArrays {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(Optional<JustSymbolEnum> justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -146,6 +147,7 @@ public class EnumArrays {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumTest.java
@@ -208,6 +208,7 @@ public class EnumTest {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(Optional<EnumStringEnum> enumString) {
     this.enumString = enumString;
   }
@@ -228,6 +229,7 @@ public class EnumTest {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -248,6 +250,7 @@ public class EnumTest {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(Optional<EnumIntegerEnum> enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -268,6 +271,7 @@ public class EnumTest {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(Optional<EnumNumberEnum> enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -288,6 +292,7 @@ public class EnumTest {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(Optional<OuterEnum> outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/File.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/File.java
@@ -42,6 +42,7 @@ public class File {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(Optional<String> sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -48,6 +48,7 @@ public class FileSchemaTestClass {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(Optional<File> file) {
     this.file = file;
   }
@@ -76,6 +77,7 @@ public class FileSchemaTestClass {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<@Valid File> files) {
     this.files = files;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FormatTest.java
@@ -93,6 +93,7 @@ public class FormatTest {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(Optional<Integer> integer) {
     this.integer = integer;
   }
@@ -115,6 +116,7 @@ public class FormatTest {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(Optional<Integer> int32) {
     this.int32 = int32;
   }
@@ -135,6 +137,7 @@ public class FormatTest {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(Optional<Long> int64) {
     this.int64 = int64;
   }
@@ -157,6 +160,7 @@ public class FormatTest {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -179,6 +183,7 @@ public class FormatTest {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(Optional<Float> _float) {
     this._float = _float;
   }
@@ -201,6 +206,7 @@ public class FormatTest {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(Optional<Double> _double) {
     this._double = _double;
   }
@@ -221,6 +227,7 @@ public class FormatTest {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(Optional<String> string) {
     this.string = string;
   }
@@ -241,6 +248,7 @@ public class FormatTest {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -261,6 +269,7 @@ public class FormatTest {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(Optional<org.springframework.core.io.Resource> binary) {
     this.binary = binary;
   }
@@ -281,6 +290,7 @@ public class FormatTest {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -301,6 +311,7 @@ public class FormatTest {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(Optional<OffsetDateTime> dateTime) {
     this.dateTime = dateTime;
   }
@@ -321,6 +332,7 @@ public class FormatTest {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(Optional<UUID> uuid) {
     this.uuid = uuid;
   }
@@ -341,6 +353,7 @@ public class FormatTest {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -361,6 +374,7 @@ public class FormatTest {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(Optional<BigDecimal> bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -45,6 +45,7 @@ public class HasOnlyReadOnly {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(Optional<String> bar) {
     this.bar = bar;
   }
@@ -65,6 +66,7 @@ public class HasOnlyReadOnly {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(Optional<String> foo) {
     this.foo = foo;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/MapTest.java
@@ -97,6 +97,7 @@ public class MapTest {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -125,6 +126,7 @@ public class MapTest {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -153,6 +155,7 @@ public class MapTest {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -181,6 +184,7 @@ public class MapTest {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -53,6 +53,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(Optional<UUID> uuid) {
     this.uuid = uuid;
   }
@@ -73,6 +74,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(Optional<OffsetDateTime> dateTime) {
     this.dateTime = dateTime;
   }
@@ -101,6 +103,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Model200Response.java
@@ -46,6 +46,7 @@ public class Model200Response {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Optional<Integer> name) {
     this.name = name;
   }
@@ -66,6 +67,7 @@ public class Model200Response {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(Optional<String> propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -47,6 +47,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(Optional<Integer> code) {
     this.code = code;
   }
@@ -67,6 +68,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(Optional<String> type) {
     this.type = type;
   }
@@ -87,6 +89,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(Optional<String> message) {
     this.message = message;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelList.java
@@ -43,6 +43,7 @@ public class ModelList {
     return _123list;
   }
 
+  @JsonProperty("123-list")
   public void set123list(Optional<String> _123list) {
     this._123list = _123list;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelReturn.java
@@ -44,6 +44,7 @@ public class ModelReturn {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(Optional<Integer> _return) {
     this._return = _return;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Name.java
@@ -59,6 +59,7 @@ public class Name {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -79,6 +80,7 @@ public class Name {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(Optional<Integer> snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -99,6 +101,7 @@ public class Name {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(Optional<String> property) {
     this.property = property;
   }
@@ -119,6 +122,7 @@ public class Name {
     return _123number;
   }
 
+  @JsonProperty("123Number")
   public void set123number(Optional<Integer> _123number) {
     this._123number = _123number;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/NumberOnly.java
@@ -42,6 +42,7 @@ public class NumberOnly {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(Optional<BigDecimal> justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Order.java
@@ -92,6 +92,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(Optional<Long> id) {
     this.id = id;
   }
@@ -112,6 +113,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(Optional<Long> petId) {
     this.petId = petId;
   }
@@ -132,6 +134,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(Optional<Integer> quantity) {
     this.quantity = quantity;
   }
@@ -152,6 +155,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(Optional<OffsetDateTime> shipDate) {
     this.shipDate = shipDate;
   }
@@ -172,6 +176,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(Optional<StatusEnum> status) {
     this.status = status;
   }
@@ -192,6 +197,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Optional<Boolean> complete) {
     this.complete = complete;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/OuterComposite.java
@@ -46,6 +46,7 @@ public class OuterComposite {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(Optional<BigDecimal> myNumber) {
     this.myNumber = myNumber;
   }
@@ -66,6 +67,7 @@ public class OuterComposite {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(Optional<String> myString) {
     this.myString = myString;
   }
@@ -86,6 +88,7 @@ public class OuterComposite {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(Optional<Boolean> myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -92,6 +92,7 @@ public class ParentWithNullable {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(Optional<TypeEnum> type) {
     this.type = type;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
@@ -112,6 +112,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(Optional<Long> id) {
     this.id = id;
   }
@@ -132,6 +133,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(Optional<Category> category) {
     this.category = category;
   }
@@ -152,6 +154,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -181,6 +184,7 @@ public class Pet {
   }
 
   @JsonDeserialize(as = LinkedHashSet.class)
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -209,6 +213,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -225,8 +230,8 @@ public class Pet {
    */
   
   @ApiModelProperty(value = "pet status in the store")
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public Optional<StatusEnum> getStatus() {
     return status;
   }
@@ -235,6 +240,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(Optional<StatusEnum> status) {
     this.status = status;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -43,6 +43,7 @@ public class ReadOnlyFirst {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(Optional<String> bar) {
     this.bar = bar;
   }
@@ -63,6 +64,7 @@ public class ReadOnlyFirst {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(Optional<String> baz) {
     this.baz = baz;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNames.java
@@ -47,6 +47,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return normalPropertyName;
   }
 
+  @JsonProperty("normalPropertyName")
   public void setNormalPropertyName(Optional<String> normalPropertyName) {
     this.normalPropertyName = normalPropertyName;
   }
@@ -67,6 +68,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return UPPER_CASE_PROPERTY_SNAKE;
   }
 
+  @JsonProperty("UPPER_CASE_PROPERTY_SNAKE")
   public void setUPPERCASEPROPERTYSNAKE(Optional<String> UPPER_CASE_PROPERTY_SNAKE) {
     this.UPPER_CASE_PROPERTY_SNAKE = UPPER_CASE_PROPERTY_SNAKE;
   }
@@ -87,6 +89,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return lowerCasePropertyDashes;
   }
 
+  @JsonProperty("lower-case-property-dashes")
   public void setLowerCasePropertyDashes(Optional<String> lowerCasePropertyDashes) {
     this.lowerCasePropertyDashes = lowerCasePropertyDashes;
   }
@@ -107,6 +110,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return propertyNameWithSpaces;
   }
 
+  @JsonProperty("property name with spaces")
   public void setPropertyNameWithSpaces(Optional<String> propertyNameWithSpaces) {
     this.propertyNameWithSpaces = propertyNameWithSpaces;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -43,6 +43,7 @@ public class SpecialModelName {
     return $specialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(Optional<Long> $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(Optional<Long> id) {
     this.id = id;
   }
@@ -63,6 +64,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Optional<String> name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -69,6 +69,7 @@ public class TypeHolderDefault {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -89,6 +90,7 @@ public class TypeHolderDefault {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -109,6 +111,7 @@ public class TypeHolderDefault {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -129,6 +132,7 @@ public class TypeHolderDefault {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -157,6 +161,7 @@ public class TypeHolderDefault {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -72,6 +72,7 @@ public class TypeHolderExample {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -92,6 +93,7 @@ public class TypeHolderExample {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -112,6 +114,7 @@ public class TypeHolderExample {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -132,6 +135,7 @@ public class TypeHolderExample {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -152,6 +156,7 @@ public class TypeHolderExample {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -180,6 +185,7 @@ public class TypeHolderExample {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/User.java
@@ -55,6 +55,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(Optional<Long> id) {
     this.id = id;
   }
@@ -75,6 +76,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(Optional<String> username) {
     this.username = username;
   }
@@ -95,6 +97,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(Optional<String> firstName) {
     this.firstName = firstName;
   }
@@ -115,6 +118,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(Optional<String> lastName) {
     this.lastName = lastName;
   }
@@ -135,6 +139,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(Optional<String> email) {
     this.email = email;
   }
@@ -155,6 +160,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(Optional<String> password) {
     this.password = password;
   }
@@ -175,6 +181,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(Optional<String> phone) {
     this.phone = phone;
   }
@@ -195,6 +202,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(Optional<Integer> userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/XmlItem.java
@@ -110,6 +110,7 @@ public class XmlItem {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(Optional<String> attributeString) {
     this.attributeString = attributeString;
   }
@@ -130,6 +131,7 @@ public class XmlItem {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(Optional<BigDecimal> attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -150,6 +152,7 @@ public class XmlItem {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(Optional<Integer> attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -170,6 +173,7 @@ public class XmlItem {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(Optional<Boolean> attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -198,6 +202,7 @@ public class XmlItem {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -218,6 +223,7 @@ public class XmlItem {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(Optional<String> nameString) {
     this.nameString = nameString;
   }
@@ -238,6 +244,7 @@ public class XmlItem {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(Optional<BigDecimal> nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -258,6 +265,7 @@ public class XmlItem {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(Optional<Integer> nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -278,6 +286,7 @@ public class XmlItem {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(Optional<Boolean> nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -306,6 +315,7 @@ public class XmlItem {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -334,6 +344,7 @@ public class XmlItem {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -354,6 +365,7 @@ public class XmlItem {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(Optional<String> prefixString) {
     this.prefixString = prefixString;
   }
@@ -374,6 +386,7 @@ public class XmlItem {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(Optional<BigDecimal> prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -394,6 +407,7 @@ public class XmlItem {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(Optional<Integer> prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -414,6 +428,7 @@ public class XmlItem {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(Optional<Boolean> prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -442,6 +457,7 @@ public class XmlItem {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -470,6 +486,7 @@ public class XmlItem {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -490,6 +507,7 @@ public class XmlItem {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(Optional<String> namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -510,6 +528,7 @@ public class XmlItem {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(Optional<BigDecimal> namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -530,6 +549,7 @@ public class XmlItem {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(Optional<Integer> namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -550,6 +570,7 @@ public class XmlItem {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(Optional<Boolean> namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -578,6 +599,7 @@ public class XmlItem {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -606,6 +628,7 @@ public class XmlItem {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -626,6 +649,7 @@ public class XmlItem {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(Optional<String> prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -646,6 +670,7 @@ public class XmlItem {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(Optional<BigDecimal> prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -666,6 +691,7 @@ public class XmlItem {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(Optional<Integer> prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -686,6 +712,7 @@ public class XmlItem {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(Optional<Boolean> prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -714,6 +741,7 @@ public class XmlItem {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -742,6 +770,7 @@ public class XmlItem {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesAnyType.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesAnyType {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesArray.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesArray {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesBoolean.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesBoolean {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesClass.java
@@ -83,6 +83,7 @@ public class AdditionalPropertiesClass {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -111,6 +112,7 @@ public class AdditionalPropertiesClass {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -139,6 +141,7 @@ public class AdditionalPropertiesClass {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -167,6 +170,7 @@ public class AdditionalPropertiesClass {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -195,6 +199,7 @@ public class AdditionalPropertiesClass {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -223,6 +228,7 @@ public class AdditionalPropertiesClass {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -251,6 +257,7 @@ public class AdditionalPropertiesClass {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -279,6 +286,7 @@ public class AdditionalPropertiesClass {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -299,6 +307,7 @@ public class AdditionalPropertiesClass {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(@Nullable Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -339,6 +348,7 @@ public class AdditionalPropertiesClass {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(@Nullable Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesInteger.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesInteger {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesNumber.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesNumber {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesObject.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesObject {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesString.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesString {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Animal.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Animal.java
@@ -67,6 +67,7 @@ public class Animal {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -87,6 +88,7 @@ public class Animal {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ArrayOfArrayOfNumberOnly.java
@@ -53,6 +53,7 @@ public class ArrayOfArrayOfNumberOnly {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ArrayOfNumberOnly.java
@@ -53,6 +53,7 @@ public class ArrayOfNumberOnly {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ArrayTest.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ArrayTest.java
@@ -59,6 +59,7 @@ public class ArrayTest {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -87,6 +88,7 @@ public class ArrayTest {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -115,6 +117,7 @@ public class ArrayTest {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/BigCat.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/BigCat.java
@@ -96,6 +96,7 @@ public class BigCat extends Cat {
     return kind;
   }
 
+  @JsonProperty("kind")
   public void setKind(@Nullable KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Capitalization.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Capitalization.java
@@ -50,6 +50,7 @@ public class Capitalization {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -70,6 +71,7 @@ public class Capitalization {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -90,6 +92,7 @@ public class Capitalization {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -110,6 +113,7 @@ public class Capitalization {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -130,6 +134,7 @@ public class Capitalization {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -150,6 +155,7 @@ public class Capitalization {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Cat.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Cat.java
@@ -64,6 +64,7 @@ public class Cat extends Animal {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Category.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Category.java
@@ -53,6 +53,7 @@ public class Category {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -73,6 +74,7 @@ public class Category {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ChildWithNullable.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ChildWithNullable.java
@@ -48,6 +48,7 @@ public class ChildWithNullable extends ParentWithNullable {
     return otherProperty;
   }
 
+  @JsonProperty("otherProperty")
   public void setOtherProperty(@Nullable String otherProperty) {
     this.otherProperty = otherProperty;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ClassModel.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ClassModel.java
@@ -41,6 +41,7 @@ public class ClassModel {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Client.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Client.java
@@ -40,6 +40,7 @@ public class Client {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ContainerDefaultValue.java
@@ -103,6 +103,7 @@ public class ContainerDefaultValue {
     return nullableRequiredArray;
   }
 
+  @JsonProperty("nullable_required_array")
   public void setNullableRequiredArray(JsonNullable<List<String>> nullableRequiredArray) {
     this.nullableRequiredArray = nullableRequiredArray;
   }
@@ -131,6 +132,7 @@ public class ContainerDefaultValue {
     return requiredArray;
   }
 
+  @JsonProperty("required_array")
   public void setRequiredArray(List<String> requiredArray) {
     this.requiredArray = requiredArray;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Dog.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Dog.java
@@ -56,6 +56,7 @@ public class Dog extends Animal {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/EnumArrays.java
@@ -117,6 +117,7 @@ public class EnumArrays {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -145,6 +146,7 @@ public class EnumArrays {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/EnumTest.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/EnumTest.java
@@ -207,6 +207,7 @@ public class EnumTest {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -227,6 +228,7 @@ public class EnumTest {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -247,6 +249,7 @@ public class EnumTest {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -267,6 +270,7 @@ public class EnumTest {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -287,6 +291,7 @@ public class EnumTest {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(@Nullable OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/File.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/File.java
@@ -41,6 +41,7 @@ public class File {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/FileSchemaTestClass.java
@@ -47,6 +47,7 @@ public class FileSchemaTestClass {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable File file) {
     this.file = file;
   }
@@ -75,6 +76,7 @@ public class FileSchemaTestClass {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<@Valid File> files) {
     this.files = files;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/FormatTest.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/FormatTest.java
@@ -92,6 +92,7 @@ public class FormatTest {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -114,6 +115,7 @@ public class FormatTest {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -134,6 +136,7 @@ public class FormatTest {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -156,6 +159,7 @@ public class FormatTest {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -178,6 +182,7 @@ public class FormatTest {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -200,6 +205,7 @@ public class FormatTest {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -220,6 +226,7 @@ public class FormatTest {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -240,6 +247,7 @@ public class FormatTest {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -260,6 +268,7 @@ public class FormatTest {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -280,6 +289,7 @@ public class FormatTest {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -300,6 +310,7 @@ public class FormatTest {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -320,6 +331,7 @@ public class FormatTest {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -340,6 +352,7 @@ public class FormatTest {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -360,6 +373,7 @@ public class FormatTest {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(@Nullable BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/HasOnlyReadOnly.java
@@ -44,6 +44,7 @@ public class HasOnlyReadOnly {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -64,6 +65,7 @@ public class HasOnlyReadOnly {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/MapTest.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/MapTest.java
@@ -96,6 +96,7 @@ public class MapTest {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -124,6 +125,7 @@ public class MapTest {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -152,6 +154,7 @@ public class MapTest {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -180,6 +183,7 @@ public class MapTest {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -52,6 +52,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -72,6 +73,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -100,6 +102,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Model200Response.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Model200Response.java
@@ -45,6 +45,7 @@ public class Model200Response {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -65,6 +66,7 @@ public class Model200Response {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ModelApiResponse.java
@@ -46,6 +46,7 @@ public class ModelApiResponse {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -66,6 +67,7 @@ public class ModelApiResponse {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -86,6 +88,7 @@ public class ModelApiResponse {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ModelList.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ModelList.java
@@ -42,6 +42,7 @@ public class ModelList {
     return _123list;
   }
 
+  @JsonProperty("123-list")
   public void set123list(@Nullable String _123list) {
     this._123list = _123list;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ModelReturn.java
@@ -43,6 +43,7 @@ public class ModelReturn {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Name.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Name.java
@@ -58,6 +58,7 @@ public class Name {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -78,6 +79,7 @@ public class Name {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -98,6 +100,7 @@ public class Name {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -118,6 +121,7 @@ public class Name {
     return _123number;
   }
 
+  @JsonProperty("123Number")
   public void set123number(@Nullable Integer _123number) {
     this._123number = _123number;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/NumberOnly.java
@@ -41,6 +41,7 @@ public class NumberOnly {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Order.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Order.java
@@ -91,6 +91,7 @@ public class Order {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -111,6 +112,7 @@ public class Order {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -131,6 +133,7 @@ public class Order {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -151,6 +154,7 @@ public class Order {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -171,6 +175,7 @@ public class Order {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -191,6 +196,7 @@ public class Order {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/OuterComposite.java
@@ -45,6 +45,7 @@ public class OuterComposite {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -65,6 +66,7 @@ public class OuterComposite {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -85,6 +87,7 @@ public class OuterComposite {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ParentWithNullable.java
@@ -91,6 +91,7 @@ public class ParentWithNullable {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable TypeEnum type) {
     this.type = type;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Pet.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Pet.java
@@ -111,6 +111,7 @@ public class Pet {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -131,6 +132,7 @@ public class Pet {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable Category category) {
     this.category = category;
   }
@@ -151,6 +153,7 @@ public class Pet {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -180,6 +183,7 @@ public class Pet {
   }
 
   @JsonDeserialize(as = LinkedHashSet.class)
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -208,6 +212,7 @@ public class Pet {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
@@ -224,8 +229,8 @@ public class Pet {
    */
   
   @Schema(name = "status", description = "pet status in the store", deprecated = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -234,6 +239,7 @@ public class Pet {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ReadOnlyFirst.java
@@ -42,6 +42,7 @@ public class ReadOnlyFirst {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -62,6 +63,7 @@ public class ReadOnlyFirst {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ResponseObjectWithDifferentFieldNames.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ResponseObjectWithDifferentFieldNames.java
@@ -46,6 +46,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return normalPropertyName;
   }
 
+  @JsonProperty("normalPropertyName")
   public void setNormalPropertyName(@Nullable String normalPropertyName) {
     this.normalPropertyName = normalPropertyName;
   }
@@ -66,6 +67,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return UPPER_CASE_PROPERTY_SNAKE;
   }
 
+  @JsonProperty("UPPER_CASE_PROPERTY_SNAKE")
   public void setUPPERCASEPROPERTYSNAKE(@Nullable String UPPER_CASE_PROPERTY_SNAKE) {
     this.UPPER_CASE_PROPERTY_SNAKE = UPPER_CASE_PROPERTY_SNAKE;
   }
@@ -86,6 +88,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return lowerCasePropertyDashes;
   }
 
+  @JsonProperty("lower-case-property-dashes")
   public void setLowerCasePropertyDashes(@Nullable String lowerCasePropertyDashes) {
     this.lowerCasePropertyDashes = lowerCasePropertyDashes;
   }
@@ -106,6 +109,7 @@ public class ResponseObjectWithDifferentFieldNames {
     return propertyNameWithSpaces;
   }
 
+  @JsonProperty("property name with spaces")
   public void setPropertyNameWithSpaces(@Nullable String propertyNameWithSpaces) {
     this.propertyNameWithSpaces = propertyNameWithSpaces;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/SpecialModelName.java
@@ -42,6 +42,7 @@ public class SpecialModelName {
     return $specialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Tag.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Tag.java
@@ -42,6 +42,7 @@ public class Tag {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -62,6 +63,7 @@ public class Tag {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/TypeHolderDefault.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/TypeHolderDefault.java
@@ -68,6 +68,7 @@ public class TypeHolderDefault {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -88,6 +89,7 @@ public class TypeHolderDefault {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -108,6 +110,7 @@ public class TypeHolderDefault {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -128,6 +131,7 @@ public class TypeHolderDefault {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -156,6 +160,7 @@ public class TypeHolderDefault {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/TypeHolderExample.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/TypeHolderExample.java
@@ -71,6 +71,7 @@ public class TypeHolderExample {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -91,6 +92,7 @@ public class TypeHolderExample {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -111,6 +113,7 @@ public class TypeHolderExample {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -131,6 +134,7 @@ public class TypeHolderExample {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -151,6 +155,7 @@ public class TypeHolderExample {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -179,6 +184,7 @@ public class TypeHolderExample {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/User.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/User.java
@@ -54,6 +54,7 @@ public class User {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -74,6 +75,7 @@ public class User {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -94,6 +96,7 @@ public class User {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -114,6 +117,7 @@ public class User {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -134,6 +138,7 @@ public class User {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -154,6 +159,7 @@ public class User {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -174,6 +180,7 @@ public class User {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -194,6 +201,7 @@ public class User {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/XmlItem.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/XmlItem.java
@@ -109,6 +109,7 @@ public class XmlItem {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(@Nullable String attributeString) {
     this.attributeString = attributeString;
   }
@@ -129,6 +130,7 @@ public class XmlItem {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(@Nullable BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -149,6 +151,7 @@ public class XmlItem {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(@Nullable Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -169,6 +172,7 @@ public class XmlItem {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(@Nullable Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -197,6 +201,7 @@ public class XmlItem {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -217,6 +222,7 @@ public class XmlItem {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(@Nullable String nameString) {
     this.nameString = nameString;
   }
@@ -237,6 +243,7 @@ public class XmlItem {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(@Nullable BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -257,6 +264,7 @@ public class XmlItem {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(@Nullable Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -277,6 +285,7 @@ public class XmlItem {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(@Nullable Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -305,6 +314,7 @@ public class XmlItem {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -333,6 +343,7 @@ public class XmlItem {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -353,6 +364,7 @@ public class XmlItem {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(@Nullable String prefixString) {
     this.prefixString = prefixString;
   }
@@ -373,6 +385,7 @@ public class XmlItem {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(@Nullable BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -393,6 +406,7 @@ public class XmlItem {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(@Nullable Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -413,6 +427,7 @@ public class XmlItem {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(@Nullable Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -441,6 +456,7 @@ public class XmlItem {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -469,6 +485,7 @@ public class XmlItem {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -489,6 +506,7 @@ public class XmlItem {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(@Nullable String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -509,6 +527,7 @@ public class XmlItem {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(@Nullable BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -529,6 +548,7 @@ public class XmlItem {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(@Nullable Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -549,6 +569,7 @@ public class XmlItem {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(@Nullable Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -577,6 +598,7 @@ public class XmlItem {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -605,6 +627,7 @@ public class XmlItem {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -625,6 +648,7 @@ public class XmlItem {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(@Nullable String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -645,6 +669,7 @@ public class XmlItem {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(@Nullable BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -665,6 +690,7 @@ public class XmlItem {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(@Nullable Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -685,6 +711,7 @@ public class XmlItem {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(@Nullable Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -713,6 +740,7 @@ public class XmlItem {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -741,6 +769,7 @@ public class XmlItem {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
@@ -57,6 +57,7 @@ public class AdditionalPropertiesClassDto {
     return mapProperty;
   }
 
+  @JsonProperty("map_property")
   public void setMapProperty(Map<String, String> mapProperty) {
     this.mapProperty = mapProperty;
   }
@@ -85,6 +86,7 @@ public class AdditionalPropertiesClassDto {
     return mapOfMapProperty;
   }
 
+  @JsonProperty("map_of_map_property")
   public void setMapOfMapProperty(Map<String, Map<String, String>> mapOfMapProperty) {
     this.mapOfMapProperty = mapOfMapProperty;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/AllOfWithSingleRefDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/AllOfWithSingleRefDto.java
@@ -47,6 +47,7 @@ public class AllOfWithSingleRefDto {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -67,6 +68,7 @@ public class AllOfWithSingleRefDto {
     return singleRefType;
   }
 
+  @JsonProperty("SingleRefType")
   public void setSingleRefType(@Nullable SingleRefTypeDto singleRefType) {
     this.singleRefType = singleRefType;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/AnimalDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/AnimalDto.java
@@ -68,6 +68,7 @@ public class AnimalDto implements com.custompackage.InterfaceToKeep, com.customp
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -88,6 +89,7 @@ public class AnimalDto implements com.custompackage.InterfaceToKeep, com.customp
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ApiResponseDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ApiResponseDto.java
@@ -47,6 +47,7 @@ public class ApiResponseDto {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -67,6 +68,7 @@ public class ApiResponseDto {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -87,6 +89,7 @@ public class ApiResponseDto {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnlyDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnlyDto.java
@@ -56,6 +56,7 @@ public class ArrayOfArrayOfNumberOnlyDto {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ArrayOfNumberOnlyDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ArrayOfNumberOnlyDto.java
@@ -56,6 +56,7 @@ public class ArrayOfNumberOnlyDto {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ArrayTestDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ArrayTestDto.java
@@ -62,6 +62,7 @@ public class ArrayTestDto {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -90,6 +91,7 @@ public class ArrayTestDto {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -118,6 +120,7 @@ public class ArrayTestDto {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirstDto>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/CapitalizationDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/CapitalizationDto.java
@@ -53,6 +53,7 @@ public class CapitalizationDto {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -73,6 +74,7 @@ public class CapitalizationDto {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -93,6 +95,7 @@ public class CapitalizationDto {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -113,6 +116,7 @@ public class CapitalizationDto {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -133,6 +137,7 @@ public class CapitalizationDto {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -153,6 +158,7 @@ public class CapitalizationDto {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/CatDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/CatDto.java
@@ -58,6 +58,7 @@ public class CatDto extends AnimalDto {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/CategoryDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/CategoryDto.java
@@ -56,6 +56,7 @@ public class CategoryDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -76,6 +77,7 @@ public class CategoryDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ChildWithNullableDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ChildWithNullableDto.java
@@ -51,6 +51,7 @@ public class ChildWithNullableDto extends ParentWithNullableDto {
     return otherProperty;
   }
 
+  @JsonProperty("otherProperty")
   public void setOtherProperty(@Nullable String otherProperty) {
     this.otherProperty = otherProperty;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ClassModelDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ClassModelDto.java
@@ -44,6 +44,7 @@ public class ClassModelDto {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ClientDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ClientDto.java
@@ -43,6 +43,7 @@ public class ClientDto {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/DeprecatedObjectDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/DeprecatedObjectDto.java
@@ -45,6 +45,7 @@ public class DeprecatedObjectDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/DogDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/DogDto.java
@@ -58,6 +58,7 @@ public class DogDto extends AnimalDto {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/EnumArraysDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/EnumArraysDto.java
@@ -120,6 +120,7 @@ public class EnumArraysDto {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -148,6 +149,7 @@ public class EnumArraysDto {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/EnumTestDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/EnumTestDto.java
@@ -220,6 +220,7 @@ public class EnumTestDto {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -240,6 +241,7 @@ public class EnumTestDto {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -260,6 +262,7 @@ public class EnumTestDto {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -280,6 +283,7 @@ public class EnumTestDto {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -320,6 +324,7 @@ public class EnumTestDto {
     return outerEnumInteger;
   }
 
+  @JsonProperty("outerEnumInteger")
   public void setOuterEnumInteger(@Nullable OuterEnumIntegerDto outerEnumInteger) {
     this.outerEnumInteger = outerEnumInteger;
   }
@@ -340,6 +345,7 @@ public class EnumTestDto {
     return outerEnumDefaultValue;
   }
 
+  @JsonProperty("outerEnumDefaultValue")
   public void setOuterEnumDefaultValue(OuterEnumDefaultValueDto outerEnumDefaultValue) {
     this.outerEnumDefaultValue = outerEnumDefaultValue;
   }
@@ -360,6 +366,7 @@ public class EnumTestDto {
     return outerEnumIntegerDefaultValue;
   }
 
+  @JsonProperty("outerEnumIntegerDefaultValue")
   public void setOuterEnumIntegerDefaultValue(OuterEnumIntegerDefaultValueDto outerEnumIntegerDefaultValue) {
     this.outerEnumIntegerDefaultValue = outerEnumIntegerDefaultValue;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/FakeBigDecimalMap200ResponseDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/FakeBigDecimalMap200ResponseDto.java
@@ -49,6 +49,7 @@ public class FakeBigDecimalMap200ResponseDto {
     return someId;
   }
 
+  @JsonProperty("someId")
   public void setSomeId(@Nullable BigDecimal someId) {
     this.someId = someId;
   }
@@ -77,6 +78,7 @@ public class FakeBigDecimalMap200ResponseDto {
     return someMap;
   }
 
+  @JsonProperty("someMap")
   public void setSomeMap(Map<String, BigDecimal> someMap) {
     this.someMap = someMap;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/FileDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/FileDto.java
@@ -44,6 +44,7 @@ public class FileDto {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/FileSchemaTestClassDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/FileSchemaTestClassDto.java
@@ -50,6 +50,7 @@ public class FileSchemaTestClassDto {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable FileDto file) {
     this.file = file;
   }
@@ -78,6 +79,7 @@ public class FileSchemaTestClassDto {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<@Valid FileDto> files) {
     this.files = files;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/FooDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/FooDto.java
@@ -43,6 +43,7 @@ public class FooDto implements com.custompackage.WithBar, com.custompackage.With
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(String bar) {
     this.bar = bar;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/FooGetDefaultResponseDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/FooGetDefaultResponseDto.java
@@ -44,6 +44,7 @@ public class FooGetDefaultResponseDto {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable FooDto string) {
     this.string = string;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/FormatTestDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/FormatTestDto.java
@@ -97,6 +97,7 @@ public class FormatTestDto {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -119,6 +120,7 @@ public class FormatTestDto {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -139,6 +141,7 @@ public class FormatTestDto {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -161,6 +164,7 @@ public class FormatTestDto {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -183,6 +187,7 @@ public class FormatTestDto {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -205,6 +210,7 @@ public class FormatTestDto {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -225,6 +231,7 @@ public class FormatTestDto {
     return decimal;
   }
 
+  @JsonProperty("decimal")
   public void setDecimal(@Nullable BigDecimal decimal) {
     this.decimal = decimal;
   }
@@ -245,6 +252,7 @@ public class FormatTestDto {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -265,6 +273,7 @@ public class FormatTestDto {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -285,6 +294,7 @@ public class FormatTestDto {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -305,6 +315,7 @@ public class FormatTestDto {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -325,6 +336,7 @@ public class FormatTestDto {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -345,6 +357,7 @@ public class FormatTestDto {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -365,6 +378,7 @@ public class FormatTestDto {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -385,6 +399,7 @@ public class FormatTestDto {
     return patternWithDigits;
   }
 
+  @JsonProperty("pattern_with_digits")
   public void setPatternWithDigits(@Nullable String patternWithDigits) {
     this.patternWithDigits = patternWithDigits;
   }
@@ -405,6 +420,7 @@ public class FormatTestDto {
     return patternWithDigitsAndDelimiter;
   }
 
+  @JsonProperty("pattern_with_digits_and_delimiter")
   public void setPatternWithDigitsAndDelimiter(@Nullable String patternWithDigitsAndDelimiter) {
     this.patternWithDigitsAndDelimiter = patternWithDigitsAndDelimiter;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/HasOnlyReadOnlyDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/HasOnlyReadOnlyDto.java
@@ -45,6 +45,7 @@ public class HasOnlyReadOnlyDto {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -65,6 +66,7 @@ public class HasOnlyReadOnlyDto {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ListDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ListDto.java
@@ -43,6 +43,7 @@ public class ListDto {
     return _123List;
   }
 
+  @JsonProperty("123-list")
   public void set123List(@Nullable String _123List) {
     this._123List = _123List;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/MapTestDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/MapTestDto.java
@@ -99,6 +99,7 @@ public class MapTestDto {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -127,6 +128,7 @@ public class MapTestDto {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -155,6 +157,7 @@ public class MapTestDto {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -183,6 +186,7 @@ public class MapTestDto {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClassDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClassDto.java
@@ -55,6 +55,7 @@ public class MixedPropertiesAndAdditionalPropertiesClassDto {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -75,6 +76,7 @@ public class MixedPropertiesAndAdditionalPropertiesClassDto {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -103,6 +105,7 @@ public class MixedPropertiesAndAdditionalPropertiesClassDto {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, AnimalDto> map) {
     this.map = map;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/Model200ResponseDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/Model200ResponseDto.java
@@ -46,6 +46,7 @@ public class Model200ResponseDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -66,6 +67,7 @@ public class Model200ResponseDto {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/NameDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/NameDto.java
@@ -61,6 +61,7 @@ public class NameDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -81,6 +82,7 @@ public class NameDto {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -101,6 +103,7 @@ public class NameDto {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -121,6 +124,7 @@ public class NameDto {
     return _123Number;
   }
 
+  @JsonProperty("123Number")
   public void set123Number(@Nullable Integer _123Number) {
     this._123Number = _123Number;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/NullableClassDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/NullableClassDto.java
@@ -272,6 +272,7 @@ public class NullableClassDto {
     return arrayItemsNullable;
   }
 
+  @JsonProperty("array_items_nullable")
   public void setArrayItemsNullable(List<Object> arrayItemsNullable) {
     this.arrayItemsNullable = arrayItemsNullable;
   }
@@ -356,6 +357,7 @@ public class NullableClassDto {
     return objectItemsNullable;
   }
 
+  @JsonProperty("object_items_nullable")
   public void setObjectItemsNullable(Map<String, Object> objectItemsNullable) {
     this.objectItemsNullable = objectItemsNullable;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/NumberOnlyDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/NumberOnlyDto.java
@@ -44,6 +44,7 @@ public class NumberOnlyDto {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ObjectWithDeprecatedFieldsDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ObjectWithDeprecatedFieldsDto.java
@@ -58,6 +58,7 @@ public class ObjectWithDeprecatedFieldsDto {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable String uuid) {
     this.uuid = uuid;
   }
@@ -74,8 +75,8 @@ public class ObjectWithDeprecatedFieldsDto {
    */
   @Valid 
   @ApiModelProperty(value = "")
-  @JsonProperty("id")
   @Deprecated
+  @JsonProperty("id")
   public @Nullable BigDecimal getId() {
     return id;
   }
@@ -84,6 +85,7 @@ public class ObjectWithDeprecatedFieldsDto {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("id")
   public void setId(@Nullable BigDecimal id) {
     this.id = id;
   }
@@ -100,8 +102,8 @@ public class ObjectWithDeprecatedFieldsDto {
    */
   @Valid 
   @ApiModelProperty(value = "")
-  @JsonProperty("deprecatedRef")
   @Deprecated
+  @JsonProperty("deprecatedRef")
   public @Nullable DeprecatedObjectDto getDeprecatedRef() {
     return deprecatedRef;
   }
@@ -110,6 +112,7 @@ public class ObjectWithDeprecatedFieldsDto {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("deprecatedRef")
   public void setDeprecatedRef(@Nullable DeprecatedObjectDto deprecatedRef) {
     this.deprecatedRef = deprecatedRef;
   }
@@ -134,8 +137,8 @@ public class ObjectWithDeprecatedFieldsDto {
    */
   
   @ApiModelProperty(value = "")
-  @JsonProperty("bars")
   @Deprecated
+  @JsonProperty("bars")
   public List<String> getBars() {
     return bars;
   }
@@ -144,6 +147,7 @@ public class ObjectWithDeprecatedFieldsDto {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("bars")
   public void setBars(List<String> bars) {
     this.bars = bars;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/OrderDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/OrderDto.java
@@ -94,6 +94,7 @@ public class OrderDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -114,6 +115,7 @@ public class OrderDto {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -134,6 +136,7 @@ public class OrderDto {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -154,6 +157,7 @@ public class OrderDto {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -174,6 +178,7 @@ public class OrderDto {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -194,6 +199,7 @@ public class OrderDto {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/OuterCompositeDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/OuterCompositeDto.java
@@ -48,6 +48,7 @@ public class OuterCompositeDto {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -68,6 +69,7 @@ public class OuterCompositeDto {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -88,6 +90,7 @@ public class OuterCompositeDto {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/OuterObjectWithEnumPropertyDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/OuterObjectWithEnumPropertyDto.java
@@ -56,6 +56,7 @@ public class OuterObjectWithEnumPropertyDto {
     return value;
   }
 
+  @JsonProperty("value")
   public void setValue(OuterEnumIntegerDto value) {
     this.value = value;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ParentWithNullableDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ParentWithNullableDto.java
@@ -93,6 +93,7 @@ public class ParentWithNullableDto {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable TypeEnum type) {
     this.type = type;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/PetDto.java
@@ -113,6 +113,7 @@ public class PetDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -133,6 +134,7 @@ public class PetDto {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable CategoryDto category) {
     this.category = category;
   }
@@ -153,6 +155,7 @@ public class PetDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -182,6 +185,7 @@ public class PetDto {
   }
 
   @JsonDeserialize(as = LinkedHashSet.class)
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -210,6 +214,7 @@ public class PetDto {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid TagDto> tags) {
     this.tags = tags;
   }
@@ -230,6 +235,7 @@ public class PetDto {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ReadOnlyFirstDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ReadOnlyFirstDto.java
@@ -45,6 +45,7 @@ public class ReadOnlyFirstDto {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -65,6 +66,7 @@ public class ReadOnlyFirstDto {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ReturnDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ReturnDto.java
@@ -44,6 +44,7 @@ public class ReturnDto {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/SpecialModelNameDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/SpecialModelNameDto.java
@@ -43,6 +43,7 @@ public class SpecialModelNameDto {
     return $SpecialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $SpecialPropertyName) {
     this.$SpecialPropertyName = $SpecialPropertyName;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/TagDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/TagDto.java
@@ -45,6 +45,7 @@ public class TagDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -65,6 +66,7 @@ public class TagDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/TestInlineFreeformAdditionalPropertiesRequestDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/TestInlineFreeformAdditionalPropertiesRequestDto.java
@@ -47,6 +47,7 @@ public class TestInlineFreeformAdditionalPropertiesRequestDto {
     return someProperty;
   }
 
+  @JsonProperty("someProperty")
   public void setSomeProperty(@Nullable String someProperty) {
     this.someProperty = someProperty;
   }

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/UserDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/UserDto.java
@@ -57,6 +57,7 @@ public class UserDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -77,6 +78,7 @@ public class UserDto {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -97,6 +99,7 @@ public class UserDto {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -117,6 +120,7 @@ public class UserDto {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -137,6 +141,7 @@ public class UserDto {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -157,6 +162,7 @@ public class UserDto {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -177,6 +183,7 @@ public class UserDto {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -197,6 +204,7 @@ public class UserDto {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AdditionalPropertiesAnyTypeDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AdditionalPropertiesAnyTypeDto.java
@@ -47,6 +47,7 @@ public class AdditionalPropertiesAnyTypeDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AdditionalPropertiesArrayDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AdditionalPropertiesArrayDto.java
@@ -48,6 +48,7 @@ public class AdditionalPropertiesArrayDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AdditionalPropertiesBooleanDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AdditionalPropertiesBooleanDto.java
@@ -47,6 +47,7 @@ public class AdditionalPropertiesBooleanDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
@@ -86,6 +86,7 @@ public class AdditionalPropertiesClassDto {
     return mapString;
   }
 
+  @JsonProperty("map_string")
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -114,6 +115,7 @@ public class AdditionalPropertiesClassDto {
     return mapNumber;
   }
 
+  @JsonProperty("map_number")
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -142,6 +144,7 @@ public class AdditionalPropertiesClassDto {
     return mapInteger;
   }
 
+  @JsonProperty("map_integer")
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -170,6 +173,7 @@ public class AdditionalPropertiesClassDto {
     return mapBoolean;
   }
 
+  @JsonProperty("map_boolean")
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -198,6 +202,7 @@ public class AdditionalPropertiesClassDto {
     return mapArrayInteger;
   }
 
+  @JsonProperty("map_array_integer")
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -226,6 +231,7 @@ public class AdditionalPropertiesClassDto {
     return mapArrayAnytype;
   }
 
+  @JsonProperty("map_array_anytype")
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -254,6 +260,7 @@ public class AdditionalPropertiesClassDto {
     return mapMapString;
   }
 
+  @JsonProperty("map_map_string")
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -282,6 +289,7 @@ public class AdditionalPropertiesClassDto {
     return mapMapAnytype;
   }
 
+  @JsonProperty("map_map_anytype")
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -302,6 +310,7 @@ public class AdditionalPropertiesClassDto {
     return anytype1;
   }
 
+  @JsonProperty("anytype_1")
   public void setAnytype1(@Nullable Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -342,6 +351,7 @@ public class AdditionalPropertiesClassDto {
     return anytype3;
   }
 
+  @JsonProperty("anytype_3")
   public void setAnytype3(@Nullable Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AdditionalPropertiesIntegerDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AdditionalPropertiesIntegerDto.java
@@ -47,6 +47,7 @@ public class AdditionalPropertiesIntegerDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AdditionalPropertiesNumberDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AdditionalPropertiesNumberDto.java
@@ -48,6 +48,7 @@ public class AdditionalPropertiesNumberDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AdditionalPropertiesObjectDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AdditionalPropertiesObjectDto.java
@@ -48,6 +48,7 @@ public class AdditionalPropertiesObjectDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AdditionalPropertiesStringDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AdditionalPropertiesStringDto.java
@@ -47,6 +47,7 @@ public class AdditionalPropertiesStringDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AnimalDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AnimalDto.java
@@ -69,6 +69,7 @@ public class AnimalDto {
     return className;
   }
 
+  @JsonProperty("className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -89,6 +90,7 @@ public class AnimalDto {
     return color;
   }
 
+  @JsonProperty("color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ApiResponseDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ApiResponseDto.java
@@ -47,6 +47,7 @@ public class ApiResponseDto {
     return code;
   }
 
+  @JsonProperty("code")
   public void setCode(@Nullable Integer code) {
     this.code = code;
   }
@@ -67,6 +68,7 @@ public class ApiResponseDto {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable String type) {
     this.type = type;
   }
@@ -87,6 +89,7 @@ public class ApiResponseDto {
     return message;
   }
 
+  @JsonProperty("message")
   public void setMessage(@Nullable String message) {
     this.message = message;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnlyDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnlyDto.java
@@ -56,6 +56,7 @@ public class ArrayOfArrayOfNumberOnlyDto {
     return arrayArrayNumber;
   }
 
+  @JsonProperty("ArrayArrayNumber")
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ArrayOfNumberOnlyDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ArrayOfNumberOnlyDto.java
@@ -56,6 +56,7 @@ public class ArrayOfNumberOnlyDto {
     return arrayNumber;
   }
 
+  @JsonProperty("ArrayNumber")
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ArrayTestDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ArrayTestDto.java
@@ -62,6 +62,7 @@ public class ArrayTestDto {
     return arrayOfString;
   }
 
+  @JsonProperty("array_of_string")
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -90,6 +91,7 @@ public class ArrayTestDto {
     return arrayArrayOfInteger;
   }
 
+  @JsonProperty("array_array_of_integer")
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -118,6 +120,7 @@ public class ArrayTestDto {
     return arrayArrayOfModel;
   }
 
+  @JsonProperty("array_array_of_model")
   public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirstDto>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/BigCatDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/BigCatDto.java
@@ -99,6 +99,7 @@ public class BigCatDto extends CatDto {
     return kind;
   }
 
+  @JsonProperty("kind")
   public void setKind(@Nullable KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/CapitalizationDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/CapitalizationDto.java
@@ -53,6 +53,7 @@ public class CapitalizationDto {
     return smallCamel;
   }
 
+  @JsonProperty("smallCamel")
   public void setSmallCamel(@Nullable String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -73,6 +74,7 @@ public class CapitalizationDto {
     return capitalCamel;
   }
 
+  @JsonProperty("CapitalCamel")
   public void setCapitalCamel(@Nullable String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -93,6 +95,7 @@ public class CapitalizationDto {
     return smallSnake;
   }
 
+  @JsonProperty("small_Snake")
   public void setSmallSnake(@Nullable String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -113,6 +116,7 @@ public class CapitalizationDto {
     return capitalSnake;
   }
 
+  @JsonProperty("Capital_Snake")
   public void setCapitalSnake(@Nullable String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -133,6 +137,7 @@ public class CapitalizationDto {
     return scAETHFlowPoints;
   }
 
+  @JsonProperty("SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(@Nullable String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -153,6 +158,7 @@ public class CapitalizationDto {
     return ATT_NAME;
   }
 
+  @JsonProperty("ATT_NAME")
   public void setATTNAME(@Nullable String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/CatDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/CatDto.java
@@ -66,6 +66,7 @@ public class CatDto extends AnimalDto {
     return declawed;
   }
 
+  @JsonProperty("declawed")
   public void setDeclawed(@Nullable Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/CategoryDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/CategoryDto.java
@@ -56,6 +56,7 @@ public class CategoryDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -76,6 +77,7 @@ public class CategoryDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ChildWithNullableDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ChildWithNullableDto.java
@@ -51,6 +51,7 @@ public class ChildWithNullableDto extends ParentWithNullableDto {
     return otherProperty;
   }
 
+  @JsonProperty("otherProperty")
   public void setOtherProperty(@Nullable String otherProperty) {
     this.otherProperty = otherProperty;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ClassModelDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ClassModelDto.java
@@ -44,6 +44,7 @@ public class ClassModelDto {
     return propertyClass;
   }
 
+  @JsonProperty("_class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ClientDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ClientDto.java
@@ -43,6 +43,7 @@ public class ClientDto {
     return client;
   }
 
+  @JsonProperty("client")
   public void setClient(@Nullable String client) {
     this.client = client;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
@@ -106,6 +106,7 @@ public class ContainerDefaultValueDto {
     return nullableRequiredArray;
   }
 
+  @JsonProperty("nullable_required_array")
   public void setNullableRequiredArray(JsonNullable<List<String>> nullableRequiredArray) {
     this.nullableRequiredArray = nullableRequiredArray;
   }
@@ -134,6 +135,7 @@ public class ContainerDefaultValueDto {
     return requiredArray;
   }
 
+  @JsonProperty("required_array")
   public void setRequiredArray(List<String> requiredArray) {
     this.requiredArray = requiredArray;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/DogDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/DogDto.java
@@ -59,6 +59,7 @@ public class DogDto extends AnimalDto {
     return breed;
   }
 
+  @JsonProperty("breed")
   public void setBreed(@Nullable String breed) {
     this.breed = breed;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/EnumArraysDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/EnumArraysDto.java
@@ -120,6 +120,7 @@ public class EnumArraysDto {
     return justSymbol;
   }
 
+  @JsonProperty("just_symbol")
   public void setJustSymbol(@Nullable JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -148,6 +149,7 @@ public class EnumArraysDto {
     return arrayEnum;
   }
 
+  @JsonProperty("array_enum")
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/EnumTestDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/EnumTestDto.java
@@ -208,6 +208,7 @@ public class EnumTestDto {
     return enumString;
   }
 
+  @JsonProperty("enum_string")
   public void setEnumString(@Nullable EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -228,6 +229,7 @@ public class EnumTestDto {
     return enumStringRequired;
   }
 
+  @JsonProperty("enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -248,6 +250,7 @@ public class EnumTestDto {
     return enumInteger;
   }
 
+  @JsonProperty("enum_integer")
   public void setEnumInteger(@Nullable EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -268,6 +271,7 @@ public class EnumTestDto {
     return enumNumber;
   }
 
+  @JsonProperty("enum_number")
   public void setEnumNumber(@Nullable EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -288,6 +292,7 @@ public class EnumTestDto {
     return outerEnum;
   }
 
+  @JsonProperty("outerEnum")
   public void setOuterEnum(@Nullable OuterEnumDto outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/FileDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/FileDto.java
@@ -44,6 +44,7 @@ public class FileDto {
     return sourceURI;
   }
 
+  @JsonProperty("sourceURI")
   public void setSourceURI(@Nullable String sourceURI) {
     this.sourceURI = sourceURI;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/FileSchemaTestClassDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/FileSchemaTestClassDto.java
@@ -50,6 +50,7 @@ public class FileSchemaTestClassDto {
     return file;
   }
 
+  @JsonProperty("file")
   public void setFile(@Nullable FileDto file) {
     this.file = file;
   }
@@ -78,6 +79,7 @@ public class FileSchemaTestClassDto {
     return files;
   }
 
+  @JsonProperty("files")
   public void setFiles(List<@Valid FileDto> files) {
     this.files = files;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/FormatTestDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/FormatTestDto.java
@@ -93,6 +93,7 @@ public class FormatTestDto {
     return integer;
   }
 
+  @JsonProperty("integer")
   public void setInteger(@Nullable Integer integer) {
     this.integer = integer;
   }
@@ -115,6 +116,7 @@ public class FormatTestDto {
     return int32;
   }
 
+  @JsonProperty("int32")
   public void setInt32(@Nullable Integer int32) {
     this.int32 = int32;
   }
@@ -135,6 +137,7 @@ public class FormatTestDto {
     return int64;
   }
 
+  @JsonProperty("int64")
   public void setInt64(@Nullable Long int64) {
     this.int64 = int64;
   }
@@ -157,6 +160,7 @@ public class FormatTestDto {
     return number;
   }
 
+  @JsonProperty("number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -179,6 +183,7 @@ public class FormatTestDto {
     return _float;
   }
 
+  @JsonProperty("float")
   public void setFloat(@Nullable Float _float) {
     this._float = _float;
   }
@@ -201,6 +206,7 @@ public class FormatTestDto {
     return _double;
   }
 
+  @JsonProperty("double")
   public void setDouble(@Nullable Double _double) {
     this._double = _double;
   }
@@ -221,6 +227,7 @@ public class FormatTestDto {
     return string;
   }
 
+  @JsonProperty("string")
   public void setString(@Nullable String string) {
     this.string = string;
   }
@@ -241,6 +248,7 @@ public class FormatTestDto {
     return _byte;
   }
 
+  @JsonProperty("byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -261,6 +269,7 @@ public class FormatTestDto {
     return binary;
   }
 
+  @JsonProperty("binary")
   public void setBinary(@Nullable org.springframework.core.io.Resource binary) {
     this.binary = binary;
   }
@@ -281,6 +290,7 @@ public class FormatTestDto {
     return date;
   }
 
+  @JsonProperty("date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -301,6 +311,7 @@ public class FormatTestDto {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -321,6 +332,7 @@ public class FormatTestDto {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -341,6 +353,7 @@ public class FormatTestDto {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -361,6 +374,7 @@ public class FormatTestDto {
     return bigDecimal;
   }
 
+  @JsonProperty("BigDecimal")
   public void setBigDecimal(@Nullable BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/HasOnlyReadOnlyDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/HasOnlyReadOnlyDto.java
@@ -45,6 +45,7 @@ public class HasOnlyReadOnlyDto {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -65,6 +66,7 @@ public class HasOnlyReadOnlyDto {
     return foo;
   }
 
+  @JsonProperty("foo")
   public void setFoo(@Nullable String foo) {
     this.foo = foo;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ListDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ListDto.java
@@ -43,6 +43,7 @@ public class ListDto {
     return _123List;
   }
 
+  @JsonProperty("123-list")
   public void set123List(@Nullable String _123List) {
     this._123List = _123List;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/MapTestDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/MapTestDto.java
@@ -99,6 +99,7 @@ public class MapTestDto {
     return mapMapOfString;
   }
 
+  @JsonProperty("map_map_of_string")
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -127,6 +128,7 @@ public class MapTestDto {
     return mapOfEnumString;
   }
 
+  @JsonProperty("map_of_enum_string")
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -155,6 +157,7 @@ public class MapTestDto {
     return directMap;
   }
 
+  @JsonProperty("direct_map")
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -183,6 +186,7 @@ public class MapTestDto {
     return indirectMap;
   }
 
+  @JsonProperty("indirect_map")
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClassDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClassDto.java
@@ -55,6 +55,7 @@ public class MixedPropertiesAndAdditionalPropertiesClassDto {
     return uuid;
   }
 
+  @JsonProperty("uuid")
   public void setUuid(@Nullable UUID uuid) {
     this.uuid = uuid;
   }
@@ -75,6 +76,7 @@ public class MixedPropertiesAndAdditionalPropertiesClassDto {
     return dateTime;
   }
 
+  @JsonProperty("dateTime")
   public void setDateTime(@Nullable OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -103,6 +105,7 @@ public class MixedPropertiesAndAdditionalPropertiesClassDto {
     return map;
   }
 
+  @JsonProperty("map")
   public void setMap(Map<String, AnimalDto> map) {
     this.map = map;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Model200ResponseDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Model200ResponseDto.java
@@ -46,6 +46,7 @@ public class Model200ResponseDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable Integer name) {
     this.name = name;
   }
@@ -66,6 +67,7 @@ public class Model200ResponseDto {
     return propertyClass;
   }
 
+  @JsonProperty("class")
   public void setPropertyClass(@Nullable String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/NameDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/NameDto.java
@@ -61,6 +61,7 @@ public class NameDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -81,6 +82,7 @@ public class NameDto {
     return snakeCase;
   }
 
+  @JsonProperty("snake_case")
   public void setSnakeCase(@Nullable Integer snakeCase) {
     this.snakeCase = snakeCase;
   }
@@ -101,6 +103,7 @@ public class NameDto {
     return property;
   }
 
+  @JsonProperty("property")
   public void setProperty(@Nullable String property) {
     this.property = property;
   }
@@ -121,6 +124,7 @@ public class NameDto {
     return _123Number;
   }
 
+  @JsonProperty("123Number")
   public void set123Number(@Nullable Integer _123Number) {
     this._123Number = _123Number;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/NumberOnlyDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/NumberOnlyDto.java
@@ -44,6 +44,7 @@ public class NumberOnlyDto {
     return justNumber;
   }
 
+  @JsonProperty("JustNumber")
   public void setJustNumber(@Nullable BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/OrderDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/OrderDto.java
@@ -94,6 +94,7 @@ public class OrderDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -114,6 +115,7 @@ public class OrderDto {
     return petId;
   }
 
+  @JsonProperty("petId")
   public void setPetId(@Nullable Long petId) {
     this.petId = petId;
   }
@@ -134,6 +136,7 @@ public class OrderDto {
     return quantity;
   }
 
+  @JsonProperty("quantity")
   public void setQuantity(@Nullable Integer quantity) {
     this.quantity = quantity;
   }
@@ -154,6 +157,7 @@ public class OrderDto {
     return shipDate;
   }
 
+  @JsonProperty("shipDate")
   public void setShipDate(@Nullable OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -174,6 +178,7 @@ public class OrderDto {
     return status;
   }
 
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }
@@ -194,6 +199,7 @@ public class OrderDto {
     return complete;
   }
 
+  @JsonProperty("complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/OuterCompositeDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/OuterCompositeDto.java
@@ -48,6 +48,7 @@ public class OuterCompositeDto {
     return myNumber;
   }
 
+  @JsonProperty("my_number")
   public void setMyNumber(@Nullable BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -68,6 +69,7 @@ public class OuterCompositeDto {
     return myString;
   }
 
+  @JsonProperty("my_string")
   public void setMyString(@Nullable String myString) {
     this.myString = myString;
   }
@@ -88,6 +90,7 @@ public class OuterCompositeDto {
     return myBoolean;
   }
 
+  @JsonProperty("my_boolean")
   public void setMyBoolean(@Nullable Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ParentWithNullableDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ParentWithNullableDto.java
@@ -93,6 +93,7 @@ public class ParentWithNullableDto {
     return type;
   }
 
+  @JsonProperty("type")
   public void setType(@Nullable TypeEnum type) {
     this.type = type;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/PetDto.java
@@ -114,6 +114,7 @@ public class PetDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -134,6 +135,7 @@ public class PetDto {
     return category;
   }
 
+  @JsonProperty("category")
   public void setCategory(@Nullable CategoryDto category) {
     this.category = category;
   }
@@ -154,6 +156,7 @@ public class PetDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(String name) {
     this.name = name;
   }
@@ -183,6 +186,7 @@ public class PetDto {
   }
 
   @JsonDeserialize(as = LinkedHashSet.class)
+  @JsonProperty("photoUrls")
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -211,6 +215,7 @@ public class PetDto {
     return tags;
   }
 
+  @JsonProperty("tags")
   public void setTags(List<@Valid TagDto> tags) {
     this.tags = tags;
   }
@@ -227,8 +232,8 @@ public class PetDto {
    */
   
   @ApiModelProperty(value = "pet status in the store")
-  @JsonProperty("status")
   @Deprecated
+  @JsonProperty("status")
   public @Nullable StatusEnum getStatus() {
     return status;
   }
@@ -237,6 +242,7 @@ public class PetDto {
    * @deprecated
    */
   @Deprecated
+  @JsonProperty("status")
   public void setStatus(@Nullable StatusEnum status) {
     this.status = status;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ReadOnlyFirstDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ReadOnlyFirstDto.java
@@ -45,6 +45,7 @@ public class ReadOnlyFirstDto {
     return bar;
   }
 
+  @JsonProperty("bar")
   public void setBar(@Nullable String bar) {
     this.bar = bar;
   }
@@ -65,6 +66,7 @@ public class ReadOnlyFirstDto {
     return baz;
   }
 
+  @JsonProperty("baz")
   public void setBaz(@Nullable String baz) {
     this.baz = baz;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNamesDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ResponseObjectWithDifferentFieldNamesDto.java
@@ -49,6 +49,7 @@ public class ResponseObjectWithDifferentFieldNamesDto {
     return normalPropertyName;
   }
 
+  @JsonProperty("normalPropertyName")
   public void setNormalPropertyName(@Nullable String normalPropertyName) {
     this.normalPropertyName = normalPropertyName;
   }
@@ -69,6 +70,7 @@ public class ResponseObjectWithDifferentFieldNamesDto {
     return UPPER_CASE_PROPERTY_SNAKE;
   }
 
+  @JsonProperty("UPPER_CASE_PROPERTY_SNAKE")
   public void setUPPERCASEPROPERTYSNAKE(@Nullable String UPPER_CASE_PROPERTY_SNAKE) {
     this.UPPER_CASE_PROPERTY_SNAKE = UPPER_CASE_PROPERTY_SNAKE;
   }
@@ -89,6 +91,7 @@ public class ResponseObjectWithDifferentFieldNamesDto {
     return lowerCasePropertyDashes;
   }
 
+  @JsonProperty("lower-case-property-dashes")
   public void setLowerCasePropertyDashes(@Nullable String lowerCasePropertyDashes) {
     this.lowerCasePropertyDashes = lowerCasePropertyDashes;
   }
@@ -109,6 +112,7 @@ public class ResponseObjectWithDifferentFieldNamesDto {
     return propertyNameWithSpaces;
   }
 
+  @JsonProperty("property name with spaces")
   public void setPropertyNameWithSpaces(@Nullable String propertyNameWithSpaces) {
     this.propertyNameWithSpaces = propertyNameWithSpaces;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ReturnDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ReturnDto.java
@@ -44,6 +44,7 @@ public class ReturnDto {
     return _return;
   }
 
+  @JsonProperty("return")
   public void setReturn(@Nullable Integer _return) {
     this._return = _return;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/SpecialModelNameDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/SpecialModelNameDto.java
@@ -43,6 +43,7 @@ public class SpecialModelNameDto {
     return $SpecialPropertyName;
   }
 
+  @JsonProperty("$special[property.name]")
   public void set$SpecialPropertyName(@Nullable Long $SpecialPropertyName) {
     this.$SpecialPropertyName = $SpecialPropertyName;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/TagDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/TagDto.java
@@ -45,6 +45,7 @@ public class TagDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -65,6 +66,7 @@ public class TagDto {
     return name;
   }
 
+  @JsonProperty("name")
   public void setName(@Nullable String name) {
     this.name = name;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/TypeHolderDefaultDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/TypeHolderDefaultDto.java
@@ -71,6 +71,7 @@ public class TypeHolderDefaultDto {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -91,6 +92,7 @@ public class TypeHolderDefaultDto {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -111,6 +113,7 @@ public class TypeHolderDefaultDto {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -131,6 +134,7 @@ public class TypeHolderDefaultDto {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -159,6 +163,7 @@ public class TypeHolderDefaultDto {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/TypeHolderExampleDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/TypeHolderExampleDto.java
@@ -74,6 +74,7 @@ public class TypeHolderExampleDto {
     return stringItem;
   }
 
+  @JsonProperty("string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -94,6 +95,7 @@ public class TypeHolderExampleDto {
     return numberItem;
   }
 
+  @JsonProperty("number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -114,6 +116,7 @@ public class TypeHolderExampleDto {
     return floatItem;
   }
 
+  @JsonProperty("float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -134,6 +137,7 @@ public class TypeHolderExampleDto {
     return integerItem;
   }
 
+  @JsonProperty("integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -154,6 +158,7 @@ public class TypeHolderExampleDto {
     return boolItem;
   }
 
+  @JsonProperty("bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -182,6 +187,7 @@ public class TypeHolderExampleDto {
     return arrayItem;
   }
 
+  @JsonProperty("array_item")
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/UserDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/UserDto.java
@@ -57,6 +57,7 @@ public class UserDto {
     return id;
   }
 
+  @JsonProperty("id")
   public void setId(@Nullable Long id) {
     this.id = id;
   }
@@ -77,6 +78,7 @@ public class UserDto {
     return username;
   }
 
+  @JsonProperty("username")
   public void setUsername(@Nullable String username) {
     this.username = username;
   }
@@ -97,6 +99,7 @@ public class UserDto {
     return firstName;
   }
 
+  @JsonProperty("firstName")
   public void setFirstName(@Nullable String firstName) {
     this.firstName = firstName;
   }
@@ -117,6 +120,7 @@ public class UserDto {
     return lastName;
   }
 
+  @JsonProperty("lastName")
   public void setLastName(@Nullable String lastName) {
     this.lastName = lastName;
   }
@@ -137,6 +141,7 @@ public class UserDto {
     return email;
   }
 
+  @JsonProperty("email")
   public void setEmail(@Nullable String email) {
     this.email = email;
   }
@@ -157,6 +162,7 @@ public class UserDto {
     return password;
   }
 
+  @JsonProperty("password")
   public void setPassword(@Nullable String password) {
     this.password = password;
   }
@@ -177,6 +183,7 @@ public class UserDto {
     return phone;
   }
 
+  @JsonProperty("phone")
   public void setPhone(@Nullable String phone) {
     this.phone = phone;
   }
@@ -197,6 +204,7 @@ public class UserDto {
     return userStatus;
   }
 
+  @JsonProperty("userStatus")
   public void setUserStatus(@Nullable Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/XmlItemDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/XmlItemDto.java
@@ -112,6 +112,7 @@ public class XmlItemDto {
     return attributeString;
   }
 
+  @JsonProperty("attribute_string")
   public void setAttributeString(@Nullable String attributeString) {
     this.attributeString = attributeString;
   }
@@ -132,6 +133,7 @@ public class XmlItemDto {
     return attributeNumber;
   }
 
+  @JsonProperty("attribute_number")
   public void setAttributeNumber(@Nullable BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -152,6 +154,7 @@ public class XmlItemDto {
     return attributeInteger;
   }
 
+  @JsonProperty("attribute_integer")
   public void setAttributeInteger(@Nullable Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -172,6 +175,7 @@ public class XmlItemDto {
     return attributeBoolean;
   }
 
+  @JsonProperty("attribute_boolean")
   public void setAttributeBoolean(@Nullable Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -200,6 +204,7 @@ public class XmlItemDto {
     return wrappedArray;
   }
 
+  @JsonProperty("wrapped_array")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -220,6 +225,7 @@ public class XmlItemDto {
     return nameString;
   }
 
+  @JsonProperty("name_string")
   public void setNameString(@Nullable String nameString) {
     this.nameString = nameString;
   }
@@ -240,6 +246,7 @@ public class XmlItemDto {
     return nameNumber;
   }
 
+  @JsonProperty("name_number")
   public void setNameNumber(@Nullable BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -260,6 +267,7 @@ public class XmlItemDto {
     return nameInteger;
   }
 
+  @JsonProperty("name_integer")
   public void setNameInteger(@Nullable Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -280,6 +288,7 @@ public class XmlItemDto {
     return nameBoolean;
   }
 
+  @JsonProperty("name_boolean")
   public void setNameBoolean(@Nullable Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -308,6 +317,7 @@ public class XmlItemDto {
     return nameArray;
   }
 
+  @JsonProperty("name_array")
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -336,6 +346,7 @@ public class XmlItemDto {
     return nameWrappedArray;
   }
 
+  @JsonProperty("name_wrapped_array")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -356,6 +367,7 @@ public class XmlItemDto {
     return prefixString;
   }
 
+  @JsonProperty("prefix_string")
   public void setPrefixString(@Nullable String prefixString) {
     this.prefixString = prefixString;
   }
@@ -376,6 +388,7 @@ public class XmlItemDto {
     return prefixNumber;
   }
 
+  @JsonProperty("prefix_number")
   public void setPrefixNumber(@Nullable BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -396,6 +409,7 @@ public class XmlItemDto {
     return prefixInteger;
   }
 
+  @JsonProperty("prefix_integer")
   public void setPrefixInteger(@Nullable Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -416,6 +430,7 @@ public class XmlItemDto {
     return prefixBoolean;
   }
 
+  @JsonProperty("prefix_boolean")
   public void setPrefixBoolean(@Nullable Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -444,6 +459,7 @@ public class XmlItemDto {
     return prefixArray;
   }
 
+  @JsonProperty("prefix_array")
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -472,6 +488,7 @@ public class XmlItemDto {
     return prefixWrappedArray;
   }
 
+  @JsonProperty("prefix_wrapped_array")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -492,6 +509,7 @@ public class XmlItemDto {
     return namespaceString;
   }
 
+  @JsonProperty("namespace_string")
   public void setNamespaceString(@Nullable String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -512,6 +530,7 @@ public class XmlItemDto {
     return namespaceNumber;
   }
 
+  @JsonProperty("namespace_number")
   public void setNamespaceNumber(@Nullable BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -532,6 +551,7 @@ public class XmlItemDto {
     return namespaceInteger;
   }
 
+  @JsonProperty("namespace_integer")
   public void setNamespaceInteger(@Nullable Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -552,6 +572,7 @@ public class XmlItemDto {
     return namespaceBoolean;
   }
 
+  @JsonProperty("namespace_boolean")
   public void setNamespaceBoolean(@Nullable Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -580,6 +601,7 @@ public class XmlItemDto {
     return namespaceArray;
   }
 
+  @JsonProperty("namespace_array")
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -608,6 +630,7 @@ public class XmlItemDto {
     return namespaceWrappedArray;
   }
 
+  @JsonProperty("namespace_wrapped_array")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -628,6 +651,7 @@ public class XmlItemDto {
     return prefixNsString;
   }
 
+  @JsonProperty("prefix_ns_string")
   public void setPrefixNsString(@Nullable String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -648,6 +672,7 @@ public class XmlItemDto {
     return prefixNsNumber;
   }
 
+  @JsonProperty("prefix_ns_number")
   public void setPrefixNsNumber(@Nullable BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -668,6 +693,7 @@ public class XmlItemDto {
     return prefixNsInteger;
   }
 
+  @JsonProperty("prefix_ns_integer")
   public void setPrefixNsInteger(@Nullable Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -688,6 +714,7 @@ public class XmlItemDto {
     return prefixNsBoolean;
   }
 
+  @JsonProperty("prefix_ns_boolean")
   public void setPrefixNsBoolean(@Nullable Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -716,6 +743,7 @@ public class XmlItemDto {
     return prefixNsArray;
   }
 
+  @JsonProperty("prefix_ns_array")
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -744,6 +772,7 @@ public class XmlItemDto {
     return prefixNsWrappedArray;
   }
 
+  @JsonProperty("prefix_ns_wrapped_array")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }


### PR DESCRIPTION
In order to fix #22757, I applied same logic used on java side by #9041 

* extract `jacksonAnnotation` partial template
* extract `xmlAccessorAnnotation` partial template
* apply `jacksonAnnotation` and `xmlAccessorAnnotation` partial templates on both getter and setter




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `@JsonProperty` to generated Spring model setters so Jackson maps JSON names correctly during deserialization. Extract shared Jackson/XML annotation partials and reuse them; skip setters for `jackson-optional-nullable` properties (fixes #22757).

- **Bug Fixes**
  - Add `@JsonProperty` on setters when using Jackson; exclude `jackson-optional-nullable`.
  - Regenerate Spring samples to show correct mapping for names like "@type", "123-list", and fields with dashes/spaces.

- **Refactors**
  - Introduce `jackson_annotations.mustache` and `xmlAccessorAnnotation.mustache`; apply via `pojo.mustache` and `lombokAnnotation.mustache` to deduplicate annotation logic.

<sup>Written for commit 3a689e16410418e49334d5e868863a24fadf31de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



