### PR TITLE
Fix Nullable imports for custom Spring generators

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -1286,7 +1286,7 @@ public class SpringCodegen extends AbstractJavaCodegen
         return extensions;
     }
 
-    private boolean isSpringCodegen() {
+    protected boolean isSpringCodegen() {
         return getName().contains("spring");
     }
 


### PR DESCRIPTION

Fixes the bug reported in #21070: when using a custom generator whose name does not contain "spring", the `Nullable` imports were not added.
This change allows extending `isSpringCodegen` so custom generators can opt into Spring behavior and include the required imports.

Fixes #21070

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ```
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))

  Commit all changed files.

  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master.
  These must match the expectations made by your contribution.
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`.
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having "fixes #123" present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/OpenAPITools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @cachescrubber (2022/02) @welshm (2022/02) @MelleD (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02) @borsch (2022/02) @banlevente (2022/02) @Zomzog (2022/09) @martin-mfg (2023/08)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing Nullable imports for custom generators by allowing them to opt into Spring behavior. Changed SpringCodegen.isSpringCodegen() to protected so subclasses can enable Spring-style imports even if their name doesn’t contain “spring” (fixes #21070).

<sup>Written for commit b5948a68c7718d1f1aa21a1d381ac259c446d7cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

