### PR TITLE
fix(python-flask): validate byte length for format:byte fields

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-flask/model.mustache
+++ b/modules/openapi-generator/src/main/resources/python-flask/model.mustache
@@ -130,12 +130,38 @@ class {{classname}}(Model):
 {{/required}}
 {{#hasValidation}}
 {{#maxLength}}
+{{#isByteArray}}
+        if {{name}} is not None:
+            import base64
+            try:
+                decoded_length = len(base64.b64decode({{name}}))
+                if decoded_length > {{maxLength}}:
+                    raise ValueError("Invalid value for `{{name}}`, byte length must be less than or equal to `{{maxLength}}`")  # noqa: E501
+            except (TypeError, ValueError, base64.binascii.Error):
+                # If it's not valid base64, other validation will catch it
+                pass
+{{/isByteArray}}
+{{^isByteArray}}
         if {{name}} is not None and len({{name}}) > {{maxLength}}:
             raise ValueError("Invalid value for `{{name}}`, length must be less than or equal to `{{maxLength}}`")  # noqa: E501
+{{/isByteArray}}
 {{/maxLength}}
 {{#minLength}}
+{{#isByteArray}}
+        if {{name}} is not None:
+            import base64
+            try:
+                decoded_length = len(base64.b64decode({{name}}))
+                if decoded_length < {{minLength}}:
+                    raise ValueError("Invalid value for `{{name}}`, byte length must be greater than or equal to `{{minLength}}`")  # noqa: E501
+            except (TypeError, ValueError, base64.binascii.Error):
+                # If it's not valid base64, other validation will catch it
+                pass
+{{/isByteArray}}
+{{^isByteArray}}
         if {{name}} is not None and len({{name}}) < {{minLength}}:
             raise ValueError("Invalid value for `{{name}}`, length must be greater than or equal to `{{minLength}}`")  # noqa: E501
+{{/isByteArray}}
 {{/minLength}}
 {{#maximum}}
         if {{name}} is not None and {{name}} >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{maximum}}:  # noqa: E501


### PR DESCRIPTION
When a string field has format:byte with minLength/maxLength constraints,
the generated validation code incorrectly checks string length instead
of base64-decoded byte length.

Added conditional logic using isByteArray flag to validate decoded
byte length for byte array fields. Maintains existing string length
validation for non-byte fields.

Fixes #450

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes validation for `format:byte` fields in the Python Flask generator by checking the base64-decoded byte length for `minLength`/`maxLength`. Prevents incorrect passes/failures when validating byte arrays; non-byte fields still use string length checks.

- **Bug Fixes**
  - Added `isByteArray` guards in `model.mustache` to validate decoded byte length for `minLength` and `maxLength`.
  - Skips enforcement on invalid base64 here so existing base64 validation can handle it.

<sup>Written for commit 25e4582f216d849437d6c0f63e841fcb855e610d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

