### PR TITLE
feat: support `date-time-local` in scala generators

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractScalaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractScalaCodegen.java
@@ -47,6 +47,9 @@ import static org.openapitools.codegen.utils.StringUtils.underscore;
 public abstract class AbstractScalaCodegen extends DefaultCodegen {
     private final Logger LOGGER = LoggerFactory.getLogger(AbstractScalaCodegen.class);
 
+    // https://spec.openapis.org/registry/format/date-time-local.html
+    protected static final String DATE_TIME_LOCAL_FORMAT = "date-time-local";
+
     @Getter protected String modelPropertyNaming = CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.camelCase.name();
     @Setter protected String invokerPackage = "org.openapitools.client";
     @Getter @Setter
@@ -137,6 +140,7 @@ public abstract class AbstractScalaCodegen extends DefaultCodegen {
 
         // Scala specific openApi types mapping
         typeMapping.put("ByteArray", "Array[Byte]");
+        typeMapping.put(DATE_TIME_LOCAL_FORMAT, "LocalDateTime");
 
 
         importMapping = new HashMap<String, String>();
@@ -226,8 +230,10 @@ public abstract class AbstractScalaCodegen extends DefaultCodegen {
         if (additionalProperties.containsKey(DATE_LIBRARY)) {
             this.setDateLibrary(additionalProperties.get(DATE_LIBRARY).toString(), false);
         }
+        this.typeMapping.put(DATE_TIME_LOCAL_FORMAT, "LocalDateTime");
         if (DateLibraries.java8.name().equals(dateLibrary)) {
             this.importMapping.put("LocalDate", "java.time.LocalDate");
+            this.importMapping.put("LocalDateTime", "java.time.LocalDateTime");
             this.importMapping.put("OffsetDateTime", "java.time.OffsetDateTime");
             this.typeMapping.put("date", "LocalDate");
             this.typeMapping.put("DateTime", "OffsetDateTime");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/AbstractScalaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/AbstractScalaCodegenTest.java
@@ -101,6 +101,27 @@ public class AbstractScalaCodegenTest {
     }
 
     @Test
+    void checkDateTimeLocalTypeMappingJava8() {
+        P_AbstractScalaCodegen codegen = new P_AbstractScalaCodegen();
+        codegen.processOpts();
+        Assert.assertEquals(codegen.typeMapping().get("date-time-local"), "LocalDateTime",
+                "date-time-local format should map to LocalDateTime");
+        Assert.assertEquals(codegen.importMapping().get("LocalDateTime"), "java.time.LocalDateTime",
+                "LocalDateTime should import from java.time when using java8 date library");
+    }
+
+    @Test
+    void checkDateTimeLocalTypeDeclaration() {
+        P_AbstractScalaCodegen codegen = new P_AbstractScalaCodegen();
+        codegen.processOpts();
+        Schema<?> schema = new ObjectSchema();
+        schema.setType("string");
+        schema.setFormat("date-time-local");
+        Assert.assertEquals(codegen.getTypeDeclaration(schema), "LocalDateTime",
+                "Schema with date-time-local format should produce LocalDateTime type");
+    }
+
+    @Test
     void checkTypeDeclarationWithByteString() {
         Schema<?> byteArraySchema = new ObjectSchema();
         byteArraySchema.setType("string");

--- a/modules/openapi-generator/src/test/resources/3_0/scala/date-time-local.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/scala/date-time-local.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.3
+info:
+  title: Date Time Local Test API
+  version: 1.0.0
+paths:
+  /events:
+    get:
+      operationId: getEvents
+      summary: Get events
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Event'
+components:
+  schemas:
+    Event:
+      type: object
+      required:
+        - name
+        - startTime
+        - createdAt
+      properties:
+        name:
+          type: string
+        startTime:
+          type: string
+          format: date-time-local
+        endTime:
+          type: string
+          format: date-time-local
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Adds support for the OAS3 [`date-time-local`](https://spec.openapis.org/registry/format/date-time-local.html) format and map it to `LocalDateTime` which is then mapped to either `java.time.LocalDateTime` or `org.joda.time.LocalDateTime` accrodingly

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @clasnake (2017/07), @shijinkui (2018/01), @ramzimaalej (2018/03), @chameleon82 (2020/03), @Bouillie (2020/04) @Fish86 (2023/06)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add OAS 3 date-time-local support to Scala generators. Fields with this format now generate as LocalDateTime, importing java.time.LocalDateTime when using the java8 date library.

- **New Features**
  - Map date-time-local to LocalDateTime in AbstractScalaCodegen.
  - Add import for java.time.LocalDateTime when dateLibrary=java8.
  - Tests: verify type mapping and generated model imports; include new sample spec (date-time-local.yaml).

<sup>Written for commit 6927e9233df739abf0e90aabd9a63ae6978b6b58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

