### PR TITLE
Fix #17754: Convert OpenAPI types to Python types in anyOf/oneOf

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
@@ -685,4 +685,30 @@ public class PythonClientCodegenTest {
         // Verify it does NOT use the legacy string format
         TestUtils.assertFileNotContains(pyprojectPath, "license = \"BSD-3-Clause\"");
     }
+
+    @Test(description = "Test anyOf with string and array types - issue #17754")
+    public void testAnyOfStringArrayTypes() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+            .setGeneratorName("python")
+            .setInputSpec("src/test/resources/3_0/issue_17754_anyof_string_array.yaml")
+            .setOutputDir(output.getAbsolutePath());
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        // The anyOf creates an inline model - check that model
+        Path valueModelPath = Paths.get(output.getAbsolutePath(), "openapi_client", "models", "key_value_pair_value.py");
+        TestUtils.assertFileExists(valueModelPath);
+
+        String content = Files.readAllLines(valueModelPath).stream().collect(Collectors.joining("\n"));
+
+        // The anyOf schemas should contain Python types (str, List[str]) not OpenAPI types (string, array)
+        // Check that ANY_OF_SCHEMAS contains "List[str]" and "str"
+        Assert.assertTrue(content.contains("KEYVALUEPAIRVALUE_ANY_OF_SCHEMAS = [\"List[str]\", \"str\"]"),
+            "Expected anyOf schemas to contain Python types: List[str], str");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/issue_17754_anyof_string_array.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_17754_anyof_string_array.yaml
@@ -1,0 +1,27 @@
+openapi: 3.1.0
+info:
+  title: Test anyOf with string and array
+  version: 1.0.0
+paths:
+  /:
+    get:
+      responses:
+        '200':
+          description: Request successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KeyValuePair'
+components:
+  schemas:
+    KeyValuePair:
+      properties:
+        key:
+          type: string
+        value:
+          anyOf:
+            - items:
+                type: string
+              type: array
+            - type: string
+      type: object


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

- Add toPythonType() helper method to convert OpenAPI types (string, array) to Python types (str, List)
- Override postProcessModels() to convert anyOf/oneOf types in AbstractPythonCodegen and AbstractPythonPydanticV1Codegen
- Add test case to verify anyOf with string and array types generates correct Python types

Before: anyOf schemas contained ['array[string]', 'string']
After: anyOf schemas contain ['List[str]', 'str']

Fixes #17754.

Python technical committee: @cbornet @tomplus @krjakbrjak @fa0311 @multani 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #17754 by converting anyOf/oneOf OpenAPI types to proper Python types in generated Python clients. Schemas like array[string] now render as List[str], and string as str.

- **Bug Fixes**
  - Added toPythonType helper to map OpenAPI types (string, array, map, etc.) to Python types (str, List, Dict, etc.).
  - Post-processed models in AbstractPythonCodegen and AbstractPythonPydanticV1Codegen to convert anyOf/oneOf entries.
  - Added a test and sample spec to verify anyOf contains ["List[str]", "str"] instead of ["array[string]", "string"].

<sup>Written for commit c35786642f942d207f082b901a072db13ad15694. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

