### PR TITLE
[Swift6] Fix TSan race condition in Swift6 SynchronizedDictionary

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift6/SynchronizedDictionary.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/SynchronizedDictionary.mustache
@@ -6,7 +6,7 @@
 
 import Foundation
 
-internal struct SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
+internal class SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
 
     private var dictionary = [K: V]()
     private let lock = NSRecursiveLock()

--- a/modules/openapi-generator/src/main/resources/swift6/libraries/alamofire/AlamofireImplementations.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/libraries/alamofire/AlamofireImplementations.mustache
@@ -24,7 +24,7 @@ fileprivate class AlamofireRequestBuilderConfiguration: @unchecked Sendable {
     static let shared = AlamofireRequestBuilderConfiguration()
     
     // Store manager to retain its reference
-    var managerStore = SynchronizedDictionary<String, Alamofire.Session>()
+    let managerStore = SynchronizedDictionary<String, Alamofire.Session>()
 }
 
 {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class AlamofireRequestBuilder<T: Sendable>: RequestBuilder<T>, @unchecked Sendable {

--- a/modules/openapi-generator/src/main/resources/swift6/libraries/urlsession/URLSessionImplementations.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/libraries/urlsession/URLSessionImplementations.mustache
@@ -66,7 +66,7 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     let defaultURLSession: URLSession
 
     // Store current URLCredential for every URLSessionTask
-    var credentialStore = SynchronizedDictionary<Int, URLCredential>()
+    let credentialStore = SynchronizedDictionary<Int, URLCredential>()
 }
 
 {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class URLSessionRequestBuilder<T: Sendable>: RequestBuilder<T>, @unchecked Sendable {

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/AlamofireImplementations.swift
@@ -24,7 +24,7 @@ fileprivate class AlamofireRequestBuilderConfiguration: @unchecked Sendable {
     static let shared = AlamofireRequestBuilderConfiguration()
     
     // Store manager to retain its reference
-    var managerStore = SynchronizedDictionary<String, Alamofire.Session>()
+    let managerStore = SynchronizedDictionary<String, Alamofire.Session>()
 }
 
 open class AlamofireRequestBuilder<T: Sendable>: RequestBuilder<T>, @unchecked Sendable {

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/SynchronizedDictionary.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/SynchronizedDictionary.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-internal struct SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
+internal class SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
 
     private var dictionary = [K: V]()
     private let lock = NSRecursiveLock()

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/AlamofireImplementations.swift
@@ -24,7 +24,7 @@ fileprivate class AlamofireRequestBuilderConfiguration: @unchecked Sendable {
     static let shared = AlamofireRequestBuilderConfiguration()
     
     // Store manager to retain its reference
-    var managerStore = SynchronizedDictionary<String, Alamofire.Session>()
+    let managerStore = SynchronizedDictionary<String, Alamofire.Session>()
 }
 
 open class AlamofireRequestBuilder<T: Sendable>: RequestBuilder<T>, @unchecked Sendable {

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/SynchronizedDictionary.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/SynchronizedDictionary.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-internal struct SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
+internal class SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
 
     private var dictionary = [K: V]()
     private let lock = NSRecursiveLock()

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/SynchronizedDictionary.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/SynchronizedDictionary.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-internal struct SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
+internal class SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
 
     private var dictionary = [K: V]()
     private let lock = NSRecursiveLock()

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/URLSessionImplementations.swift
@@ -66,7 +66,7 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     let defaultURLSession: URLSession
 
     // Store current URLCredential for every URLSessionTask
-    var credentialStore = SynchronizedDictionary<Int, URLCredential>()
+    let credentialStore = SynchronizedDictionary<Int, URLCredential>()
 }
 
 open class URLSessionRequestBuilder<T: Sendable>: RequestBuilder<T>, @unchecked Sendable {

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/SynchronizedDictionary.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/SynchronizedDictionary.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-internal struct SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
+internal class SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
 
     private var dictionary = [K: V]()
     private let lock = NSRecursiveLock()

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
@@ -66,7 +66,7 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     let defaultURLSession: URLSession
 
     // Store current URLCredential for every URLSessionTask
-    var credentialStore = SynchronizedDictionary<Int, URLCredential>()
+    let credentialStore = SynchronizedDictionary<Int, URLCredential>()
 }
 
 open class URLSessionRequestBuilder<T: Sendable>: RequestBuilder<T>, @unchecked Sendable {

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/SynchronizedDictionary.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/SynchronizedDictionary.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-internal struct SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
+internal class SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
 
     private var dictionary = [K: V]()
     private let lock = NSRecursiveLock()

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/URLSessionImplementations.swift
@@ -66,7 +66,7 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     let defaultURLSession: URLSession
 
     // Store current URLCredential for every URLSessionTask
-    var credentialStore = SynchronizedDictionary<Int, URLCredential>()
+    let credentialStore = SynchronizedDictionary<Int, URLCredential>()
 }
 
 open class URLSessionRequestBuilder<T: Sendable>: RequestBuilder<T>, @unchecked Sendable {

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/SynchronizedDictionary.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/SynchronizedDictionary.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-internal struct SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
+internal class SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
 
     private var dictionary = [K: V]()
     private let lock = NSRecursiveLock()

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/URLSessionImplementations.swift
@@ -66,7 +66,7 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     let defaultURLSession: URLSession
 
     // Store current URLCredential for every URLSessionTask
-    var credentialStore = SynchronizedDictionary<Int, URLCredential>()
+    let credentialStore = SynchronizedDictionary<Int, URLCredential>()
 }
 
 open class URLSessionRequestBuilder<T: Sendable>: RequestBuilder<T>, @unchecked Sendable {

--- a/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/SynchronizedDictionary.swift
+++ b/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/SynchronizedDictionary.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-internal struct SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
+internal class SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
 
     private var dictionary = [K: V]()
     private let lock = NSRecursiveLock()

--- a/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/URLSessionImplementations.swift
@@ -66,7 +66,7 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     let defaultURLSession: URLSession
 
     // Store current URLCredential for every URLSessionTask
-    var credentialStore = SynchronizedDictionary<Int, URLCredential>()
+    let credentialStore = SynchronizedDictionary<Int, URLCredential>()
 }
 
 open class URLSessionRequestBuilder<T: Sendable>: RequestBuilder<T>, @unchecked Sendable {

--- a/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/SynchronizedDictionary.swift
+++ b/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/SynchronizedDictionary.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-internal struct SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
+internal class SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
 
     private var dictionary = [K: V]()
     private let lock = NSRecursiveLock()

--- a/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
@@ -66,7 +66,7 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     let defaultURLSession: URLSession
 
     // Store current URLCredential for every URLSessionTask
-    var credentialStore = SynchronizedDictionary<Int, URLCredential>()
+    let credentialStore = SynchronizedDictionary<Int, URLCredential>()
 }
 
 open class URLSessionRequestBuilder<T: Sendable>: RequestBuilder<T>, @unchecked Sendable {

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/SynchronizedDictionary.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/SynchronizedDictionary.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-internal struct SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
+internal class SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
 
     private var dictionary = [K: V]()
     private let lock = NSRecursiveLock()

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
@@ -66,7 +66,7 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     let defaultURLSession: URLSession
 
     // Store current URLCredential for every URLSessionTask
-    var credentialStore = SynchronizedDictionary<Int, URLCredential>()
+    let credentialStore = SynchronizedDictionary<Int, URLCredential>()
 }
 
 open class URLSessionRequestBuilder<T: Sendable>: RequestBuilder<T>, @unchecked Sendable {

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/SynchronizedDictionary.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/SynchronizedDictionary.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-internal struct SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
+internal class SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
 
     private var dictionary = [K: V]()
     private let lock = NSRecursiveLock()

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
@@ -66,7 +66,7 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     let defaultURLSession: URLSession
 
     // Store current URLCredential for every URLSessionTask
-    var credentialStore = SynchronizedDictionary<Int, URLCredential>()
+    let credentialStore = SynchronizedDictionary<Int, URLCredential>()
 }
 
 internal class URLSessionRequestBuilder<T: Sendable>: RequestBuilder<T>, @unchecked Sendable {

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/SynchronizedDictionary.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/SynchronizedDictionary.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-internal struct SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
+internal class SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
 
     private var dictionary = [K: V]()
     private let lock = NSRecursiveLock()

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
@@ -66,7 +66,7 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     let defaultURLSession: URLSession
 
     // Store current URLCredential for every URLSessionTask
-    var credentialStore = SynchronizedDictionary<Int, URLCredential>()
+    let credentialStore = SynchronizedDictionary<Int, URLCredential>()
 }
 
 open class URLSessionRequestBuilder<T: Sendable>: RequestBuilder<T>, @unchecked Sendable {

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/SynchronizedDictionary.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/SynchronizedDictionary.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-internal struct SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
+internal class SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
 
     private var dictionary = [K: V]()
     private let lock = NSRecursiveLock()

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/URLSessionImplementations.swift
@@ -66,7 +66,7 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     let defaultURLSession: URLSession
 
     // Store current URLCredential for every URLSessionTask
-    var credentialStore = SynchronizedDictionary<Int, URLCredential>()
+    let credentialStore = SynchronizedDictionary<Int, URLCredential>()
 }
 
 open class URLSessionRequestBuilder<T: Sendable>: RequestBuilder<T>, @unchecked Sendable {

--- a/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/SynchronizedDictionary.swift
+++ b/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/SynchronizedDictionary.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-internal struct SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
+internal class SynchronizedDictionary<K: Hashable, V> : @unchecked Sendable {
 
     private var dictionary = [K: V]()
     private let lock = NSRecursiveLock()

--- a/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/URLSessionImplementations.swift
@@ -66,7 +66,7 @@ fileprivate class URLSessionRequestBuilderConfiguration: @unchecked Sendable {
     let defaultURLSession: URLSession
 
     // Store current URLCredential for every URLSessionTask
-    var credentialStore = SynchronizedDictionary<Int, URLCredential>()
+    let credentialStore = SynchronizedDictionary<Int, URLCredential>()
 }
 
 open class URLSessionRequestBuilder<T: Sendable>: RequestBuilder<T>, @unchecked Sendable {


### PR DESCRIPTION
 ### Problem

  SynchronizedDictionary is a struct held as a var property on shared singleton classes (URLSessionRequestBuilderConfiguration and AlamofireRequestBuilderConfiguration). When multiple concurrent network requests mutate credentialStore or managerStore from different
  threads, Swift's memory exclusivity rules treat each subscript mutation as a modifying access to the entire struct — causing a real ThreadSanitizer "Swift access race".

###  Changes

  struct → class (SynchronizedDictionary.mustache + 13 sample files)

  Changing SynchronizedDictionary from a value type to a reference type makes mutations go through pointer indirection. Concurrent subscript writes now only touch the object's internal state (already protected by NSRecursiveLock), rather than triggering a modifying
  access on the owning class's stored property.

  var → let (URLSessionImplementations.mustache + 11 sample files, AlamofireImplementations.mustache + 2 sample files)

  Since SynchronizedDictionary is now a class, the properties credentialStore and managerStore only need to hold a stable reference — they never get reassigned. Declaring them as let makes this intent explicit and prevents any residual exclusivity issues on the property
   itself.
   Fixes #23055
   
   @4brunu 

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a ThreadSanitizer Swift access race in Swift6 clients by making SynchronizedDictionary a class and storing stable references for credentialStore and managerStore. This removes exclusivity violations during concurrent URLSession and Alamofire requests.

- **Bug Fixes**
  - SynchronizedDictionary switched from struct to class so concurrent writes mutate internal state behind NSRecursiveLock rather than the owning property.
  - credentialStore and managerStore are now let on configuration singletons to keep stable references and prevent residual exclusivity issues.

<sup>Written for commit 3d4101a720880ffd193a1c0fc67188d8b342f396. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

