### PR TITLE
fix(kotlin): support oneOf with primitive types in kotlinx_serialization

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/oneof_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/oneof_class.mustache
@@ -39,22 +39,22 @@ import kotlinx.serialization.encoding.Encoder
 {{/enumUnknownDefaultCase}}
 {{^enumUnknownDefaultCase}}
 {{#generateOneOfAnyOfWrappers}}
-{{#discriminator}}
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-{{/discriminator}}
 {{/generateOneOfAnyOfWrappers}}
 {{/enumUnknownDefaultCase}}
 {{#generateOneOfAnyOfWrappers}}
-{{#discriminator}}
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor
 import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.JsonEncoder
-import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonPrimitive
+{{#discriminator}}
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 {{/discriminator}}
@@ -100,6 +100,9 @@ import java.io.IOException
 {{#discriminator}}
 @Serializable(with = {{classname}}Serializer::class)
 {{/discriminator}}
+{{^discriminator}}
+{{#serializableModel}}@KSerializable(with = {{classname}}.{{classname}}Serializer::class){{/serializableModel}}{{^serializableModel}}@Serializable(with = {{classname}}.{{classname}}Serializer::class){{/serializableModel}}
+{{/discriminator}}
 {{/generateOneOfAnyOfWrappers}}
 {{/kotlinx_serialization}}
 {{#isDeprecated}}
@@ -107,6 +110,7 @@ import java.io.IOException
 {{/isDeprecated}}
 {{>additionalModelTypeAnnotations}}
 {{#kotlinx_serialization}}
+{{#discriminator}}
 {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}sealed interface {{classname}} {
 {{#discriminator.mappedModels}}
     @JvmInline
@@ -150,6 +154,78 @@ import java.io.IOException
         }
     }
 }
+{{/discriminator}}
+{{^discriminator}}
+{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}data class {{classname}}(var actualInstance: Any? = null) {
+
+    {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}object {{classname}}Serializer : KSerializer<{{classname}}> {
+        override val descriptor: SerialDescriptor = buildClassSerialDescriptor("{{classname}}") {
+            element("type", JsonPrimitive.serializer().descriptor)
+            element("actualInstance", JsonElement.serializer().descriptor)
+        }
+
+        override fun serialize(encoder: Encoder, value: {{classname}}) {
+            val jsonEncoder = encoder as? JsonEncoder ?: throw SerializationException("{{classname}} can only be serialized with Json")
+
+            when (val instance = value.actualInstance) {
+                {{#composedSchemas}}
+                {{#oneOf}}
+                {{#isPrimitiveType}}
+                {{#isString}}
+                is kotlin.String -> jsonEncoder.encodeString(instance)
+                {{/isString}}
+                {{#isBoolean}}
+                is kotlin.Boolean -> jsonEncoder.encodeBoolean(instance)
+                {{/isBoolean}}
+                {{#isInteger}}
+                {{^isLong}}
+                is kotlin.Int -> jsonEncoder.encodeInt(instance)
+                {{/isLong}}
+                {{/isInteger}}
+                {{#isLong}}
+                is kotlin.Long -> jsonEncoder.encodeLong(instance)
+                {{/isLong}}
+                {{#isNumber}}
+                {{#isDouble}}
+                is kotlin.Double -> jsonEncoder.encodeDouble(instance)
+                {{/isDouble}}
+                {{#isFloat}}
+                is kotlin.Float -> jsonEncoder.encodeFloat(instance)
+                {{/isFloat}}
+                {{/isNumber}}
+                {{/isPrimitiveType}}
+                {{^isPrimitiveType}}
+                is {{{dataType}}} -> jsonEncoder.encodeSerializableValue({{{dataType}}}.serializer(), instance)
+                {{/isPrimitiveType}}
+                {{/oneOf}}
+                {{/composedSchemas}}
+                null -> jsonEncoder.encodeJsonElement(JsonNull)
+                else -> throw SerializationException("Unknown type in actualInstance: ${instance::class}")
+            }
+        }
+
+        override fun deserialize(decoder: Decoder): {{classname}} {
+            val jsonDecoder = decoder as? JsonDecoder ?: throw SerializationException("{{classname}} can only be deserialized with Json")
+            val jsonElement = jsonDecoder.decodeJsonElement()
+
+            val errorMessages = mutableListOf<String>()
+
+            {{#composedSchemas}}
+            {{#oneOf}}
+            try {
+                val instance = jsonDecoder.json.decodeFromJsonElement<{{{dataType}}}>(jsonElement)
+                return {{classname}}(actualInstance = instance)
+            } catch (e: Exception) {
+                errorMessages.add("Failed to deserialize as {{{dataType}}}: ${e.message}")
+            }
+            {{/oneOf}}
+            {{/composedSchemas}}
+
+            throw SerializationException("Cannot deserialize {{classname}}. Tried: ${errorMessages.joinToString(", ")}")
+        }
+    }
+}
+{{/discriminator}}
 {{/kotlinx_serialization}}
 {{^kotlinx_serialization}}
 {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}data class {{classname}}(var actualInstance: Any? = null) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
@@ -614,6 +614,40 @@ public class KotlinClientCodegenModelTest {
         TestUtils.assertFileContains(birdKt, "@SerialName(value = \"BIRD\")");
     }
 
+    @Test(description = "generate oneOf wrapper with primitive types using kotlinx_serialization")
+    public void oneOfPrimitiveKotlinxSerialization() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("kotlin")
+                .setLibrary("jvm-retrofit2")
+                .setAdditionalProperties(new HashMap<>() {{
+                    put(CodegenConstants.SERIALIZATION_LIBRARY, "kotlinx_serialization");
+                    put("generateOneOfAnyOfWrappers", true);
+                }})
+                .setInputSpec("src/test/resources/3_0/issue_19942.json")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.opts(clientOptInput).generate();
+
+        final Path oneOfModelKt = Paths.get(output + "/src/main/kotlin/org/openapitools/client/models/ObjectWithComplexOneOfId.kt");
+        // generates data class with actualInstance (not empty sealed interface)
+        TestUtils.assertFileContains(oneOfModelKt, "data class ObjectWithComplexOneOfId");
+        TestUtils.assertFileContains(oneOfModelKt, "var actualInstance: Any?");
+        // has a custom KSerializer
+        TestUtils.assertFileContains(oneOfModelKt, "object ObjectWithComplexOneOfIdSerializer : KSerializer<ObjectWithComplexOneOfId>");
+        // serializer handles primitive types
+        TestUtils.assertFileContains(oneOfModelKt, "is kotlin.String -> jsonEncoder.encodeString(instance)");
+        // serializer handles deserialization via try-each
+        TestUtils.assertFileContains(oneOfModelKt, "decodeFromJsonElement<kotlin.String>(jsonElement)");
+        // parent model references the oneOf wrapper type
+        final Path parentModelKt = Paths.get(output + "/src/main/kotlin/org/openapitools/client/models/ObjectWithComplexOneOf.kt");
+        TestUtils.assertFileContains(parentModelKt, "val id: ObjectWithComplexOneOfId?");
+    }
+
     @Test(description = "generate polymorphic jackson model")
     public void polymorphicJacksonSerialization() throws IOException {
         File output = Files.createTempDirectory("test").toFile();


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

### Description

The kotlin-client generator with `jvm-retrofit2` library and `kotlinx_serialization` failed to generate working code for oneOf schemas containing primitive types (e.g. string, integer) without a discriminator. The existing template only handled discriminator-based oneOf via sealed interfaces, producing an empty class for primitive oneOf.

```yaml
company_id:
  oneOf:
    - type: string
    - type: integer
      format: int64
```

Changes:
- Add a non-discriminator fallback in oneof_class.mustache that generates a data class with actualInstance and a custom KSerializer, ported from the multiplatform template
- Add isLong (int64) handling to the serialize branch, with an isInteger guard to avoid generating a dead branch for int64 types
- Add test for oneOf primitive types with kotlinx_serialization

#### Before

```kotlin
@Serializable
class TestModelCompanyId () {
}
```

#### After

```kotlin
@Serializable(with = TestModelCompanyId.TestModelCompanyIdSerializer::class)
data class TestModelCompanyId(var actualInstance: Any? = null) {

    object TestModelCompanyIdSerializer : KSerializer<TestModelCompanyId> {
        override fun serialize(encoder: Encoder, value: TestModelCompanyId) {
            when (val instance = value.actualInstance) {
                is kotlin.String -> jsonEncoder.encodeString(instance)
                is kotlin.Long -> jsonEncoder.encodeLong(instance)
                null -> jsonEncoder.encodeJsonElement(JsonNull)
                else -> throw SerializationException(...)
            }
        }

        override fun deserialize(decoder: Decoder): TestModelCompanyId {
            // try each type in schema order
            try { decodeFromJsonElement<kotlin.String>(...) } catch { ... }
            try { decodeFromJsonElement<kotlin.Long>(...) } catch { ... }
        }
    }
}
```


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description) (no existing issue)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. (cc:  @karismann @Zomzog @andrewemery @4brunu @yutaka0m @stefankoppier @e5l @dennisameling)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Kotlin client generation for jvm-retrofit2 + kotlinx_serialization when oneOf includes primitive types without a discriminator. Generates a data-class wrapper with a nested KSerializer that handles primitives and null, and tries each type on decode.

- **Bug Fixes**
  - Add non-discriminator fallback in oneof_class.mustache for kotlinx_serialization: data-class wrapper + nested KSerializer; handles String, Boolean, Int, Long (int64 guarded), Float, Double, and null; delegates non-primitives.
  - Add test validating wrapper generation, primitive try-each deserialization, and that the parent model references the wrapper type.

<sup>Written for commit 7296d21c164bbf919f3b9b59127614c990cf719c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



