### PR TITLE
Add security schemes filter normalizer option

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -75,7 +75,7 @@ Excluding `SupportingFiles`, each of the above options may result in multiple fi
 Note that user-defined templates will merge with built-in template definitions. If a supporting file with the sample template file path exists, it will be replaced with the user-defined template, otherwise the user-defined template will be added to the list of template files to compile. If the generator's built-in template is `model_docs.mustache` and you define `model-docs.mustache`, this will result in duplicated model docs (if `destinationFilename` differs) or undefined behavior as whichever template compiles last will overwrite the previous model docs (if `destinationFilename` matches the extension or suffix in the generator's code).
 
 ## Custom Generator (and Template)
- 
+
 <a id="creating-a-new-template"></a> If none of the built-in generators suit your needs and you need to do more than just modify the mustache templates to tweak generated code, you can create a brand new generator and its associated templates. OpenAPI Generator can help with this, using the `meta` command:
 
 ```sh
@@ -95,7 +95,7 @@ To compile your library, enter the `out/generators/my-codegen` directory, run `m
 
 **NOTE** Running your custom generator requires adding it to the classpath. This differs on [Windows](https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html) slightly from [unix](https://docs.oracle.com/javase/8/docs/technotes/tools/unix/classpath.html).
 If you are running a Windows Subsystem for Linux or a shell such as gitbash, and have issues with the unix variant, try the Windows syntax below.
- 
+
 Now, execute the generator:
 
 ```sh
@@ -536,7 +536,7 @@ Another useful option is `inlineSchemaOptions`, which allows you to customize ho
 
 OpenAPI Normalizer transforms the input OpenAPI doc/spec (which may not perfectly conform to the specification) to make it workable with OpenAPI Generator. A few rules are switched on by default since 7.0.0 release:
 
-- SIMPLIFY_ONEOF_ANYOF 
+- SIMPLIFY_ONEOF_ANYOF
 - SIMPLIFY_BOOLEAN_ENUM
 - SIMPLIFY_ONEOF_ANYOF_ENUM
 - REFACTOR_ALLOF_WITH_PROPERTIES_ONLY
@@ -637,7 +637,7 @@ Example:
 java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g java -i modules/openapi-generator/src/test/resources/3_0/enableKeepOnlyFirstTagInOperation_test.yaml -o /tmp/java-okhttp/ --openapi-normalizer REMOVE_X_INTERNAL=true
 ```
 
-- `NORMALIZER_CLASS`: Set to full classname of a class extending the default org.openapitools.codegen.OpenAPINormalizer. It allows customization of the default normalizer. 
+- `NORMALIZER_CLASS`: Set to full classname of a class extending the default org.openapitools.codegen.OpenAPINormalizer. It allows customization of the default normalizer.
 
 Example:
 ```
@@ -687,16 +687,16 @@ The `FILTER` parameter allows selective inclusion of API operations based on spe
 
 ### Available Filters
 
-- **`operationId`**  
+- **`operationId`**
   When set to `operationId:addPet|getPetById`, operations **not** matching `addPet` or `getPetById` will be marked as internal (`x-internal: true`), and excluded from generation. Matching operations will have `x-internal: false`.
 
-- **`method`**  
+- **`method`**
   When set to `method:get|post`, operations **not** using `GET` or `POST` methods will be marked as internal (`x-internal: true`), preventing their generation.
 
-- **`tag`**  
+- **`tag`**
   When set to `tag:person|basic`, operations **not** tagged with `person` or `basic` will be marked as internal (`x-internal: true`), and will not be generated.
 
-- **`path`**  
+- **`path`**
   When set to `path:/v1|/v2`, operations on paths **not** starting with `/v1` or with `/v2` will be marked as internal (`x-internal: true`), and will not be generated.
 
 ### Example Usage
@@ -756,7 +756,7 @@ Into this securityScheme:
 
 - `SECURITY_SCHEMES_FILTER`
 
-The `SECURITY_SCHEMES_FILTER` parameter allows selective inclusion of API security schemes based on specific criteria. It applies the `x-internal: true` property to operations that do **not** match the specified values, preventing them from being generated. Multiple filters can be separated by a semicolon.
+The `SECURITY_SCHEMES_FILTER` parameter allows selective inclusion of API security schemes based on specific criteria. It removes security schemes that do **not** match the specified values, preventing them from being generated. All references to removed security schemes also deleted. Multiple filters can be separated by a semicolon.
 
 ### Available Filters
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -754,6 +754,28 @@ Into this securityScheme:
       type: http
 ```
 
+- `SECURITY_SCHEMES_FILTER`
+
+The `SECURITY_SCHEMES_FILTER` parameter allows selective inclusion of API security schemes based on specific criteria. It applies the `x-internal: true` property to operations that do **not** match the specified values, preventing them from being generated. Multiple filters can be separated by a semicolon.
+
+### Available Filters
+
+- **`key`**
+  When set to `key:api_key|http_bearer`, security schemes **not** matching `api_key` or `http_bearer` will be marked as internal (`x-internal: true`), and excluded from generation. Matching operations will have `x-internal: false`.
+
+- **`type`**
+  When set to `type:apiKey|http`, security schemes **not** using `apiKey` or `http` types will be marked as internal (`x-internal: true`), preventing their generation.
+
+### Example Usage
+
+```sh
+java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate \
+  -g java \
+  -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml \
+  -o /tmp/java-okhttp/ \
+  --openapi-normalizer SECURITY_SCHEMES_FILTER="key:api_key|http_bearer ; type:oauth2"
+```
+
 - `SORT_MODEL_PROPERTIES`: When set to true, model properties will be sorted alphabetically by name. This ensures deterministic code generation output regardless of property ordering in the source spec.
 
 Example:

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -75,7 +75,7 @@ Excluding `SupportingFiles`, each of the above options may result in multiple fi
 Note that user-defined templates will merge with built-in template definitions. If a supporting file with the sample template file path exists, it will be replaced with the user-defined template, otherwise the user-defined template will be added to the list of template files to compile. If the generator's built-in template is `model_docs.mustache` and you define `model-docs.mustache`, this will result in duplicated model docs (if `destinationFilename` differs) or undefined behavior as whichever template compiles last will overwrite the previous model docs (if `destinationFilename` matches the extension or suffix in the generator's code).
 
 ## Custom Generator (and Template)
-
+ 
 <a id="creating-a-new-template"></a> If none of the built-in generators suit your needs and you need to do more than just modify the mustache templates to tweak generated code, you can create a brand new generator and its associated templates. OpenAPI Generator can help with this, using the `meta` command:
 
 ```sh
@@ -95,7 +95,7 @@ To compile your library, enter the `out/generators/my-codegen` directory, run `m
 
 **NOTE** Running your custom generator requires adding it to the classpath. This differs on [Windows](https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html) slightly from [unix](https://docs.oracle.com/javase/8/docs/technotes/tools/unix/classpath.html).
 If you are running a Windows Subsystem for Linux or a shell such as gitbash, and have issues with the unix variant, try the Windows syntax below.
-
+ 
 Now, execute the generator:
 
 ```sh
@@ -536,7 +536,7 @@ Another useful option is `inlineSchemaOptions`, which allows you to customize ho
 
 OpenAPI Normalizer transforms the input OpenAPI doc/spec (which may not perfectly conform to the specification) to make it workable with OpenAPI Generator. A few rules are switched on by default since 7.0.0 release:
 
-- SIMPLIFY_ONEOF_ANYOF
+- SIMPLIFY_ONEOF_ANYOF 
 - SIMPLIFY_BOOLEAN_ENUM
 - SIMPLIFY_ONEOF_ANYOF_ENUM
 - REFACTOR_ALLOF_WITH_PROPERTIES_ONLY
@@ -637,7 +637,7 @@ Example:
 java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g java -i modules/openapi-generator/src/test/resources/3_0/enableKeepOnlyFirstTagInOperation_test.yaml -o /tmp/java-okhttp/ --openapi-normalizer REMOVE_X_INTERNAL=true
 ```
 
-- `NORMALIZER_CLASS`: Set to full classname of a class extending the default org.openapitools.codegen.OpenAPINormalizer. It allows customization of the default normalizer.
+- `NORMALIZER_CLASS`: Set to full classname of a class extending the default org.openapitools.codegen.OpenAPINormalizer. It allows customization of the default normalizer. 
 
 Example:
 ```
@@ -687,16 +687,16 @@ The `FILTER` parameter allows selective inclusion of API operations based on spe
 
 ### Available Filters
 
-- **`operationId`**
+- **`operationId`**  
   When set to `operationId:addPet|getPetById`, operations **not** matching `addPet` or `getPetById` will be marked as internal (`x-internal: true`), and excluded from generation. Matching operations will have `x-internal: false`.
 
-- **`method`**
+- **`method`**  
   When set to `method:get|post`, operations **not** using `GET` or `POST` methods will be marked as internal (`x-internal: true`), preventing their generation.
 
-- **`tag`**
+- **`tag`**  
   When set to `tag:person|basic`, operations **not** tagged with `person` or `basic` will be marked as internal (`x-internal: true`), and will not be generated.
 
-- **`path`**
+- **`path`**  
   When set to `path:/v1|/v2`, operations on paths **not** starting with `/v1` or with `/v2` will be marked as internal (`x-internal: true`), and will not be generated.
 
 ### Example Usage

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -679,7 +679,7 @@ public class OpenAPINormalizer {
             return;
         }
 
-        // clean up global security requirements
+        // Global security requirements
         if (openAPI.getSecurity() != null) {
             List<SecurityRequirement> cleanRequirements = cleanupSecurityRequirements(openAPI.getSecurity(),
                     schemesToClean);
@@ -688,20 +688,54 @@ public class OpenAPINormalizer {
             }
         }
 
-        // loop through all the paths and operations to clean up the references
+        // Paths
         if (openAPI.getPaths() != null) {
             for (PathItem path : openAPI.getPaths().values()) {
-                List<Operation> operations = new ArrayList<>(path.readOperations());
-                for (Operation operation : operations) {
-                    if (operation.getSecurity() == null) {
-                        continue;
-                    }
+                cleanupPathItemSecuritySchemes(path, schemesToClean);
+            }
+        }
 
-                    List<SecurityRequirement> cleanRequirements = cleanupSecurityRequirements(operation.getSecurity(), schemesToClean);
-                    if (cleanRequirements.size() != operation.getSecurity().size()) {
-                        operation.setSecurity(cleanRequirements);
-                    }
+        // Webhooks
+        if (openAPI.getWebhooks() != null) {
+            for (PathItem path : openAPI.getWebhooks().values()) {
+                cleanupPathItemSecuritySchemes(path, schemesToClean);
+            }
+        }
+
+        // Callbacks
+        if (openAPI.getComponents() != null && openAPI.getComponents().getCallbacks() != null) {
+            Map<String, Callback> callbacks = openAPI.getComponents().getCallbacks();
+            for (Callback callback : callbacks.values()) {
+                if (callback == null)
+                    continue;
+
+                for (PathItem path : callback.values()) {
+                    cleanupPathItemSecuritySchemes(path, schemesToClean);
                 }
+            }
+        }
+    }
+
+    /**
+     * Cleans up the references to the security schemes that are removed by the filter in a given PathItem.
+     * @param path the PathItem to clean up
+     * @param schemesToClean the security schemes keys to remove
+     */
+    private void cleanupPathItemSecuritySchemes(PathItem path, Iterable<String> schemesToClean) {
+        if (path == null || schemesToClean == null) {
+            return;
+        }
+
+        List<Operation> operations = new ArrayList<>(path.readOperations());
+        for (Operation operation : operations) {
+            if (operation.getSecurity() == null) {
+                continue;
+            }
+
+            List<SecurityRequirement> cleanRequirements = cleanupSecurityRequirements(operation.getSecurity(),
+                    schemesToClean);
+            if (cleanRequirements.size() != operation.getSecurity().size()) {
+                operation.setSecurity(cleanRequirements);
             }
         }
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -349,10 +349,10 @@ public class OpenAPINormalizer {
      * @param openApi Contract used in the filtering (could be used for customization).
      * @param input full input value
      *
-     * @return an OperationsFilter containing the parsed filters.
+     * @return an Filter containing the parsed filters.
      */
-    protected OperationsFilter createOperationsFilter(OpenAPI openApi, String input) {
-        return new OperationsFilter(input);
+    protected Filter createFilter(OpenAPI openApi, String input) {
+        return new Filter(input);
     }
 
     /**
@@ -415,10 +415,10 @@ public class OpenAPINormalizer {
             return;
         }
 
-        OperationsFilter filter = null;
+        Filter filter = null;
         if (Boolean.TRUE.equals(getRule(FILTER))) {
             String filters = inputRules.get(FILTER);
-            filter = createOperationsFilter(this.openAPI, filters);
+            filter = createFilter(this.openAPI, filters);
             if (!filter.parse()) {
                 filter = null;
             }
@@ -702,7 +702,7 @@ public class OpenAPINormalizer {
             }
         }
 
-        // Callbacks
+        // Callbacks from Components
         if (openAPI.getComponents() != null && openAPI.getComponents().getCallbacks() != null) {
             Map<String, Callback> callbacks = openAPI.getComponents().getCallbacks();
             for (Callback callback : callbacks.values()) {
@@ -714,11 +714,21 @@ public class OpenAPINormalizer {
                 }
             }
         }
+
+        // Path items from Components
+        if (openAPI.getComponents() != null && openAPI.getComponents().getPathItems() != null) {
+            Map<String, PathItem> pathItems = openAPI.getComponents().getPathItems();
+            for (PathItem path : pathItems.values()) {
+                cleanupPathItemSecuritySchemes(path, schemesToClean);
+            }
+        }
     }
 
     /**
-     * Cleans up the references to the security schemes that are removed by the filter in a given PathItem.
-     * @param path the PathItem to clean up
+     * Cleans up the references to the security schemes that are removed by the
+     * filter in a given PathItem.
+     *
+     * @param path           the PathItem to clean up
      * @param schemesToClean the security schemes keys to remove
      */
     private void cleanupPathItemSecuritySchemes(PathItem path, Iterable<String> schemesToClean) {
@@ -726,8 +736,20 @@ public class OpenAPINormalizer {
             return;
         }
 
-        List<Operation> operations = new ArrayList<>(path.readOperations());
-        for (Operation operation : operations) {
+        List<Operation> operations = new LinkedList<>(path.readOperations());
+        // An infinite loop is impossible here because it is impossible without using
+        // references from components and we clean up components separately
+        while (!operations.isEmpty()) {
+            Operation operation = operations.remove(0);
+            Map<String, Callback> callbacks = operation.getCallbacks();
+            if (callbacks != null) {
+                for (Callback callback : callbacks.values()) {
+                    for (PathItem callbackPath : callback.values()) {
+                        operations.addAll(callbackPath.readOperations());
+                    }
+                }
+            }
+
             if (operation.getSecurity() == null) {
                 continue;
             }
@@ -2453,13 +2475,19 @@ public class OpenAPINormalizer {
         }
     }
 
-    protected static class OperationsFilter extends BaseFilter {
+    // Filter for API operations
+    protected static class Filter extends BaseFilter {
         public static final String OPERATION_ID = "operationId";
         public static final String METHOD = "method";
         public static final String TAG = "tag";
         public static final String PATH = "path";
+        // Keep next four fields for backward compatibility of custom made filters. New filters should use filteringMethodsMap directly.
+        protected Set<String> operationIdFilters = Collections.emptySet();
+        protected Set<String> methodFilters = Collections.emptySet();
+        protected Set<String> tagFilters = Collections.emptySet();
+        protected Set<String> pathStartingWithFilters = Collections.emptySet();
 
-        protected OperationsFilter(String filters) {
+        protected Filter(String filters) {
             super(filters);
         }
 
@@ -2472,12 +2500,35 @@ public class OpenAPINormalizer {
         public String usageMessage() {
             return String.format(Locale.ROOT,
                         "FILTER rule must be in the form of `%s:name1|name2|name3` or `%s:get|post|put` or `%s:tag1|tag2|tag3` or `%s:/v1|/v2`.",
-                        OperationsFilter.OPERATION_ID, OperationsFilter.METHOD, OperationsFilter.TAG, OperationsFilter.PATH);
+                        Filter.OPERATION_ID, Filter.METHOD, Filter.TAG, Filter.PATH);
         }
 
         @Override
         protected void logMatch(String filterName, String subjectId) {
             getLogger().info("Operation `{}` matches the {} filter and remains", subjectId, filterName);
+        }
+
+        // Having that just to fill the fields for backward compatibility of custom made filters
+        @Override
+        public boolean parse() {
+            boolean result = super.parse();
+            operationIdFilters = filteringMethodsMap.getOrDefault(OPERATION_ID, Collections.emptySet());
+            methodFilters = filteringMethodsMap.getOrDefault(METHOD, Collections.emptySet());
+            tagFilters = filteringMethodsMap.getOrDefault(TAG, Collections.emptySet());
+            pathStartingWithFilters = filteringMethodsMap.getOrDefault(PATH, Collections.emptySet());
+            return result;
+        }
+
+        // Keep next two methods for backward compatibility of custom made filters.
+        protected boolean logIfMatch(String filterName, Operation operation, boolean filterMatched) {
+            if (filterMatched) {
+                logMatch(filterName, operation);
+            }
+            return filterMatched;
+        }
+
+        protected void logMatch(String filterName, Operation operation) {
+            getLogger().info("operation `{}` marked as internal only (x-internal: true) by the {} FILTER", operation.getOperationId(), filterName);
         }
 
         /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -332,16 +332,29 @@ public class OpenAPINormalizer {
     }
 
     /**
-     * Create the filter to process the FILTER normalizer.
+     * Create the operations filter to process the FILTER normalizer.
      * Override this to create a custom filter normalizer.
      *
      * @param openApi Contract used in the filtering (could be used for customization).
-     * @param filters full FILTER value
+     * @param input full input value
      *
-     * @return a Filter containing the parsed filters.
+     * @return an OperationsFilter containing the parsed filters.
      */
-    protected Filter createFilter(OpenAPI openApi, String filters) {
-        return new Filter(filters);
+    protected OperationsFilter createOperationsFilter(OpenAPI openApi, String input) {
+        return new OperationsFilter(input);
+    }
+
+    /**
+     * Create the security schemes filter to process the FILTER normalizer.
+     * Override this to create a custom filter normalizer.
+     *
+     * @param openApi Contract used in the filtering (could be used for customization).
+     * @param input full input value
+     *
+     * @return an SecuritySchemesFilter containing the parsed filters.
+     */
+    protected SecuritySchemesFilter createSecuritySchemesFilter(OpenAPI openApi, String input) {
+        return new SecuritySchemesFilter(input);
     }
 
     /**
@@ -408,7 +421,7 @@ public class OpenAPINormalizer {
 
             if (Boolean.TRUE.equals(getRule(FILTER))) {
                 String filters = inputRules.get(FILTER);
-                Filter filter = createFilter(this.openAPI, filters);
+                OperationsFilter filter = createOperationsFilter(this.openAPI, filters);
                 if (filter.parse()) {
                     // Iterates over each HTTP method in methodMap, retrieves the corresponding Operations from the PathItem,
                     // and marks it as internal (`x-internal=true`) if the method/operationId/tag/path is not in the filters.
@@ -591,9 +604,9 @@ public class OpenAPINormalizer {
      * Normalizes securitySchemes in components
      */
     protected void normalizeComponentsSecuritySchemes() {
-         if (StringUtils.isEmpty(bearerAuthSecuritySchemeName)) {
-             return;
-         }
+        if (StringUtils.isEmpty(bearerAuthSecuritySchemeName)) {
+            return;
+        }
 
         Map<String, SecurityScheme> schemes = openAPI.getComponents().getSecuritySchemes();
         if (schemes == null) {
@@ -2182,20 +2195,22 @@ public class OpenAPINormalizer {
 
     // ===================== end of rules =====================
 
-    protected static class Filter {
-        public static final String OPERATION_ID = "operationId";
-        public static final String METHOD = "method";
-        public static final String TAG = "tag";
-        public static final String PATH = "path";
-        private final String filters;
-        protected Set<String> operationIdFilters = Collections.emptySet();
-        protected Set<String> methodFilters = Collections.emptySet();
-        protected Set<String> tagFilters = Collections.emptySet();
-        protected Set<String> pathStartingWithFilters = Collections.emptySet();
-        private boolean hasFilter;
+    // Base class for filters. It provides basic parsing logic and utility functions for filters.
+    // All filters should have the same syntax:
+    // `filterName:value1|value2|value3` and multiple filters can be separated by `;`.
+    protected static abstract class BaseFilter {
+        protected boolean hasFilter;
+        private final String input;
+        // Key - filtering method, value - set of accepted values.
+        // For example, to filter operations by method the key would be "method" and the value is a set of {"get", "post"}.
+        protected Map<String, Set<String>> filteringMethodsMap;
 
-        protected Filter(String filters) {
-            this.filters = filters.trim();
+        protected BaseFilter(String input) {
+            this.input = input.trim();
+        }
+
+        public boolean hasFilter() {
+            return hasFilter;
         }
 
         /**
@@ -2204,23 +2219,34 @@ public class OpenAPINormalizer {
          * @return true if filters need to be processed
          */
         public boolean parse() {
-            if (StringUtils.isEmpty(filters)) {
+            if (StringUtils.isEmpty(input)) {
                 return false;
             }
             try {
                 doParse();
                 return hasFilter();
             } catch (RuntimeException e) {
-                String message = String.format(Locale.ROOT, "FILTER rule [%s] must be in the form of `%s:name1|name2|name3` or `%s:get|post|put` or `%s:tag1|tag2|tag3` or `%s:/v1|/v2`. Error: %s",
-                        filters, Filter.OPERATION_ID, Filter.METHOD, Filter.TAG, Filter.PATH, e.getMessage());
+                String usage = usageMessage();
+                String message = String.format(Locale.ROOT, "%s Input: `%s` Error: %s", usage, input, e.getMessage());
                 // throw an exception. This is a breaking change compared to pre 7.16.0
                 // Workaround: fix the syntax!
                 throw new IllegalArgumentException(message);
             }
         }
 
+        // Defines the filtering methods supported by the filter.
+        // Can be overridden by child classes to customize filtering.
+        public abstract Set<String> filteringMethods();
+
+        // Defines the subject being filtered, e.g. operation, security scheme, etc. This is used for logging purposes.
+        public abstract String filteringSubject();
+
+        // Defines the usage message for the filter. This is used for logging purposes when the filter syntax is incorrect.
+        public abstract String usageMessage();
+
         private void doParse() {
-            for (String filter : filters.split(";")) {
+            Set<String> filteringMethods = filteringMethods();
+            for (String filter : input.split(";")) {
                 filter = filter.trim();
                 String[] filterStrs = filter.split(":");
                 if (filterStrs.length != 2) { // only support filter with : at the moment
@@ -2230,15 +2256,16 @@ public class OpenAPINormalizer {
                     String filterValue = filterStrs[1];
                     Set<String> parsedFilters = splitByPipe(filterValue);
                     hasFilter = true;
-                    if (OPERATION_ID.equals(filterKey)) {
-                        operationIdFilters = parsedFilters;
-                    } else if (METHOD.equals(filterKey)) {
-                        methodFilters = parsedFilters;
-                    } else if (TAG.equals(filterKey)) {
-                        tagFilters = parsedFilters;
-                    } else if (PATH.equals(filterKey)) {
-                        pathStartingWithFilters = parsedFilters;
-                    } else {
+
+                    boolean found = false;
+                    for (String method : filteringMethods) {
+                        if (method.equals(filterKey)) {
+                            found = true;
+                            filteringMethodsMap.put(filterKey, parsedFilters);
+                            break;
+                        }
+                    }
+                    if (!found) {
                         parse(filterKey, filterValue);
                     }
                 }
@@ -2258,7 +2285,7 @@ public class OpenAPINormalizer {
         }
 
         /**
-         * Parse non default filters.
+         * Parse non default filtering methods.
          *
          * Override this method to add custom parsing logic.
          *
@@ -2275,6 +2302,50 @@ public class OpenAPINormalizer {
             throw new IllegalArgumentException("filter not supported :[" + filterName + ":" + filterValue + "]");
         }
 
+        protected boolean logIfMatch(String filterName, String subjectId, boolean filterMatched) {
+            if (filterMatched) {
+                logMatch(filterName, subjectId);
+            }
+            return filterMatched;
+        }
+
+        protected void logMatch(String filterName, String subjectId) {
+            getLogger().info("{} `{}` marked as internal only (x-internal: true) by the {} filter", filteringSubject(),
+                    subjectId, filterName);
+        }
+
+        protected Logger getLogger() {
+            return OpenAPINormalizer.LOGGER;
+        }
+    }
+
+    protected static class OperationsFilter extends BaseFilter {
+        public static final String OPERATION_ID = "operationId";
+        public static final String METHOD = "method";
+        public static final String TAG = "tag";
+        public static final String PATH = "path";
+
+        protected OperationsFilter(String filters) {
+            super(filters);
+        }
+
+        @Override
+        public Set<String> filteringMethods() {
+            return Set.of(OPERATION_ID, METHOD, TAG, PATH);
+        }
+
+        @Override
+        public String filteringSubject() {
+            return "Operation";
+        }
+
+        @Override
+        public String usageMessage() {
+            return String.format(Locale.ROOT,
+                        "FILTER rule must be in the form of `%s:name1|name2|name3` or `%s:get|post|put` or `%s:tag1|tag2|tag3` or `%s:/v1|/v2`.",
+                        OperationsFilter.OPERATION_ID, OperationsFilter.METHOD, OperationsFilter.TAG, OperationsFilter.PATH);
+        }
+
         /**
          * Test if the OpenAPI contract match an extra filter.
          *
@@ -2289,19 +2360,16 @@ public class OpenAPINormalizer {
             return false;
         }
 
-        public boolean hasFilter() {
-            return hasFilter;
-        }
-
         public void apply(String path, PathItem pathItem, Map<String, Function<PathItem, Operation>> methodMap) {
             methodMap.forEach((method, getter) -> {
                 Operation operation = getter.apply(pathItem);
                 if (operation != null) {
                     boolean found = false;
-                    found |= logIfMatch(PATH, operation, hasPathStarting(path));
-                    found |= logIfMatch(TAG, operation, hasTag(operation));
-                    found |= logIfMatch(OPERATION_ID, operation, hasOperationId(operation));
-                    found |= logIfMatch(METHOD, operation, hasMethod(method));
+                    String operationId = operation.getOperationId();
+                    found |= logIfMatch(PATH, operationId, hasPathStarting(path));
+                    found |= logIfMatch(TAG, operationId, hasTag(operation));
+                    found |= logIfMatch(OPERATION_ID, operationId, hasOperationId(operation));
+                    found |= logIfMatch(METHOD, operationId, hasMethod(method));
                     found |= hasCustomFilterMatch(path, operation);
 
                     operation.addExtension(X_INTERNAL, !found);
@@ -2309,35 +2377,83 @@ public class OpenAPINormalizer {
             });
         }
 
-        protected boolean logIfMatch(String filterName, Operation operation, boolean filterMatched) {
-            if (filterMatched) {
-                logMatch(filterName, operation);
-            }
-            return filterMatched;
-        }
-
-        protected void logMatch(String filterName, Operation operation) {
-            getLogger().info("operation `{}` marked as internal only (x-internal: true) by the {} FILTER", operation.getOperationId(), filterName);
-        }
-
-        protected Logger getLogger() {
-            return OpenAPINormalizer.LOGGER;
-        }
-
         private boolean hasPathStarting(String path) {
+            Set<String> pathStartingWithFilters = filteringMethodsMap.getOrDefault(PATH, Collections.emptySet());
             return pathStartingWithFilters.stream().anyMatch(filter -> path.startsWith(filter));
         }
 
-        private boolean hasTag( Operation operation) {
+        private boolean hasTag(Operation operation) {
+            Set<String> tagFilters = filteringMethodsMap.getOrDefault(TAG, Collections.emptySet());
             return operation.getTags() != null && operation.getTags().stream().anyMatch(tagFilters::contains);
         }
 
         private boolean hasOperationId(Operation operation) {
+            Set<String> operationIdFilters = filteringMethodsMap.getOrDefault(OPERATION_ID, Collections.emptySet());
             return operationIdFilters.contains(operation.getOperationId());
         }
 
         private boolean hasMethod(String method) {
+            Set<String> methodFilters = filteringMethodsMap.getOrDefault(METHOD, Collections.emptySet());
             return methodFilters.contains(method);
+        }
+    }
+
+    protected static class SecuritySchemesFilter extends BaseFilter {
+        public static final String KEY = "key";
+        public static final String TYPE = "type";
+
+        protected SecuritySchemesFilter(String filters) {
+            super(filters);
+        }
+
+        @Override
+        public Set<String> filteringMethods() {
+            return Set.of(KEY, TYPE);
+        }
+
+        @Override
+        public String filteringSubject() {
+            return "Security scheme";
+        }
+
+        @Override
+        public String usageMessage() {
+            return String.format(Locale.ROOT,
+                        "SECURITY_SCHEMES_FILTER rule must be in the form of `%s:key1|key2|key3` or `%s:apiKey|http|mutualTLS|oauth2|openIdConnect`.",
+                        KEY, TYPE);
+        }
+
+        /**
+         * Test if the OpenAPI contract match an extra filter.
+         *
+         * Override this method to add custom logic.
+         *
+         * @param schemeKey  Security scheme key
+         * @param scheme  Security scheme
+         *
+         * @return true if the security scheme matches the filter
+         */
+        protected boolean hasCustomFilterMatch(String schemeKey, SecurityScheme scheme) {
+            return false;
+        }
+
+        public void apply(String schemeKey, SecurityScheme scheme) {
+            boolean found = false;
+            found |= logIfMatch(KEY, schemeKey, hasKey(schemeKey));
+            found |= logIfMatch(TYPE, schemeKey, hasType(scheme.getType()));
+            found |= hasCustomFilterMatch(schemeKey, scheme);
+
+            scheme.addExtension(X_INTERNAL, !found);
+        }
+
+        private boolean hasKey(String key) {
+            Set<String> keyFilters = filteringMethodsMap.getOrDefault(KEY, Collections.emptySet());
+            return keyFilters.contains(key);
+        }
+
+        private boolean hasType(String type) {
+            Set<String> typeFilters = filteringMethodsMap.getOrDefault(TYPE, Collections.emptySet());
+            return typeFilters.contains(type);
         }
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -28,6 +28,7 @@ import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.security.SecurityScheme.Type;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.slf4j.Logger;
@@ -632,6 +633,7 @@ public class OpenAPINormalizer {
             }
         }
 
+        List<String> deletedSchemes = new ArrayList<>();
         Iterator<Map.Entry<String, SecurityScheme>> it = schemes.entrySet().iterator();
         while (it.hasNext()) {
             Map.Entry<String, SecurityScheme> entry = it.next();
@@ -657,7 +659,41 @@ public class OpenAPINormalizer {
             if (filter != null && filter.hasFilter()) {
                 boolean keep = filter.apply(schemeKey, scheme);
                 if (!keep) {
+                    deletedSchemes.add(schemeKey);
                     it.remove();
+                }
+            }
+        }
+
+        // Cleanup all the references to schemes we just deleted.
+        cleanupSecuritySchemeReferences(deletedSchemes);
+    }
+
+    /**
+     * Cleans up the references to the security schemes that are removed by the filter.
+     *
+     * @param schemesToClean the security schemes keys to clean up
+     */
+    protected void cleanupSecuritySchemeReferences(Iterable<String> schemesToClean) {
+        if (schemesToClean == null || openAPI.getPaths() == null) {
+            return;
+        }
+
+        for (String schemeKey : schemesToClean) {
+            // loop through all the paths and operations to clean up the reference
+
+            for (PathItem path : openAPI.getPaths().values()) {
+                List<Operation> operations = new ArrayList<>(path.readOperations());
+                for (Operation operation : operations) {
+                    if (operation.getSecurity() == null) {
+                        continue;
+                    }
+
+                    for (SecurityRequirement securityRequirement : operation.getSecurity()) {
+                        if (securityRequirement.containsKey(schemeKey)) {
+                            securityRequirement.remove(schemeKey);
+                        }
+                    }
                 }
             }
         }
@@ -2271,9 +2307,6 @@ public class OpenAPINormalizer {
         // Can be overridden by child classes to customize filtering.
         public abstract Set<String> filteringMethods();
 
-        // Defines the subject being filtered, e.g. operation, security scheme, etc. This is used for logging purposes.
-        public abstract String filteringSubject();
-
         // Defines the usage message for the filter. This is used for logging purposes when the filter syntax is incorrect.
         public abstract String usageMessage();
 
@@ -2342,10 +2375,7 @@ public class OpenAPINormalizer {
             return filterMatched;
         }
 
-        protected void logMatch(String filterName, String subjectId) {
-            getLogger().info("{} `{}` marked as internal only (x-internal: true) by the {} filter", filteringSubject(),
-                    subjectId, filterName);
-        }
+        protected abstract void logMatch(String filterName, String subjectId);
 
         protected Logger getLogger() {
             return OpenAPINormalizer.LOGGER;
@@ -2368,15 +2398,15 @@ public class OpenAPINormalizer {
         }
 
         @Override
-        public String filteringSubject() {
-            return "Operation";
-        }
-
-        @Override
         public String usageMessage() {
             return String.format(Locale.ROOT,
                         "FILTER rule must be in the form of `%s:name1|name2|name3` or `%s:get|post|put` or `%s:tag1|tag2|tag3` or `%s:/v1|/v2`.",
                         OperationsFilter.OPERATION_ID, OperationsFilter.METHOD, OperationsFilter.TAG, OperationsFilter.PATH);
+        }
+
+        @Override
+        protected void logMatch(String filterName, String subjectId) {
+            getLogger().info("Operation `{}` matches the {} filter and remains", subjectId, filterName);
         }
 
         /**
@@ -2406,6 +2436,9 @@ public class OpenAPINormalizer {
                     found |= hasCustomFilterMatch(path, operation);
 
                     operation.addExtension(X_INTERNAL, !found);
+                    if (!found) {
+                        getLogger().info("Operation `{}` does not match any filter and is marked as internal only (x-internal: true)", operationId);
+                    }
                 }
             });
         }
@@ -2445,15 +2478,15 @@ public class OpenAPINormalizer {
         }
 
         @Override
-        public String filteringSubject() {
-            return "Security scheme";
-        }
-
-        @Override
         public String usageMessage() {
             return String.format(Locale.ROOT,
                         "SECURITY_SCHEMES_FILTER rule must be in the form of `%s:key1|key2|key3` or `%s:apiKey|http|mutualTLS|oauth2|openIdConnect`.",
                         KEY, TYPE);
+        }
+
+        @Override
+        protected void logMatch(String filterName, String subjectId) {
+            getLogger().info("Security scheme `{}` matches the {} filter and remains", subjectId, filterName);
         }
 
         /**
@@ -2476,6 +2509,9 @@ public class OpenAPINormalizer {
             found |= logIfMatch(TYPE, schemeKey, hasType(scheme.getType().toString()));
             found |= hasCustomFilterMatch(schemeKey, scheme);
 
+            if (!found) {
+                getLogger().info("Security scheme `{}` does not match any filter and is removed", schemeKey);
+            }
             return found;
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -632,9 +632,13 @@ public class OpenAPINormalizer {
             }
         }
 
-        for (String schemeKey : schemes.keySet()) {
+        Iterator<Map.Entry<String, SecurityScheme>> it = schemes.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<String, SecurityScheme> entry = it.next();
+            String schemeKey = entry.getKey();
+            SecurityScheme scheme = entry.getValue();
+
             if (schemeKey.equals(bearerAuthSecuritySchemeName)) {
-                SecurityScheme scheme = schemes.get(schemeKey);
                 scheme.setType(SecurityScheme.Type.HTTP);
                 scheme.setScheme("bearer");
                 scheme.setIn(null);
@@ -651,8 +655,10 @@ public class OpenAPINormalizer {
             // It may happen that bearer scheme will be filtered out on this step.
             // To keep the scheme - change filter input.
             if (filter != null && filter.hasFilter()) {
-                SecurityScheme scheme = schemes.get(schemeKey);
-                filter.apply(schemeKey, scheme);
+                boolean keep = filter.apply(schemeKey, scheme);
+                if (!keep) {
+                    it.remove();
+                }
             }
         }
     }
@@ -2464,13 +2470,13 @@ public class OpenAPINormalizer {
             return false;
         }
 
-        public void apply(String schemeKey, SecurityScheme scheme) {
+        public boolean apply(String schemeKey, SecurityScheme scheme) {
             boolean found = false;
             found |= logIfMatch(KEY, schemeKey, hasKey(schemeKey));
             found |= logIfMatch(TYPE, schemeKey, hasType(scheme.getType().toString()));
             found |= hasCustomFilterMatch(schemeKey, scheme);
 
-            scheme.addExtension(X_INTERNAL, !found);
+            return found;
         }
 
         private boolean hasKey(String key) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -217,6 +217,7 @@ public class OpenAPINormalizer {
         ruleNames.add(NORMALIZE_31SPEC);
         ruleNames.add(REMOVE_X_INTERNAL);
         ruleNames.add(FILTER);
+        ruleNames.add(SECURITY_SCHEMES_FILTER);
         ruleNames.add(SET_CONTAINER_TO_NULLABLE);
         ruleNames.add(SET_PRIMITIVE_TYPES_TO_NULLABLE);
         ruleNames.add(SIMPLIFY_ONEOF_ANYOF_ENUM);
@@ -289,6 +290,11 @@ public class OpenAPINormalizer {
 
         if (inputRules.get(FILTER) != null) {
             rules.put(FILTER, true);
+            // actual parsing is delayed to allow customization of the Filter processing
+        }
+
+        if (inputRules.get(SECURITY_SCHEMES_FILTER) != null) {
+            rules.put(SECURITY_SCHEMES_FILTER, true);
             // actual parsing is delayed to allow customization of the Filter processing
         }
 
@@ -408,6 +414,15 @@ public class OpenAPINormalizer {
             return;
         }
 
+        OperationsFilter filter = null;
+        if (Boolean.TRUE.equals(getRule(FILTER))) {
+            String filters = inputRules.get(FILTER);
+            filter = createOperationsFilter(this.openAPI, filters);
+            if (!filter.parse()) {
+                filter = null;
+            }
+        }
+
         for (Map.Entry<String, PathItem> pathsEntry : paths.entrySet()) {
             PathItem path = pathsEntry.getValue();
             List<Operation> operations = new ArrayList<>(path.readOperations());
@@ -423,14 +438,10 @@ public class OpenAPINormalizer {
                     "trace", PathItem::getTrace
             );
 
-            if (Boolean.TRUE.equals(getRule(FILTER))) {
-                String filters = inputRules.get(FILTER);
-                OperationsFilter filter = createOperationsFilter(this.openAPI, filters);
-                if (filter.parse()) {
-                    // Iterates over each HTTP method in methodMap, retrieves the corresponding Operations from the PathItem,
-                    // and marks it as internal (`x-internal=true`) if the method/operationId/tag/path is not in the filters.
-                    filter.apply(pathsEntry.getKey(), path, methodMap);
-                }
+            if (filter != null && filter.hasFilter()) {
+                // Iterates over each HTTP method in methodMap, retrieves the corresponding Operations from the PathItem,
+                // and marks it as internal (`x-internal=true`) if the method/operationId/tag/path is not in the filters.
+                filter.apply(pathsEntry.getKey(), path, methodMap);
             }
 
             // Include callback operation as well
@@ -608,13 +619,17 @@ public class OpenAPINormalizer {
      * Normalizes securitySchemes in components
      */
     protected void normalizeComponentsSecuritySchemes() {
-        if (StringUtils.isEmpty(bearerAuthSecuritySchemeName)) {
-            return;
-        }
-
         Map<String, SecurityScheme> schemes = openAPI.getComponents().getSecuritySchemes();
         if (schemes == null) {
             return;
+        }
+
+        SecuritySchemesFilter filter = null;
+        if (Boolean.TRUE.equals(getRule(SECURITY_SCHEMES_FILTER))) {
+            filter = createSecuritySchemesFilter(openAPI, inputRules.get(SECURITY_SCHEMES_FILTER));
+            if (!filter.parse()) {
+                filter = null;
+            }
         }
 
         for (String schemeKey : schemes.keySet()) {
@@ -630,6 +645,14 @@ public class OpenAPINormalizer {
                 scheme.setExtensions(null);
                 scheme.set$ref(null);
                 schemes.put(schemeKey, scheme);
+            }
+
+            // At first we transform a scheme to HTTP bearer and then apply the filter.
+            // It may happen that bearer scheme will be filtered out on this step.
+            // To keep the scheme - change filter input.
+            if (filter != null && filter.hasFilter()) {
+                SecurityScheme scheme = schemes.get(schemeKey);
+                filter.apply(schemeKey, scheme);
             }
         }
     }
@@ -2199,7 +2222,7 @@ public class OpenAPINormalizer {
 
     // ===================== end of rules =====================
 
-    // Base class for filters. It provides basic parsing logic and utility functions for filters.
+    // Base class for filters. It provides parsing logic and utility functions for filters.
     // All filters should have the same syntax:
     // `filterName:value1|value2|value3` and multiple filters can be separated by `;`.
     protected static abstract class BaseFilter {
@@ -2231,7 +2254,7 @@ public class OpenAPINormalizer {
                 return hasFilter();
             } catch (RuntimeException e) {
                 String usage = usageMessage();
-                String message = String.format(Locale.ROOT, "%s Input: `%s` Error: %s", usage, input, e.getMessage());
+                String message = String.format(Locale.ROOT, "%s Input: `%s`. Error: %s", usage, input, e.getMessage());
                 // throw an exception. This is a breaking change compared to pre 7.16.0
                 // Workaround: fix the syntax!
                 throw new IllegalArgumentException(message);
@@ -2444,7 +2467,7 @@ public class OpenAPINormalizer {
         public void apply(String schemeKey, SecurityScheme scheme) {
             boolean found = false;
             found |= logIfMatch(KEY, schemeKey, hasKey(schemeKey));
-            found |= logIfMatch(TYPE, schemeKey, hasType(scheme.getType()));
+            found |= logIfMatch(TYPE, schemeKey, hasType(scheme.getType().toString()));
             found |= hasCustomFilterMatch(schemeKey, scheme);
 
             scheme.addExtension(X_INTERNAL, !found);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -27,6 +27,7 @@ import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme.Type;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.slf4j.Logger;
@@ -140,6 +141,9 @@ public class OpenAPINormalizer {
 
     // when set (e.g. operationId:getPetById|addPet), filter out (or remove) everything else
     final String FILTER = "FILTER";
+
+    // when set (e.g. type:http|oauth2), filter out (or remove) everything else
+    final String SECURITY_SCHEMES_FILTER = "SECURITY_SCHEMES_FILTER";
 
     // when set (e.g. operationId:getPetById|addPet), filter out (or remove) everything else
     final String SET_CONTAINER_TO_NULLABLE = "SET_CONTAINER_TO_NULLABLE";
@@ -2203,7 +2207,7 @@ public class OpenAPINormalizer {
         private final String input;
         // Key - filtering method, value - set of accepted values.
         // For example, to filter operations by method the key would be "method" and the value is a set of {"get", "post"}.
-        protected Map<String, Set<String>> filteringMethodsMap;
+        protected Map<String, Set<String>> filteringMethodsMap = new HashMap<>();
 
         protected BaseFilter(String input) {
             this.input = input.trim();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -674,14 +674,22 @@ public class OpenAPINormalizer {
      *
      * @param schemesToClean the security schemes keys to clean up
      */
-    protected void cleanupSecuritySchemeReferences(Iterable<String> schemesToClean) {
-        if (schemesToClean == null || openAPI.getPaths() == null) {
+    private void cleanupSecuritySchemeReferences(Iterable<String> schemesToClean) {
+        if (schemesToClean == null) {
             return;
         }
 
-        for (String schemeKey : schemesToClean) {
-            // loop through all the paths and operations to clean up the reference
+        // clean up global security requirements
+        if (openAPI.getSecurity() != null) {
+            List<SecurityRequirement> cleanRequirements = cleanupSecurityRequirements(openAPI.getSecurity(),
+                    schemesToClean);
+            if (cleanRequirements.size() != openAPI.getSecurity().size()) {
+                openAPI.setSecurity(cleanRequirements);
+            }
+        }
 
+        // loop through all the paths and operations to clean up the references
+        if (openAPI.getPaths() != null) {
             for (PathItem path : openAPI.getPaths().values()) {
                 List<Operation> operations = new ArrayList<>(path.readOperations());
                 for (Operation operation : operations) {
@@ -689,14 +697,43 @@ public class OpenAPINormalizer {
                         continue;
                     }
 
-                    for (SecurityRequirement securityRequirement : operation.getSecurity()) {
-                        if (securityRequirement.containsKey(schemeKey)) {
-                            securityRequirement.remove(schemeKey);
-                        }
+                    List<SecurityRequirement> cleanRequirements = cleanupSecurityRequirements(operation.getSecurity(), schemesToClean);
+                    if (cleanRequirements.size() != operation.getSecurity().size()) {
+                        operation.setSecurity(cleanRequirements);
                     }
                 }
             }
         }
+    }
+
+    /**
+     * Removes given security schemes from the list of security requirements and remove the requirement if it becomes empty after the cleanup.
+     *
+     * @param requirements the list of security requirements to clean up
+     * @param schemesToClean the security schemes keys to clean up
+     * @return the cleaned list of security requirements
+     */
+    private List<SecurityRequirement> cleanupSecurityRequirements(List<SecurityRequirement> requirements, Iterable<String> schemesToClean) {
+        if (requirements == null || schemesToClean == null) {
+            return requirements;
+        }
+
+        List<SecurityRequirement> cleanRequirements = new ArrayList<>();
+        for (SecurityRequirement req : requirements) {
+            boolean hasSchemeToClean = false;
+            for (String schemeKey : schemesToClean) {
+                if (req.containsKey(schemeKey)) {
+                    req.remove(schemeKey);
+                    hasSchemeToClean = true;
+                }
+            }
+            // Remove the requirement if it becomes empty after the cleanup.
+            // The requirement could be empty from the beginning we leave it in such a case.
+            if (!req.isEmpty() || !hasSchemeToClean) {
+                cleanRequirements.add(req);
+            }
+        }
+        return cleanRequirements;
     }
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -2543,7 +2543,7 @@ public class OpenAPINormalizer {
         public boolean apply(String schemeKey, SecurityScheme scheme) {
             boolean found = false;
             found |= logIfMatch(KEY, schemeKey, hasKey(schemeKey));
-            found |= logIfMatch(TYPE, schemeKey, hasType(scheme.getType().toString()));
+            found |= logIfMatch(TYPE, schemeKey, scheme.getType() != null && hasType(scheme.getType().toString()));
             found |= hasCustomFilterMatch(schemeKey, scheme);
 
             if (!found) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -795,15 +795,15 @@ public class OpenAPINormalizerTest {
         assertEquals(openAPI.getPaths().get("/person/display/{personId}").getPut().getExtensions().get(X_INTERNAL), true);
     }
 
-    static OpenAPINormalizer.OperationsFilter parseOperationsFilter(String filters) {
-        OpenAPINormalizer.OperationsFilter filter = new OpenAPINormalizer.OperationsFilter(filters);
+    static OpenAPINormalizer.Filter parseOperationsFilter(String filters) {
+        OpenAPINormalizer.Filter filter = new OpenAPINormalizer.Filter(filters);
         filter.parse();
         return filter;
     }
 
     @Test
     public void testOperationsFilterParsing() {
-        OpenAPINormalizer.OperationsFilter filter;
+        OpenAPINormalizer.Filter filter;
 
         // no filter
         filter = parseOperationsFilter(" ");
@@ -819,33 +819,51 @@ public class OpenAPINormalizerTest {
         // extra spaces are trimmed
         filter = parseOperationsFilter("method:\n\t\t\t\tget");
         assertTrue(filter.hasFilter());
-        assertEquals(filter.filteringMethodsMap.get(OpenAPINormalizer.OperationsFilter.METHOD), Set.of("get"));
-        assertFalse(filter.filteringMethodsMap.containsKey(OpenAPINormalizer.OperationsFilter.OPERATION_ID));
-        assertFalse(filter.filteringMethodsMap.containsKey(OpenAPINormalizer.OperationsFilter.TAG));
-        assertFalse(filter.filteringMethodsMap.containsKey(OpenAPINormalizer.OperationsFilter.PATH));
+        assertEquals(filter.filteringMethodsMap.get(OpenAPINormalizer.Filter.METHOD), Set.of("get"));
+        assertFalse(filter.filteringMethodsMap.containsKey(OpenAPINormalizer.Filter.OPERATION_ID));
+        assertFalse(filter.filteringMethodsMap.containsKey(OpenAPINormalizer.Filter.TAG));
+        assertFalse(filter.filteringMethodsMap.containsKey(OpenAPINormalizer.Filter.PATH));
+        // Verify also compatibility fields
+        assertEquals(filter.methodFilters, Set.of("get"));
+        assertTrue(filter.operationIdFilters.isEmpty());
+        assertTrue(filter.tagFilters.isEmpty());
+        assertTrue(filter.pathStartingWithFilters.isEmpty());
 
         // multiple values separated by pipe
         filter = parseOperationsFilter("operationId:\n\t\t\t\tdelete|\n\t\tlist\t");
         assertTrue(filter.hasFilter());
-        assertFalse(filter.filteringMethodsMap.containsKey(OpenAPINormalizer.OperationsFilter.METHOD));
-        assertEquals(filter.filteringMethodsMap.get(OpenAPINormalizer.OperationsFilter.OPERATION_ID), Set.of("delete", "list"));
-        assertFalse(filter.filteringMethodsMap.containsKey(OpenAPINormalizer.OperationsFilter.TAG));
-        assertFalse(filter.filteringMethodsMap.containsKey(OpenAPINormalizer.OperationsFilter.PATH));
+        assertFalse(filter.filteringMethodsMap.containsKey(OpenAPINormalizer.Filter.METHOD));
+        assertEquals(filter.filteringMethodsMap.get(OpenAPINormalizer.Filter.OPERATION_ID), Set.of("delete", "list"));
+        assertFalse(filter.filteringMethodsMap.containsKey(OpenAPINormalizer.Filter.TAG));
+        assertFalse(filter.filteringMethodsMap.containsKey(OpenAPINormalizer.Filter.PATH));
+        // Verify also compatibility fields
+        assertTrue(filter.methodFilters.isEmpty());
+        assertEquals(filter.operationIdFilters, Set.of("delete", "list"));
+        assertTrue(filter.tagFilters.isEmpty());
+        assertTrue(filter.pathStartingWithFilters.isEmpty());
 
         // multiple filters
         filter = parseOperationsFilter("operationId:delete|list;path:/v1");
         assertTrue(filter.hasFilter());
-        assertFalse(filter.filteringMethodsMap.containsKey(OpenAPINormalizer.OperationsFilter.METHOD));
-        assertEquals(filter.filteringMethodsMap.get(OpenAPINormalizer.OperationsFilter.OPERATION_ID), Set.of("delete", "list"));
-        assertFalse(filter.filteringMethodsMap.containsKey(OpenAPINormalizer.OperationsFilter.TAG));
-        assertEquals(filter.filteringMethodsMap.get(OpenAPINormalizer.OperationsFilter.PATH), Set.of("/v1"));
+        assertFalse(filter.filteringMethodsMap.containsKey(OpenAPINormalizer.Filter.METHOD));
+        assertEquals(filter.filteringMethodsMap.get(OpenAPINormalizer.Filter.OPERATION_ID), Set.of("delete", "list"));
+        assertFalse(filter.filteringMethodsMap.containsKey(OpenAPINormalizer.Filter.TAG));
+        assertEquals(filter.filteringMethodsMap.get(OpenAPINormalizer.Filter.PATH), Set.of("/v1"));
+        // Verify also compatibility fields
+        assertTrue(filter.methodFilters.isEmpty());
+        assertEquals(filter.operationIdFilters, Set.of("delete", "list"));
+        assertTrue(filter.tagFilters.isEmpty());
+        assertEquals(filter.pathStartingWithFilters, Set.of("/v1"));
     }
 
     @Test
     public void testMultiFilterParsing() {
-        OpenAPINormalizer.OperationsFilter filter = parseOperationsFilter("operationId: delete| list ;  tag : testA |testB ");
-        assertEquals(filter.filteringMethodsMap.get(OpenAPINormalizer.OperationsFilter.OPERATION_ID), Set.of("delete", "list"));
-        assertEquals(filter.filteringMethodsMap.get(OpenAPINormalizer.OperationsFilter.TAG), Set.of("testA", "testB"));
+        OpenAPINormalizer.Filter filter = parseOperationsFilter("operationId: delete| list ;  tag : testA |testB ");
+        assertEquals(filter.filteringMethodsMap.get(OpenAPINormalizer.Filter.OPERATION_ID), Set.of("delete", "list"));
+        assertEquals(filter.filteringMethodsMap.get(OpenAPINormalizer.Filter.TAG), Set.of("testA", "testB"));
+        // Verify also compatibility fields
+        assertEquals(filter.operationIdFilters, Set.of("delete", "list"));
+        assertEquals(filter.tagFilters, Set.of("testA", "testB"));
     }
 
     @Test
@@ -871,7 +889,7 @@ public class OpenAPINormalizerTest {
         Map<String, String> options = Map.of("FILTER", "role:admin");
         OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, options) {
             @Override
-            protected OperationsFilter createOperationsFilter(OpenAPI openApi, String filters) {
+            protected OpenAPINormalizer.Filter createFilter(OpenAPI openApi, String filters) {
                 return new CustomRoleFilter(filters);
             }
         };
@@ -882,7 +900,7 @@ public class OpenAPINormalizerTest {
         assertEquals(openAPI.getPaths().get("/person/display/{personId}").getPut().getExtensions().get(X_INTERNAL), false);
     }
 
-    private class CustomRoleFilter extends OpenAPINormalizer.OperationsFilter {
+    private class CustomRoleFilter extends OpenAPINormalizer.Filter {
         private Set<String> filteredRoles;
 
         public CustomRoleFilter(String filters) {
@@ -1004,8 +1022,7 @@ public class OpenAPINormalizerTest {
                 .anyMatch(map -> map.containsKey("openIdConnect1")));
         assertFalse(openAPI.getPaths().get("/openIdConnect2").getPost().getSecurity().stream()
                 .anyMatch(map -> map.containsKey("openIdConnect2")));
-        // One of security requirements becomes empty after clean up - we should remove
-        // it
+        // One of security requirements becomes empty after clean up - we should remove it
         assertEquals(openAPI.getPaths().get("/multipleSecuritySchemes").getGet().getSecurity().size(), 1);
         // Another requirement should contain only api_key1 and oauth2_1 schemes
         assertEquals(openAPI.getPaths().get("/multipleSecuritySchemes").getGet().getSecurity().get(0).size(), 2);
@@ -1019,6 +1036,41 @@ public class OpenAPINormalizerTest {
         assertEquals(
                 openAPI.getPaths().get("/multipleSecuritySchemes").getGet().getSecurity().get(0).get("oauth2_1").get(0),
                 "read:pets");
+        // Callbacks defined inline
+        assertTrue(openAPI.getPaths().get("/callbackInline").getPost().getCallbacks().get("callbackAllSecuritySchemes")
+                .get("{$request.body#/callbackUrl}").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("api_key1")));
+        assertFalse(openAPI.getPaths().get("/callbackInline").getPost().getCallbacks().get("callbackAllSecuritySchemes")
+                .get("{$request.body#/callbackUrl}").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("api_key2")));
+        assertFalse(openAPI.getPaths().get("/callbackInline").getPost().getCallbacks().get("callbackAllSecuritySchemes")
+                .get("{$request.body#/callbackUrl}").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("http1")));
+        assertFalse(openAPI.getPaths().get("/callbackInline").getPost().getCallbacks().get("callbackAllSecuritySchemes")
+                .get("{$request.body#/callbackUrl}").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("http2")));
+        assertFalse(openAPI.getPaths().get("/callbackInline").getPost().getCallbacks().get("callbackAllSecuritySchemes")
+                .get("{$request.body#/callbackUrl}").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("mutualTLS1")));
+        assertFalse(openAPI.getPaths().get("/callbackInline").getPost().getCallbacks().get("callbackAllSecuritySchemes")
+                .get("{$request.body#/callbackUrl}").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("mutualTLS2")));
+        assertTrue(openAPI.getPaths().get("/callbackInline").getPost().getCallbacks().get("callbackAllSecuritySchemes")
+                .get("{$request.body#/callbackUrl}").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("oauth2_1")));
+        assertTrue(openAPI.getPaths().get("/callbackInline").getPost().getCallbacks().get("callbackAllSecuritySchemes")
+                .get("{$request.body#/callbackUrl}").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("oauth2_2")));
+        assertFalse(openAPI.getPaths().get("/callbackInline").getPost().getCallbacks().get("callbackAllSecuritySchemes")
+                .get("{$request.body#/callbackUrl}").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("openIdConnect1")));
+        assertFalse(openAPI.getPaths().get("/callbackInline").getPost().getCallbacks().get("callbackAllSecuritySchemes")
+                .get("{$request.body#/callbackUrl}").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("openIdConnect2")));
+        // We should leave only one (the original one) empty security requirement object
+        assertEquals(openAPI.getPaths().get("/callbackInline").getPost().getCallbacks().get("callbackAllSecuritySchemes")
+                .get("{$request.body#/callbackUrl}").getPost().getSecurity().stream()
+                .filter(map -> map.isEmpty()).count(), 1);
 
         // Webhooks
         assertTrue(openAPI.getWebhooks().get("webhookAllSecuritySchemes").getPost().getSecurity().stream()
@@ -1045,7 +1097,7 @@ public class OpenAPINormalizerTest {
         assertEquals(openAPI.getWebhooks().get("webhookAllSecuritySchemes").getPost().getSecurity().stream()
                 .filter(map -> map.isEmpty()).count(), 1);
 
-        // Callbacks
+        // Callbacks from Components
         assertTrue(openAPI.getComponents().getCallbacks().get("callbackAllSecuritySchemes")
                 .get("{$request.body#/callbackUrl}").getPost().getSecurity().stream()
                 .anyMatch(map -> map.containsKey("api_key1")));
@@ -1080,6 +1132,77 @@ public class OpenAPINormalizerTest {
         assertEquals(openAPI.getComponents().getCallbacks().get("callbackAllSecuritySchemes")
                 .get("{$request.body#/callbackUrl}").getPost().getSecurity().stream().filter(map -> map.isEmpty())
                 .count(), 1);
+
+        // Path items from Components
+        // Get operation
+        assertTrue(
+                openAPI.getComponents().getPathItems().get("pathItemAllSecuritySchemes").getGet().getSecurity().stream()
+                        .anyMatch(map -> map.containsKey("api_key1")));
+        assertFalse(
+                openAPI.getComponents().getPathItems().get("pathItemAllSecuritySchemes").getGet().getSecurity().stream()
+                        .anyMatch(map -> map.containsKey("api_key2")));
+        assertFalse(
+                openAPI.getComponents().getPathItems().get("pathItemAllSecuritySchemes").getGet().getSecurity().stream()
+                        .anyMatch(map -> map.containsKey("http1")));
+        assertFalse(
+                openAPI.getComponents().getPathItems().get("pathItemAllSecuritySchemes").getGet().getSecurity().stream()
+                        .anyMatch(map -> map.containsKey("http2")));
+        assertFalse(
+                openAPI.getComponents().getPathItems().get("pathItemAllSecuritySchemes").getGet().getSecurity().stream()
+                        .anyMatch(map -> map.containsKey("mutualTLS1")));
+        assertFalse(
+                openAPI.getComponents().getPathItems().get("pathItemAllSecuritySchemes").getGet().getSecurity().stream()
+                        .anyMatch(map -> map.containsKey("mutualTLS2")));
+        assertTrue(
+                openAPI.getComponents().getPathItems().get("pathItemAllSecuritySchemes").getGet().getSecurity().stream()
+                        .anyMatch(map -> map.containsKey("oauth2_1")));
+        assertTrue(
+                openAPI.getComponents().getPathItems().get("pathItemAllSecuritySchemes").getGet().getSecurity().stream()
+                        .anyMatch(map -> map.containsKey("oauth2_2")));
+        assertFalse(
+                openAPI.getComponents().getPathItems().get("pathItemAllSecuritySchemes").getGet().getSecurity().stream()
+                        .anyMatch(map -> map.containsKey("openIdConnect1")));
+        assertFalse(
+                openAPI.getComponents().getPathItems().get("pathItemAllSecuritySchemes").getGet().getSecurity().stream()
+                        .anyMatch(map -> map.containsKey("openIdConnect2")));
+        // We should leave only one (the original one) empty security requirement object
+        assertEquals(openAPI.getComponents().getPathItems().get("pathItemAllSecuritySchemes").getGet().getSecurity().stream()
+                .filter(map -> map.isEmpty()).count(), 1);
+
+        // The same for POST operation
+        assertTrue(
+                openAPI.getComponents().getPathItems().get("pathItemAllSecuritySchemes").getPost().getSecurity().stream()
+                        .anyMatch(map -> map.containsKey("api_key1")));
+        assertFalse(
+                openAPI.getComponents().getPathItems().get("pathItemAllSecuritySchemes").getPost().getSecurity().stream()
+                        .anyMatch(map -> map.containsKey("api_key2")));
+        assertFalse(
+                openAPI.getComponents().getPathItems().get("pathItemAllSecuritySchemes").getPost().getSecurity().stream()
+                        .anyMatch(map -> map.containsKey("http1")));
+        assertFalse(
+                openAPI.getComponents().getPathItems().get("pathItemAllSecuritySchemes").getPost().getSecurity().stream()
+                        .anyMatch(map -> map.containsKey("http2")));
+        assertFalse(
+                openAPI.getComponents().getPathItems().get("pathItemAllSecuritySchemes").getPost().getSecurity().stream()
+                        .anyMatch(map -> map.containsKey("mutualTLS1")));
+        assertFalse(
+                openAPI.getComponents().getPathItems().get("pathItemAllSecuritySchemes").getPost().getSecurity().stream()
+                        .anyMatch(map -> map.containsKey("mutualTLS2")));
+        assertTrue(
+                openAPI.getComponents().getPathItems().get("pathItemAllSecuritySchemes").getPost().getSecurity().stream()
+                        .anyMatch(map -> map.containsKey("oauth2_1")));
+        assertTrue(
+                openAPI.getComponents().getPathItems().get("pathItemAllSecuritySchemes").getPost().getSecurity().stream()
+                        .anyMatch(map -> map.containsKey("oauth2_2")));
+        assertFalse(
+                openAPI.getComponents().getPathItems().get("pathItemAllSecuritySchemes").getPost().getSecurity().stream()
+                        .anyMatch(map -> map.containsKey("openIdConnect1")));
+        assertFalse(
+                openAPI.getComponents().getPathItems().get("pathItemAllSecuritySchemes").getPost().getSecurity().stream()
+                        .anyMatch(map -> map.containsKey("openIdConnect2")));
+        // We should leave only one (the original one) empty security requirement object
+        assertEquals(openAPI.getComponents().getPathItems().get("pathItemAllSecuritySchemes").getPost().getSecurity().stream()
+                .filter(map -> map.isEmpty()).count(), 1);
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -913,7 +913,7 @@ public class OpenAPINormalizerTest {
             new OpenAPINormalizer(openAPI, options).normalize();
             fail("Expected IllegalArgumentException");
         } catch (IllegalArgumentException e) {
-            assertEquals(e.getMessage(), "FILTER rule must be in the form of `operationId:name1|name2|name3` or `method:get|post|put` or `tag:tag1|tag2|tag3` or `path:/v1|/v2`. Input: `tag ; invalid`. Error: filter with no value not supported :[tag]");
+            assertEquals(e.getMessage(), "FILTER rule [tag ; invalid] must be in the form of `operationId:name1|name2|name3` or `method:get|post|put` or `tag:tag1|tag2|tag3` or `path:/v1|/v2`. Error: filter with no value not supported :[tag]");
         }
     }
 
@@ -926,7 +926,7 @@ public class OpenAPINormalizerTest {
             new OpenAPINormalizer(openAPI, options).normalize();
             fail("Expected IllegalArgumentException");
         } catch (IllegalArgumentException e) {
-            assertEquals(e.getMessage(), "FILTER rule must be in the form of `operationId:name1|name2|name3` or `method:get|post|put` or `tag:tag1|tag2|tag3` or `path:/v1|/v2`. Input: `method:get ; unknown:test`. Error: filter not supported :[unknown:test]");
+            assertEquals(e.getMessage(), "FILTER rule [method:get ; unknown:test] must be in the form of `operationId:name1|name2|name3` or `method:get|post|put` or `tag:tag1|tag2|tag3` or `path:/v1|/v2`. Error: filter not supported :[unknown:test]");
         }
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -948,8 +948,8 @@ public class OpenAPINormalizerTest {
         assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("openIdConnect1"), false);
         assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("openIdConnect2"), false);
 
-        // Check how we clean up the references to the removed security schemes in the
-        // global security requirement
+        // Check how we clean up the references to the removed security schemes
+        // Global security requirements
         assertTrue(openAPI.getSecurity().stream().anyMatch(map -> map.containsKey("api_key1")));
         assertFalse(openAPI.getSecurity().stream().anyMatch(map -> map.containsKey("api_key2")));
         assertFalse(openAPI.getSecurity().stream().anyMatch(map -> map.containsKey("http1")));
@@ -963,8 +963,7 @@ public class OpenAPINormalizerTest {
         // We should leave only one (the original one) empty security requirement object
         assertEquals(openAPI.getSecurity().stream().filter(map -> map.isEmpty()).count(), 1);
 
-        // Check how we clean up the references to the removed security schemes in the
-        // paths
+        // Paths
         assertTrue(openAPI.getPaths().get("/api_keys").getGet().getSecurity().stream()
                 .anyMatch(map -> map.containsKey("api_key1")));
         assertFalse(openAPI.getPaths().get("/api_keys").getGet().getSecurity().stream()
@@ -1005,14 +1004,82 @@ public class OpenAPINormalizerTest {
                 .anyMatch(map -> map.containsKey("openIdConnect1")));
         assertFalse(openAPI.getPaths().get("/openIdConnect2").getPost().getSecurity().stream()
                 .anyMatch(map -> map.containsKey("openIdConnect2")));
-        // One of security requirements becomes empty after clean up - we should remove it
+        // One of security requirements becomes empty after clean up - we should remove
+        // it
         assertEquals(openAPI.getPaths().get("/multipleSecuritySchemes").getGet().getSecurity().size(), 1);
         // Another requirement should contain only api_key1 and oauth2_1 schemes
         assertEquals(openAPI.getPaths().get("/multipleSecuritySchemes").getGet().getSecurity().get(0).size(), 2);
-        assertTrue(openAPI.getPaths().get("/multipleSecuritySchemes").getGet().getSecurity().get(0).containsKey("api_key1"));
-        assertTrue(openAPI.getPaths().get("/multipleSecuritySchemes").getGet().getSecurity().get(0).containsKey("oauth2_1"));
-        assertEquals(openAPI.getPaths().get("/multipleSecuritySchemes").getGet().getSecurity().get(0).get("oauth2_1").size(), 1);
-        assertEquals(openAPI.getPaths().get("/multipleSecuritySchemes").getGet().getSecurity().get(0).get("oauth2_1").get(0), "read:pets");
+        assertTrue(openAPI.getPaths().get("/multipleSecuritySchemes").getGet().getSecurity().get(0)
+                .containsKey("api_key1"));
+        assertTrue(openAPI.getPaths().get("/multipleSecuritySchemes").getGet().getSecurity().get(0)
+                .containsKey("oauth2_1"));
+        assertEquals(
+                openAPI.getPaths().get("/multipleSecuritySchemes").getGet().getSecurity().get(0).get("oauth2_1").size(),
+                1);
+        assertEquals(
+                openAPI.getPaths().get("/multipleSecuritySchemes").getGet().getSecurity().get(0).get("oauth2_1").get(0),
+                "read:pets");
+
+        // Webhooks
+        assertTrue(openAPI.getWebhooks().get("webhookAllSecuritySchemes").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("api_key1")));
+        assertFalse(openAPI.getWebhooks().get("webhookAllSecuritySchemes").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("api_key2")));
+        assertFalse(openAPI.getWebhooks().get("webhookAllSecuritySchemes").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("http1")));
+        assertFalse(openAPI.getWebhooks().get("webhookAllSecuritySchemes").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("http2")));
+        assertFalse(openAPI.getWebhooks().get("webhookAllSecuritySchemes").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("mutualTLS1")));
+        assertFalse(openAPI.getWebhooks().get("webhookAllSecuritySchemes").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("mutualTLS2")));
+        assertTrue(openAPI.getWebhooks().get("webhookAllSecuritySchemes").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("oauth2_1")));
+        assertTrue(openAPI.getWebhooks().get("webhookAllSecuritySchemes").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("oauth2_2")));
+        assertFalse(openAPI.getWebhooks().get("webhookAllSecuritySchemes").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("openIdConnect1")));
+        assertFalse(openAPI.getWebhooks().get("webhookAllSecuritySchemes").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("openIdConnect2")));
+        // We should leave only one (the original one) empty security requirement object
+        assertEquals(openAPI.getWebhooks().get("webhookAllSecuritySchemes").getPost().getSecurity().stream()
+                .filter(map -> map.isEmpty()).count(), 1);
+
+        // Callbacks
+        assertTrue(openAPI.getComponents().getCallbacks().get("callbackAllSecuritySchemes")
+                .get("{$request.body#/callbackUrl}").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("api_key1")));
+        assertFalse(openAPI.getComponents().getCallbacks().get("callbackAllSecuritySchemes")
+                .get("{$request.body#/callbackUrl}").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("api_key2")));
+        assertFalse(openAPI.getComponents().getCallbacks().get("callbackAllSecuritySchemes")
+                .get("{$request.body#/callbackUrl}").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("http1")));
+        assertFalse(openAPI.getComponents().getCallbacks().get("callbackAllSecuritySchemes")
+                .get("{$request.body#/callbackUrl}").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("http2")));
+        assertFalse(openAPI.getComponents().getCallbacks().get("callbackAllSecuritySchemes")
+                .get("{$request.body#/callbackUrl}").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("mutualTLS1")));
+        assertFalse(openAPI.getComponents().getCallbacks().get("callbackAllSecuritySchemes")
+                .get("{$request.body#/callbackUrl}").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("mutualTLS2")));
+        assertTrue(openAPI.getComponents().getCallbacks().get("callbackAllSecuritySchemes")
+                .get("{$request.body#/callbackUrl}").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("oauth2_1")));
+        assertTrue(openAPI.getComponents().getCallbacks().get("callbackAllSecuritySchemes")
+                .get("{$request.body#/callbackUrl}").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("oauth2_2")));
+        assertFalse(openAPI.getComponents().getCallbacks().get("callbackAllSecuritySchemes")
+                .get("{$request.body#/callbackUrl}").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("openIdConnect1")));
+        assertFalse(openAPI.getComponents().getCallbacks().get("callbackAllSecuritySchemes")
+                .get("{$request.body#/callbackUrl}").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("openIdConnect2")));
+        // We should leave only one (the original one) empty security requirement object
+        assertEquals(openAPI.getComponents().getCallbacks().get("callbackAllSecuritySchemes")
+                .get("{$request.body#/callbackUrl}").getPost().getSecurity().stream().filter(map -> map.isEmpty())
+                .count(), 1);
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -795,57 +795,57 @@ public class OpenAPINormalizerTest {
         assertEquals(openAPI.getPaths().get("/person/display/{personId}").getPut().getExtensions().get(X_INTERNAL), true);
     }
 
-    static OpenAPINormalizer.Filter parseFilter(String filters) {
-        OpenAPINormalizer.Filter filter = new OpenAPINormalizer.Filter(filters);
+    static OpenAPINormalizer.OperationsFilter parseOperationsFilter(String filters) {
+        OpenAPINormalizer.OperationsFilter filter = new OpenAPINormalizer.OperationsFilter(filters);
         filter.parse();
         return filter;
     }
 
     @Test
-    public void testFilterParsing() {
-        OpenAPINormalizer.Filter filter;
+    public void testOperationsFilterParsing() {
+        OpenAPINormalizer.OperationsFilter filter;
 
         // no filter
-        filter = parseFilter(" ");
+        filter = parseOperationsFilter(" ");
         assertFalse(filter.hasFilter());
 
         // invalid filter
         assertThrows(IllegalArgumentException.class, () ->
-                parseFilter("operationId:"));
+                parseOperationsFilter("operationId:"));
 
         assertThrows(IllegalArgumentException.class, () ->
-                parseFilter("invalid:invalid:"));
+                parseOperationsFilter("invalid:invalid:"));
 
         // extra spaces are trimmed
-        filter = parseFilter("method:\n\t\t\t\tget");
+        filter = parseOperationsFilter("method:\n\t\t\t\tget");
         assertTrue(filter.hasFilter());
-        assertEquals(filter.methodFilters, Set.of("get"));
-        assertTrue(filter.operationIdFilters.isEmpty());
-        assertTrue(filter.tagFilters.isEmpty());
-        assertTrue(filter.pathStartingWithFilters.isEmpty());
+        assertEquals(filter.filteringMethodsMap.get(OpenAPINormalizer.OperationsFilter.METHOD), Set.of("get"));
+        assertFalse(filter.filteringMethodsMap.containsKey(OpenAPINormalizer.OperationsFilter.OPERATION_ID));
+        assertFalse(filter.filteringMethodsMap.containsKey(OpenAPINormalizer.OperationsFilter.TAG));
+        assertFalse(filter.filteringMethodsMap.containsKey(OpenAPINormalizer.OperationsFilter.PATH));
 
         // multiple values separated by pipe
-        filter = parseFilter("operationId:\n\t\t\t\tdelete|\n\t\tlist\t");
+        filter = parseOperationsFilter("operationId:\n\t\t\t\tdelete|\n\t\tlist\t");
         assertTrue(filter.hasFilter());
-        assertTrue(filter.methodFilters.isEmpty());
-        assertEquals(filter.operationIdFilters, Set.of("delete", "list"));
-        assertTrue(filter.tagFilters.isEmpty());
-        assertTrue(filter.pathStartingWithFilters.isEmpty());
+        assertFalse(filter.filteringMethodsMap.containsKey(OpenAPINormalizer.OperationsFilter.METHOD));
+        assertEquals(filter.filteringMethodsMap.get(OpenAPINormalizer.OperationsFilter.OPERATION_ID), Set.of("delete", "list"));
+        assertFalse(filter.filteringMethodsMap.containsKey(OpenAPINormalizer.OperationsFilter.TAG));
+        assertFalse(filter.filteringMethodsMap.containsKey(OpenAPINormalizer.OperationsFilter.PATH));
 
         // multiple filters
-        filter = parseFilter("operationId:delete|list;path:/v1");
+        filter = parseOperationsFilter("operationId:delete|list;path:/v1");
         assertTrue(filter.hasFilter());
-        assertTrue(filter.methodFilters.isEmpty());
-        assertEquals(filter.operationIdFilters, Set.of("delete", "list"));
-        assertTrue(filter.tagFilters.isEmpty());
-        assertEquals(filter.pathStartingWithFilters, Set.of("/v1"));
+        assertFalse(filter.filteringMethodsMap.containsKey(OpenAPINormalizer.OperationsFilter.METHOD));
+        assertEquals(filter.filteringMethodsMap.get(OpenAPINormalizer.OperationsFilter.OPERATION_ID), Set.of("delete", "list"));
+        assertFalse(filter.filteringMethodsMap.containsKey(OpenAPINormalizer.OperationsFilter.TAG));
+        assertEquals(filter.filteringMethodsMap.get(OpenAPINormalizer.OperationsFilter.PATH), Set.of("/v1"));
     }
 
     @Test
     public void testMultiFilterParsing() {
-        OpenAPINormalizer.Filter filter = parseFilter("operationId: delete| list ;  tag : testA |testB ");
-        assertEquals(filter.operationIdFilters, Set.of("delete", "list"));
-        assertEquals(filter.tagFilters, Set.of("testA", "testB"));
+        OpenAPINormalizer.OperationsFilter filter = parseOperationsFilter("operationId: delete| list ;  tag : testA |testB ");
+        assertEquals(filter.filteringMethodsMap.get(OpenAPINormalizer.OperationsFilter.OPERATION_ID), Set.of("delete", "list"));
+        assertEquals(filter.filteringMethodsMap.get(OpenAPINormalizer.OperationsFilter.TAG), Set.of("testA", "testB"));
     }
 
     @Test
@@ -871,7 +871,7 @@ public class OpenAPINormalizerTest {
         Map<String, String> options = Map.of("FILTER", "role:admin");
         OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, options) {
             @Override
-            protected Filter createFilter(OpenAPI openApi, String filters) {
+            protected OperationsFilter createOperationsFilter(OpenAPI openApi, String filters) {
                 return new CustomRoleFilter(filters);
             }
         };
@@ -882,7 +882,7 @@ public class OpenAPINormalizerTest {
         assertEquals(openAPI.getPaths().get("/person/display/{personId}").getPut().getExtensions().get(X_INTERNAL), false);
     }
 
-    private class CustomRoleFilter extends OpenAPINormalizer.Filter {
+    private class CustomRoleFilter extends OpenAPINormalizer.OperationsFilter {
         private Set<String> filteredRoles;
 
         public CustomRoleFilter(String filters) {
@@ -1402,30 +1402,30 @@ public class OpenAPINormalizerTest {
         OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/inline_x_internal_test.yaml");
         Schema parentSchema = openAPI.getComponents().getSchemas().get("ParentSchema");
         Schema inlineProperty = (Schema) parentSchema.getProperties().get("inlineXInternalProperty");
-        
+
         // Before normalization: x-internal should be present on inline property
         assertNotNull(inlineProperty.getExtensions());
         assertEquals(inlineProperty.getExtensions().get("x-internal"), true);
-        
+
         // Run normalizer with REMOVE_X_INTERNAL=true
         Map<String, String> options = new HashMap<>();
         options.put("REMOVE_X_INTERNAL", "true");
         OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, options);
         openAPINormalizer.normalize();
-        
+
         // After normalization: x-internal should be removed from inline property
         Schema parentSchemaAfter = openAPI.getComponents().getSchemas().get("ParentSchema");
         Schema inlinePropertyAfter = (Schema) parentSchemaAfter.getProperties().get("inlineXInternalProperty");
-        
+
         // x-internal extension should be removed (null or not present in map)
         if (inlinePropertyAfter.getExtensions() != null) {
             assertNull(inlinePropertyAfter.getExtensions().get("x-internal"));
         }
-        
+
         // The property itself should still exist (we're removing the flag, not the property)
         assertNotNull(inlinePropertyAfter);
         assertEquals(inlinePropertyAfter.getType(), "object");
-        
+
         // Nested properties should still exist
         assertNotNull(inlinePropertyAfter.getProperties());
         assertNotNull(inlinePropertyAfter.getProperties().get("nestedField"));

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -948,36 +948,80 @@ public class OpenAPINormalizerTest {
         assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("openIdConnect1"), false);
         assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("openIdConnect2"), false);
 
-        // Check how we clean up the references to the removed security schemes in the paths
-        assertTrue(openAPI.getPaths().get("/api_keys").getGet().getSecurity().stream().anyMatch(map -> map.containsKey("api_key1")));
-        assertFalse(openAPI.getPaths().get("/api_keys").getGet().getSecurity().stream().anyMatch(map -> map.containsKey("api_key2")));
-        assertTrue(openAPI.getPaths().get("/api_key1").getHead().getSecurity().stream().anyMatch(map -> map.containsKey("api_key1")));
-        assertFalse(openAPI.getPaths().get("/api_key2").getPost().getSecurity().stream().anyMatch(map -> map.containsKey("api_key2")));
-        assertFalse(openAPI.getPaths().get("/httpschemes").getGet().getSecurity().stream().anyMatch(map -> map.containsKey("http1")));
-        assertFalse(openAPI.getPaths().get("/httpschemes").getGet().getSecurity().stream().anyMatch(map -> map.containsKey("http2")));
-        assertFalse(openAPI.getPaths().get("/http1").getHead().getSecurity().stream().anyMatch(map -> map.containsKey("http1")));
-        assertFalse(openAPI.getPaths().get("/http2").getPost().getSecurity().stream().anyMatch(map -> map.containsKey("http2")));
-        assertFalse(openAPI.getPaths().get("/mutualTLSschemes").getGet().getSecurity().stream().anyMatch(map -> map.containsKey("mutualTLS1")));
-        assertFalse(openAPI.getPaths().get("/mutualTLSschemes").getGet().getSecurity().stream().anyMatch(map -> map.containsKey("mutualTLS2")));
-        assertFalse(openAPI.getPaths().get("/mutualTLS1").getHead().getSecurity().stream().anyMatch(map -> map.containsKey("mutualTLS1")));
-        assertFalse(openAPI.getPaths().get("/mutualTLS2").getPost().getSecurity().stream().anyMatch(map -> map.containsKey("mutualTLS2")));
-        assertTrue(openAPI.getPaths().get("/oauth2schemes").getGet().getSecurity().stream().anyMatch(map -> map.containsKey("oauth2_1")));
-        assertTrue(openAPI.getPaths().get("/oauth2schemes").getGet().getSecurity().stream().anyMatch(map -> map.containsKey("oauth2_2")));
-        assertTrue(openAPI.getPaths().get("/oauth2_1").getHead().getSecurity().stream().anyMatch(map -> map.containsKey("oauth2_1")));
-        assertTrue(openAPI.getPaths().get("/oauth2_2").getPost().getSecurity().stream().anyMatch(map -> map.containsKey("oauth2_2")));
-        assertFalse(openAPI.getPaths().get("/openidconnectschemes").getGet().getSecurity().stream().anyMatch(map -> map.containsKey("openIdConnect1")));
-        assertFalse(openAPI.getPaths().get("/openidconnectschemes").getGet().getSecurity().stream().anyMatch(map -> map.containsKey("openIdConnect2")));
-        assertFalse(openAPI.getPaths().get("/openIdConnect1").getHead().getSecurity().stream().anyMatch(map -> map.containsKey("openIdConnect1")));
-        assertFalse(openAPI.getPaths().get("/openIdConnect2").getPost().getSecurity().stream().anyMatch(map -> map.containsKey("openIdConnect2")));
+        // Check how we clean up the references to the removed security schemes in the
+        // global security requirement
+        assertTrue(openAPI.getSecurity().stream().anyMatch(map -> map.containsKey("api_key1")));
+        assertFalse(openAPI.getSecurity().stream().anyMatch(map -> map.containsKey("api_key2")));
+        assertFalse(openAPI.getSecurity().stream().anyMatch(map -> map.containsKey("http1")));
+        assertFalse(openAPI.getSecurity().stream().anyMatch(map -> map.containsKey("http2")));
+        assertFalse(openAPI.getSecurity().stream().anyMatch(map -> map.containsKey("mutualTLS1")));
+        assertFalse(openAPI.getSecurity().stream().anyMatch(map -> map.containsKey("mutualTLS2")));
+        assertTrue(openAPI.getSecurity().stream().anyMatch(map -> map.containsKey("oauth2_1")));
+        assertTrue(openAPI.getSecurity().stream().anyMatch(map -> map.containsKey("oauth2_2")));
+        assertFalse(openAPI.getSecurity().stream().anyMatch(map -> map.containsKey("openIdConnect1")));
+        assertFalse(openAPI.getSecurity().stream().anyMatch(map -> map.containsKey("openIdConnect2")));
+        // We should leave only one (the original one) empty security requirement object
+        assertEquals(openAPI.getSecurity().stream().filter(map -> map.isEmpty()).count(), 1);
+
+        // Check how we clean up the references to the removed security schemes in the
+        // paths
+        assertTrue(openAPI.getPaths().get("/api_keys").getGet().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("api_key1")));
+        assertFalse(openAPI.getPaths().get("/api_keys").getGet().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("api_key2")));
+        assertTrue(openAPI.getPaths().get("/api_key1").getHead().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("api_key1")));
+        assertFalse(openAPI.getPaths().get("/api_key2").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("api_key2")));
+        assertFalse(openAPI.getPaths().get("/httpschemes").getGet().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("http1")));
+        assertFalse(openAPI.getPaths().get("/httpschemes").getGet().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("http2")));
+        assertFalse(openAPI.getPaths().get("/http1").getHead().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("http1")));
+        assertFalse(openAPI.getPaths().get("/http2").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("http2")));
+        assertFalse(openAPI.getPaths().get("/mutualTLSschemes").getGet().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("mutualTLS1")));
+        assertFalse(openAPI.getPaths().get("/mutualTLSschemes").getGet().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("mutualTLS2")));
+        assertFalse(openAPI.getPaths().get("/mutualTLS1").getHead().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("mutualTLS1")));
+        assertFalse(openAPI.getPaths().get("/mutualTLS2").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("mutualTLS2")));
+        assertTrue(openAPI.getPaths().get("/oauth2schemes").getGet().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("oauth2_1")));
+        assertTrue(openAPI.getPaths().get("/oauth2schemes").getGet().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("oauth2_2")));
+        assertTrue(openAPI.getPaths().get("/oauth2_1").getHead().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("oauth2_1")));
+        assertTrue(openAPI.getPaths().get("/oauth2_2").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("oauth2_2")));
+        assertFalse(openAPI.getPaths().get("/openidconnectschemes").getGet().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("openIdConnect1")));
+        assertFalse(openAPI.getPaths().get("/openidconnectschemes").getGet().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("openIdConnect2")));
+        assertFalse(openAPI.getPaths().get("/openIdConnect1").getHead().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("openIdConnect1")));
+        assertFalse(openAPI.getPaths().get("/openIdConnect2").getPost().getSecurity().stream()
+                .anyMatch(map -> map.containsKey("openIdConnect2")));
+        // One of security requirements becomes empty after clean up - we should remove it
+        assertEquals(openAPI.getPaths().get("/multipleSecuritySchemes").getGet().getSecurity().size(), 1);
+        // Another requirement should contain only api_key1 and oauth2_1 schemes
+        assertEquals(openAPI.getPaths().get("/multipleSecuritySchemes").getGet().getSecurity().get(0).size(), 2);
+        assertTrue(openAPI.getPaths().get("/multipleSecuritySchemes").getGet().getSecurity().get(0).containsKey("api_key1"));
+        assertTrue(openAPI.getPaths().get("/multipleSecuritySchemes").getGet().getSecurity().get(0).containsKey("oauth2_1"));
+        assertEquals(openAPI.getPaths().get("/multipleSecuritySchemes").getGet().getSecurity().get(0).get("oauth2_1").size(), 1);
+        assertEquals(openAPI.getPaths().get("/multipleSecuritySchemes").getGet().getSecurity().get(0).get("oauth2_1").get(0), "read:pets");
     }
 
     @Test
     public void testSecuritySchemesFilterAndBearerAuthName() {
-        // We expect that api_key1 scheme will be converted to bearer auth at first and then the filter will be applied
+        // We expect that api_key1 scheme will be converted to bearer auth at first and
+        // then the filter will be applied
         OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/all_security_schemes.yaml");
         Map<String, String> options = Map.of("SECURITY_SCHEMES_FILTER", "key:api_key1",
-                    "SET_BEARER_AUTH_FOR_NAME", "api_key1"
-        );
+                "SET_BEARER_AUTH_FOR_NAME", "api_key1");
 
         new OpenAPINormalizer(openAPI, options).normalize();
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -937,20 +937,16 @@ public class OpenAPINormalizerTest {
 
         new OpenAPINormalizer(openAPI, options).normalize();
 
-        assertEquals(openAPI.getComponents().getSecuritySchemes().get("api_key1").getExtensions().get(X_INTERNAL),
-                false);
-        assertEquals(openAPI.getComponents().getSecuritySchemes().get("api_key2").getExtensions().get(X_INTERNAL),
-                true);
-        assertEquals(openAPI.getComponents().getSecuritySchemes().get("http1").getExtensions().get(X_INTERNAL), true);
-        assertEquals(openAPI.getComponents().getSecuritySchemes().get("http2").getExtensions().get(X_INTERNAL), true);
-        assertEquals(openAPI.getComponents().getSecuritySchemes().get("mutualTLS1").getExtensions().get(X_INTERNAL), true);
-        assertEquals(openAPI.getComponents().getSecuritySchemes().get("mutualTLS2").getExtensions().get(X_INTERNAL), true);
-        assertEquals(openAPI.getComponents().getSecuritySchemes().get("oauth2_1").getExtensions().get(X_INTERNAL),
-                false);
-        assertEquals(openAPI.getComponents().getSecuritySchemes().get("oauth2_2").getExtensions().get(X_INTERNAL),
-                false);
-        assertEquals(openAPI.getComponents().getSecuritySchemes().get("openIdConnect1").getExtensions().get(X_INTERNAL), true);
-        assertEquals(openAPI.getComponents().getSecuritySchemes().get("openIdConnect2").getExtensions().get(X_INTERNAL), true);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("api_key1"), true);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("api_key2"), false);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("http1"), false);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("http2"), false);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("mutualTLS1"), false);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("mutualTLS2"), false);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("oauth2_1"), true);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("oauth2_2"), true);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("openIdConnect1"), false);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("openIdConnect2"), false);
     }
 
     @Test
@@ -963,23 +959,19 @@ public class OpenAPINormalizerTest {
 
         new OpenAPINormalizer(openAPI, options).normalize();
 
-        assertEquals(openAPI.getComponents().getSecuritySchemes().get("api_key1").getExtensions().get(X_INTERNAL),
-                false);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("api_key1"), true);
         SecurityScheme scheme = openAPI.getComponents().getSecuritySchemes().get("api_key1");
         assertEquals(scheme.getType(), SecurityScheme.Type.HTTP);
         assertEquals(scheme.getScheme(), "bearer");
-        assertEquals(openAPI.getComponents().getSecuritySchemes().get("api_key2").getExtensions().get(X_INTERNAL),
-                true);
-        assertEquals(openAPI.getComponents().getSecuritySchemes().get("http1").getExtensions().get(X_INTERNAL), true);
-        assertEquals(openAPI.getComponents().getSecuritySchemes().get("http2").getExtensions().get(X_INTERNAL), true);
-        assertEquals(openAPI.getComponents().getSecuritySchemes().get("mutualTLS1").getExtensions().get(X_INTERNAL), true);
-        assertEquals(openAPI.getComponents().getSecuritySchemes().get("mutualTLS2").getExtensions().get(X_INTERNAL), true);
-        assertEquals(openAPI.getComponents().getSecuritySchemes().get("oauth2_1").getExtensions().get(X_INTERNAL),
-                true);
-        assertEquals(openAPI.getComponents().getSecuritySchemes().get("oauth2_2").getExtensions().get(X_INTERNAL),
-                true);
-        assertEquals(openAPI.getComponents().getSecuritySchemes().get("openIdConnect1").getExtensions().get(X_INTERNAL), true);
-        assertEquals(openAPI.getComponents().getSecuritySchemes().get("openIdConnect2").getExtensions().get(X_INTERNAL), true);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("api_key2"), false);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("http1"), false);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("http2"), false);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("mutualTLS1"), false);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("mutualTLS2"), false);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("oauth2_1"), false);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("oauth2_2"), false);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("openIdConnect1"), false);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("openIdConnect2"), false);
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -913,7 +913,7 @@ public class OpenAPINormalizerTest {
             new OpenAPINormalizer(openAPI, options).normalize();
             fail("Expected IllegalArgumentException");
         } catch (IllegalArgumentException e) {
-            assertEquals(e.getMessage(), "FILTER rule [tag ; invalid] must be in the form of `operationId:name1|name2|name3` or `method:get|post|put` or `tag:tag1|tag2|tag3` or `path:/v1|/v2`. Error: filter with no value not supported :[tag]");
+            assertEquals(e.getMessage(), "FILTER rule must be in the form of `operationId:name1|name2|name3` or `method:get|post|put` or `tag:tag1|tag2|tag3` or `path:/v1|/v2`. Input: `tag ; invalid`. Error: filter with no value not supported :[tag]");
         }
     }
 
@@ -926,7 +926,7 @@ public class OpenAPINormalizerTest {
             new OpenAPINormalizer(openAPI, options).normalize();
             fail("Expected IllegalArgumentException");
         } catch (IllegalArgumentException e) {
-            assertEquals(e.getMessage(), "FILTER rule [method:get ; unknown:test] must be in the form of `operationId:name1|name2|name3` or `method:get|post|put` or `tag:tag1|tag2|tag3` or `path:/v1|/v2`. Error: filter not supported :[unknown:test]");
+            assertEquals(e.getMessage(), "FILTER rule must be in the form of `operationId:name1|name2|name3` or `method:get|post|put` or `tag:tag1|tag2|tag3` or `path:/v1|/v2`. Input: `method:get ; unknown:test`. Error: filter not supported :[unknown:test]");
         }
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -973,7 +973,7 @@ public class OpenAPINormalizerTest {
 
     @Test
     public void testSecuritySchemesFilterAndBearerAuthName() {
-        // We expect that api_key1 scheme will converted to bearer auth at first and then the filter will be applied
+        // We expect that api_key1 scheme will be converted to bearer auth at first and then the filter will be applied
         OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/all_security_schemes.yaml");
         Map<String, String> options = Map.of("SECURITY_SCHEMES_FILTER", "key:api_key1",
                     "SET_BEARER_AUTH_FOR_NAME", "api_key1"

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -913,7 +913,7 @@ public class OpenAPINormalizerTest {
             new OpenAPINormalizer(openAPI, options).normalize();
             fail("Expected IllegalArgumentException");
         } catch (IllegalArgumentException e) {
-            assertEquals(e.getMessage(), "FILTER rule [tag ; invalid] must be in the form of `operationId:name1|name2|name3` or `method:get|post|put` or `tag:tag1|tag2|tag3` or `path:/v1|/v2`. Error: filter with no value not supported :[tag]");
+            assertEquals(e.getMessage(), "FILTER rule must be in the form of `operationId:name1|name2|name3` or `method:get|post|put` or `tag:tag1|tag2|tag3` or `path:/v1|/v2`. Input: `tag ; invalid`. Error: filter with no value not supported :[tag]");
         }
     }
 
@@ -926,8 +926,34 @@ public class OpenAPINormalizerTest {
             new OpenAPINormalizer(openAPI, options).normalize();
             fail("Expected IllegalArgumentException");
         } catch (IllegalArgumentException e) {
-            assertEquals(e.getMessage(), "FILTER rule [method:get ; unknown:test] must be in the form of `operationId:name1|name2|name3` or `method:get|post|put` or `tag:tag1|tag2|tag3` or `path:/v1|/v2`. Error: filter not supported :[unknown:test]");
+            assertEquals(e.getMessage(), "FILTER rule must be in the form of `operationId:name1|name2|name3` or `method:get|post|put` or `tag:tag1|tag2|tag3` or `path:/v1|/v2`. Input: `method:get ; unknown:test`. Error: filter not supported :[unknown:test]");
         }
+    }
+
+    @Test
+    public void testSecuritySchemesFilter() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/all_security_schemes.yaml");
+        Map<String, String> options = Map.of("SECURITY_SCHEMES_FILTER", "key:api_key1 ; type:oauth2");
+
+        new OpenAPINormalizer(openAPI, options).normalize();
+
+        System.err.println("Security schemes after filter3: " + openAPI.getComponents().getSecuritySchemes().get("api_key1").toString());
+        System.err.println("Security schemes after filter4: " + openAPI.getComponents().getSecuritySchemes().get("api_key1").getExtensions().toString());
+
+        assertEquals(openAPI.getComponents().getSecuritySchemes().get("api_key1").getExtensions().get(X_INTERNAL),
+                false);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().get("api_key2").getExtensions().get(X_INTERNAL),
+                true);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().get("http1").getExtensions().get(X_INTERNAL), true);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().get("http2").getExtensions().get(X_INTERNAL), true);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().get("mutualTLS1").getExtensions().get(X_INTERNAL), true);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().get("mutualTLS2").getExtensions().get(X_INTERNAL), true);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().get("oauth2_1").getExtensions().get(X_INTERNAL),
+                false);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().get("oauth2_2").getExtensions().get(X_INTERNAL),
+                false);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().get("openIdConnect1").getExtensions().get(X_INTERNAL), true);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().get("openIdConnect2").getExtensions().get(X_INTERNAL), true);
     }
 
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -947,6 +947,28 @@ public class OpenAPINormalizerTest {
         assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("oauth2_2"), true);
         assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("openIdConnect1"), false);
         assertEquals(openAPI.getComponents().getSecuritySchemes().containsKey("openIdConnect2"), false);
+
+        // Check how we clean up the references to the removed security schemes in the paths
+        assertTrue(openAPI.getPaths().get("/api_keys").getGet().getSecurity().stream().anyMatch(map -> map.containsKey("api_key1")));
+        assertFalse(openAPI.getPaths().get("/api_keys").getGet().getSecurity().stream().anyMatch(map -> map.containsKey("api_key2")));
+        assertTrue(openAPI.getPaths().get("/api_key1").getHead().getSecurity().stream().anyMatch(map -> map.containsKey("api_key1")));
+        assertFalse(openAPI.getPaths().get("/api_key2").getPost().getSecurity().stream().anyMatch(map -> map.containsKey("api_key2")));
+        assertFalse(openAPI.getPaths().get("/httpschemes").getGet().getSecurity().stream().anyMatch(map -> map.containsKey("http1")));
+        assertFalse(openAPI.getPaths().get("/httpschemes").getGet().getSecurity().stream().anyMatch(map -> map.containsKey("http2")));
+        assertFalse(openAPI.getPaths().get("/http1").getHead().getSecurity().stream().anyMatch(map -> map.containsKey("http1")));
+        assertFalse(openAPI.getPaths().get("/http2").getPost().getSecurity().stream().anyMatch(map -> map.containsKey("http2")));
+        assertFalse(openAPI.getPaths().get("/mutualTLSschemes").getGet().getSecurity().stream().anyMatch(map -> map.containsKey("mutualTLS1")));
+        assertFalse(openAPI.getPaths().get("/mutualTLSschemes").getGet().getSecurity().stream().anyMatch(map -> map.containsKey("mutualTLS2")));
+        assertFalse(openAPI.getPaths().get("/mutualTLS1").getHead().getSecurity().stream().anyMatch(map -> map.containsKey("mutualTLS1")));
+        assertFalse(openAPI.getPaths().get("/mutualTLS2").getPost().getSecurity().stream().anyMatch(map -> map.containsKey("mutualTLS2")));
+        assertTrue(openAPI.getPaths().get("/oauth2schemes").getGet().getSecurity().stream().anyMatch(map -> map.containsKey("oauth2_1")));
+        assertTrue(openAPI.getPaths().get("/oauth2schemes").getGet().getSecurity().stream().anyMatch(map -> map.containsKey("oauth2_2")));
+        assertTrue(openAPI.getPaths().get("/oauth2_1").getHead().getSecurity().stream().anyMatch(map -> map.containsKey("oauth2_1")));
+        assertTrue(openAPI.getPaths().get("/oauth2_2").getPost().getSecurity().stream().anyMatch(map -> map.containsKey("oauth2_2")));
+        assertFalse(openAPI.getPaths().get("/openidconnectschemes").getGet().getSecurity().stream().anyMatch(map -> map.containsKey("openIdConnect1")));
+        assertFalse(openAPI.getPaths().get("/openidconnectschemes").getGet().getSecurity().stream().anyMatch(map -> map.containsKey("openIdConnect2")));
+        assertFalse(openAPI.getPaths().get("/openIdConnect1").getHead().getSecurity().stream().anyMatch(map -> map.containsKey("openIdConnect1")));
+        assertFalse(openAPI.getPaths().get("/openIdConnect2").getPost().getSecurity().stream().anyMatch(map -> map.containsKey("openIdConnect2")));
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -937,9 +937,6 @@ public class OpenAPINormalizerTest {
 
         new OpenAPINormalizer(openAPI, options).normalize();
 
-        System.err.println("Security schemes after filter3: " + openAPI.getComponents().getSecuritySchemes().get("api_key1").toString());
-        System.err.println("Security schemes after filter4: " + openAPI.getComponents().getSecuritySchemes().get("api_key1").getExtensions().toString());
-
         assertEquals(openAPI.getComponents().getSecuritySchemes().get("api_key1").getExtensions().get(X_INTERNAL),
                 false);
         assertEquals(openAPI.getComponents().getSecuritySchemes().get("api_key2").getExtensions().get(X_INTERNAL),
@@ -956,6 +953,34 @@ public class OpenAPINormalizerTest {
         assertEquals(openAPI.getComponents().getSecuritySchemes().get("openIdConnect2").getExtensions().get(X_INTERNAL), true);
     }
 
+    @Test
+    public void testSecuritySchemesFilterAndBearerAuthName() {
+        // We expect that api_key1 scheme will converted to bearer auth at first and then the filter will be applied
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/all_security_schemes.yaml");
+        Map<String, String> options = Map.of("SECURITY_SCHEMES_FILTER", "key:api_key1",
+                    "SET_BEARER_AUTH_FOR_NAME", "api_key1"
+        );
+
+        new OpenAPINormalizer(openAPI, options).normalize();
+
+        assertEquals(openAPI.getComponents().getSecuritySchemes().get("api_key1").getExtensions().get(X_INTERNAL),
+                false);
+        SecurityScheme scheme = openAPI.getComponents().getSecuritySchemes().get("api_key1");
+        assertEquals(scheme.getType(), SecurityScheme.Type.HTTP);
+        assertEquals(scheme.getScheme(), "bearer");
+        assertEquals(openAPI.getComponents().getSecuritySchemes().get("api_key2").getExtensions().get(X_INTERNAL),
+                true);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().get("http1").getExtensions().get(X_INTERNAL), true);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().get("http2").getExtensions().get(X_INTERNAL), true);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().get("mutualTLS1").getExtensions().get(X_INTERNAL), true);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().get("mutualTLS2").getExtensions().get(X_INTERNAL), true);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().get("oauth2_1").getExtensions().get(X_INTERNAL),
+                true);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().get("oauth2_2").getExtensions().get(X_INTERNAL),
+                true);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().get("openIdConnect1").getExtensions().get(X_INTERNAL), true);
+        assertEquals(openAPI.getComponents().getSecuritySchemes().get("openIdConnect2").getExtensions().get(X_INTERNAL), true);
+    }
 
     @Test
     public void testComposedSchemaDoesNotThrow() {

--- a/modules/openapi-generator/src/test/resources/3_1/all_security_schemes.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/all_security_schemes.yaml
@@ -1,0 +1,255 @@
+openapi: 3.1.0
+servers:
+  - url: 'http://petstore.swagger.io/v2'
+info:
+  description: >-
+    This is OpenAPI spec with all possible security schemes.
+  version: 1.0.0
+  title: OpenAPI All Security Schemes
+  license:
+    name: Apache-2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+paths:
+  '/pet/{petId}':
+    parameters:
+      - name: petId
+        in: path
+        description: ID of pet to return
+        required: true
+        schema:
+          type: integer
+          format: int64
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+      security:
+        - api_key1: []
+        - api_key2: []
+
+components:
+  securitySchemes:
+    api_key1:
+      type: apiKey
+      description: API Key Authentication sample 1
+      name: api_key
+      in: header
+    api_key2:
+      type: apiKey
+      description: API Key Authentication sample 2
+      name: api_key
+      in: query
+    http1:
+      type: http
+      description: HTTP Authentication sample 1
+      scheme: bearer
+      bearerFormat: JWT
+    http2:
+      type: http
+      description: HTTP Authentication sample 2
+      scheme: basic
+    mutualTLS1:
+      type: mutualTLS
+      description: Mutual TLS Authentication sample 1
+    mutualTLS2:
+      type: mutualTLS
+      description: Mutual TLS Authentication sample 2
+    oauth2_1:
+      type: oauth2
+      description: OAuth2 Authentication sample 1
+      flows:
+        implicit:
+          authorizationUrl: 'http://petstore.swagger.io/api/oauth/dialog'
+          scopes:
+            'write:pets': modify pets in your account
+            'read:pets': read your pets
+    oauth2_2:
+      type: oauth2
+      description: OAuth2 Authentication sample 2
+      flows:
+        password:
+          tokenUrl: 'http://petstore.swagger.io/api/oauth/token'
+          scopes:
+            'write:pets': modify pets in your account
+            'read:pets': read your pets
+    openIdConnect1:
+      type: openIdConnect
+      description: OpenID Connect Authentication sample 1
+      openIdConnectUrl: 'http://petstore.swagger.io/.well-known/openid-configuration'
+    openIdConnect2:
+      type: openIdConnect
+      description: OpenID Connect Authentication sample 2
+      openIdConnectUrl: 'http://petstore.swagger.io/.well-known/openid-configuration2'
+
+  responses:
+    JustAnotherResponse:
+      description: JustAnotherResponse
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              uuid:
+                type: integer
+              label:
+                type: string
+  requestBodies:
+    Pet:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Pet'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/Pet'
+      description: Pet object that needs to be added to the store
+      required: true
+  schemas:
+    Order:
+      title: Pet Order
+      description: An order for a pets from the pet store
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        petId:
+          type: integer
+          format: int64
+        quantity:
+          type: integer
+          format: int32
+        shipDate:
+          type: string
+          format: date-time
+        status:
+          type: string
+          description: Order Status
+          enum:
+            - placed
+            - approved
+            - delivered
+        complete:
+          type: boolean
+          default: false
+      xml:
+        name: Order
+    Category:
+      title: Pet category
+      description: A category for a pet
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+          pattern: '^[a-zA-Z0-9]+[a-zA-Z0-9\.\-_]*[a-zA-Z0-9]+$'
+      xml:
+        name: Category
+    User:
+      title: a User
+      description: A User who is purchasing from the pet store
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        username:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+        password:
+          type: string
+        phone:
+          type: string
+        userStatus:
+          type: integer
+          format: int32
+          description: User Status
+      xml:
+        name: User
+    Tag:
+      title: Pet Tag
+      description: A tag for a pet
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Tag
+    Pet:
+      title: a Pet
+      description: A pet for sale in the pet store
+      type: object
+      required:
+        - name
+        - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+        category:
+          $ref: '#/components/schemas/Category'
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            $ref: '#/components/schemas/Tag'
+        status:
+          type: string
+          description: pet status in the store
+          deprecated: true
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: Pet
+    ApiResponse:
+      title: An uploaded response
+      description: Describes the result of uploading an image resource
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        type:
+          type: string
+        message:
+          type: string

--- a/modules/openapi-generator/src/test/resources/3_1/all_security_schemes.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/all_security_schemes.yaml
@@ -260,6 +260,32 @@ components:
       description: OpenID Connect Authentication sample 2
       openIdConnectUrl: 'http://petstore.swagger.io/.well-known/openid-configuration2'
 
+  callbacks:
+    callbackAllSecuritySchemes:
+      '{$request.body#/callbackUrl}':
+        post:
+          requestBody:
+            description: Callback payload
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/Dummy'
+          responses:
+            '200':
+              description: successful operation
+          security:
+            - {}
+            - api_key1: []
+            - api_key2: []
+            - http1: []
+            - http2: []
+            - mutualTLS1: []
+            - mutualTLS2: []
+            - oauth2_1: ["read:pets"]
+            - oauth2_2: ["write:pets", "read:pets"]
+            - openIdConnect1: []
+            - openIdConnect2: []
+
   schemas:
     Dummy:
       title: Dummy schema
@@ -269,3 +295,30 @@ components:
         id:
           type: integer
           format: int64
+
+webhooks:
+  webhookAllSecuritySchemes:
+    post:
+      summary: Dummy webhook endpoint
+      operationId: dummyWebhook
+      requestBody:
+        description: Webhook payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Dummy'
+      responses:
+        '200':
+          description: successful operation
+      security:
+          - {}
+          - api_key1: []
+          - api_key2: []
+          - http1: []
+          - http2: []
+          - mutualTLS1: []
+          - mutualTLS2: []
+          - oauth2_1: ["read:pets"]
+          - oauth2_2: ["write:pets", "read:pets"]
+          - openIdConnect1: []
+          - openIdConnect2: []

--- a/modules/openapi-generator/src/test/resources/3_1/all_security_schemes.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/all_security_schemes.yaml
@@ -9,6 +9,18 @@ info:
   license:
     name: Apache-2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+security:
+  - {}
+  - api_key1: []
+  - api_key2: []
+  - http1: []
+  - http2: []
+  - mutualTLS1: []
+  - mutualTLS2: []
+  - oauth2_1: ["read:pets"]
+  - oauth2_2: ["write:pets", "read:pets"]
+  - openIdConnect1: []
+  - openIdConnect2: []
 paths:
   '/api_keys':
     get:
@@ -174,7 +186,26 @@ paths:
           description: successful operation
       security:
         - openIdConnect2: []
-
+  '/multipleSecuritySchemes':
+    get:
+      summary: Dummy endpoint with multiple security schemes. To test how schemes are cleaned up.
+      operationId: getMultipleSecuritySchemes
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dummy'
+      security:
+        - api_key1: []
+          http1: []
+          mutualTLS1: []
+          oauth2_1: ["read:pets"]
+          openIdConnect1: []
+        - http1: []
+          mutualTLS2: []
+          openIdConnect1: []
 components:
   securitySchemes:
     api_key1:

--- a/modules/openapi-generator/src/test/resources/3_1/all_security_schemes.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/all_security_schemes.yaml
@@ -206,6 +206,45 @@ paths:
         - http1: []
           mutualTLS2: []
           openIdConnect1: []
+  '/callbackInline':
+    post:
+      summary: Dummy endpoint with inline callback with all security schemes
+      operationId: postCallbackInline
+      requestBody:
+        description: Request payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Dummy'
+      responses:
+        '200':
+          description: successful operation
+      callbacks:
+        callbackAllSecuritySchemes:
+          '{$request.body#/callbackUrl}':
+            post:
+              requestBody:
+                description: Callback payload
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/Dummy'
+              responses:
+                '200':
+                  description: successful operation
+              security:
+                - {}
+                - api_key1: []
+                - api_key2: []
+                - http1: []
+                - http2: []
+                - mutualTLS1: []
+                - mutualTLS2: []
+                - oauth2_1: ["read:pets"]
+                - oauth2_2: ["write:pets", "read:pets"]
+                - openIdConnect1: []
+                - openIdConnect2: []
+
 components:
   securitySchemes:
     api_key1:
@@ -285,6 +324,56 @@ components:
             - oauth2_2: ["write:pets", "read:pets"]
             - openIdConnect1: []
             - openIdConnect2: []
+
+  pathItems:
+    pathItemAllSecuritySchemes:
+      summary: Dummy path item with all security schemes
+      description: >-
+        This is a dummy path item to test that security schemes defined on path items are cleaned up correctly.
+      get:
+        summary: Dummy GET operation
+        operationId: dummyGetOperation
+        responses:
+          '200':
+            description: successful operation
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/Dummy'
+        security:
+          - {}
+          - api_key1: []
+          - api_key2: []
+          - http1: []
+          - http2: []
+          - mutualTLS1: []
+          - mutualTLS2: []
+          - oauth2_1: ["read:pets"]
+          - oauth2_2: ["write:pets", "read:pets"]
+          - openIdConnect1: []
+          - openIdConnect2: []
+      post:
+        summary: Dummy POST operation
+        operationId: dummyPostOperation
+        responses:
+          '200':
+            description: successful operation
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/Dummy'
+        security:
+          - {}
+          - api_key1: []
+          - api_key2: []
+          - http1: []
+          - http2: []
+          - mutualTLS1: []
+          - mutualTLS2: []
+          - oauth2_1: ["read:pets"]
+          - oauth2_2: ["write:pets", "read:pets"]
+          - openIdConnect1: []
+          - openIdConnect2: []
 
   schemas:
     Dummy:

--- a/modules/openapi-generator/src/test/resources/3_1/all_security_schemes.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/all_security_schemes.yaml
@@ -10,38 +10,170 @@ info:
     name: Apache-2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
 paths:
-  '/pet/{petId}':
-    parameters:
-      - name: petId
-        in: path
-        description: ID of pet to return
-        required: true
-        schema:
-          type: integer
-          format: int64
+  '/api_keys':
     get:
-      tags:
-        - pet
-      summary: Find pet by ID
-      description: Returns a single pet
-      operationId: getPetById
+      summary: Dummy endpoint with all security schemes of type apiKey
+      operationId: getApiKeys
       responses:
         '200':
           description: successful operation
           content:
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/Pet'
             application/json:
               schema:
-                $ref: '#/components/schemas/Pet'
-        '400':
-          description: Invalid ID supplied
-        '404':
-          description: Pet not found
+                $ref: '#/components/schemas/Dummy'
       security:
         - api_key1: []
         - api_key2: []
+  '/api_key1':
+    head:
+      summary: Dummy endpoint with security scheme api_key1
+      operationId: getApiKey1
+      responses:
+        '200':
+          description: successful operation
+      security:
+        - api_key1: []
+  '/api_key2':
+    post:
+      summary: Dummy endpoint with security scheme api_key2
+      operationId: getApiKey2
+      responses:
+        '200':
+          description: successful operation
+      security:
+        - api_key2: []
+
+  '/httpschemes':
+    get:
+      summary: Dummy endpoint with all security schemes of type http
+      operationId: getHttpSchemes
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dummy'
+      security:
+        - http1: []
+        - http2: []
+  '/http1':
+    head:
+      summary: Dummy endpoint with security scheme http1
+      operationId: getHttp1
+      responses:
+        '200':
+          description: successful operation
+      security:
+        - http1: []
+  '/http2':
+    post:
+      summary: Dummy endpoint with security scheme http2
+      operationId: getHttp2
+      responses:
+        '200':
+          description: successful operation
+      security:
+        - http2: []
+
+  '/mutualTLSschemes':
+    get:
+      summary: Dummy endpoint with all security schemes of type mutualTLS
+      operationId: getMutualTLSSchemes
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dummy'
+      security:
+        - mutualTLS1: []
+        - mutualTLS2: []
+  '/mutualTLS1':
+    head:
+      summary: Dummy endpoint with security scheme mutualTLS1
+      operationId: getMutualTLS1
+      responses:
+        '200':
+          description: successful operation
+      security:
+        - mutualTLS1: []
+  '/mutualTLS2':
+    post:
+      summary: Dummy endpoint with security scheme mutualTLS2
+      operationId: getMutualTLS2
+      responses:
+        '200':
+          description: successful operation
+      security:
+        - mutualTLS2: []
+
+  '/oauth2schemes':
+    get:
+      summary: Dummy endpoint with all security schemes of type oauth2
+      operationId: getOAuth2Schemes
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dummy'
+      security:
+        - oauth2_1: ["read:pets"]
+        - oauth2_2: ["write:pets", "read:pets"]
+  '/oauth2_1':
+    head:
+      summary: Dummy endpoint with security scheme oauth2_1
+      operationId: getOAuth2_1
+      responses:
+        '200':
+          description: successful operation
+      security:
+        - oauth2_1: ["write:pets"]
+  '/oauth2_2':
+    post:
+      summary: Dummy endpoint with security scheme oauth2_2
+      operationId: getOAuth2_2
+      responses:
+        '200':
+          description: successful operation
+      security:
+        - oauth2_2: []
+
+  '/openidconnectschemes':
+    get:
+      summary: Dummy endpoint with all security schemes of type openIdConnect
+      operationId: getOpenIdConnectSchemes
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dummy'
+      security:
+        - openIdConnect1: []
+        - openIdConnect2: []
+  '/openIdConnect1':
+    head:
+      summary: Dummy endpoint with security scheme openIdConnect1
+      operationId: getOpenIdConnect1
+      responses:
+        '200':
+          description: successful operation
+      security:
+        - openIdConnect1: []
+  '/openIdConnect2':
+    post:
+      summary: Dummy endpoint with security scheme openIdConnect2
+      operationId: getOpenIdConnect2
+      responses:
+        '200':
+          description: successful operation
+      security:
+        - openIdConnect2: []
 
 components:
   securitySchemes:
@@ -97,159 +229,12 @@ components:
       description: OpenID Connect Authentication sample 2
       openIdConnectUrl: 'http://petstore.swagger.io/.well-known/openid-configuration2'
 
-  responses:
-    JustAnotherResponse:
-      description: JustAnotherResponse
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              uuid:
-                type: integer
-              label:
-                type: string
-  requestBodies:
-    Pet:
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Pet'
-        application/xml:
-          schema:
-            $ref: '#/components/schemas/Pet'
-      description: Pet object that needs to be added to the store
-      required: true
   schemas:
-    Order:
-      title: Pet Order
-      description: An order for a pets from the pet store
+    Dummy:
+      title: Dummy schema
+      description: A dummy schema for testing purposes. We don't care about the content of this schema.
       type: object
       properties:
         id:
           type: integer
           format: int64
-        petId:
-          type: integer
-          format: int64
-        quantity:
-          type: integer
-          format: int32
-        shipDate:
-          type: string
-          format: date-time
-        status:
-          type: string
-          description: Order Status
-          enum:
-            - placed
-            - approved
-            - delivered
-        complete:
-          type: boolean
-          default: false
-      xml:
-        name: Order
-    Category:
-      title: Pet category
-      description: A category for a pet
-      type: object
-      properties:
-        id:
-          type: integer
-          format: int64
-        name:
-          type: string
-          pattern: '^[a-zA-Z0-9]+[a-zA-Z0-9\.\-_]*[a-zA-Z0-9]+$'
-      xml:
-        name: Category
-    User:
-      title: a User
-      description: A User who is purchasing from the pet store
-      type: object
-      properties:
-        id:
-          type: integer
-          format: int64
-        username:
-          type: string
-        firstName:
-          type: string
-        lastName:
-          type: string
-        email:
-          type: string
-        password:
-          type: string
-        phone:
-          type: string
-        userStatus:
-          type: integer
-          format: int32
-          description: User Status
-      xml:
-        name: User
-    Tag:
-      title: Pet Tag
-      description: A tag for a pet
-      type: object
-      properties:
-        id:
-          type: integer
-          format: int64
-        name:
-          type: string
-      xml:
-        name: Tag
-    Pet:
-      title: a Pet
-      description: A pet for sale in the pet store
-      type: object
-      required:
-        - name
-        - photoUrls
-      properties:
-        id:
-          type: integer
-          format: int64
-        category:
-          $ref: '#/components/schemas/Category'
-        name:
-          type: string
-          example: doggie
-        photoUrls:
-          type: array
-          xml:
-            name: photoUrl
-            wrapped: true
-          items:
-            type: string
-        tags:
-          type: array
-          xml:
-            name: tag
-            wrapped: true
-          items:
-            $ref: '#/components/schemas/Tag'
-        status:
-          type: string
-          description: pet status in the store
-          deprecated: true
-          enum:
-            - available
-            - pending
-            - sold
-      xml:
-        name: Pet
-    ApiResponse:
-      title: An uploaded response
-      description: Describes the result of uploading an image resource
-      type: object
-      properties:
-        code:
-          type: integer
-          format: int32
-        type:
-          type: string
-        message:
-          type: string


### PR DESCRIPTION
This PR adds new normalizer option to remove unnecessary security schemes. I have decided to make it similar to `FILTER` option to have this functionality more universal and allow to filter schemes by name and by type.
I have tried to follow DRY principle and uniform the logic with current `FILTER` implementation that's why it required to touch existent logic.
I have also moved `FILTER` parse logic outside loop to not repeat it every iteration.

TODO:
- [x] add more unit tests for the new logic
- [x] make sure that new logic works well with `SET_BEARER_AUTH_FOR_NAME` option
- [x] document new option
- [x] consider to remove security object references from operations for removed security schemes
- [x] consider to fix log message `marked as internal only (x-internal: true) by the {} filter`

Resolves #22954 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `SECURITY_SCHEMES_FILTER` to keep selected security schemes by `key` or `type`, remove others from `components.securitySchemes`, and clean all references globally, per operation, webhooks, callbacks (including nested), and components’ path items. Also adds a reusable, backward‑compatible filter framework with single-pass parsing and clearer errors/logging. Resolves #22954.

- **New Features**
  - `SECURITY_SCHEMES_FILTER` supports `key:`/`type:` (e.g., `key:api_key1|api_key2;type:oauth2`; types: `apiKey|http|mutualTLS|oauth2|openIdConnect`). Removes non-matching schemes and their references, drops emptied requirements while keeping original empty ones, and works with `SET_BEARER_AUTH_FOR_NAME` (conversion happens before filtering). Cleans references across global security, operations, webhooks, callbacks (incl. nested), and components’ callbacks and path items.

- **Refactors**
  - Introduces `BaseFilter`; `Filter` is now the operations filter and remains backward compatible with custom filters; adds `SecuritySchemesFilter`. New hooks: `createOperationsFilter`, `createSecuritySchemesFilter`; parse `FILTER`/`SECURITY_SCHEMES_FILTER` once; clearer usage-and-input errors and log messages.

<sup>Written for commit 5ff2e3db8d0e13a71aadb3e7a3ddadf2abce89a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



