### PR TITLE
Support numeric exclusiveMinimum/exclusiveMaximum in OpenAPI 3.1

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -1891,16 +1891,42 @@ public class OpenAPINormalizer {
 
         // OAS 3.1 numeric exclusiveMinimum
         BigDecimal exclusiveMinValue = schema.getExclusiveMinimumValue();
-        if (schema.getMinimum() == null && exclusiveMinValue != null) {
-            schema.setMinimum(exclusiveMinValue);
-            schema.setExclusiveMinimum(Boolean.TRUE);
+        if (exclusiveMinValue != null) {
+            BigDecimal minimum = schema.getMinimum();
+
+            if (minimum == null) {
+                schema.setMinimum(exclusiveMinValue);
+                schema.setExclusiveMinimum(Boolean.TRUE);
+            } else {
+                int cmp = exclusiveMinValue.compareTo(minimum);
+
+                if (cmp > 0) {
+                    schema.setMinimum(exclusiveMinValue);
+                    schema.setExclusiveMinimum(Boolean.TRUE);
+                } else if (cmp == 0) {
+                    schema.setExclusiveMinimum(Boolean.TRUE);
+                }
+            }
         }
 
         // OAS 3.1 numeric exclusiveMaximum
         BigDecimal exclusiveMaxValue = schema.getExclusiveMaximumValue();
-        if (schema.getMaximum() == null && exclusiveMaxValue != null) {
-            schema.setMaximum(exclusiveMaxValue);
-            schema.setExclusiveMaximum(Boolean.TRUE);
+        if (exclusiveMaxValue != null) {
+            BigDecimal maximum = schema.getMaximum();
+
+            if (maximum == null) {
+                schema.setMaximum(exclusiveMaxValue);
+                schema.setExclusiveMaximum(Boolean.TRUE);
+            } else {
+                int cmp = exclusiveMaxValue.compareTo(maximum);
+
+                if (cmp < 0) {
+                    schema.setMaximum(exclusiveMaxValue);
+                    schema.setExclusiveMaximum(Boolean.TRUE);
+                } else if (cmp == 0) {
+                    schema.setExclusiveMaximum(Boolean.TRUE);
+                }
+            }
         }
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -621,7 +621,7 @@ public class OpenAPINormalizerTest {
     }
 
     @Test
-    public void testNormalize31ExclusiveMinMaxNumeric() {
+    public void testNormalize31ExclusiveMinMaxNumericOnly() {
         OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/exclusive-min-max.yaml");
 
         OpenAPINormalizer n = new OpenAPINormalizer(openAPI, Map.of("NORMALIZE_31SPEC", "true"));
@@ -634,11 +634,114 @@ public class OpenAPINormalizerTest {
                 .get(0)
                 .getSchema();
 
+        // exclusiveMinimum: 0
+        assertEquals(new BigDecimal("0"), schema.getExclusiveMinimumValue());
         assertEquals(new BigDecimal("0"), schema.getMinimum());
         assertEquals(Boolean.TRUE, schema.getExclusiveMinimum());
 
+        // exclusiveMaximum: 10
+        assertEquals(new BigDecimal("10"), schema.getExclusiveMaximumValue());
         assertEquals(new BigDecimal("10"), schema.getMaximum());
         assertEquals(Boolean.TRUE, schema.getExclusiveMaximum());
+    }
+
+    @Test
+    public void testNormalize31ExclusiveMinMaxStricterThanMinMax() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/exclusive-min-max.yaml");
+
+        OpenAPINormalizer n = new OpenAPINormalizer(openAPI, Map.of("NORMALIZE_31SPEC", "true"));
+        n.normalize();
+
+        Schema<?> schema = openAPI.getPaths()
+                .get("/foo")
+                .getGet()
+                .getParameters()
+                .get(0)
+                .getSchema();
+
+        assertEquals(new BigDecimal("1"), schema.getExclusiveMinimumValue());
+        assertEquals(new BigDecimal("1"), schema.getMinimum());
+        assertEquals(Boolean.TRUE, schema.getExclusiveMinimum());
+
+        assertEquals(new BigDecimal("10"), schema.getExclusiveMaximumValue());
+        assertEquals(new BigDecimal("10"), schema.getMaximum());
+        assertEquals(Boolean.TRUE, schema.getExclusiveMaximum());
+    }
+
+    @Test
+    public void testNormalize31ExclusiveMinMaxEqualToMinMax() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/exclusive-min-max.yaml");
+
+        OpenAPINormalizer n = new OpenAPINormalizer(openAPI, Map.of("NORMALIZE_31SPEC", "true"));
+        n.normalize();
+
+        Schema<?> schema = openAPI.getPaths()
+                .get("/bar")
+                .getGet()
+                .getParameters()
+                .get(0)
+                .getSchema();
+
+        // minimum: 0 + exclusiveMinimum: 0 → must remain exclusive
+        assertEquals(new BigDecimal("0"), schema.getExclusiveMinimumValue());
+        assertEquals(new BigDecimal("0"), schema.getMinimum());
+        assertEquals(Boolean.TRUE, schema.getExclusiveMinimum());
+
+        // maximum: 10 + exclusiveMaximum: 10 → must remain exclusive
+        assertEquals(new BigDecimal("10"), schema.getExclusiveMaximumValue());
+        assertEquals(new BigDecimal("10"), schema.getMaximum());
+        assertEquals(Boolean.TRUE, schema.getExclusiveMaximum());
+    }
+
+    @Test
+    public void testNormalize31ExclusiveMinMaxInclusiveStricterThanExclusiveValue() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/exclusive-min-max.yaml");
+
+        OpenAPINormalizer n = new OpenAPINormalizer(openAPI, Map.of("NORMALIZE_31SPEC", "true"));
+        n.normalize();
+
+        Schema<?> schema = openAPI.getPaths()
+                .get("/baz")
+                .getGet()
+                .getParameters()
+                .get(0)
+                .getSchema();
+
+        // minimum: 5 is stricter than exclusiveMinimum: 0 (x >= 5 dominates x > 0)
+        assertEquals(new BigDecimal("0"), schema.getExclusiveMinimumValue());
+        assertEquals(new BigDecimal("5"), schema.getMinimum());
+        assertNull(schema.getExclusiveMinimum());
+
+        // maximum: 10 is stricter than exclusiveMaximum: 11 (x <= 10 dominates x < 11)
+        assertEquals(new BigDecimal("11"), schema.getExclusiveMaximumValue());
+        assertEquals(new BigDecimal("10"), schema.getMaximum());
+        assertNull(schema.getExclusiveMaximum());
+    }
+
+    @Test
+    public void testNormalize31ExclusiveMinMaxBooleanExclusiveAlreadySet() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/exclusive-min-max.yaml");
+
+        OpenAPINormalizer n = new OpenAPINormalizer(openAPI, Map.of("NORMALIZE_31SPEC", "true"));
+        n.normalize();
+
+        Schema<?> schema = openAPI.getPaths()
+                .get("/old")
+                .getGet()
+                .getParameters()
+                .get(0)
+                .getSchema();
+
+        // 3.0-style boolean exclusive flags should remain intact
+        assertEquals(new BigDecimal("0"), schema.getMinimum());
+        assertNull(schema.getExclusiveMinimum());
+
+        assertEquals(new BigDecimal("10"), schema.getMaximum());
+        assertNull(schema.getExclusiveMaximum());
+
+        // Ensure numeric 3.1 value fields are not unexpectedly set by normalization
+        assertNull(schema.getExclusiveMinimumValue());
+        assertNull(schema.getExclusiveMaximumValue());
     }
 
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -961,7 +961,7 @@ public class SpringCodegenTest {
         files.keySet().stream().sorted().forEach(System.out::println);
 
 
-        File apiFile = files.get("XApi.java"); // oder XApi.java je nach Tag/operation grouping
+        File apiFile = files.get("XApi.java");
         assertThat(apiFile).isNotNull();
 
         String content = Files.readString(apiFile.toPath());

--- a/modules/openapi-generator/src/test/resources/3_1/exclusive-min-max.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/exclusive-min-max.yaml
@@ -15,3 +15,67 @@ paths:
       responses:
         "200":
           description: ok
+  /foo:
+    get:
+      operationId: getFoo
+      parameters:
+        - name: foo
+          in: query
+          required: true
+          schema:
+            type: number
+            minimum: 0
+            exclusiveMinimum: 1
+            maximum: 11
+            exclusiveMaximum: 10
+      responses:
+        "200":
+          description: ok
+  /bar:
+    get:
+      operationId: getBar
+      parameters:
+        - name: bar
+          in: query
+          required: true
+          schema:
+            type: number
+            minimum: 0
+            exclusiveMinimum: 0
+            maximum: 10
+            exclusiveMaximum: 10
+      responses:
+        "200":
+          description: ok
+  /baz:
+    get:
+      operationId: getBaz
+      parameters:
+        - name: baz
+          in: query
+          required: true
+          schema:
+            type: number
+            minimum: 5
+            exclusiveMinimum: 0
+            maximum: 10
+            exclusiveMaximum: 11
+      responses:
+        "200":
+          description: ok
+  /old:
+    get:
+      operationId: getOld
+      parameters:
+        - name: old
+          in: query
+          required: true
+          schema:
+            type: number
+            minimum: 0
+            exclusiveMinimum: true
+            maximum: 10
+            exclusiveMaximum: true
+      responses:
+        "200":
+          description: ok


### PR DESCRIPTION
… (#22943)

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)

This PR solves following issue: [Compatibility with exclusiveMinimum in OpenAPI 3.0.0 vs. 3.1.0](github.com/OpenAPITools/openapi-generator/issues/22943)

**Description**

OpenAPI 3.1 follows JSON Schema, where exclusiveMinimum/exclusiveMaximum can be specified as numeric values (e.g. exclusiveMinimum: 0) instead of the OpenAPI 3.0 boolean + minimum/maximum combination.

This PR updates the NORMALIZE_31SPEC rule in OpenAPINormalizer to handle the numeric 3.1 form by converting it into a 3.0-compatible shape that the generator already understands:

- exclusiveMinimum: <number> → minimum = [number] and exclusiveMinimum = true
- exclusiveMaximum: <number> → maximum = [number] and exclusiveMaximum = true

This keeps downstream validation/codegen logic unchanged (e.g. Bean Validation @DecimalMin/@DecimalMax generation continues to rely on minimum/maximum + boolean exclusivity).

**Reproduction (minimal spec)**
```
openapi: 3.1.0
info: { title: t, version: 1.0.0 }
paths:
  /x:
    get:
      operationId: getX
      parameters:
        - name: price
          in: query
          required: true
          schema:
            type: number
            exclusiveMinimum: 0
            exclusiveMaximum: 10
      responses:
        "200":
          description: ok
```

**Tests**
Adds a normalization test verifying that after OpenAPINormalizer runs with NORMALIZE_31SPEC=true, the schema has:
minimum=0, exclusiveMinimum=true
maximum=10, exclusiveMaximum=true

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for numeric exclusiveMinimum/exclusiveMaximum in OpenAPI 3.1 and preserves the stricter bound when both numeric-exclusive and inclusive min/max are defined. Keeps validation and codegen consistent (e.g., Bean Validation annotations).

- **Bug Fixes**
  - Normalize 3.1 numeric exclusiveMinimum/exclusiveMaximum to minimum/maximum + exclusive=true in OpenAPINormalizer when NORMALIZE_31SPEC is enabled.
  - When min/max already exist, compare and keep the stricter constraint; set exclusive=true only when the exclusive bound is used.
  - Skip $ref schemas.
  - Add tests for numeric-only, stricter/equal/inclusive-dominant cases and Spring codegen; include a 3.1 sample spec. Fixes #22943.

<sup>Written for commit 87795c7fcfcdc3022ab41669c5805afc0e66b974. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

