### PR TITLE
Rust-server: implement ValidateComposited traits for complex types and add integer enum support

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/example-client-main.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/example-client-main.mustache
@@ -44,17 +44,19 @@ fn main() {
     let matches = Command::new("client")
         .arg(Arg::new("operation")
             .help("Sets the operation to run")
-            .value_parser([
+            .value_parser(Vec::<&str>::from([
 {{#apiInfo}}
   {{#apis}}
     {{#operations}}
       {{#operation}}
+        {{^exts.x-no-client-example}}
                 "{{{operationId}}}",
+        {{/exts.x-no-client-example}}
       {{/operation}}
     {{/operations}}
   {{/apis}}
 {{/apiInfo}}
-            ])
+            ]))
             .required(true)
             .index(1))
         .arg(Arg::new("https")

--- a/modules/openapi-generator/src/main/resources/rust-server/models.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/models.mustache
@@ -146,6 +146,16 @@ impl serde_valid::validation::ValidateCompositedMinLength for {{{classname}}} {
         Ok(())
     }
 }
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for {{{classname}}} {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
 {{/hasConflictingModelNames}}
 {{#exts.x-to-string-support}}
 {{#exts.x-is-string}}
@@ -431,6 +441,28 @@ pub struct {{{classname}}} {
 
 {{/vars}}
 }
+
+{{^hasConflictingModelNames}}
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for {{{classname}}} {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for {{{classname}}} {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
+{{/hasConflictingModelNames}}
 
 {{#vars}}
 {{#hasValidation}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/rust/RustServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/rust/RustServerCodegenTest.java
@@ -59,4 +59,27 @@ public class RustServerCodegenTest {
         // Clean up
         target.toFile().deleteOnExit();
     }
+
+    /**
+     * Test that required query params without examples disable the client example.
+     */
+    @Test
+    public void testRequiredQueryParamWithoutExampleDisablesClientExample() throws IOException {
+        Path target = Files.createTempDirectory("test");
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("rust-server")
+                .setInputSpec("src/test/resources/3_0/rust-server/openapi-v3.yaml")
+                .setSkipOverwrite(false)
+                .setOutputDir(target.toAbsolutePath().toString().replace("\\", "/"));
+        List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        Path exampleClientMain = Path.of(target.toString(), "/examples/client/main.rs");
+        TestUtils.assertFileExists(exampleClientMain);
+        TestUtils.assertFileContains(exampleClientMain, "Disabled because there's no example.");
+        TestUtils.assertFileContains(exampleClientMain, "Some(\"QueryExampleGet\")");
+
+        // Clean up
+        target.toFile().deleteOnExit();
+    }
 }

--- a/modules/openapi-generator/src/test/resources/2_0/rust-server/rust-server-test.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/rust-server/rust-server-test.yaml
@@ -108,7 +108,6 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/allOfObject'
-
 parameters:
   nested_response:
     name: nested_response

--- a/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
@@ -80,6 +80,26 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/anotherXmlObject"
+  /query-example:
+    get:
+      summary: Test required query params with and without examples
+      operationId: queryExampleGet
+      parameters:
+        - name: required_no_example
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: required_with_example
+          in: query
+          required: true
+          example: 42
+          schema:
+            type: integer
+            format: int32
+      responses:
+        200:
+          description: OK
   /multiget:
     get:
       summary: Get some stuff.

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/README.md
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/README.md
@@ -100,6 +100,7 @@ cargo run --example openapi-v3-client MultipleAuthSchemeGet
 cargo run --example openapi-v3-client OneOfGet
 cargo run --example openapi-v3-client OverrideServerGet
 cargo run --example openapi-v3-client ParamgetGet
+cargo run --example openapi-v3-client QueryExampleGet
 cargo run --example openapi-v3-client ReadonlyAuthSchemeGet
 cargo run --example openapi-v3-client RegisterCallbackPost
 cargo run --example openapi-v3-client RequiredOctetStreamPut
@@ -166,6 +167,7 @@ Method | HTTP request | Description
 [****](docs/default_api.md#) | **GET** /one-of | 
 [****](docs/default_api.md#) | **GET** /override-server | 
 [****](docs/default_api.md#) | **GET** /paramget | Get some stuff with parameters.
+[**queryExampleGet**](docs/default_api.md#queryExampleGet) | **GET** /query-example | Test required query params with and without examples
 [****](docs/default_api.md#) | **GET** /readonly_auth_scheme | 
 [****](docs/default_api.md#) | **POST** /register-callback | 
 [****](docs/default_api.md#) | **PUT** /required_octet_stream | 

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/api/openapi.yaml
@@ -67,6 +67,30 @@ paths:
                 $ref: "#/components/schemas/anotherXmlObject"
           description: JSON rsp
       summary: Get some stuff with parameters.
+  /query-example:
+    get:
+      operationId: queryExampleGet
+      parameters:
+      - explode: true
+        in: query
+        name: required_no_example
+        required: true
+        schema:
+          type: string
+        style: form
+      - example: 42
+        explode: true
+        in: query
+        name: required_with_example
+        required: true
+        schema:
+          format: int32
+          type: integer
+        style: form
+      responses:
+        "200":
+          description: OK
+      summary: Test required query params with and without examples
   /multiget:
     get:
       responses:

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/bin/cli.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/bin/cli.rs
@@ -19,6 +19,7 @@ use openapi_v3::{
     OneOfGetResponse,
     OverrideServerGetResponse,
     ParamgetGetResponse,
+    QueryExampleGetResponse,
     ReadonlyAuthSchemeGetResponse,
     RegisterCallbackPostResponse,
     RequiredOctetStreamPutResponse,
@@ -150,6 +151,11 @@ enum Operation {
         /// Some list to pass as query parameter
         #[structopt(parse(try_from_str = parse_json), long)]
         some_list: Option<Vec<models::MyId>>,
+    },
+    /// Test required query params with and without examples
+    QueryExampleGet {
+        required_no_example: String,
+        required_with_example: i32,
     },
     ReadonlyAuthSchemeGet {
     },
@@ -544,6 +550,24 @@ async fn main() -> Result<()> {
                 => "JSONRsp\n".to_string()
                    +
                     &serde_json::to_string_pretty(&body)?,
+            }
+        }
+        Operation::QueryExampleGet {
+            required_no_example,
+            required_with_example,
+        } => {
+            info!("Performing a QueryExampleGet request");
+
+            let result = client.query_example_get(
+                required_no_example,
+                required_with_example,
+            ).await?;
+            debug!("Result: {:?}", result);
+
+            match result {
+                QueryExampleGetResponse::OK
+                => "OK\n".to_string()
+                    ,
             }
         }
         Operation::ReadonlyAuthSchemeGet {

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/docs/default_api.md
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/docs/default_api.md
@@ -18,6 +18,7 @@ Method | HTTP request | Description
 ****](default_api.md#) | **GET** /one-of | 
 ****](default_api.md#) | **GET** /override-server | 
 ****](default_api.md#) | **GET** /paramget | Get some stuff with parameters.
+**queryExampleGet**](default_api.md#queryExampleGet) | **GET** /query-example | Test required query params with and without examples
 ****](default_api.md#) | **GET** /readonly_auth_scheme | 
 ****](default_api.md#) | **POST** /register-callback | 
 ****](default_api.md#) | **PUT** /required_octet_stream | 
@@ -409,6 +410,32 @@ No authorization required
 
  - **Content-Type**: Not defined
  - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **queryExampleGet**
+> queryExampleGet(required_no_example, required_with_example)
+Test required query params with and without examples
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **required_no_example** | **String**|  | 
+  **required_with_example** | **i32**|  | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/examples/client/main.rs
@@ -20,6 +20,7 @@ use openapi_v3::{Api, ApiNoContext, Claims, Client, ContextWrapperExt, models,
                       OneOfGetResponse,
                       OverrideServerGetResponse,
                       ParamgetGetResponse,
+                      QueryExampleGetResponse,
                       ReadonlyAuthSchemeGetResponse,
                       RegisterCallbackPostResponse,
                       RequiredOctetStreamPutResponse,
@@ -79,6 +80,7 @@ fn main() {
                 "OneOfGet",
                 "OverrideServerGet",
                 "ParamgetGet",
+                "QueryExampleGet",
                 "ReadonlyAuthSchemeGet",
                 "RegisterCallbackPost",
                 "RequiredOctetStreamPut",
@@ -251,6 +253,13 @@ fn main() {
                   Some(serde_json::from_str::<uuid::Uuid>(r#"38400000-8cf0-11bd-b23e-10b96e4ef00d"#).expect("Failed to parse JSON example")),
                   None,
                   Some(&Vec::new())
+            ));
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
+        },
+        Some("QueryExampleGet") => {
+            let result = rt.block_on(client.query_example_get(
+                  "required_no_example_example".to_string(),
+                  42
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/examples/server/server.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/examples/server/server.rs
@@ -116,6 +116,7 @@ use openapi_v3::{
     OneOfGetResponse,
     OverrideServerGetResponse,
     ParamgetGetResponse,
+    QueryExampleGetResponse,
     ReadonlyAuthSchemeGetResponse,
     RegisterCallbackPostResponse,
     RequiredOctetStreamPutResponse,
@@ -253,6 +254,16 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         context: &C) -> Result<ParamgetGetResponse, ApiError>
     {
         info!("paramget_get({:?}, {:?}, {:?}) - X-Span-ID: {:?}", uuid, some_object, some_list, context.get().0.clone());
+        Err(ApiError("Api-Error: Operation is NOT implemented".into()))
+    }
+    /// Test required query params with and without examples
+    async fn query_example_get(
+        &self,
+        required_no_example: String,
+        required_with_example: i32,
+        context: &C) -> Result<QueryExampleGetResponse, ApiError>
+    {
+        info!("query_example_get(\"{}\", {}) - X-Span-ID: {:?}", required_no_example, required_with_example, context.get().0.clone());
         Err(ApiError("Api-Error: Operation is NOT implemented".into()))
     }
     async fn readonly_auth_scheme_get(

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/src/client/mod.rs
@@ -52,6 +52,7 @@ use crate::{Api,
      OneOfGetResponse,
      OverrideServerGetResponse,
      ParamgetGetResponse,
+     QueryExampleGetResponse,
      ReadonlyAuthSchemeGetResponse,
      RegisterCallbackPostResponse,
      RequiredOctetStreamPutResponse,
@@ -1581,6 +1582,77 @@ impl<S, C> Api<C> for Client<S, C> where
 
                 Ok(ParamgetGetResponse::JSONRsp
                     (body)
+                )
+            }
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body()
+                       .take(100)
+                       .into_raw().await;
+                Err(ApiError(format!("Unexpected response code {code}:\n{headers:?}\n\n{}",
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {e:?}>"),
+                        },
+                        Err(e) => format!("<Failed to read body: {e}>"),
+                    }
+                )))
+            }
+        }
+    }
+    async fn query_example_get(
+        &self,
+        param_required_no_example: String,
+        param_required_with_example: i32,
+        context: &C) -> Result<QueryExampleGetResponse, ApiError>
+    {
+        let mut client_service = self.client_service.clone();
+        #[allow(clippy::uninlined_format_args)]
+        let mut uri = format!(
+            "{}/query-example",
+            self.base_path
+        );
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+                query_string.append_pair("required_no_example",
+                    &param_required_no_example);
+                query_string.append_pair("required_with_example",
+                    &param_required_with_example.to_string());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {err}"))),
+        };
+
+        let mut request = match Request::builder()
+            .method("GET")
+            .uri(uri)
+            .body(Body::empty()) {
+                Ok(req) => req,
+                Err(e) => return Err(ApiError(format!("Unable to create request: {e}")))
+        };
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(HeaderName::from_static("x-span-id"), match header {
+            Ok(h) => h,
+            Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {e}")))
+        });
+
+        let response = client_service.call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {e}"))).await?;
+
+        match response.status().as_u16() {
+            200 => {
+                Ok(
+                    QueryExampleGetResponse::OK
                 )
             }
             code => {

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/src/lib.rs
@@ -129,6 +129,11 @@ pub enum ParamgetGetResponse {
     (models::AnotherXmlObject)
 }
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum QueryExampleGetResponse {
+    /// OK
+    OK
+}
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum ReadonlyAuthSchemeGetResponse {
     /// Check that limiting to a single required auth scheme works
     CheckThatLimitingToASingleRequiredAuthSchemeWorks
@@ -356,6 +361,13 @@ pub trait Api<C: Send + Sync> {
         some_list: Option<&Vec<models::MyId>>,
         context: &C) -> Result<ParamgetGetResponse, ApiError>;
 
+    /// Test required query params with and without examples
+    async fn query_example_get(
+        &self,
+        required_no_example: String,
+        required_with_example: i32,
+        context: &C) -> Result<QueryExampleGetResponse, ApiError>;
+
     async fn readonly_auth_scheme_get(
         &self,
         context: &C) -> Result<ReadonlyAuthSchemeGetResponse, ApiError>;
@@ -522,6 +534,13 @@ pub trait ApiNoContext<C: Send + Sync> {
         some_object: Option<serde_json::Value>,
         some_list: Option<&Vec<models::MyId>>,
         ) -> Result<ParamgetGetResponse, ApiError>;
+
+    /// Test required query params with and without examples
+    async fn query_example_get(
+        &self,
+        required_no_example: String,
+        required_with_example: i32,
+        ) -> Result<QueryExampleGetResponse, ApiError>;
 
     async fn readonly_auth_scheme_get(
         &self,
@@ -758,6 +777,17 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     {
         let context = self.context().clone();
         self.api().paramget_get(uuid, some_object, some_list, &context).await
+    }
+
+    /// Test required query params with and without examples
+    async fn query_example_get(
+        &self,
+        required_no_example: String,
+        required_with_example: i32,
+        ) -> Result<QueryExampleGetResponse, ApiError>
+    {
+        let context = self.context().clone();
+        self.api().query_example_get(required_no_example, required_with_example, &context).await
     }
 
     async fn readonly_auth_scheme_get(

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/src/server/mod.rs
@@ -38,6 +38,7 @@ use crate::{Api,
      OneOfGetResponse,
      OverrideServerGetResponse,
      ParamgetGetResponse,
+     QueryExampleGetResponse,
      ReadonlyAuthSchemeGetResponse,
      RegisterCallbackPostResponse,
      RequiredOctetStreamPutResponse,
@@ -83,6 +84,7 @@ mod paths {
             r"^/operation-two-first-letter-headers$",
             r"^/override-server$",
             r"^/paramget$",
+            r"^/query-example$",
             r"^/readonly_auth_scheme$",
             r"^/register-callback$",
             r"^/repos$",
@@ -127,24 +129,25 @@ mod paths {
     pub(crate) static ID_OPERATION_TWO_FIRST_LETTER_HEADERS: usize = 14;
     pub(crate) static ID_OVERRIDE_SERVER: usize = 15;
     pub(crate) static ID_PARAMGET: usize = 16;
-    pub(crate) static ID_READONLY_AUTH_SCHEME: usize = 17;
-    pub(crate) static ID_REGISTER_CALLBACK: usize = 18;
-    pub(crate) static ID_REPOS: usize = 19;
-    pub(crate) static ID_REPOS_REPOID: usize = 20;
+    pub(crate) static ID_QUERY_EXAMPLE: usize = 17;
+    pub(crate) static ID_READONLY_AUTH_SCHEME: usize = 18;
+    pub(crate) static ID_REGISTER_CALLBACK: usize = 19;
+    pub(crate) static ID_REPOS: usize = 20;
+    pub(crate) static ID_REPOS_REPOID: usize = 21;
     lazy_static! {
         pub static ref REGEX_REPOS_REPOID: regex::Regex =
             #[allow(clippy::invalid_regex)]
             regex::Regex::new(r"^/repos/(?P<repoId>[^/?#]*)$")
                 .expect("Unable to create regex for REPOS_REPOID");
     }
-    pub(crate) static ID_REQUIRED_OCTET_STREAM: usize = 21;
-    pub(crate) static ID_RESPONSES_WITH_HEADERS: usize = 22;
-    pub(crate) static ID_RFC7807: usize = 23;
-    pub(crate) static ID_UNTYPED_PROPERTY: usize = 24;
-    pub(crate) static ID_UUID: usize = 25;
-    pub(crate) static ID_XML: usize = 26;
-    pub(crate) static ID_XML_EXTRA: usize = 27;
-    pub(crate) static ID_XML_OTHER: usize = 28;
+    pub(crate) static ID_REQUIRED_OCTET_STREAM: usize = 22;
+    pub(crate) static ID_RESPONSES_WITH_HEADERS: usize = 23;
+    pub(crate) static ID_RFC7807: usize = 24;
+    pub(crate) static ID_UNTYPED_PROPERTY: usize = 25;
+    pub(crate) static ID_UUID: usize = 26;
+    pub(crate) static ID_XML: usize = 27;
+    pub(crate) static ID_XML_EXTRA: usize = 28;
+    pub(crate) static ID_XML_OTHER: usize = 29;
 }
 
 pub struct MakeService<T, C> where
@@ -995,6 +998,87 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                                     // JSON Body
                                                     let body = serde_json::to_string(&body).expect("impossible to fail to serialize");
                                                     *response.body_mut() = Body::from(body);
+                                                },
+                                            },
+                                            Err(_) => {
+                                                // Application code returned an error. This should not happen, as the implementation should
+                                                // return a valid response.
+                                                *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+                                                *response.body_mut() = Body::from("An internal error occurred");
+                                            },
+                                        }
+
+                                        Ok(response)
+            },
+            // QueryExampleGet - GET /query-example
+            hyper::Method::GET if path.matched(paths::ID_QUERY_EXAMPLE) => {
+                // Query parameters (note that non-required or collection query parameters will ignore garbage values, rather than causing a 400 response)
+                let query_params = form_urlencoded::parse(uri.query().unwrap_or_default().as_bytes()).collect::<Vec<_>>();
+                let param_required_no_example = query_params.iter().filter(|e| e.0 == "required_no_example").map(|e| e.1.clone())
+                    .next();
+                let param_required_no_example = match param_required_no_example {
+                    Some(param_required_no_example) => {
+                        let param_required_no_example =
+                            <String as std::str::FromStr>::from_str
+                                (&param_required_no_example);
+                        match param_required_no_example {
+                            Ok(param_required_no_example) => Some(param_required_no_example),
+                            Err(e) => return Ok(Response::builder()
+                                .status(StatusCode::BAD_REQUEST)
+                                .body(Body::from(format!("Couldn't parse query parameter required_no_example - doesn't match schema: {e}")))
+                                .expect("Unable to create Bad Request response for invalid query parameter required_no_example")),
+                        }
+                    },
+                    None => None,
+                };
+                let param_required_no_example = match param_required_no_example {
+                    Some(param_required_no_example) => param_required_no_example,
+                    None => return Ok(Response::builder()
+                        .status(StatusCode::BAD_REQUEST)
+                        .body(Body::from("Missing required query parameter required_no_example"))
+                        .expect("Unable to create Bad Request response for missing query parameter required_no_example")),
+                };
+                let param_required_with_example = query_params.iter().filter(|e| e.0 == "required_with_example").map(|e| e.1.clone())
+                    .next();
+                let param_required_with_example = match param_required_with_example {
+                    Some(param_required_with_example) => {
+                        let param_required_with_example =
+                            <i32 as std::str::FromStr>::from_str
+                                (&param_required_with_example);
+                        match param_required_with_example {
+                            Ok(param_required_with_example) => Some(param_required_with_example),
+                            Err(e) => return Ok(Response::builder()
+                                .status(StatusCode::BAD_REQUEST)
+                                .body(Body::from(format!("Couldn't parse query parameter required_with_example - doesn't match schema: {e}")))
+                                .expect("Unable to create Bad Request response for invalid query parameter required_with_example")),
+                        }
+                    },
+                    None => None,
+                };
+                let param_required_with_example = match param_required_with_example {
+                    Some(param_required_with_example) => param_required_with_example,
+                    None => return Ok(Response::builder()
+                        .status(StatusCode::BAD_REQUEST)
+                        .body(Body::from("Missing required query parameter required_with_example"))
+                        .expect("Unable to create Bad Request response for missing query parameter required_with_example")),
+                };
+
+                                let result = api_impl.query_example_get(
+                                            param_required_no_example,
+                                            param_required_with_example,
+                                        &context
+                                    ).await;
+                                let mut response = Response::new(Body::empty());
+                                response.headers_mut().insert(
+                                            HeaderName::from_static("x-span-id"),
+                                            HeaderValue::from_str((&context as &dyn Has<XSpanIdString>).get().0.clone().as_str())
+                                                .expect("Unable to create X-Span-ID header value"));
+
+                                        match result {
+                                            Ok(rsp) => match rsp {
+                                                QueryExampleGetResponse::OK
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(200).expect("Unable to turn 200 into a StatusCode");
                                                 },
                                             },
                                             Err(_) => {
@@ -2119,6 +2203,7 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
             _ if path.matched(paths::ID_OPERATION_TWO_FIRST_LETTER_HEADERS) => method_not_allowed(),
             _ if path.matched(paths::ID_OVERRIDE_SERVER) => method_not_allowed(),
             _ if path.matched(paths::ID_PARAMGET) => method_not_allowed(),
+            _ if path.matched(paths::ID_QUERY_EXAMPLE) => method_not_allowed(),
             _ if path.matched(paths::ID_READONLY_AUTH_SCHEME) => method_not_allowed(),
             _ if path.matched(paths::ID_REGISTER_CALLBACK) => method_not_allowed(),
             _ if path.matched(paths::ID_REPOS) => method_not_allowed(),
@@ -2176,6 +2261,8 @@ impl<T> RequestParser<T> for ApiRequestParser {
             hyper::Method::GET if path.matched(paths::ID_OVERRIDE_SERVER) => Some("OverrideServerGet"),
             // ParamgetGet - GET /paramget
             hyper::Method::GET if path.matched(paths::ID_PARAMGET) => Some("ParamgetGet"),
+            // QueryExampleGet - GET /query-example
+            hyper::Method::GET if path.matched(paths::ID_QUERY_EXAMPLE) => Some("QueryExampleGet"),
             // ReadonlyAuthSchemeGet - GET /readonly_auth_scheme
             hyper::Method::GET if path.matched(paths::ID_READONLY_AUTH_SCHEME) => Some("ReadonlyAuthSchemeGet"),
             // RegisterCallbackPost - POST /register-callback

--- a/samples/server/petstore/rust-server/output/multipart-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/examples/client/main.rs
@@ -35,11 +35,11 @@ fn main() {
     let matches = Command::new("client")
         .arg(Arg::new("operation")
             .help("Sets the operation to run")
-            .value_parser([
+            .value_parser(Vec::<&str>::from([
                 "MultipartRelatedRequestPost",
                 "MultipartRequestPost",
                 "MultipleIdenticalMimeTypesPost",
-            ])
+            ]))
             .required(true)
             .index(1))
         .arg(Arg::new("https")

--- a/samples/server/petstore/rust-server/output/multipart-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/src/models.rs
@@ -28,6 +28,26 @@ pub struct MultipartRelatedRequest {
 
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for MultipartRelatedRequest {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for MultipartRelatedRequest {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
+
 
 impl MultipartRelatedRequest {
     #[allow(clippy::new_without_default)]
@@ -197,6 +217,26 @@ pub struct MultipartRequestObjectField {
     #[serde(skip_serializing_if="Option::is_none")]
     pub field_b: Option<Vec<String>>,
 
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for MultipartRequestObjectField {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for MultipartRequestObjectField {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
 }
 
 
@@ -370,6 +410,26 @@ pub struct MultipleIdenticalMimeTypesPostRequest {
     #[serde(skip_serializing_if="Option::is_none")]
     pub binary2: Option<swagger::ByteArray>,
 
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for MultipleIdenticalMimeTypesPostRequest {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for MultipleIdenticalMimeTypesPostRequest {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
 }
 
 

--- a/samples/server/petstore/rust-server/output/no-example-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/no-example-v3/examples/client/main.rs
@@ -33,9 +33,8 @@ fn main() {
     let matches = Command::new("client")
         .arg(Arg::new("operation")
             .help("Sets the operation to run")
-            .value_parser([
-                "OpGet",
-            ])
+            .value_parser(Vec::<&str>::from([
+            ]))
             .required(true)
             .index(1))
         .arg(Arg::new("https")

--- a/samples/server/petstore/rust-server/output/no-example-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/no-example-v3/src/models.rs
@@ -17,6 +17,26 @@ pub struct OpGetRequest {
 
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for OpGetRequest {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for OpGetRequest {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
+
 
 impl OpGetRequest {
     #[allow(clippy::new_without_default)]

--- a/samples/server/petstore/rust-server/output/openapi-v3/README.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/README.md
@@ -87,13 +87,11 @@ To run a client, follow one of the following simple steps:
 
 ```
 cargo run --example openapi-v3-client AnyOfGet
-cargo run --example openapi-v3-client CallbackWithHeaderPost
 cargo run --example openapi-v3-client ComplexQueryParamGet
 cargo run --example openapi-v3-client ExamplesTest
 cargo run --example openapi-v3-client FormTest
 cargo run --example openapi-v3-client GetWithBooleanParameter
 cargo run --example openapi-v3-client JsonComplexQueryParamGet
-cargo run --example openapi-v3-client MandatoryRequestHeaderGet
 cargo run --example openapi-v3-client MergePatchJsonGet
 cargo run --example openapi-v3-client MultigetGet
 cargo run --example openapi-v3-client MultipleAuthSchemeGet
@@ -101,7 +99,6 @@ cargo run --example openapi-v3-client OneOfGet
 cargo run --example openapi-v3-client OverrideServerGet
 cargo run --example openapi-v3-client ParamgetGet
 cargo run --example openapi-v3-client ReadonlyAuthSchemeGet
-cargo run --example openapi-v3-client RegisterCallbackPost
 cargo run --example openapi-v3-client RequiredOctetStreamPut
 cargo run --example openapi-v3-client ResponsesWithHeadersGet
 cargo run --example openapi-v3-client Rfc7807Get
@@ -114,9 +111,7 @@ cargo run --example openapi-v3-client XmlOtherPut
 cargo run --example openapi-v3-client XmlPost
 cargo run --example openapi-v3-client XmlPut
 cargo run --example openapi-v3-client EnumInPathPathParamGet
-cargo run --example openapi-v3-client MultiplePathParamsWithVeryLongPathToTestFormattingPathParamAPathParamBGet
 cargo run --example openapi-v3-client CreateRepo
-cargo run --example openapi-v3-client GetRepoInfo
 ```
 
 ### HTTPS
@@ -192,6 +187,7 @@ Method | HTTP request | Description
 [****](docs/default_api.md#) | **GET** /one-of | 
 [****](docs/default_api.md#) | **GET** /override-server | 
 [****](docs/default_api.md#) | **GET** /paramget | Get some stuff with parameters.
+[**queryExampleGet**](docs/default_api.md#queryExampleGet) | **GET** /query-example | Test required query params with and without examples
 [****](docs/default_api.md#) | **GET** /readonly_auth_scheme | 
 [****](docs/default_api.md#) | **POST** /register-callback | 
 [****](docs/default_api.md#) | **PUT** /required_octet_stream | 

--- a/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
@@ -67,6 +67,30 @@ paths:
                 $ref: "#/components/schemas/anotherXmlObject"
           description: JSON rsp
       summary: Get some stuff with parameters.
+  /query-example:
+    get:
+      operationId: queryExampleGet
+      parameters:
+      - explode: true
+        in: query
+        name: required_no_example
+        required: true
+        schema:
+          type: string
+        style: form
+      - example: 42
+        explode: true
+        in: query
+        name: required_with_example
+        required: true
+        schema:
+          format: int32
+          type: integer
+        style: form
+      responses:
+        "200":
+          description: OK
+      summary: Test required query params with and without examples
   /multiget:
     get:
       responses:

--- a/samples/server/petstore/rust-server/output/openapi-v3/bin/cli.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/bin/cli.rs
@@ -20,6 +20,7 @@ use openapi_v3::{
     OneOfGetResponse,
     OverrideServerGetResponse,
     ParamgetGetResponse,
+    QueryExampleGetResponse,
     ReadonlyAuthSchemeGetResponse,
     RegisterCallbackPostResponse,
     RequiredOctetStreamPutResponse,
@@ -150,6 +151,11 @@ enum Operation {
         /// Some list to pass as query parameter
         #[clap(value_parser = parse_json::<models::MyIdList>)]
         some_list: Option<models::MyIdList>,
+    },
+    /// Test required query params with and without examples
+    QueryExampleGet {
+        required_no_example: String,
+        required_with_example: i32,
     },
     ReadonlyAuthSchemeGet {
     },
@@ -552,6 +558,24 @@ async fn main() -> Result<()> {
                 => "JSONRsp\n".to_string()
                    +
                     &serde_json::to_string_pretty(&body)?,
+            }
+        }
+        Operation::QueryExampleGet {
+            required_no_example,
+            required_with_example,
+        } => {
+            info!("Performing a QueryExampleGet request");
+
+            let result = client.query_example_get(
+                required_no_example,
+                required_with_example,
+            ).await?;
+            debug!("Result: {:?}", result);
+
+            match result {
+                QueryExampleGetResponse::OK
+                => "OK\n".to_string()
+                    ,
             }
         }
         Operation::ReadonlyAuthSchemeGet {

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/default_api.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/default_api.md
@@ -18,6 +18,7 @@ Method | HTTP request | Description
 ****](default_api.md#) | **GET** /one-of | 
 ****](default_api.md#) | **GET** /override-server | 
 ****](default_api.md#) | **GET** /paramget | Get some stuff with parameters.
+**queryExampleGet**](default_api.md#queryExampleGet) | **GET** /query-example | Test required query params with and without examples
 ****](default_api.md#) | **GET** /readonly_auth_scheme | 
 ****](default_api.md#) | **POST** /register-callback | 
 ****](default_api.md#) | **PUT** /required_octet_stream | 
@@ -409,6 +410,32 @@ No authorization required
 
  - **Content-Type**: Not defined
  - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **queryExampleGet**
+> queryExampleGet(required_no_example, required_with_example)
+Test required query params with and without examples
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **required_no_example** | **String**|  | 
+  **required_with_example** | **i32**|  | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
@@ -20,6 +20,7 @@ use openapi_v3::{Api, ApiNoContext, Claims, Client, ContextWrapperExt, models,
                       OneOfGetResponse,
                       OverrideServerGetResponse,
                       ParamgetGetResponse,
+                      QueryExampleGetResponse,
                       ReadonlyAuthSchemeGetResponse,
                       RegisterCallbackPostResponse,
                       RequiredOctetStreamPutResponse,
@@ -64,15 +65,13 @@ fn main() {
     let matches = Command::new("client")
         .arg(Arg::new("operation")
             .help("Sets the operation to run")
-            .value_parser([
+            .value_parser(Vec::<&str>::from([
                 "AnyOfGet",
-                "CallbackWithHeaderPost",
                 "ComplexQueryParamGet",
                 "ExamplesTest",
                 "FormTest",
                 "GetWithBooleanParameter",
                 "JsonComplexQueryParamGet",
-                "MandatoryRequestHeaderGet",
                 "MergePatchJsonGet",
                 "MultigetGet",
                 "MultipleAuthSchemeGet",
@@ -80,7 +79,6 @@ fn main() {
                 "OverrideServerGet",
                 "ParamgetGet",
                 "ReadonlyAuthSchemeGet",
-                "RegisterCallbackPost",
                 "RequiredOctetStreamPut",
                 "ResponsesWithHeadersGet",
                 "Rfc7807Get",
@@ -93,10 +91,8 @@ fn main() {
                 "XmlPost",
                 "XmlPut",
                 "EnumInPathPathParamGet",
-                "MultiplePathParamsWithVeryLongPathToTestFormattingPathParamAPathParamBGet",
                 "CreateRepo",
-                "GetRepoInfo",
-            ])
+            ]))
             .required(true)
             .index(1))
         .arg(Arg::new("https")
@@ -192,12 +188,14 @@ fn main() {
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
+        /* Disabled because there's no example.
         Some("CallbackWithHeaderPost") => {
             let result = rt.block_on(client.callback_with_header_post(
-                  "url_example".to_string()
+                  ???
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
+        */
         Some("ComplexQueryParamGet") => {
             let result = rt.block_on(client.complex_query_param_get(
                   Some(&Vec::new())
@@ -229,12 +227,14 @@ fn main() {
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
+        /* Disabled because there's no example.
         Some("MandatoryRequestHeaderGet") => {
             let result = rt.block_on(client.mandatory_request_header_get(
-                  "x_header_example".to_string()
+                  ???
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
+        */
         Some("MergePatchJsonGet") => {
             let result = rt.block_on(client.merge_patch_json_get(
             ));
@@ -262,23 +262,34 @@ fn main() {
         },
         Some("ParamgetGet") => {
             let result = rt.block_on(client.paramget_get(
-                  Some(serde_json::from_str::<uuid::Uuid>(r#"38400000-8cf0-11bd-b23e-10b96e4ef00d"#).expect("Failed to parse JSON example")),
+                  None,
                   None,
                   None
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
+        /* Disabled because there's no example.
+        Some("QueryExampleGet") => {
+            let result = rt.block_on(client.query_example_get(
+                  ???,
+                  42
+            ));
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
+        },
+        */
         Some("ReadonlyAuthSchemeGet") => {
             let result = rt.block_on(client.readonly_auth_scheme_get(
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
+        /* Disabled because there's no example.
         Some("RegisterCallbackPost") => {
             let result = rt.block_on(client.register_callback_post(
-                  "url_example".to_string()
+                  ???
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
+        */
         Some("RequiredOctetStreamPut") => {
             let result = rt.block_on(client.required_octet_stream_put(
                   swagger::ByteArray(Vec::from("BYTE_ARRAY_DATA_HERE"))
@@ -349,25 +360,29 @@ fn main() {
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
+        /* Disabled because there's no example.
         Some("MultiplePathParamsWithVeryLongPathToTestFormattingPathParamAPathParamBGet") => {
             let result = rt.block_on(client.multiple_path_params_with_very_long_path_to_test_formatting_path_param_a_path_param_b_get(
-                  "path_param_a_example".to_string(),
-                  "path_param_b_example".to_string()
+                  ???,
+                  ???
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
+        */
         Some("CreateRepo") => {
             let result = rt.block_on(client.create_repo(
                   serde_json::from_str::<models::ObjectParam>(r#"{"requiredParam":true}"#).expect("Failed to parse JSON example")
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
+        /* Disabled because there's no example.
         Some("GetRepoInfo") => {
             let result = rt.block_on(client.get_repo_info(
-                  "repo_id_example".to_string()
+                  ???
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
+        */
         _ => {
             panic!("Invalid operation provided")
         }

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
@@ -151,6 +151,7 @@ use openapi_v3::{
     OneOfGetResponse,
     OverrideServerGetResponse,
     ParamgetGetResponse,
+    QueryExampleGetResponse,
     ReadonlyAuthSchemeGetResponse,
     RegisterCallbackPostResponse,
     RequiredOctetStreamPutResponse,
@@ -301,6 +302,17 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         context: &C) -> Result<ParamgetGetResponse, ApiError>
     {
         info!("paramget_get({:?}, {:?}, {:?}) - X-Span-ID: {:?}", uuid, some_object, some_list, context.get().0.clone());
+        Err(ApiError("Api-Error: Operation is NOT implemented".into()))
+    }
+
+    /// Test required query params with and without examples
+    async fn query_example_get(
+        &self,
+        required_no_example: String,
+        required_with_example: i32,
+        context: &C) -> Result<QueryExampleGetResponse, ApiError>
+    {
+        info!("query_example_get(\"{}\", {}) - X-Span-ID: {:?}", required_no_example, required_with_example, context.get().0.clone());
         Err(ApiError("Api-Error: Operation is NOT implemented".into()))
     }
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
@@ -146,6 +146,12 @@ pub enum ParamgetGetResponse {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum QueryExampleGetResponse {
+    /// OK
+    OK
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum ReadonlyAuthSchemeGetResponse {
     /// Check that limiting to a single required auth scheme works
     CheckThatLimitingToASingleRequiredAuthSchemeWorks
@@ -387,6 +393,13 @@ pub trait Api<C: Send + Sync> {
         some_list: Option<models::MyIdList>,
         context: &C) -> Result<ParamgetGetResponse, ApiError>;
 
+    /// Test required query params with and without examples
+    async fn query_example_get(
+        &self,
+        required_no_example: String,
+        required_with_example: i32,
+        context: &C) -> Result<QueryExampleGetResponse, ApiError>;
+
     async fn readonly_auth_scheme_get(
         &self,
         context: &C) -> Result<ReadonlyAuthSchemeGetResponse, ApiError>;
@@ -556,6 +569,13 @@ pub trait ApiNoContext<C: Send + Sync> {
         some_object: Option<models::ObjectParam>,
         some_list: Option<models::MyIdList>,
         ) -> Result<ParamgetGetResponse, ApiError>;
+
+    /// Test required query params with and without examples
+    async fn query_example_get(
+        &self,
+        required_no_example: String,
+        required_with_example: i32,
+        ) -> Result<QueryExampleGetResponse, ApiError>;
 
     async fn readonly_auth_scheme_get(
         &self,
@@ -788,6 +808,17 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     {
         let context = self.context().clone();
         self.api().paramget_get(uuid, some_object, some_list, &context).await
+    }
+
+    /// Test required query params with and without examples
+    async fn query_example_get(
+        &self,
+        required_no_example: String,
+        required_with_example: i32,
+        ) -> Result<QueryExampleGetResponse, ApiError>
+    {
+        let context = self.context().clone();
+        self.api().query_example_get(required_no_example, required_with_example, &context).await
     }
 
     async fn readonly_auth_scheme_get(

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
@@ -304,6 +304,7 @@ pub struct AdditionalPropertiesWithNullable {
 }
 
 
+
 impl AdditionalPropertiesWithNullable {
     #[allow(clippy::new_without_default)]
     pub fn new() -> AdditionalPropertiesWithNullable {
@@ -807,6 +808,7 @@ pub struct AnotherXmlObject {
     pub inner_string: Option<String>,
 
 }
+
 
 
 impl AnotherXmlObject {
@@ -1539,6 +1541,7 @@ pub struct AnyOfProperty {
 }
 
 
+
 impl AnyOfProperty {
     #[allow(clippy::new_without_default)]
     pub fn new(required_any_of: models::AnyOfObject, ) -> AnyOfProperty {
@@ -1716,6 +1719,7 @@ pub struct DuplicateXmlObject {
     pub inner_array: models::XmlArray,
 
 }
+
 
 
 impl DuplicateXmlObject {
@@ -2683,6 +2687,7 @@ pub struct MultigetGet201Response {
 }
 
 
+
 impl MultigetGet201Response {
     #[allow(clippy::new_without_default)]
     pub fn new() -> MultigetGet201Response {
@@ -3500,6 +3505,7 @@ pub struct NullableTest {
 }
 
 
+
 impl NullableTest {
     #[allow(clippy::new_without_default)]
     pub fn new(nullable: swagger::Nullable<String>, ) -> NullableTest {
@@ -3740,6 +3746,7 @@ pub struct ObjectHeader {
 }
 
 
+
 impl ObjectHeader {
     #[allow(clippy::new_without_default)]
     pub fn new(required_object_header: bool, ) -> ObjectHeader {
@@ -3923,6 +3930,7 @@ pub struct ObjectParam {
     pub optional_param: Option<u64>,
 
 }
+
 
 
 impl ObjectParam {
@@ -4116,6 +4124,7 @@ pub struct ObjectUntypedProps {
 }
 
 
+
 impl ObjectUntypedProps {
     #[allow(clippy::new_without_default)]
     pub fn new(required_untyped: serde_json::Value, required_untyped_nullable: swagger::Nullable<serde_json::Value>, ) -> ObjectUntypedProps {
@@ -4297,6 +4306,7 @@ pub struct ObjectWithArrayOfObjects {
     pub object_array: Option<Vec<models::StringObject>>,
 
 }
+
 
 
 impl ObjectWithArrayOfObjects {
@@ -5888,6 +5898,7 @@ pub struct XmlObject {
     pub other_inner_rename: Option<i32>,
 
 }
+
 
 
 impl XmlObject {

--- a/samples/server/petstore/rust-server/output/ops-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/examples/client/main.rs
@@ -69,7 +69,7 @@ fn main() {
     let matches = Command::new("client")
         .arg(Arg::new("operation")
             .help("Sets the operation to run")
-            .value_parser([
+            .value_parser(Vec::<&str>::from([
                 "Op10Get",
                 "Op11Get",
                 "Op12Get",
@@ -107,7 +107,7 @@ fn main() {
                 "Op7Get",
                 "Op8Get",
                 "Op9Get",
-            ])
+            ]))
             .required(true)
             .index(1))
         .arg(Arg::new("https")

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/README.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/README.md
@@ -95,7 +95,6 @@ cargo run --example petstore-with-fake-endpoints-models-for-testing-client FakeR
 cargo run --example petstore-with-fake-endpoints-models-for-testing-client TestEndpointParameters
 cargo run --example petstore-with-fake-endpoints-models-for-testing-client TestEnumParameters
 cargo run --example petstore-with-fake-endpoints-models-for-testing-client TestJsonFormData
-cargo run --example petstore-with-fake-endpoints-models-for-testing-client HyphenParam
 cargo run --example petstore-with-fake-endpoints-models-for-testing-client FindPetsByStatus
 cargo run --example petstore-with-fake-endpoints-models-for-testing-client FindPetsByTags
 cargo run --example petstore-with-fake-endpoints-models-for-testing-client DeletePet
@@ -103,14 +102,10 @@ cargo run --example petstore-with-fake-endpoints-models-for-testing-client GetPe
 cargo run --example petstore-with-fake-endpoints-models-for-testing-client UpdatePetWithForm
 cargo run --example petstore-with-fake-endpoints-models-for-testing-client UploadFile
 cargo run --example petstore-with-fake-endpoints-models-for-testing-client GetInventory
-cargo run --example petstore-with-fake-endpoints-models-for-testing-client DeleteOrder
 cargo run --example petstore-with-fake-endpoints-models-for-testing-client GetOrderById
 cargo run --example petstore-with-fake-endpoints-models-for-testing-client CreateUsersWithArrayInput
 cargo run --example petstore-with-fake-endpoints-models-for-testing-client CreateUsersWithListInput
-cargo run --example petstore-with-fake-endpoints-models-for-testing-client LoginUser
 cargo run --example petstore-with-fake-endpoints-models-for-testing-client LogoutUser
-cargo run --example petstore-with-fake-endpoints-models-for-testing-client DeleteUser
-cargo run --example petstore-with-fake-endpoints-models-for-testing-client GetUserByName
 ```
 
 ### HTTPS

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/client/main.rs
@@ -67,43 +67,28 @@ fn main() {
     let matches = Command::new("client")
         .arg(Arg::new("operation")
             .help("Sets the operation to run")
-            .value_parser([
-                "TestSpecialTags",
+            .value_parser(Vec::<&str>::from([
                 "Call123example",
                 "FakeOuterBooleanSerialize",
                 "FakeOuterCompositeSerialize",
                 "FakeOuterNumberSerialize",
                 "FakeOuterStringSerialize",
                 "FakeResponseWithNumericalDescription",
-                "TestBodyWithQueryParams",
-                "TestClientModel",
                 "TestEndpointParameters",
                 "TestEnumParameters",
-                "TestInlineAdditionalProperties",
                 "TestJsonFormData",
-                "HyphenParam",
-                "TestClassname",
-                "AddPet",
                 "FindPetsByStatus",
                 "FindPetsByTags",
-                "UpdatePet",
                 "DeletePet",
                 "GetPetById",
                 "UpdatePetWithForm",
                 "UploadFile",
                 "GetInventory",
-                "PlaceOrder",
-                "DeleteOrder",
                 "GetOrderById",
-                "CreateUser",
                 "CreateUsersWithArrayInput",
                 "CreateUsersWithListInput",
-                "LoginUser",
                 "LogoutUser",
-                "DeleteUser",
-                "GetUserByName",
-                "UpdateUser",
-            ])
+            ]))
             .required(true)
             .index(1))
         .arg(Arg::new("https")
@@ -233,7 +218,7 @@ fn main() {
         /* Disabled because there's no example.
         Some("TestBodyWithQueryParams") => {
             let result = rt.block_on(client.test_body_with_query_params(
-                  "query_example".to_string(),
+                  ???,
                   ???
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
@@ -293,12 +278,14 @@ fn main() {
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
+        /* Disabled because there's no example.
         Some("HyphenParam") => {
             let result = rt.block_on(client.hyphen_param(
-                  "hyphen_param_example".to_string()
+                  ???
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
+        */
         /* Disabled because there's no example.
         Some("TestClassname") => {
             let result = rt.block_on(client.test_classname(
@@ -337,20 +324,20 @@ fn main() {
         */
         Some("DeletePet") => {
             let result = rt.block_on(client.delete_pet(
-                  789,
-                  Some("api_key_example".to_string())
+                  0,
+                  None
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("GetPetById") => {
             let result = rt.block_on(client.get_pet_by_id(
-                  789
+                  0
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("UpdatePetWithForm") => {
             let result = rt.block_on(client.update_pet_with_form(
-                  789,
+                  0,
                   Some("name_example".to_string()),
                   Some("status_example".to_string())
             ));
@@ -358,7 +345,7 @@ fn main() {
         },
         Some("UploadFile") => {
             let result = rt.block_on(client.upload_file(
-                  789,
+                  0,
                   Some("additional_metadata_example".to_string()),
                   Some(swagger::ByteArray(Vec::from("BINARY_DATA_HERE")))
             ));
@@ -377,15 +364,17 @@ fn main() {
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         */
+        /* Disabled because there's no example.
         Some("DeleteOrder") => {
             let result = rt.block_on(client.delete_order(
-                  "order_id_example".to_string()
+                  ???
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
+        */
         Some("GetOrderById") => {
             let result = rt.block_on(client.get_order_by_id(
-                  789
+                  0
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
@@ -409,34 +398,40 @@ fn main() {
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
+        /* Disabled because there's no example.
         Some("LoginUser") => {
             let result = rt.block_on(client.login_user(
-                  "username_example".to_string(),
-                  "password_example".to_string()
+                  ???,
+                  ???
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
+        */
         Some("LogoutUser") => {
             let result = rt.block_on(client.logout_user(
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
+        /* Disabled because there's no example.
         Some("DeleteUser") => {
             let result = rt.block_on(client.delete_user(
-                  "username_example".to_string()
+                  ???
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
+        */
+        /* Disabled because there's no example.
         Some("GetUserByName") => {
             let result = rt.block_on(client.get_user_by_name(
-                  "username_example".to_string()
+                  ???
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
+        */
         /* Disabled because there's no example.
         Some("UpdateUser") => {
             let result = rt.block_on(client.update_user(
-                  "username_example".to_string(),
+                  ???,
                   ???
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
@@ -23,6 +23,26 @@ pub struct AdditionalPropertiesClass {
 
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for AdditionalPropertiesClass {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for AdditionalPropertiesClass {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
+
 
 impl AdditionalPropertiesClass {
     #[allow(clippy::new_without_default)]
@@ -195,6 +215,26 @@ pub struct Animal {
     #[serde(skip_serializing_if="Option::is_none")]
     pub color: Option<String>,
 
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for Animal {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for Animal {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
 }
 
 
@@ -563,6 +603,26 @@ pub struct ApiResponse {
 
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for ApiResponse {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for ApiResponse {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
+
 
 impl ApiResponse {
     #[allow(clippy::new_without_default)]
@@ -756,6 +816,26 @@ pub struct ArrayOfArrayOfNumberOnly {
 
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for ArrayOfArrayOfNumberOnly {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for ArrayOfArrayOfNumberOnly {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
+
 
 impl ArrayOfArrayOfNumberOnly {
     #[allow(clippy::new_without_default)]
@@ -919,6 +999,26 @@ pub struct ArrayOfNumberOnly {
     #[serde(skip_serializing_if="Option::is_none")]
     pub array_number: Option<Vec<f64>>,
 
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for ArrayOfNumberOnly {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for ArrayOfNumberOnly {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
 }
 
 
@@ -1106,6 +1206,26 @@ pub struct ArrayTest {
     #[serde(skip_serializing_if="Option::is_none")]
     pub array_of_enum: Option<Vec<models::MapTestMapMapOfEnumValueValue>>,
 
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for ArrayTest {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for ArrayTest {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
 }
 
 
@@ -1317,6 +1437,26 @@ pub struct Capitalization {
     #[serde(skip_serializing_if="Option::is_none")]
     pub att_name: Option<String>,
 
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for Capitalization {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for Capitalization {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
 }
 
 
@@ -1554,6 +1694,26 @@ pub struct Cat {
 
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for Cat {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for Cat {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
+
 
 impl Cat {
     #[allow(clippy::new_without_default)]
@@ -1749,6 +1909,26 @@ pub struct Category {
 
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for Category {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for Category {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
+
 
 impl Category {
     #[allow(clippy::new_without_default)]
@@ -1932,6 +2112,26 @@ pub struct ClassModel {
 
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for ClassModel {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for ClassModel {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
+
 
 impl ClassModel {
     #[allow(clippy::new_without_default)]
@@ -2101,6 +2301,26 @@ pub struct Client {
     #[serde(skip_serializing_if="Option::is_none")]
     pub client: Option<String>,
 
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for Client {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for Client {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
 }
 
 
@@ -2281,6 +2501,26 @@ pub struct Dog {
     #[serde(skip_serializing_if="Option::is_none")]
     pub breed: Option<String>,
 
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for Dog {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for Dog {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
 }
 
 
@@ -2473,6 +2713,26 @@ pub struct DollarSpecialLeftSquareBracketModelNameRightSquareBracket {
 
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for DollarSpecialLeftSquareBracketModelNameRightSquareBracket {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for DollarSpecialLeftSquareBracketModelNameRightSquareBracket {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
+
 
 impl DollarSpecialLeftSquareBracketModelNameRightSquareBracket {
     #[allow(clippy::new_without_default)]
@@ -2655,6 +2915,26 @@ pub struct EnumArrays {
     #[serde(skip_serializing_if="Option::is_none")]
     pub array_array_enum: Option<Vec<Vec<models::EnumArraysArrayArrayEnumInnerInner>>>,
 
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for EnumArrays {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for EnumArrays {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
 }
 
 
@@ -3353,6 +3633,26 @@ pub struct EnumTest {
 
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for EnumTest {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for EnumTest {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
+
 
 impl EnumTest {
     #[allow(clippy::new_without_default)]
@@ -4008,6 +4308,26 @@ pub struct FormatTest {
 
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for FormatTest {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for FormatTest {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
+
 lazy_static::lazy_static! {
     static ref RE_FORMATTEST_STRING: regex::Regex = regex::Regex::new(r"/[a-z]/i").unwrap();
 }
@@ -4296,6 +4616,26 @@ pub struct HasOnlyReadOnly {
 
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for HasOnlyReadOnly {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for HasOnlyReadOnly {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
+
 
 impl HasOnlyReadOnly {
     #[allow(clippy::new_without_default)]
@@ -4476,6 +4816,26 @@ pub struct List {
     #[serde(skip_serializing_if="Option::is_none")]
     pub param_123_list: Option<String>,
 
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for List {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for List {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
 }
 
 
@@ -4659,6 +5019,26 @@ pub struct MapTest {
     #[serde(skip_serializing_if="Option::is_none")]
     pub map_of_enum_string: Option<std::collections::HashMap<String, models::MapTestMapMapOfEnumValueValue>>,
 
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for MapTest {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for MapTest {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
 }
 
 
@@ -4970,6 +5350,26 @@ pub struct MixedPropertiesAndAdditionalPropertiesClass {
 
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for MixedPropertiesAndAdditionalPropertiesClass {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for MixedPropertiesAndAdditionalPropertiesClass {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
+
 
 impl MixedPropertiesAndAdditionalPropertiesClass {
     #[allow(clippy::new_without_default)]
@@ -5152,6 +5552,26 @@ pub struct Model200Response {
     #[serde(skip_serializing_if="Option::is_none")]
     pub class: Option<String>,
 
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for Model200Response {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for Model200Response {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
 }
 
 
@@ -5350,6 +5770,26 @@ pub struct Name {
     #[serde(skip_serializing_if="Option::is_none")]
     pub param_123_number: Option<i32>,
 
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for Name {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for Name {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
 }
 
 
@@ -5552,6 +5992,26 @@ pub struct NumberOnly {
 
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for NumberOnly {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for NumberOnly {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
+
 
 impl NumberOnly {
     #[allow(clippy::new_without_default)]
@@ -5722,6 +6182,26 @@ pub struct ObjectContainingObjectWithOnlyAdditionalProperties {
     #[serde(skip_serializing_if="Option::is_none")]
     pub inner: Option<models::ObjectWithOnlyAdditionalProperties>,
 
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for ObjectContainingObjectWithOnlyAdditionalProperties {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for ObjectContainingObjectWithOnlyAdditionalProperties {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
 }
 
 
@@ -5921,6 +6401,16 @@ impl serde_valid::validation::ValidateCompositedMinLength for ObjectWithOnlyAddi
         Ok(())
     }
 }
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for ObjectWithOnlyAdditionalProperties {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
 /// Converts the ObjectWithOnlyAdditionalProperties value to the Query Parameters representation (style=form, explode=false)
 /// specified in <https://swagger.io/docs/specification/serialization/>
 /// Should be implemented in a serde serializer
@@ -6064,6 +6554,26 @@ pub struct Order {
     #[serde(skip_serializing_if="Option::is_none")]
     pub complete: Option<bool>,
 
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for Order {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for Order {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
 }
 
 
@@ -6441,6 +6951,16 @@ impl serde_valid::validation::ValidateCompositedMinLength for OuterBoolean {
         Ok(())
     }
 }
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for OuterBoolean {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
 /// Converts the OuterBoolean value to the Query Parameters representation (style=form, explode=false)
 /// specified in <https://swagger.io/docs/specification/serialization/>
 /// Should be implemented in a serde serializer
@@ -6569,6 +7089,26 @@ pub struct OuterComposite {
     #[serde(skip_serializing_if="Option::is_none")]
     pub my_boolean: Option<bool>,
 
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for OuterComposite {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for OuterComposite {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
 }
 
 
@@ -6922,6 +7462,16 @@ impl serde_valid::validation::ValidateCompositedMinLength for OuterNumber {
         Ok(())
     }
 }
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for OuterNumber {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
 /// Converts the OuterNumber value to the Query Parameters representation (style=form, explode=false)
 /// specified in <https://swagger.io/docs/specification/serialization/>
 /// Should be implemented in a serde serializer
@@ -7073,6 +7623,16 @@ impl serde_valid::validation::ValidateCompositedMinLength for OuterString {
         Ok(())
     }
 }
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for OuterString {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
 impl std::fmt::Display for OuterString {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0.clone())
@@ -7208,6 +7768,26 @@ pub struct Pet {
     #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<models::PetStatus>,
 
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for Pet {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for Pet {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
 }
 
 
@@ -7544,6 +8124,26 @@ pub struct ReadOnlyFirst {
 
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for ReadOnlyFirst {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for ReadOnlyFirst {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
+
 
 impl ReadOnlyFirst {
     #[allow(clippy::new_without_default)]
@@ -7728,6 +8328,26 @@ pub struct Return {
 
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for Return {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for Return {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
+
 
 impl Return {
     #[allow(clippy::new_without_default)]
@@ -7903,6 +8523,26 @@ pub struct Tag {
     #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
 
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for Tag {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for Tag {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
 }
 
 
@@ -8741,6 +9381,26 @@ pub struct User {
     #[serde(skip_serializing_if="Option::is_none")]
     pub user_status: Option<i32>,
 
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for User {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for User {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
 }
 
 

--- a/samples/server/petstore/rust-server/output/ping-bearer-auth/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/ping-bearer-auth/examples/client/main.rs
@@ -33,9 +33,9 @@ fn main() {
     let matches = Command::new("client")
         .arg(Arg::new("operation")
             .help("Sets the operation to run")
-            .value_parser([
+            .value_parser(Vec::<&str>::from([
                 "PingGet",
-            ])
+            ]))
             .required(true)
             .index(1))
         .arg(Arg::new("https")

--- a/samples/server/petstore/rust-server/output/rust-server-test/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/examples/client/main.rs
@@ -41,17 +41,15 @@ fn main() {
     let matches = Command::new("client")
         .arg(Arg::new("operation")
             .help("Sets the operation to run")
-            .value_parser([
+            .value_parser(Vec::<&str>::from([
                 "AllOfGet",
                 "DummyGet",
-                "DummyPut",
                 "FileResponseGet",
                 "GetStructuredYaml",
                 "HtmlPost",
                 "PostYaml",
                 "RawJsonGet",
-                "SoloObjectPost",
-            ])
+            ]))
             .required(true)
             .index(1))
         .arg(Arg::new("https")

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/models.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/models.rs
@@ -24,6 +24,26 @@ pub struct ANullableContainer {
 
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for ANullableContainer {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for ANullableContainer {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
+
 
 impl ANullableContainer {
     #[allow(clippy::new_without_default)]
@@ -223,6 +243,16 @@ impl serde_valid::validation::ValidateCompositedMinLength for AdditionalProperti
         Ok(())
     }
 }
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for AdditionalPropertiesObject {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
 /// Converts the AdditionalPropertiesObject value to the Query Parameters representation (style=form, explode=false)
 /// specified in <https://swagger.io/docs/specification/serialization/>
 /// Should be implemented in a serde serializer
@@ -335,6 +365,26 @@ pub struct AllOfObject {
     #[serde(skip_serializing_if="Option::is_none")]
     pub sample_property: Option<String>,
 
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for AllOfObject {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for AllOfObject {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
 }
 
 
@@ -510,6 +560,26 @@ pub struct BaseAllOf {
 
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for BaseAllOf {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for BaseAllOf {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
+
 
 impl BaseAllOf {
     #[allow(clippy::new_without_default)]
@@ -674,6 +744,26 @@ pub struct DummyPutRequest {
     #[serde(skip_serializing_if="Option::is_none")]
     pub password: Option<String>,
 
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for DummyPutRequest {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for DummyPutRequest {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
 }
 
 
@@ -847,6 +937,26 @@ pub struct GetYamlResponse {
 
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for GetYamlResponse {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for GetYamlResponse {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
+
 
 impl GetYamlResponse {
     #[allow(clippy::new_without_default)]
@@ -1011,6 +1121,26 @@ pub struct ObjectOfObjects {
 
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for ObjectOfObjects {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for ObjectOfObjects {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
+}
+
 
 impl ObjectOfObjects {
     #[allow(clippy::new_without_default)]
@@ -1170,6 +1300,26 @@ pub struct ObjectOfObjectsInner {
     #[serde(skip_serializing_if="Option::is_none")]
     pub optional_thing: Option<i32>,
 
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for ObjectOfObjectsInner {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for ObjectOfObjectsInner {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
 }
 
 
@@ -1345,6 +1495,26 @@ pub struct UnnamedAllofUnderProperties {
     #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<u32>,
 
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for UnnamedAllofUnderProperties {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for UnnamedAllofUnderProperties {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
+        Ok(())
+    }
 }
 
 
@@ -1539,6 +1709,16 @@ impl serde_valid::validation::ValidateCompositedMinLength for UnnamedReference {
         &self,
         _min_length: usize,
     ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMaxLength for UnnamedReference {
+    fn validate_composited_max_length(
+        &self,
+        _max_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MaxLengthError>> {
         Ok(())
     }
 }


### PR DESCRIPTION
The client example generator in processParam used an empty string fallback when no example was specified in the OpenAPI spec. For boolean and numeric primitive types this produced invalid Rust, either empty arguments or bare commas, this caused compilation failures in the generated client examples.

These defaults appear only in generated client example code (examples/client/main.rs) and are commented. Parameters of other types without examples continue to disable the operation via the existing x-no-client-example mechanism.


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds serde_valid composite validation traits to rust-server models, improves client example generation to avoid invalid Rust, and adds integer enum support. Client examples now skip operations when required query params lack examples, and query param examples are only used when provided in the spec.

- **New Features**
  - Implemented ValidateCompositedMinLength and ValidateCompositedMaxLength for complex types (behind the validate feature).
  - Added support for integer enums.

- **Bug Fixes**
  - Disabled client examples when required query parameters have no examples and filtered those ops from the CLI list.
  - Stopped auto-generating query parameter examples; only use examples from the spec.
  - Ensured query parameters are processed for example generation.

<sup>Written for commit 9cac9c81e2d4a47a87f10daf6e36510d46adc7d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

