### PR TITLE
feat(python): expose all config properties in constructor

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-pydantic-v1/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python-pydantic-v1/configuration.mustache
@@ -161,7 +161,7 @@ conf = {{{packageName}}}.Configuration(
 {{/hasHttpSignatureMethods}}
                  server_index=None, server_variables=None,
                  server_operation_index=None, server_operation_variables=None,
-                 verify_ssl=True, ssl_ca_cert=None,
+                 ssl_ca_cert=None, verify_ssl=True,
                  ) -> None:
         """Constructor
         """

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -199,7 +199,7 @@ class Configuration:
     :param key_file: the path to a client key file, for mTLS.
     :param assert_hostname: Set this to True/False to enable/disable SSL hostname verification.
     :param tls_server_name: SSL/TLS Server Name Indication (SNI). Set this to the SNI value expected by the server.
-    :param connection_pool_maxsize: Connection pool max size. Defaults to 100 for async, cpu_count * 5 for sync.
+    :param connection_pool_maxsize: Connection pool max size. None in the constructor is coerced to 100 for async and cpu_count * 5 for sync.
     :param proxy: Proxy URL.
     :param proxy_headers: Proxy headers.
     :param safe_chars_for_path_param: Safe characters for path parameter encoding.
@@ -311,12 +311,12 @@ conf = {{{packageName}}}.Configuration(
         server_operation_index: Optional[Dict[int, int]]=None,
         server_operation_variables: Optional[Dict[int, ServerVariablesT]]=None,
         ignore_operation_servers: bool=False,
-        verify_ssl: bool=True,
         ssl_ca_cert: Optional[str]=None,
         retries: Optional[Union[int, Any]] = None,
         ca_cert_data: Optional[Union[str, bytes]] = None,
         cert_file: Optional[str]=None,
         key_file: Optional[str]=None,
+        verify_ssl: bool=True,
         assert_hostname: Optional[bool]=None,
         tls_server_name: Optional[str]=None,
         connection_pool_maxsize: Optional[int]=None,
@@ -434,16 +434,13 @@ conf = {{{packageName}}}.Configuration(
         {{#async}}
         self.connection_pool_maxsize = connection_pool_maxsize if connection_pool_maxsize is not None else 100
         """This value is passed to the aiohttp to limit simultaneous connections.
-           Default values is 100, None means no-limit.
+           None in the constructor is coerced to default 100.
         """
         {{/async}}
         {{^async}}
         self.connection_pool_maxsize = connection_pool_maxsize if connection_pool_maxsize is not None else multiprocessing.cpu_count() * 5
         """urllib3 connection pool's maximum number of connections saved
-           per pool. urllib3 uses 1 connection as default value, but this is
-           not the best value when you are making a lot of possibly parallel
-           requests to the same host, which is often the case here.
-           cpu_count * 5 is used as default value to increase performance.
+           per pool. None in the constructor is coerced to cpu_count * 5.
         """
         {{/async}}
 

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/configuration.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/configuration.py
@@ -169,7 +169,7 @@ class Configuration:
     :param key_file: the path to a client key file, for mTLS.
     :param assert_hostname: Set this to True/False to enable/disable SSL hostname verification.
     :param tls_server_name: SSL/TLS Server Name Indication (SNI). Set this to the SNI value expected by the server.
-    :param connection_pool_maxsize: Connection pool max size. Defaults to 100 for async, cpu_count * 5 for sync.
+    :param connection_pool_maxsize: Connection pool max size. None in the constructor is coerced to 100 for async and cpu_count * 5 for sync.
     :param proxy: Proxy URL.
     :param proxy_headers: Proxy headers.
     :param safe_chars_for_path_param: Safe characters for path parameter encoding.
@@ -212,12 +212,12 @@ conf = openapi_client.Configuration(
         server_operation_index: Optional[Dict[int, int]]=None,
         server_operation_variables: Optional[Dict[int, ServerVariablesT]]=None,
         ignore_operation_servers: bool=False,
-        verify_ssl: bool=True,
         ssl_ca_cert: Optional[str]=None,
         retries: Optional[Union[int, Any]] = None,
         ca_cert_data: Optional[Union[str, bytes]] = None,
         cert_file: Optional[str]=None,
         key_file: Optional[str]=None,
+        verify_ssl: bool=True,
         assert_hostname: Optional[bool]=None,
         tls_server_name: Optional[str]=None,
         connection_pool_maxsize: Optional[int]=None,
@@ -325,10 +325,7 @@ conf = openapi_client.Configuration(
 
         self.connection_pool_maxsize = connection_pool_maxsize if connection_pool_maxsize is not None else multiprocessing.cpu_count() * 5
         """urllib3 connection pool's maximum number of connections saved
-           per pool. urllib3 uses 1 connection as default value, but this is
-           not the best value when you are making a lot of possibly parallel
-           requests to the same host, which is often the case here.
-           cpu_count * 5 is used as default value to increase performance.
+           per pool. None in the constructor is coerced to cpu_count * 5.
         """
 
         self.proxy = proxy

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/configuration.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/configuration.py
@@ -96,7 +96,7 @@ conf = openapi_client.Configuration(
                  access_token=None,
                  server_index=None, server_variables=None,
                  server_operation_index=None, server_operation_variables=None,
-                 verify_ssl=True, ssl_ca_cert=None,
+                 ssl_ca_cert=None, verify_ssl=True,
                  ) -> None:
         """Constructor
         """

--- a/samples/client/echo_api/python/openapi_client/configuration.py
+++ b/samples/client/echo_api/python/openapi_client/configuration.py
@@ -169,7 +169,7 @@ class Configuration:
     :param key_file: the path to a client key file, for mTLS.
     :param assert_hostname: Set this to True/False to enable/disable SSL hostname verification.
     :param tls_server_name: SSL/TLS Server Name Indication (SNI). Set this to the SNI value expected by the server.
-    :param connection_pool_maxsize: Connection pool max size. Defaults to 100 for async, cpu_count * 5 for sync.
+    :param connection_pool_maxsize: Connection pool max size. None in the constructor is coerced to 100 for async and cpu_count * 5 for sync.
     :param proxy: Proxy URL.
     :param proxy_headers: Proxy headers.
     :param safe_chars_for_path_param: Safe characters for path parameter encoding.
@@ -212,12 +212,12 @@ conf = openapi_client.Configuration(
         server_operation_index: Optional[Dict[int, int]]=None,
         server_operation_variables: Optional[Dict[int, ServerVariablesT]]=None,
         ignore_operation_servers: bool=False,
-        verify_ssl: bool=True,
         ssl_ca_cert: Optional[str]=None,
         retries: Optional[Union[int, Any]] = None,
         ca_cert_data: Optional[Union[str, bytes]] = None,
         cert_file: Optional[str]=None,
         key_file: Optional[str]=None,
+        verify_ssl: bool=True,
         assert_hostname: Optional[bool]=None,
         tls_server_name: Optional[str]=None,
         connection_pool_maxsize: Optional[int]=None,
@@ -325,10 +325,7 @@ conf = openapi_client.Configuration(
 
         self.connection_pool_maxsize = connection_pool_maxsize if connection_pool_maxsize is not None else multiprocessing.cpu_count() * 5
         """urllib3 connection pool's maximum number of connections saved
-           per pool. urllib3 uses 1 connection as default value, but this is
-           not the best value when you are making a lot of possibly parallel
-           requests to the same host, which is often the case here.
-           cpu_count * 5 is used as default value to increase performance.
+           per pool. None in the constructor is coerced to cpu_count * 5.
         """
 
         self.proxy = proxy

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/configuration.py
@@ -174,7 +174,7 @@ class Configuration:
     :param key_file: the path to a client key file, for mTLS.
     :param assert_hostname: Set this to True/False to enable/disable SSL hostname verification.
     :param tls_server_name: SSL/TLS Server Name Indication (SNI). Set this to the SNI value expected by the server.
-    :param connection_pool_maxsize: Connection pool max size. Defaults to 100 for async, cpu_count * 5 for sync.
+    :param connection_pool_maxsize: Connection pool max size. None in the constructor is coerced to 100 for async and cpu_count * 5 for sync.
     :param proxy: Proxy URL.
     :param proxy_headers: Proxy headers.
     :param safe_chars_for_path_param: Safe characters for path parameter encoding.
@@ -276,12 +276,12 @@ conf = petstore_api.Configuration(
         server_operation_index: Optional[Dict[int, int]]=None,
         server_operation_variables: Optional[Dict[int, ServerVariablesT]]=None,
         ignore_operation_servers: bool=False,
-        verify_ssl: bool=True,
         ssl_ca_cert: Optional[str]=None,
         retries: Optional[Union[int, Any]] = None,
         ca_cert_data: Optional[Union[str, bytes]] = None,
         cert_file: Optional[str]=None,
         key_file: Optional[str]=None,
+        verify_ssl: bool=True,
         assert_hostname: Optional[bool]=None,
         tls_server_name: Optional[str]=None,
         connection_pool_maxsize: Optional[int]=None,
@@ -393,7 +393,7 @@ conf = petstore_api.Configuration(
 
         self.connection_pool_maxsize = connection_pool_maxsize if connection_pool_maxsize is not None else 100
         """This value is passed to the aiohttp to limit simultaneous connections.
-           Default values is 100, None means no-limit.
+           None in the constructor is coerced to default 100.
         """
 
         self.proxy = proxy

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/configuration.py
@@ -174,7 +174,7 @@ class Configuration:
     :param key_file: the path to a client key file, for mTLS.
     :param assert_hostname: Set this to True/False to enable/disable SSL hostname verification.
     :param tls_server_name: SSL/TLS Server Name Indication (SNI). Set this to the SNI value expected by the server.
-    :param connection_pool_maxsize: Connection pool max size. Defaults to 100 for async, cpu_count * 5 for sync.
+    :param connection_pool_maxsize: Connection pool max size. None in the constructor is coerced to 100 for async and cpu_count * 5 for sync.
     :param proxy: Proxy URL.
     :param proxy_headers: Proxy headers.
     :param safe_chars_for_path_param: Safe characters for path parameter encoding.
@@ -276,12 +276,12 @@ conf = petstore_api.Configuration(
         server_operation_index: Optional[Dict[int, int]]=None,
         server_operation_variables: Optional[Dict[int, ServerVariablesT]]=None,
         ignore_operation_servers: bool=False,
-        verify_ssl: bool=True,
         ssl_ca_cert: Optional[str]=None,
         retries: Optional[Union[int, Any]] = None,
         ca_cert_data: Optional[Union[str, bytes]] = None,
         cert_file: Optional[str]=None,
         key_file: Optional[str]=None,
+        verify_ssl: bool=True,
         assert_hostname: Optional[bool]=None,
         tls_server_name: Optional[str]=None,
         connection_pool_maxsize: Optional[int]=None,
@@ -393,7 +393,7 @@ conf = petstore_api.Configuration(
 
         self.connection_pool_maxsize = connection_pool_maxsize if connection_pool_maxsize is not None else 100
         """This value is passed to the aiohttp to limit simultaneous connections.
-           Default values is 100, None means no-limit.
+           None in the constructor is coerced to default 100.
         """
 
         self.proxy = proxy

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/configuration.py
@@ -175,7 +175,7 @@ class Configuration:
     :param key_file: the path to a client key file, for mTLS.
     :param assert_hostname: Set this to True/False to enable/disable SSL hostname verification.
     :param tls_server_name: SSL/TLS Server Name Indication (SNI). Set this to the SNI value expected by the server.
-    :param connection_pool_maxsize: Connection pool max size. Defaults to 100 for async, cpu_count * 5 for sync.
+    :param connection_pool_maxsize: Connection pool max size. None in the constructor is coerced to 100 for async and cpu_count * 5 for sync.
     :param proxy: Proxy URL.
     :param proxy_headers: Proxy headers.
     :param safe_chars_for_path_param: Safe characters for path parameter encoding.
@@ -277,12 +277,12 @@ conf = petstore_api.Configuration(
         server_operation_index: Optional[Dict[int, int]]=None,
         server_operation_variables: Optional[Dict[int, ServerVariablesT]]=None,
         ignore_operation_servers: bool=False,
-        verify_ssl: bool=True,
         ssl_ca_cert: Optional[str]=None,
         retries: Optional[Union[int, Any]] = None,
         ca_cert_data: Optional[Union[str, bytes]] = None,
         cert_file: Optional[str]=None,
         key_file: Optional[str]=None,
+        verify_ssl: bool=True,
         assert_hostname: Optional[bool]=None,
         tls_server_name: Optional[str]=None,
         connection_pool_maxsize: Optional[int]=None,
@@ -395,10 +395,7 @@ conf = petstore_api.Configuration(
 
         self.connection_pool_maxsize = connection_pool_maxsize if connection_pool_maxsize is not None else multiprocessing.cpu_count() * 5
         """urllib3 connection pool's maximum number of connections saved
-           per pool. urllib3 uses 1 connection as default value, but this is
-           not the best value when you are making a lot of possibly parallel
-           requests to the same host, which is often the case here.
-           cpu_count * 5 is used as default value to increase performance.
+           per pool. None in the constructor is coerced to cpu_count * 5.
         """
 
         self.proxy = proxy

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/configuration.py
@@ -155,7 +155,7 @@ conf = petstore_api.Configuration(
                  signing_info=None,
                  server_index=None, server_variables=None,
                  server_operation_index=None, server_operation_variables=None,
-                 verify_ssl=True, ssl_ca_cert=None,
+                 ssl_ca_cert=None, verify_ssl=True,
                  ) -> None:
         """Constructor
         """

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/configuration.py
@@ -156,7 +156,7 @@ conf = petstore_api.Configuration(
                  signing_info=None,
                  server_index=None, server_variables=None,
                  server_operation_index=None, server_operation_variables=None,
-                 verify_ssl=True, ssl_ca_cert=None,
+                 ssl_ca_cert=None, verify_ssl=True,
                  ) -> None:
         """Constructor
         """

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -175,7 +175,7 @@ class Configuration:
     :param key_file: the path to a client key file, for mTLS.
     :param assert_hostname: Set this to True/False to enable/disable SSL hostname verification.
     :param tls_server_name: SSL/TLS Server Name Indication (SNI). Set this to the SNI value expected by the server.
-    :param connection_pool_maxsize: Connection pool max size. Defaults to 100 for async, cpu_count * 5 for sync.
+    :param connection_pool_maxsize: Connection pool max size. None in the constructor is coerced to 100 for async and cpu_count * 5 for sync.
     :param proxy: Proxy URL.
     :param proxy_headers: Proxy headers.
     :param safe_chars_for_path_param: Safe characters for path parameter encoding.
@@ -277,12 +277,12 @@ conf = petstore_api.Configuration(
         server_operation_index: Optional[Dict[int, int]]=None,
         server_operation_variables: Optional[Dict[int, ServerVariablesT]]=None,
         ignore_operation_servers: bool=False,
-        verify_ssl: bool=True,
         ssl_ca_cert: Optional[str]=None,
         retries: Optional[Union[int, Any]] = None,
         ca_cert_data: Optional[Union[str, bytes]] = None,
         cert_file: Optional[str]=None,
         key_file: Optional[str]=None,
+        verify_ssl: bool=True,
         assert_hostname: Optional[bool]=None,
         tls_server_name: Optional[str]=None,
         connection_pool_maxsize: Optional[int]=None,
@@ -395,10 +395,7 @@ conf = petstore_api.Configuration(
 
         self.connection_pool_maxsize = connection_pool_maxsize if connection_pool_maxsize is not None else multiprocessing.cpu_count() * 5
         """urllib3 connection pool's maximum number of connections saved
-           per pool. urllib3 uses 1 connection as default value, but this is
-           not the best value when you are making a lot of possibly parallel
-           requests to the same host, which is often the case here.
-           cpu_count * 5 is used as default value to increase performance.
+           per pool. None in the constructor is coerced to cpu_count * 5.
         """
 
         self.proxy = proxy


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->

Configuration options that were only assignable after construction are now constructor parameters for the Python generator, so callers can set them in one place.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @cbornet (2017/09) @tomplus (2018/10) @krjakbrjak (2023/02) @fa0311 (2023/10) @multani (2023/10)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose more Configuration options as constructor args for the Python generator, and add verify_ssl to Python-Pydantic-V1. This lets callers set SSL, retries, proxies, pool size, and serialization at construction, with verify_ssl and pool size defaults applied correctly.

- **New Features**
  - Python (sync/async): Added constructor params verify_ssl, ssl_ca_cert, retries, ca_cert_data, cert_file, key_file, assert_hostname, tls_server_name, connection_pool_maxsize, proxy, proxy_headers, safe_chars_for_path_param, client_side_validation, socket_options, datetime_format, date_format.
  - Python-Pydantic-V1: Added verify_ssl constructor param.
  - Updated templates and regenerated Python and Python-Pydantic-V1 samples; verify_ssl is now taken from the constructor, and connection_pool_maxsize respects the passed value (None coerced to 100 async, cpu_count*5 sync).

<sup>Written for commit bb0ead068313bbebb0d03d3b17a175cd66c31906. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



