### PR TITLE
Change width of dokumentation container to see all columns of CONFIG …

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -23,6 +23,7 @@ secondaryColor: '#464446',
     --ifm-color-primary-lightest: #97eb2e;
     --button-margin: 0.25rem;
     --ifm-code-font-size: 90%;
+    --ifm-container-width-xl: 1900px;
 }
 
 html[data-theme='light'] {


### PR DESCRIPTION
On the documentation on https://openapi-generator.tech/docs/generators pages the CONFIG OPTION table have the default values column hidden because the containg element is to narrow.

I have tested in the browser that changing this value from the default 1520px to 1900px, all content in the table is visible

To test this before merging, run this javascript in browser console
document.documentElement.style.setProperty("--ifm-container-width-xl", "1900px");

@wing328 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets --ifm-container-width-xl to 1900px to ensure all columns, including Default value, are visible in the CONFIG OPTIONS tables on generator docs pages.

<sup>Written for commit 26c6a24a1eb7e81279473b7bd7cc35cedda8d6e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

