### PR TITLE
DRAFT: Jaxrs-spec: Resolve @JsonTypeName with the mapping key of the discriminator in the child models when OpenAPI specification uses OneOf for polymorphism

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
@@ -26,6 +26,7 @@ import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.features.DocumentationFeature;
 import org.openapitools.codegen.meta.features.SecurityFeature;
 import org.openapitools.codegen.model.ModelMap;
+import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationsMap;
 
 import java.io.File;
@@ -325,6 +326,33 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
         if (property.isByteArray) {
             model.imports.add("Arrays");
         }
+    }
+
+    @Override
+    public Map<String, ModelsMap> postProcessAllModels(Map<String, ModelsMap> objs) {
+        Map<String, ModelsMap> result = super.postProcessAllModels(objs);
+        for (ModelsMap modelsMap : result.values()) {
+            for (ModelMap mo : modelsMap.getModels()) {
+                CodegenModel cm = mo.getModel();
+                if (cm.parentModel != null) {
+                    CodegenDiscriminator discriminator = cm.parentModel.getDiscriminator();
+                    if (discriminator != null) {
+                        for (CodegenDiscriminator.MappedModel mappedModel : discriminator.getMappedModels()) {
+                            if (mappedModel.getModelName().equals(cm.name)) {
+                                cm.getVendorExtensions().put("x-discriminator-value", mappedModel.getMappingName());
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public ModelsMap postProcessModels(ModelsMap objs) {
+        return super.postProcessModels(objs);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
@@ -333,13 +333,13 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
         Map<String, ModelsMap> result = super.postProcessAllModels(objs);
         for (ModelsMap modelsMap : result.values()) {
             for (ModelMap modelMap : modelsMap.getModels()) {
-                CodegenModel cm = modelMap.getModel();
-                if (cm.parentModel != null) {
-                    CodegenDiscriminator discriminator = cm.parentModel.getDiscriminator();
+                CodegenModel model = modelMap.getModel();
+                if (model.parentModel != null) {
+                    CodegenDiscriminator discriminator = model.parentModel.getDiscriminator();
                     if (discriminator != null) {
                         for (CodegenDiscriminator.MappedModel mappedModel : discriminator.getMappedModels()) {
-                            if (mappedModel.getModelName().equals(cm.name)) {
-                                cm.getVendorExtensions().put("x-discriminator-value", mappedModel.getMappingName());
+                            if (mappedModel.getModelName().equals(model.name)) {
+                                model.getVendorExtensions().put("x-discriminator-value", mappedModel.getMappingName());
                                 break;
                             }
                         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
@@ -329,6 +329,18 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
     }
 
     @Override
+    public ModelsMap postProcessModels(ModelsMap objs) {
+        return super.postProcessModels(objs);
+    }
+
+    @Override
+    public OperationsMap postProcessOperationsWithModels(OperationsMap objs, List<ModelMap> allModels) {
+        objs = super.postProcessOperationsWithModels(objs, allModels);
+        removeImport(objs, "java.util.List");
+        return objs;
+    }
+
+    @Override
     public Map<String, ModelsMap> postProcessAllModels(Map<String, ModelsMap> objs) {
         Map<String, ModelsMap> result = super.postProcessAllModels(objs);
         for (ModelsMap modelsMap : result.values()) {
@@ -349,17 +361,4 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
         }
         return result;
     }
-
-    @Override
-    public ModelsMap postProcessModels(ModelsMap objs) {
-        return super.postProcessModels(objs);
-    }
-
-    @Override
-    public OperationsMap postProcessOperationsWithModels(OperationsMap objs, List<ModelMap> allModels) {
-        objs = super.postProcessOperationsWithModels(objs, allModels);
-        removeImport(objs, "java.util.List");
-        return objs;
-    }
-
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
@@ -332,8 +332,8 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
     public Map<String, ModelsMap> postProcessAllModels(Map<String, ModelsMap> objs) {
         Map<String, ModelsMap> result = super.postProcessAllModels(objs);
         for (ModelsMap modelsMap : result.values()) {
-            for (ModelMap mo : modelsMap.getModels()) {
-                CodegenModel cm = mo.getModel();
+            for (ModelMap modelMap : modelsMap.getModels()) {
+                CodegenModel cm = modelMap.getModel();
                 if (cm.parentModel != null) {
                     CodegenDiscriminator discriminator = cm.parentModel.getDiscriminator();
                     if (discriminator != null) {

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
@@ -38,7 +38,7 @@ import {{javaxPackage}}.xml.bind.annotation.XmlEnumValue;
 @Schema({{#title}}title="{{{.}}}", {{/title}}{{#description}}description="{{{.}}}"{{/description}}{{^description}}description=""{{/description}}){{/useSwaggerV3Annotations}}{{#useMicroProfileOpenAPIAnnotations}}
 @org.eclipse.microprofile.openapi.annotations.media.Schema({{#title}}title="{{{.}}}", {{/title}}{{#description}}description="{{{.}}}"{{/description}}{{^description}}description=""{{/description}}){{/useMicroProfileOpenAPIAnnotations}}
 {{#jackson}}
-@JsonTypeName("{{name}}")
+@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
 {{#additionalProperties}}
 @JsonFormat(shape=JsonFormat.Shape.OBJECT)
 {{/additionalProperties}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
@@ -1268,5 +1268,4 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
                 .fileContains("@JsonTypeName(\"DOG\")")
                 .fileDoesNotContain("@JsonTypeName(\"DogRequest\")");
     }
-
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
@@ -1237,4 +1237,36 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
         assertFileNotContains(files.get("RequiredProperties.java").toPath(), "@JsonCreator");
     }
 
+    @Test
+    public void testDiscriminatorMappingUsedInJsonTypeName() throws Exception {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/jaxrs/pestore-with-discriminator.yaml", null, new ParseOptions()).getOpenAPI();
+
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput input = new ClientOptInput()
+                .openAPI(openAPI)
+                .config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        Map<String, File> files = generator.opts(input).generate().stream()
+                .collect(Collectors.toMap(File::getName, Function.identity()));
+
+        // Parent model uses its own name
+        JavaFileAssert.assertThat(files.get("PetRequest.java"))
+                .fileContains("@JsonTypeName(\"PetRequest\")");
+
+        // Child models must use the discriminator mapping value (e.g. "CAT"), not the class name (e.g. "CatRequest")
+        JavaFileAssert.assertThat(files.get("CatRequest.java"))
+                .fileContains("@JsonTypeName(\"CAT\")")
+                .fileDoesNotContain("@JsonTypeName(\"CatRequest\")");
+
+        JavaFileAssert.assertThat(files.get("DogRequest.java"))
+                .fileContains("@JsonTypeName(\"DOG\")")
+                .fileDoesNotContain("@JsonTypeName(\"DogRequest\")");
+    }
+
 }

--- a/modules/openapi-generator/src/test/resources/3_0/jaxrs/pestore-with-discriminator.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/jaxrs/pestore-with-discriminator.yaml
@@ -1,0 +1,99 @@
+openapi: 3.0.0
+servers:
+  - url: 'http://petstore.swagger.io/v2'
+info:
+  description: >-
+    This is a sample server Petstore server that uses polymorphism and inheritance with a discriminator.
+  version: 1.0.0
+  title: OpenAPI Petstore
+  license:
+    name: Apache-2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+
+tags:
+  - name: pet
+    description: Everything about your Pets
+
+paths:
+  /pets:
+    post:
+      operationId: createPet
+      security: []
+      tags: [ pet ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PetRequest'
+      responses:
+        '201':
+          description: Pet created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetResponse'
+
+components:
+  schemas:
+    PetRequest:
+      type: object
+      required:
+        - petType
+      properties:
+        petType:
+          type: string
+        name:
+          type: string
+      oneOf:
+        - $ref: '#/components/schemas/CatRequest'
+        - $ref: '#/components/schemas/DogRequest'
+      discriminator:
+        propertyName: petType
+        mapping:
+          CAT: '#/components/schemas/CatRequest'
+          DOG: '#/components/schemas/DogRequest'
+    CatRequest:
+      allOf:
+        - $ref: '#/components/schemas/PetRequest'
+        - type: object
+          properties:
+            indoor:
+              type: boolean
+    DogRequest:
+      allOf:
+        - $ref: '#/components/schemas/PetRequest'
+        - type: object
+          properties:
+            bark:
+              type: string
+
+    PetResponse:
+      type: object
+      required:
+        - petType
+      oneOf:
+        - $ref: '#/components/schemas/CatResponse'
+        - $ref: '#/components/schemas/DogResponse'
+      discriminator:
+        propertyName: petType
+        mapping:
+          CAT: '#/components/schemas/CatResponse'
+          DOG: '#/components/schemas/DogResponse'
+
+    CatResponse:
+        type: object
+        properties:
+          indoor:
+            type: boolean
+          petType:
+            type: string
+            enum: [CAT]
+    DogResponse:
+      type: object
+      properties:
+        bark:
+          type: string
+        petType:
+          type: string
+          enum: [DOG]

--- a/modules/openapi-generator/src/test/resources/3_0/jaxrs/pestore-with-discriminator.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/jaxrs/pestore-with-discriminator.yaml
@@ -32,7 +32,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PetResponse'
+                $ref: '#/components/schemas/PetRequest'
 
 components:
   schemas:
@@ -67,33 +67,3 @@ components:
           properties:
             bark:
               type: string
-
-    PetResponse:
-      type: object
-      required:
-        - petType
-      oneOf:
-        - $ref: '#/components/schemas/CatResponse'
-        - $ref: '#/components/schemas/DogResponse'
-      discriminator:
-        propertyName: petType
-        mapping:
-          CAT: '#/components/schemas/CatResponse'
-          DOG: '#/components/schemas/DogResponse'
-
-    CatResponse:
-        type: object
-        properties:
-          indoor:
-            type: boolean
-          petType:
-            type: string
-            enum: [CAT]
-    DogResponse:
-      type: object
-      properties:
-        bark:
-          type: string
-        petType:
-          type: string
-          enum: [DOG]


### PR DESCRIPTION
The Jaxrx-spec adds the class name to the `@JsonTypeName` annotation in child classes when the OpenAPI specification has a `OneOf` with a discriminator mapping. Instead, the generator should add the mapping `key` of the discriminator. 

This MR updates the `POJO` mustache template to inject the  vendor extension `x-discriminator-value` to the `@JsonTypeName` annotation when the discriminator has a mapping or defaults to the original behaviour with the class name when not available. 

This MR will fix [#10822](https://github.com/OpenAPITools/openapi-generator/issues/10822) and will fix [#17343](https://github.com/OpenAPITools/openapi-generator/issues/17343)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes wrong @JsonTypeName in the JAX-RS spec generator for oneOf + discriminator mappings. Child models now use the discriminator mapping key (e.g., CAT); parents keep their names. Fixes #17343, #10822.

- **Bug Fixes**
  - Set vendorExtensions.x-discriminator-value on child models in postProcessAllModels by matching the parent discriminator.mappedModels.
  - Update pojo.mustache to use that value in @JsonTypeName, falling back to the model name if absent.
  - Add tests and a sample spec (PetRequest/CatRequest/DogRequest) to confirm parents keep names and children use mapping values.

<sup>Written for commit 763a35407bb09741c8e4d9fd2295795c14fe75e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



