### PR TITLE
[PHP] Always prefer host config over static servers from OpenAPI declaration

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/libraries/psr-18/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/libraries/psr-18/api.mustache
@@ -704,15 +704,15 @@ use function sprintf;
             $headers
         );
 
-        {{^servers.0}}
         $operationHost = $this->config->getHost();
-        {{/servers.0}}
         {{#servers.0}}
-        $operationHosts = [{{#servers}}"{{{url}}}"{{^-last}}, {{/-last}}{{/servers}}];
-        if ($this->hostIndex < 0 || $this->hostIndex >= sizeof($operationHosts)) {
-            throw new \InvalidArgumentException("Invalid index {$this->hostIndex} when selecting the host. Must be less than ".sizeof($operationHosts));
+        if (!$operationHost) {
+            $operationHosts = [{{#servers}}"{{{url}}}"{{^-last}}, {{/-last}}{{/servers}}];
+            if ($this->hostIndex < 0 || $this->hostIndex >= sizeof($operationHosts)) {
+                throw new \InvalidArgumentException("Invalid index {$this->hostIndex} when selecting the host. Must be less than ".sizeof($operationHosts));
+            }
+            $operationHost = $operationHosts[$this->hostIndex];
         }
-        $operationHost = $operationHosts[$this->hostIndex];
         {{/servers.0}}
 
         $uri = $this->createUri($operationHost, $resourcePath, $queryParams);


### PR DESCRIPTION
This PR fixes the bug described in #23016.

Currently the host in the config object is ignored if an operation declares its own `servers` in the OpenAPI file, which makes it impossible to override it in the application.

With this change, the host, defined in the config, always has priority over the servers declared in the operation. 

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), [@ybelenko](https://github.com/ybelenko) (2018/07), @renepardon (2018/12)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always use the config host for PHP PSR-18 clients, even when an operation defines its own servers, so apps can override OpenAPI-declared hosts. Fixes #23016.

- **Bug Fixes**
  - Use config host if set; only fall back to operation servers when config host is empty, with hostIndex validation.

<sup>Written for commit 195abcf6b70782d94a6c5f04e4e1f50c3cdcc2bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

