### PR TITLE
typescript-fetch: only mark RequestOpts as async when auth methods are present

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -360,7 +360,7 @@ export class {{classname}} extends runtime.BaseAPI {
      {{/isDeprecated}}
      */
     async {{nickname}}Raw({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request, {{/allParams.0}}initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{{{returnType}}}{{^returnType}}void{{/returnType}}>> {
-        const requestOptions = await this.{{nickname}}RequestOpts({{#allParams.0}}requestParameters{{/allParams.0}});
+        const requestOptions = {{#hasAuthMethods}}await {{/hasAuthMethods}}this.{{nickname}}RequestOpts({{#allParams.0}}requestParameters{{/allParams.0}});
         const response = await this.request(requestOptions, initOverrides);
 
         {{#returnType}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -53,7 +53,7 @@ export interface {{classname}}Interface {
      * @throws {RequiredError}
      * @memberof {{classname}}Interface
      */
-    {{nickname}}RequestOpts({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request{{/allParams.0}}): Promise<runtime.RequestOpts>;
+    {{nickname}}RequestOpts({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request{{/allParams.0}}): {{#hasAuthMethods}}Promise<{{/hasAuthMethods}}runtime.RequestOpts{{#hasAuthMethods}}>{{/hasAuthMethods}};
 
     /**
      * {{&notes}}
@@ -113,7 +113,7 @@ export class {{classname}} extends runtime.BaseAPI {
      * @deprecated
      {{/isDeprecated}}
      */
-    async {{nickname}}RequestOpts({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request{{/allParams.0}}): Promise<runtime.RequestOpts> {
+    {{#hasAuthMethods}}async {{/hasAuthMethods}}{{nickname}}RequestOpts({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request{{/allParams.0}}): {{#hasAuthMethods}}Promise<{{/hasAuthMethods}}runtime.RequestOpts{{#hasAuthMethods}}>{{/hasAuthMethods}} {
         {{#allParams}}
         {{#required}}
         if (requestParameters['{{paramName}}'] == null) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -458,6 +458,28 @@ public class TypeScriptFetchClientCodegenTest {
         TestUtils.assertFileContains(modelsIndex, "[property: string]:");
     }
 
+    /**
+     * Endpoints without auth methods should generate synchronous RequestOpts functions,
+     * while endpoints with auth methods should generate async RequestOpts functions.
+     */
+    @Test(description = "Verify RequestOpts is only async when auth methods are present")
+    public void testRequestOptsIsAsyncOnlyWithAuthMethods() throws IOException {
+        File output = generate(
+            Collections.emptyMap(),
+            "src/test/resources/3_0/typescript-fetch/api-with-and-without-auth.yaml"
+        );
+
+        Path apiFile = Paths.get(output + "/apis/DefaultApi.ts");
+        TestUtils.assertFileExists(apiFile);
+
+        // Endpoint without auth: synchronous signature
+        TestUtils.assertFileContains(apiFile, "listPublicItemsRequestOpts(): runtime.RequestOpts {");
+        TestUtils.assertFileNotContains(apiFile, "listPublicItemsRequestOpts(): Promise<runtime.RequestOpts>");
+
+        // Endpoint with auth: async signature
+        TestUtils.assertFileContains(apiFile, "async listPrivateItemsRequestOpts(): Promise<runtime.RequestOpts> {");
+    }
+
     private static File generate(
         Map<String, Object> properties
     ) throws IOException {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -472,12 +472,14 @@ public class TypeScriptFetchClientCodegenTest {
         Path apiFile = Paths.get(output + "/apis/DefaultApi.ts");
         TestUtils.assertFileExists(apiFile);
 
-        // Endpoint without auth: synchronous signature
+        // Endpoint without auth: synchronous signature and no await at call site
         TestUtils.assertFileContains(apiFile, "listPublicItemsRequestOpts(): runtime.RequestOpts {");
         TestUtils.assertFileNotContains(apiFile, "listPublicItemsRequestOpts(): Promise<runtime.RequestOpts>");
+        TestUtils.assertFileContains(apiFile, "const requestOptions = this.listPublicItemsRequestOpts()");
 
-        // Endpoint with auth: async signature
+        // Endpoint with auth: async signature and await at call site
         TestUtils.assertFileContains(apiFile, "async listPrivateItemsRequestOpts(): Promise<runtime.RequestOpts> {");
+        TestUtils.assertFileContains(apiFile, "const requestOptions = await this.listPrivateItemsRequestOpts()");
     }
 
     private static File generate(

--- a/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/api-with-and-without-auth.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/api-with-and-without-auth.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.3
+info:
+  title: API with mixed auth
+  version: 1.0.0
+paths:
+  /public/items:
+    get:
+      operationId: listPublicItems
+      summary: List public items (no auth)
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Item'
+  /private/items:
+    get:
+      operationId: listPrivateItems
+      summary: List private items (requires API key)
+      security:
+        - ApiKeyAuth: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Item'
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-KEY
+  schemas:
+    Item:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+        name:
+          type: string

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/apis/DefaultApi.ts
@@ -61,7 +61,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      */
     async listRaw(requestParameters: ListRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Club>> {
-        const requestOptions = await this.listRequestOpts(requestParameters);
+        const requestOptions = this.listRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ClubFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/apis/DefaultApi.ts
@@ -34,7 +34,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Creates request options for list without sending the request
      */
-    async listRequestOpts(requestParameters: ListRequest): Promise<runtime.RequestOpts> {
+    listRequestOpts(requestParameters: ListRequest): runtime.RequestOpts {
         if (requestParameters['personId'] == null) {
             throw new runtime.RequiredError(
                 'personId',

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/apis/DefaultApi.ts
@@ -61,7 +61,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      */
     async listRaw(requestParameters: ListRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Club>> {
-        const requestOptions = await this.listRequestOpts(requestParameters);
+        const requestOptions = this.listRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ClubFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/apis/DefaultApi.ts
@@ -34,7 +34,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Creates request options for list without sending the request
      */
-    async listRequestOpts(requestParameters: ListRequest): Promise<runtime.RequestOpts> {
+    listRequestOpts(requestParameters: ListRequest): runtime.RequestOpts {
         if (requestParameters['personId'] == null) {
             throw new runtime.RequiredError(
                 'personId',

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/AnotherFakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/AnotherFakeApi.ts
@@ -65,7 +65,7 @@ export class AnotherFakeApi extends runtime.BaseAPI {
      * To test special tags
      */
     async _123testSpecialTagsRaw(requestParameters: 123testSpecialTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Client>> {
-        const requestOptions = await this._123testSpecialTagsRequestOpts(requestParameters);
+        const requestOptions = this._123testSpecialTagsRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ClientFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/AnotherFakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/AnotherFakeApi.ts
@@ -34,7 +34,7 @@ export class AnotherFakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for _123testSpecialTags without sending the request
      */
-    async _123testSpecialTagsRequestOpts(requestParameters: 123testSpecialTagsRequest): Promise<runtime.RequestOpts> {
+    _123testSpecialTagsRequestOpts(requestParameters: 123testSpecialTagsRequest): runtime.RequestOpts {
         if (requestParameters['client'] == null) {
             throw new runtime.RequiredError(
                 'client',

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/DefaultApi.ts
@@ -30,7 +30,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Creates request options for fooGet without sending the request
      */
-    async fooGetRequestOpts(): Promise<runtime.RequestOpts> {
+    fooGetRequestOpts(): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/DefaultApi.ts
@@ -49,7 +49,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      */
     async fooGetRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FooGetDefaultResponse>> {
-        const requestOptions = await this.fooGetRequestOpts();
+        const requestOptions = this.fooGetRequestOpts();
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => FooGetDefaultResponseFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
@@ -196,7 +196,7 @@ export class FakeApi extends runtime.BaseAPI {
      * for Java apache and Java native, test toUrlQueryString for maps with BegDecimal keys
      */
     async fakeBigDecimalMapRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FakeBigDecimalMap200Response>> {
-        const requestOptions = await this.fakeBigDecimalMapRequestOpts();
+        const requestOptions = this.fakeBigDecimalMapRequestOpts();
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => FakeBigDecimalMap200ResponseFromJSON(jsonValue));
@@ -233,7 +233,7 @@ export class FakeApi extends runtime.BaseAPI {
      * Health check endpoint
      */
     async fakeHealthGetRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<HealthCheckResult>> {
-        const requestOptions = await this.fakeHealthGetRequestOpts();
+        const requestOptions = this.fakeHealthGetRequestOpts();
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => HealthCheckResultFromJSON(jsonValue));
@@ -327,7 +327,7 @@ export class FakeApi extends runtime.BaseAPI {
      * Test serialization of outer boolean types
      */
     async fakeOuterBooleanSerializeRaw(requestParameters: FakeOuterBooleanSerializeRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<boolean>> {
-        const requestOptions = await this.fakeOuterBooleanSerializeRequestOpts(requestParameters);
+        const requestOptions = this.fakeOuterBooleanSerializeRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         if (this.isJsonMime(response.headers.get('content-type'))) {
@@ -371,7 +371,7 @@ export class FakeApi extends runtime.BaseAPI {
      * Test serialization of object with outer number type
      */
     async fakeOuterCompositeSerializeRaw(requestParameters: FakeOuterCompositeSerializeRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<OuterComposite>> {
-        const requestOptions = await this.fakeOuterCompositeSerializeRequestOpts(requestParameters);
+        const requestOptions = this.fakeOuterCompositeSerializeRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OuterCompositeFromJSON(jsonValue));
@@ -411,7 +411,7 @@ export class FakeApi extends runtime.BaseAPI {
      * Test serialization of outer number types
      */
     async fakeOuterNumberSerializeRaw(requestParameters: FakeOuterNumberSerializeRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<number>> {
-        const requestOptions = await this.fakeOuterNumberSerializeRequestOpts(requestParameters);
+        const requestOptions = this.fakeOuterNumberSerializeRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         if (this.isJsonMime(response.headers.get('content-type'))) {
@@ -455,7 +455,7 @@ export class FakeApi extends runtime.BaseAPI {
      * Test serialization of outer string types
      */
     async fakeOuterStringSerializeRaw(requestParameters: FakeOuterStringSerializeRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<string>> {
-        const requestOptions = await this.fakeOuterStringSerializeRequestOpts(requestParameters);
+        const requestOptions = this.fakeOuterStringSerializeRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         if (this.isJsonMime(response.headers.get('content-type'))) {
@@ -506,7 +506,7 @@ export class FakeApi extends runtime.BaseAPI {
      * Test serialization of enum (int) properties with examples
      */
     async fakePropertyEnumIntegerSerializeRaw(requestParameters: FakePropertyEnumIntegerSerializeRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<OuterObjectWithEnumProperty>> {
-        const requestOptions = await this.fakePropertyEnumIntegerSerializeRequestOpts(requestParameters);
+        const requestOptions = this.fakePropertyEnumIntegerSerializeRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OuterObjectWithEnumPropertyFromJSON(jsonValue));
@@ -554,7 +554,7 @@ export class FakeApi extends runtime.BaseAPI {
      * test referenced additionalProperties
      */
     async testAdditionalPropertiesReferenceRaw(requestParameters: TestAdditionalPropertiesReferenceRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.testAdditionalPropertiesReferenceRequestOpts(requestParameters);
+        const requestOptions = this.testAdditionalPropertiesReferenceRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -601,7 +601,7 @@ export class FakeApi extends runtime.BaseAPI {
      * For this test, the body has to be a binary file.
      */
     async testBodyWithBinaryRaw(requestParameters: TestBodyWithBinaryRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.testBodyWithBinaryRequestOpts(requestParameters);
+        const requestOptions = this.testBodyWithBinaryRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -647,7 +647,7 @@ export class FakeApi extends runtime.BaseAPI {
      * For this test, the body for this request must reference a schema named `File`.
      */
     async testBodyWithFileSchemaRaw(requestParameters: TestBodyWithFileSchemaRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.testBodyWithFileSchemaRequestOpts(requestParameters);
+        const requestOptions = this.testBodyWithFileSchemaRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -703,7 +703,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      */
     async testBodyWithQueryParamsRaw(requestParameters: TestBodyWithQueryParamsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.testBodyWithQueryParamsRequestOpts(requestParameters);
+        const requestOptions = this.testBodyWithQueryParamsRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -749,7 +749,7 @@ export class FakeApi extends runtime.BaseAPI {
      * To test \"client\" model
      */
     async testClientModelRaw(requestParameters: TestClientModelRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Client>> {
-        const requestOptions = await this.testClientModelRequestOpts(requestParameters);
+        const requestOptions = this.testClientModelRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ClientFromJSON(jsonValue));
@@ -981,7 +981,7 @@ export class FakeApi extends runtime.BaseAPI {
      * To test enum parameters
      */
     async testEnumParametersRaw(requestParameters: TestEnumParametersRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.testEnumParametersRequestOpts(requestParameters);
+        const requestOptions = this.testEnumParametersRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -1120,7 +1120,7 @@ export class FakeApi extends runtime.BaseAPI {
      * test inline additionalProperties
      */
     async testInlineAdditionalPropertiesRaw(requestParameters: TestInlineAdditionalPropertiesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.testInlineAdditionalPropertiesRequestOpts(requestParameters);
+        const requestOptions = this.testInlineAdditionalPropertiesRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -1168,7 +1168,7 @@ export class FakeApi extends runtime.BaseAPI {
      * test inline free-form additionalProperties
      */
     async testInlineFreeformAdditionalPropertiesRaw(requestParameters: TestInlineFreeformAdditionalPropertiesOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.testInlineFreeformAdditionalPropertiesRequestOpts(requestParameters);
+        const requestOptions = this.testInlineFreeformAdditionalPropertiesRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -1243,7 +1243,7 @@ export class FakeApi extends runtime.BaseAPI {
      * test json serialization of form data
      */
     async testJsonFormDataRaw(requestParameters: TestJsonFormDataRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.testJsonFormDataRequestOpts(requestParameters);
+        const requestOptions = this.testJsonFormDataRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -1291,7 +1291,7 @@ export class FakeApi extends runtime.BaseAPI {
      * test nullable parent property
      */
     async testNullableRaw(requestParameters: TestNullableRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.testNullableRequestOpts(requestParameters);
+        const requestOptions = this.testNullableRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -1400,7 +1400,7 @@ export class FakeApi extends runtime.BaseAPI {
      * To test the collection format in query parameters
      */
     async testQueryParameterCollectionFormatRaw(requestParameters: TestQueryParameterCollectionFormatRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.testQueryParameterCollectionFormatRequestOpts(requestParameters);
+        const requestOptions = this.testQueryParameterCollectionFormatRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -1447,7 +1447,7 @@ export class FakeApi extends runtime.BaseAPI {
      * test referenced string map
      */
     async testStringMapReferenceRaw(requestParameters: TestStringMapReferenceRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.testStringMapReferenceRequestOpts(requestParameters);
+        const requestOptions = this.testStringMapReferenceRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
@@ -176,7 +176,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for fakeBigDecimalMap without sending the request
      */
-    async fakeBigDecimalMapRequestOpts(): Promise<runtime.RequestOpts> {
+    fakeBigDecimalMapRequestOpts(): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -213,7 +213,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for fakeHealthGet without sending the request
      */
-    async fakeHealthGetRequestOpts(): Promise<runtime.RequestOpts> {
+    fakeHealthGetRequestOpts(): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -304,7 +304,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for fakeOuterBooleanSerialize without sending the request
      */
-    async fakeOuterBooleanSerializeRequestOpts(requestParameters: FakeOuterBooleanSerializeRequest): Promise<runtime.RequestOpts> {
+    fakeOuterBooleanSerializeRequestOpts(requestParameters: FakeOuterBooleanSerializeRequest): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -348,7 +348,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for fakeOuterCompositeSerialize without sending the request
      */
-    async fakeOuterCompositeSerializeRequestOpts(requestParameters: FakeOuterCompositeSerializeRequest): Promise<runtime.RequestOpts> {
+    fakeOuterCompositeSerializeRequestOpts(requestParameters: FakeOuterCompositeSerializeRequest): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -388,7 +388,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for fakeOuterNumberSerialize without sending the request
      */
-    async fakeOuterNumberSerializeRequestOpts(requestParameters: FakeOuterNumberSerializeRequest): Promise<runtime.RequestOpts> {
+    fakeOuterNumberSerializeRequestOpts(requestParameters: FakeOuterNumberSerializeRequest): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -432,7 +432,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for fakeOuterStringSerialize without sending the request
      */
-    async fakeOuterStringSerializeRequestOpts(requestParameters: FakeOuterStringSerializeRequest): Promise<runtime.RequestOpts> {
+    fakeOuterStringSerializeRequestOpts(requestParameters: FakeOuterStringSerializeRequest): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -476,7 +476,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for fakePropertyEnumIntegerSerialize without sending the request
      */
-    async fakePropertyEnumIntegerSerializeRequestOpts(requestParameters: FakePropertyEnumIntegerSerializeRequest): Promise<runtime.RequestOpts> {
+    fakePropertyEnumIntegerSerializeRequestOpts(requestParameters: FakePropertyEnumIntegerSerializeRequest): runtime.RequestOpts {
         if (requestParameters['outerObjectWithEnumProperty'] == null) {
             throw new runtime.RequiredError(
                 'outerObjectWithEnumProperty',
@@ -523,7 +523,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for testAdditionalPropertiesReference without sending the request
      */
-    async testAdditionalPropertiesReferenceRequestOpts(requestParameters: TestAdditionalPropertiesReferenceRequest): Promise<runtime.RequestOpts> {
+    testAdditionalPropertiesReferenceRequestOpts(requestParameters: TestAdditionalPropertiesReferenceRequest): runtime.RequestOpts {
         if (requestParameters['requestBody'] == null) {
             throw new runtime.RequiredError(
                 'requestBody',
@@ -571,7 +571,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for testBodyWithBinary without sending the request
      */
-    async testBodyWithBinaryRequestOpts(requestParameters: TestBodyWithBinaryRequest): Promise<runtime.RequestOpts> {
+    testBodyWithBinaryRequestOpts(requestParameters: TestBodyWithBinaryRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -617,7 +617,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for testBodyWithFileSchema without sending the request
      */
-    async testBodyWithFileSchemaRequestOpts(requestParameters: TestBodyWithFileSchemaRequest): Promise<runtime.RequestOpts> {
+    testBodyWithFileSchemaRequestOpts(requestParameters: TestBodyWithFileSchemaRequest): runtime.RequestOpts {
         if (requestParameters['fileSchemaTestClass'] == null) {
             throw new runtime.RequiredError(
                 'fileSchemaTestClass',
@@ -663,7 +663,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for testBodyWithQueryParams without sending the request
      */
-    async testBodyWithQueryParamsRequestOpts(requestParameters: TestBodyWithQueryParamsRequest): Promise<runtime.RequestOpts> {
+    testBodyWithQueryParamsRequestOpts(requestParameters: TestBodyWithQueryParamsRequest): runtime.RequestOpts {
         if (requestParameters['query'] == null) {
             throw new runtime.RequiredError(
                 'query',
@@ -718,7 +718,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for testClientModel without sending the request
      */
-    async testClientModelRequestOpts(requestParameters: TestClientModelRequest): Promise<runtime.RequestOpts> {
+    testClientModelRequestOpts(requestParameters: TestClientModelRequest): runtime.RequestOpts {
         if (requestParameters['client'] == null) {
             throw new runtime.RequiredError(
                 'client',
@@ -909,7 +909,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for testEnumParameters without sending the request
      */
-    async testEnumParametersRequestOpts(requestParameters: TestEnumParametersRequest): Promise<runtime.RequestOpts> {
+    testEnumParametersRequestOpts(requestParameters: TestEnumParametersRequest): runtime.RequestOpts {
         const queryParameters: any = {};
 
         if (requestParameters['enumQueryStringArray'] != null) {
@@ -1089,7 +1089,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for testInlineAdditionalProperties without sending the request
      */
-    async testInlineAdditionalPropertiesRequestOpts(requestParameters: TestInlineAdditionalPropertiesRequest): Promise<runtime.RequestOpts> {
+    testInlineAdditionalPropertiesRequestOpts(requestParameters: TestInlineAdditionalPropertiesRequest): runtime.RequestOpts {
         if (requestParameters['requestBody'] == null) {
             throw new runtime.RequiredError(
                 'requestBody',
@@ -1137,7 +1137,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for testInlineFreeformAdditionalProperties without sending the request
      */
-    async testInlineFreeformAdditionalPropertiesRequestOpts(requestParameters: TestInlineFreeformAdditionalPropertiesOperationRequest): Promise<runtime.RequestOpts> {
+    testInlineFreeformAdditionalPropertiesRequestOpts(requestParameters: TestInlineFreeformAdditionalPropertiesOperationRequest): runtime.RequestOpts {
         if (requestParameters['testInlineFreeformAdditionalPropertiesRequest'] == null) {
             throw new runtime.RequiredError(
                 'testInlineFreeformAdditionalPropertiesRequest',
@@ -1185,7 +1185,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for testJsonFormData without sending the request
      */
-    async testJsonFormDataRequestOpts(requestParameters: TestJsonFormDataRequest): Promise<runtime.RequestOpts> {
+    testJsonFormDataRequestOpts(requestParameters: TestJsonFormDataRequest): runtime.RequestOpts {
         if (requestParameters['param'] == null) {
             throw new runtime.RequiredError(
                 'param',
@@ -1260,7 +1260,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for testNullable without sending the request
      */
-    async testNullableRequestOpts(requestParameters: TestNullableRequest): Promise<runtime.RequestOpts> {
+    testNullableRequestOpts(requestParameters: TestNullableRequest): runtime.RequestOpts {
         if (requestParameters['childWithNullable'] == null) {
             throw new runtime.RequiredError(
                 'childWithNullable',
@@ -1308,7 +1308,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for testQueryParameterCollectionFormat without sending the request
      */
-    async testQueryParameterCollectionFormatRequestOpts(requestParameters: TestQueryParameterCollectionFormatRequest): Promise<runtime.RequestOpts> {
+    testQueryParameterCollectionFormatRequestOpts(requestParameters: TestQueryParameterCollectionFormatRequest): runtime.RequestOpts {
         if (requestParameters['pipe'] == null) {
             throw new runtime.RequiredError(
                 'pipe',
@@ -1416,7 +1416,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for testStringMapReference without sending the request
      */
-    async testStringMapReferenceRequestOpts(requestParameters: TestStringMapReferenceRequest): Promise<runtime.RequestOpts> {
+    testStringMapReferenceRequestOpts(requestParameters: TestStringMapReferenceRequest): runtime.RequestOpts {
         if (requestParameters['requestBody'] == null) {
             throw new runtime.RequiredError(
                 'requestBody',

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/StoreApi.ts
@@ -71,7 +71,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Delete purchase order by ID
      */
     async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.deleteOrderRequestOpts(requestParameters);
+        const requestOptions = this.deleteOrderRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -160,7 +160,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Find purchase order by ID
      */
     async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        const requestOptions = await this.getOrderByIdRequestOpts(requestParameters);
+        const requestOptions = this.getOrderByIdRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
@@ -209,7 +209,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Place an order for a pet
      */
     async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        const requestOptions = await this.placeOrderRequestOpts(requestParameters);
+        const requestOptions = this.placeOrderRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/StoreApi.ts
@@ -42,7 +42,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for deleteOrder without sending the request
      */
-    async deleteOrderRequestOpts(requestParameters: DeleteOrderRequest): Promise<runtime.RequestOpts> {
+    deleteOrderRequestOpts(requestParameters: DeleteOrderRequest): runtime.RequestOpts {
         if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
@@ -131,7 +131,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for getOrderById without sending the request
      */
-    async getOrderByIdRequestOpts(requestParameters: GetOrderByIdRequest): Promise<runtime.RequestOpts> {
+    getOrderByIdRequestOpts(requestParameters: GetOrderByIdRequest): runtime.RequestOpts {
         if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
@@ -178,7 +178,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for placeOrder without sending the request
      */
-    async placeOrderRequestOpts(requestParameters: PlaceOrderRequest): Promise<runtime.RequestOpts> {
+    placeOrderRequestOpts(requestParameters: PlaceOrderRequest): runtime.RequestOpts {
         if (requestParameters['order'] == null) {
             throw new runtime.RequiredError(
                 'order',

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/UserApi.ts
@@ -60,7 +60,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUser without sending the request
      */
-    async createUserRequestOpts(requestParameters: CreateUserRequest): Promise<runtime.RequestOpts> {
+    createUserRequestOpts(requestParameters: CreateUserRequest): runtime.RequestOpts {
         if (requestParameters['user'] == null) {
             throw new runtime.RequiredError(
                 'user',
@@ -108,7 +108,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUsersWithArrayInput without sending the request
      */
-    async createUsersWithArrayInputRequestOpts(requestParameters: CreateUsersWithArrayInputRequest): Promise<runtime.RequestOpts> {
+    createUsersWithArrayInputRequestOpts(requestParameters: CreateUsersWithArrayInputRequest): runtime.RequestOpts {
         if (requestParameters['user'] == null) {
             throw new runtime.RequiredError(
                 'user',
@@ -156,7 +156,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUsersWithListInput without sending the request
      */
-    async createUsersWithListInputRequestOpts(requestParameters: CreateUsersWithListInputRequest): Promise<runtime.RequestOpts> {
+    createUsersWithListInputRequestOpts(requestParameters: CreateUsersWithListInputRequest): runtime.RequestOpts {
         if (requestParameters['user'] == null) {
             throw new runtime.RequiredError(
                 'user',
@@ -204,7 +204,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for deleteUser without sending the request
      */
-    async deleteUserRequestOpts(requestParameters: DeleteUserRequest): Promise<runtime.RequestOpts> {
+    deleteUserRequestOpts(requestParameters: DeleteUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -250,7 +250,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for getUserByName without sending the request
      */
-    async getUserByNameRequestOpts(requestParameters: GetUserByNameRequest): Promise<runtime.RequestOpts> {
+    getUserByNameRequestOpts(requestParameters: GetUserByNameRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -297,7 +297,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for loginUser without sending the request
      */
-    async loginUserRequestOpts(requestParameters: LoginUserRequest): Promise<runtime.RequestOpts> {
+    loginUserRequestOpts(requestParameters: LoginUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -362,7 +362,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for logoutUser without sending the request
      */
-    async logoutUserRequestOpts(): Promise<runtime.RequestOpts> {
+    logoutUserRequestOpts(): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -400,7 +400,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for updateUser without sending the request
      */
-    async updateUserRequestOpts(requestParameters: UpdateUserRequest): Promise<runtime.RequestOpts> {
+    updateUserRequestOpts(requestParameters: UpdateUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/UserApi.ts
@@ -91,7 +91,7 @@ export class UserApi extends runtime.BaseAPI {
      * Create user
      */
     async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUserRequestOpts(requestParameters);
+        const requestOptions = this.createUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -139,7 +139,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUsersWithArrayInputRequestOpts(requestParameters);
+        const requestOptions = this.createUsersWithArrayInputRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -187,7 +187,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUsersWithListInputRequestOpts(requestParameters);
+        const requestOptions = this.createUsersWithListInputRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -233,7 +233,7 @@ export class UserApi extends runtime.BaseAPI {
      * Delete user
      */
     async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.deleteUserRequestOpts(requestParameters);
+        const requestOptions = this.deleteUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -279,7 +279,7 @@ export class UserApi extends runtime.BaseAPI {
      * Get user by user name
      */
     async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<User>> {
-        const requestOptions = await this.getUserByNameRequestOpts(requestParameters);
+        const requestOptions = this.getUserByNameRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => UserFromJSON(jsonValue));
@@ -340,7 +340,7 @@ export class UserApi extends runtime.BaseAPI {
      * Logs user into the system
      */
     async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<string>> {
-        const requestOptions = await this.loginUserRequestOpts(requestParameters);
+        const requestOptions = this.loginUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         if (this.isJsonMime(response.headers.get('content-type'))) {
@@ -383,7 +383,7 @@ export class UserApi extends runtime.BaseAPI {
      * Logs out current logged in user session
      */
     async logoutUserRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.logoutUserRequestOpts();
+        const requestOptions = this.logoutUserRequestOpts();
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -439,7 +439,7 @@ export class UserApi extends runtime.BaseAPI {
      * Updated user
      */
     async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.updateUserRequestOpts(requestParameters);
+        const requestOptions = this.updateUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/StoreApi.ts
@@ -71,7 +71,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Delete purchase order by ID
      */
     async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.deleteOrderRequestOpts(requestParameters);
+        const requestOptions = this.deleteOrderRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -160,7 +160,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Find purchase order by ID
      */
     async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        const requestOptions = await this.getOrderByIdRequestOpts(requestParameters);
+        const requestOptions = this.getOrderByIdRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
@@ -208,7 +208,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Place an order for a pet
      */
     async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        const requestOptions = await this.placeOrderRequestOpts(requestParameters);
+        const requestOptions = this.placeOrderRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/StoreApi.ts
@@ -42,7 +42,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for deleteOrder without sending the request
      */
-    async deleteOrderRequestOpts(requestParameters: DeleteOrderRequest): Promise<runtime.RequestOpts> {
+    deleteOrderRequestOpts(requestParameters: DeleteOrderRequest): runtime.RequestOpts {
         if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
@@ -131,7 +131,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for getOrderById without sending the request
      */
-    async getOrderByIdRequestOpts(requestParameters: GetOrderByIdRequest): Promise<runtime.RequestOpts> {
+    getOrderByIdRequestOpts(requestParameters: GetOrderByIdRequest): runtime.RequestOpts {
         if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
@@ -178,7 +178,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for placeOrder without sending the request
      */
-    async placeOrderRequestOpts(requestParameters: PlaceOrderRequest): Promise<runtime.RequestOpts> {
+    placeOrderRequestOpts(requestParameters: PlaceOrderRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/UserApi.ts
@@ -60,7 +60,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUser without sending the request
      */
-    async createUserRequestOpts(requestParameters: CreateUserRequest): Promise<runtime.RequestOpts> {
+    createUserRequestOpts(requestParameters: CreateUserRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -108,7 +108,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUsersWithArrayInput without sending the request
      */
-    async createUsersWithArrayInputRequestOpts(requestParameters: CreateUsersWithArrayInputRequest): Promise<runtime.RequestOpts> {
+    createUsersWithArrayInputRequestOpts(requestParameters: CreateUsersWithArrayInputRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -154,7 +154,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUsersWithListInput without sending the request
      */
-    async createUsersWithListInputRequestOpts(requestParameters: CreateUsersWithListInputRequest): Promise<runtime.RequestOpts> {
+    createUsersWithListInputRequestOpts(requestParameters: CreateUsersWithListInputRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -200,7 +200,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for deleteUser without sending the request
      */
-    async deleteUserRequestOpts(requestParameters: DeleteUserRequest): Promise<runtime.RequestOpts> {
+    deleteUserRequestOpts(requestParameters: DeleteUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -246,7 +246,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for getUserByName without sending the request
      */
-    async getUserByNameRequestOpts(requestParameters: GetUserByNameRequest): Promise<runtime.RequestOpts> {
+    getUserByNameRequestOpts(requestParameters: GetUserByNameRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -291,7 +291,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for loginUser without sending the request
      */
-    async loginUserRequestOpts(requestParameters: LoginUserRequest): Promise<runtime.RequestOpts> {
+    loginUserRequestOpts(requestParameters: LoginUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -354,7 +354,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for logoutUser without sending the request
      */
-    async logoutUserRequestOpts(): Promise<runtime.RequestOpts> {
+    logoutUserRequestOpts(): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -390,7 +390,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for updateUser without sending the request
      */
-    async updateUserRequestOpts(requestParameters: UpdateUserRequest): Promise<runtime.RequestOpts> {
+    updateUserRequestOpts(requestParameters: UpdateUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/UserApi.ts
@@ -91,7 +91,7 @@ export class UserApi extends runtime.BaseAPI {
      * Create user
      */
     async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUserRequestOpts(requestParameters);
+        const requestOptions = this.createUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -138,7 +138,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUsersWithArrayInputRequestOpts(requestParameters);
+        const requestOptions = this.createUsersWithArrayInputRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -184,7 +184,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUsersWithListInputRequestOpts(requestParameters);
+        const requestOptions = this.createUsersWithListInputRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -229,7 +229,7 @@ export class UserApi extends runtime.BaseAPI {
      * Delete user
      */
     async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.deleteUserRequestOpts(requestParameters);
+        const requestOptions = this.deleteUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -274,7 +274,7 @@ export class UserApi extends runtime.BaseAPI {
      * Get user by user name
      */
     async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<User>> {
-        const requestOptions = await this.getUserByNameRequestOpts(requestParameters);
+        const requestOptions = this.getUserByNameRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => UserFromJSON(jsonValue));
@@ -333,7 +333,7 @@ export class UserApi extends runtime.BaseAPI {
      * Logs user into the system
      */
     async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<string>> {
-        const requestOptions = await this.loginUserRequestOpts(requestParameters);
+        const requestOptions = this.loginUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         if (this.isJsonMime(response.headers.get('content-type'))) {
@@ -374,7 +374,7 @@ export class UserApi extends runtime.BaseAPI {
      * Logs out current logged in user session
      */
     async logoutUserRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.logoutUserRequestOpts();
+        const requestOptions = this.logoutUserRequestOpts();
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -429,7 +429,7 @@ export class UserApi extends runtime.BaseAPI {
      * Updated user
      */
     async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.updateUserRequestOpts(requestParameters);
+        const requestOptions = this.updateUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/enum/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/apis/DefaultApi.ts
@@ -96,7 +96,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      */
     async fakeEnumRequestGetInlineRaw(requestParameters: FakeEnumRequestGetInlineRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FakeEnumRequestGetInline200Response>> {
-        const requestOptions = await this.fakeEnumRequestGetInlineRequestOpts(requestParameters);
+        const requestOptions = this.fakeEnumRequestGetInlineRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => FakeEnumRequestGetInline200ResponseFromJSON(jsonValue));
@@ -147,7 +147,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      */
     async fakeEnumRequestGetRefRaw(requestParameters: FakeEnumRequestGetRefRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<EnumPatternObject>> {
-        const requestOptions = await this.fakeEnumRequestGetRefRequestOpts(requestParameters);
+        const requestOptions = this.fakeEnumRequestGetRefRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => EnumPatternObjectFromJSON(jsonValue));
@@ -185,7 +185,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      */
     async fakeEnumRequestPostInlineRaw(requestParameters: FakeEnumRequestPostInlineRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FakeEnumRequestGetInline200Response>> {
-        const requestOptions = await this.fakeEnumRequestPostInlineRequestOpts(requestParameters);
+        const requestOptions = this.fakeEnumRequestPostInlineRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => FakeEnumRequestGetInline200ResponseFromJSON(jsonValue));
@@ -223,7 +223,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      */
     async fakeEnumRequestPostRefRaw(requestParameters: FakeEnumRequestPostRefRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<EnumPatternObject>> {
-        const requestOptions = await this.fakeEnumRequestPostRefRequestOpts(requestParameters);
+        const requestOptions = this.fakeEnumRequestPostRefRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => EnumPatternObjectFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/enum/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/apis/DefaultApi.ts
@@ -61,7 +61,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Creates request options for fakeEnumRequestGetInline without sending the request
      */
-    async fakeEnumRequestGetInlineRequestOpts(requestParameters: FakeEnumRequestGetInlineRequest): Promise<runtime.RequestOpts> {
+    fakeEnumRequestGetInlineRequestOpts(requestParameters: FakeEnumRequestGetInlineRequest): runtime.RequestOpts {
         const queryParameters: any = {};
 
         if (requestParameters['stringEnum'] != null) {
@@ -112,7 +112,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Creates request options for fakeEnumRequestGetRef without sending the request
      */
-    async fakeEnumRequestGetRefRequestOpts(requestParameters: FakeEnumRequestGetRefRequest): Promise<runtime.RequestOpts> {
+    fakeEnumRequestGetRefRequestOpts(requestParameters: FakeEnumRequestGetRefRequest): runtime.RequestOpts {
         const queryParameters: any = {};
 
         if (requestParameters['stringEnum'] != null) {
@@ -163,7 +163,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Creates request options for fakeEnumRequestPostInline without sending the request
      */
-    async fakeEnumRequestPostInlineRequestOpts(requestParameters: FakeEnumRequestPostInlineRequest): Promise<runtime.RequestOpts> {
+    fakeEnumRequestPostInlineRequestOpts(requestParameters: FakeEnumRequestPostInlineRequest): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -201,7 +201,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Creates request options for fakeEnumRequestPostRef without sending the request
      */
-    async fakeEnumRequestPostRefRequestOpts(requestParameters: FakeEnumRequestPostRefRequest): Promise<runtime.RequestOpts> {
+    fakeEnumRequestPostRefRequestOpts(requestParameters: FakeEnumRequestPostRefRequest): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/StoreApi.ts
@@ -71,7 +71,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Delete purchase order by ID
      */
     async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.deleteOrderRequestOpts(requestParameters);
+        const requestOptions = this.deleteOrderRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -160,7 +160,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Find purchase order by ID
      */
     async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        const requestOptions = await this.getOrderByIdRequestOpts(requestParameters);
+        const requestOptions = this.getOrderByIdRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
@@ -208,7 +208,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Place an order for a pet
      */
     async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        const requestOptions = await this.placeOrderRequestOpts(requestParameters);
+        const requestOptions = this.placeOrderRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/StoreApi.ts
@@ -42,7 +42,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for deleteOrder without sending the request
      */
-    async deleteOrderRequestOpts(requestParameters: DeleteOrderRequest): Promise<runtime.RequestOpts> {
+    deleteOrderRequestOpts(requestParameters: DeleteOrderRequest): runtime.RequestOpts {
         if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
@@ -131,7 +131,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for getOrderById without sending the request
      */
-    async getOrderByIdRequestOpts(requestParameters: GetOrderByIdRequest): Promise<runtime.RequestOpts> {
+    getOrderByIdRequestOpts(requestParameters: GetOrderByIdRequest): runtime.RequestOpts {
         if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
@@ -178,7 +178,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for placeOrder without sending the request
      */
-    async placeOrderRequestOpts(requestParameters: PlaceOrderRequest): Promise<runtime.RequestOpts> {
+    placeOrderRequestOpts(requestParameters: PlaceOrderRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/UserApi.ts
@@ -60,7 +60,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUser without sending the request
      */
-    async createUserRequestOpts(requestParameters: CreateUserRequest): Promise<runtime.RequestOpts> {
+    createUserRequestOpts(requestParameters: CreateUserRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -108,7 +108,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUsersWithArrayInput without sending the request
      */
-    async createUsersWithArrayInputRequestOpts(requestParameters: CreateUsersWithArrayInputRequest): Promise<runtime.RequestOpts> {
+    createUsersWithArrayInputRequestOpts(requestParameters: CreateUsersWithArrayInputRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -154,7 +154,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUsersWithListInput without sending the request
      */
-    async createUsersWithListInputRequestOpts(requestParameters: CreateUsersWithListInputRequest): Promise<runtime.RequestOpts> {
+    createUsersWithListInputRequestOpts(requestParameters: CreateUsersWithListInputRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -200,7 +200,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for deleteUser without sending the request
      */
-    async deleteUserRequestOpts(requestParameters: DeleteUserRequest): Promise<runtime.RequestOpts> {
+    deleteUserRequestOpts(requestParameters: DeleteUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -246,7 +246,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for getUserByName without sending the request
      */
-    async getUserByNameRequestOpts(requestParameters: GetUserByNameRequest): Promise<runtime.RequestOpts> {
+    getUserByNameRequestOpts(requestParameters: GetUserByNameRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -291,7 +291,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for loginUser without sending the request
      */
-    async loginUserRequestOpts(requestParameters: LoginUserRequest): Promise<runtime.RequestOpts> {
+    loginUserRequestOpts(requestParameters: LoginUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -354,7 +354,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for logoutUser without sending the request
      */
-    async logoutUserRequestOpts(): Promise<runtime.RequestOpts> {
+    logoutUserRequestOpts(): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -390,7 +390,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for updateUser without sending the request
      */
-    async updateUserRequestOpts(requestParameters: UpdateUserRequest): Promise<runtime.RequestOpts> {
+    updateUserRequestOpts(requestParameters: UpdateUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/UserApi.ts
@@ -91,7 +91,7 @@ export class UserApi extends runtime.BaseAPI {
      * Create user
      */
     async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUserRequestOpts(requestParameters);
+        const requestOptions = this.createUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -138,7 +138,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUsersWithArrayInputRequestOpts(requestParameters);
+        const requestOptions = this.createUsersWithArrayInputRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -184,7 +184,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUsersWithListInputRequestOpts(requestParameters);
+        const requestOptions = this.createUsersWithListInputRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -229,7 +229,7 @@ export class UserApi extends runtime.BaseAPI {
      * Delete user
      */
     async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.deleteUserRequestOpts(requestParameters);
+        const requestOptions = this.deleteUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -274,7 +274,7 @@ export class UserApi extends runtime.BaseAPI {
      * Get user by user name
      */
     async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<User>> {
-        const requestOptions = await this.getUserByNameRequestOpts(requestParameters);
+        const requestOptions = this.getUserByNameRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => UserFromJSON(jsonValue));
@@ -333,7 +333,7 @@ export class UserApi extends runtime.BaseAPI {
      * Logs user into the system
      */
     async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<string>> {
-        const requestOptions = await this.loginUserRequestOpts(requestParameters);
+        const requestOptions = this.loginUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         if (this.isJsonMime(response.headers.get('content-type'))) {
@@ -374,7 +374,7 @@ export class UserApi extends runtime.BaseAPI {
      * Logs out current logged in user session
      */
     async logoutUserRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.logoutUserRequestOpts();
+        const requestOptions = this.logoutUserRequestOpts();
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -429,7 +429,7 @@ export class UserApi extends runtime.BaseAPI {
      * Updated user
      */
     async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.updateUserRequestOpts(requestParameters);
+        const requestOptions = this.updateUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/StoreApi.ts
@@ -71,7 +71,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Delete purchase order by ID
      */
     async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.deleteOrderRequestOpts(requestParameters);
+        const requestOptions = this.deleteOrderRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -160,7 +160,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Find purchase order by ID
      */
     async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        const requestOptions = await this.getOrderByIdRequestOpts(requestParameters);
+        const requestOptions = this.getOrderByIdRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
@@ -208,7 +208,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Place an order for a pet
      */
     async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        const requestOptions = await this.placeOrderRequestOpts(requestParameters);
+        const requestOptions = this.placeOrderRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/StoreApi.ts
@@ -42,7 +42,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for deleteOrder without sending the request
      */
-    async deleteOrderRequestOpts(requestParameters: DeleteOrderRequest): Promise<runtime.RequestOpts> {
+    deleteOrderRequestOpts(requestParameters: DeleteOrderRequest): runtime.RequestOpts {
         if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
@@ -131,7 +131,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for getOrderById without sending the request
      */
-    async getOrderByIdRequestOpts(requestParameters: GetOrderByIdRequest): Promise<runtime.RequestOpts> {
+    getOrderByIdRequestOpts(requestParameters: GetOrderByIdRequest): runtime.RequestOpts {
         if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
@@ -178,7 +178,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for placeOrder without sending the request
      */
-    async placeOrderRequestOpts(requestParameters: PlaceOrderRequest): Promise<runtime.RequestOpts> {
+    placeOrderRequestOpts(requestParameters: PlaceOrderRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/UserApi.ts
@@ -60,7 +60,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUser without sending the request
      */
-    async createUserRequestOpts(requestParameters: CreateUserRequest): Promise<runtime.RequestOpts> {
+    createUserRequestOpts(requestParameters: CreateUserRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -108,7 +108,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUsersWithArrayInput without sending the request
      */
-    async createUsersWithArrayInputRequestOpts(requestParameters: CreateUsersWithArrayInputRequest): Promise<runtime.RequestOpts> {
+    createUsersWithArrayInputRequestOpts(requestParameters: CreateUsersWithArrayInputRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -154,7 +154,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUsersWithListInput without sending the request
      */
-    async createUsersWithListInputRequestOpts(requestParameters: CreateUsersWithListInputRequest): Promise<runtime.RequestOpts> {
+    createUsersWithListInputRequestOpts(requestParameters: CreateUsersWithListInputRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -200,7 +200,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for deleteUser without sending the request
      */
-    async deleteUserRequestOpts(requestParameters: DeleteUserRequest): Promise<runtime.RequestOpts> {
+    deleteUserRequestOpts(requestParameters: DeleteUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -246,7 +246,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for getUserByName without sending the request
      */
-    async getUserByNameRequestOpts(requestParameters: GetUserByNameRequest): Promise<runtime.RequestOpts> {
+    getUserByNameRequestOpts(requestParameters: GetUserByNameRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -291,7 +291,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for loginUser without sending the request
      */
-    async loginUserRequestOpts(requestParameters: LoginUserRequest): Promise<runtime.RequestOpts> {
+    loginUserRequestOpts(requestParameters: LoginUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -354,7 +354,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for logoutUser without sending the request
      */
-    async logoutUserRequestOpts(): Promise<runtime.RequestOpts> {
+    logoutUserRequestOpts(): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -390,7 +390,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for updateUser without sending the request
      */
-    async updateUserRequestOpts(requestParameters: UpdateUserRequest): Promise<runtime.RequestOpts> {
+    updateUserRequestOpts(requestParameters: UpdateUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/UserApi.ts
@@ -91,7 +91,7 @@ export class UserApi extends runtime.BaseAPI {
      * Create user
      */
     async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUserRequestOpts(requestParameters);
+        const requestOptions = this.createUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -138,7 +138,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUsersWithArrayInputRequestOpts(requestParameters);
+        const requestOptions = this.createUsersWithArrayInputRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -184,7 +184,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUsersWithListInputRequestOpts(requestParameters);
+        const requestOptions = this.createUsersWithListInputRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -229,7 +229,7 @@ export class UserApi extends runtime.BaseAPI {
      * Delete user
      */
     async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.deleteUserRequestOpts(requestParameters);
+        const requestOptions = this.deleteUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -274,7 +274,7 @@ export class UserApi extends runtime.BaseAPI {
      * Get user by user name
      */
     async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<User>> {
-        const requestOptions = await this.getUserByNameRequestOpts(requestParameters);
+        const requestOptions = this.getUserByNameRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => UserFromJSON(jsonValue));
@@ -333,7 +333,7 @@ export class UserApi extends runtime.BaseAPI {
      * Logs user into the system
      */
     async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<string>> {
-        const requestOptions = await this.loginUserRequestOpts(requestParameters);
+        const requestOptions = this.loginUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         if (this.isJsonMime(response.headers.get('content-type'))) {
@@ -374,7 +374,7 @@ export class UserApi extends runtime.BaseAPI {
      * Logs out current logged in user session
      */
     async logoutUserRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.logoutUserRequestOpts();
+        const requestOptions = this.logoutUserRequestOpts();
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -429,7 +429,7 @@ export class UserApi extends runtime.BaseAPI {
      * Updated user
      */
     async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.updateUserRequestOpts(requestParameters);
+        const requestOptions = this.updateUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/apis/DefaultApi.ts
@@ -36,7 +36,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Creates request options for test without sending the request
      */
-    async testRequestOpts(): Promise<runtime.RequestOpts> {
+    testRequestOpts(): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -71,7 +71,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Creates request options for testArray without sending the request
      */
-    async testArrayRequestOpts(): Promise<runtime.RequestOpts> {
+    testArrayRequestOpts(): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -106,7 +106,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Creates request options for testDiscriminator without sending the request
      */
-    async testDiscriminatorRequestOpts(): Promise<runtime.RequestOpts> {
+    testDiscriminatorRequestOpts(): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/apis/DefaultApi.ts
@@ -55,7 +55,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      */
     async testRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<TestResponse>> {
-        const requestOptions = await this.testRequestOpts();
+        const requestOptions = this.testRequestOpts();
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => TestResponseFromJSON(jsonValue));
@@ -90,7 +90,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      */
     async testArrayRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<TestArrayResponse>> {
-        const requestOptions = await this.testArrayRequestOpts();
+        const requestOptions = this.testArrayRequestOpts();
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => TestArrayResponseFromJSON(jsonValue));
@@ -125,7 +125,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      */
     async testDiscriminatorRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<TestDiscriminatorResponse>> {
-        const requestOptions = await this.testDiscriminatorRequestOpts();
+        const requestOptions = this.testDiscriminatorRequestOpts();
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => TestDiscriminatorResponseFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/StoreApi.ts
@@ -42,7 +42,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for deleteOrder without sending the request
      */
-    async deleteOrderRequestOpts(requestParameters: StoreApiDeleteOrderRequest): Promise<runtime.RequestOpts> {
+    deleteOrderRequestOpts(requestParameters: StoreApiDeleteOrderRequest): runtime.RequestOpts {
         if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
@@ -131,7 +131,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for getOrderById without sending the request
      */
-    async getOrderByIdRequestOpts(requestParameters: StoreApiGetOrderByIdRequest): Promise<runtime.RequestOpts> {
+    getOrderByIdRequestOpts(requestParameters: StoreApiGetOrderByIdRequest): runtime.RequestOpts {
         if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
@@ -178,7 +178,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for placeOrder without sending the request
      */
-    async placeOrderRequestOpts(requestParameters: StoreApiPlaceOrderRequest): Promise<runtime.RequestOpts> {
+    placeOrderRequestOpts(requestParameters: StoreApiPlaceOrderRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/StoreApi.ts
@@ -71,7 +71,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Delete purchase order by ID
      */
     async deleteOrderRaw(requestParameters: StoreApiDeleteOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.deleteOrderRequestOpts(requestParameters);
+        const requestOptions = this.deleteOrderRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -160,7 +160,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Find purchase order by ID
      */
     async getOrderByIdRaw(requestParameters: StoreApiGetOrderByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        const requestOptions = await this.getOrderByIdRequestOpts(requestParameters);
+        const requestOptions = this.getOrderByIdRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
@@ -208,7 +208,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Place an order for a pet
      */
     async placeOrderRaw(requestParameters: StoreApiPlaceOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        const requestOptions = await this.placeOrderRequestOpts(requestParameters);
+        const requestOptions = this.placeOrderRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/UserApi.ts
@@ -91,7 +91,7 @@ export class UserApi extends runtime.BaseAPI {
      * Create user
      */
     async createUserRaw(requestParameters: UserApiCreateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUserRequestOpts(requestParameters);
+        const requestOptions = this.createUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -138,7 +138,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithArrayInputRaw(requestParameters: UserApiCreateUsersWithArrayInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUsersWithArrayInputRequestOpts(requestParameters);
+        const requestOptions = this.createUsersWithArrayInputRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -184,7 +184,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithListInputRaw(requestParameters: UserApiCreateUsersWithListInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUsersWithListInputRequestOpts(requestParameters);
+        const requestOptions = this.createUsersWithListInputRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -229,7 +229,7 @@ export class UserApi extends runtime.BaseAPI {
      * Delete user
      */
     async deleteUserRaw(requestParameters: UserApiDeleteUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.deleteUserRequestOpts(requestParameters);
+        const requestOptions = this.deleteUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -274,7 +274,7 @@ export class UserApi extends runtime.BaseAPI {
      * Get user by user name
      */
     async getUserByNameRaw(requestParameters: UserApiGetUserByNameRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<User>> {
-        const requestOptions = await this.getUserByNameRequestOpts(requestParameters);
+        const requestOptions = this.getUserByNameRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => UserFromJSON(jsonValue));
@@ -333,7 +333,7 @@ export class UserApi extends runtime.BaseAPI {
      * Logs user into the system
      */
     async loginUserRaw(requestParameters: UserApiLoginUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<string>> {
-        const requestOptions = await this.loginUserRequestOpts(requestParameters);
+        const requestOptions = this.loginUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         if (this.isJsonMime(response.headers.get('content-type'))) {
@@ -374,7 +374,7 @@ export class UserApi extends runtime.BaseAPI {
      * Logs out current logged in user session
      */
     async logoutUserRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.logoutUserRequestOpts();
+        const requestOptions = this.logoutUserRequestOpts();
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -429,7 +429,7 @@ export class UserApi extends runtime.BaseAPI {
      * Updated user
      */
     async updateUserRaw(requestParameters: UserApiUpdateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.updateUserRequestOpts(requestParameters);
+        const requestOptions = this.updateUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/UserApi.ts
@@ -60,7 +60,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUser without sending the request
      */
-    async createUserRequestOpts(requestParameters: UserApiCreateUserRequest): Promise<runtime.RequestOpts> {
+    createUserRequestOpts(requestParameters: UserApiCreateUserRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -108,7 +108,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUsersWithArrayInput without sending the request
      */
-    async createUsersWithArrayInputRequestOpts(requestParameters: UserApiCreateUsersWithArrayInputRequest): Promise<runtime.RequestOpts> {
+    createUsersWithArrayInputRequestOpts(requestParameters: UserApiCreateUsersWithArrayInputRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -154,7 +154,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUsersWithListInput without sending the request
      */
-    async createUsersWithListInputRequestOpts(requestParameters: UserApiCreateUsersWithListInputRequest): Promise<runtime.RequestOpts> {
+    createUsersWithListInputRequestOpts(requestParameters: UserApiCreateUsersWithListInputRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -200,7 +200,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for deleteUser without sending the request
      */
-    async deleteUserRequestOpts(requestParameters: UserApiDeleteUserRequest): Promise<runtime.RequestOpts> {
+    deleteUserRequestOpts(requestParameters: UserApiDeleteUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -246,7 +246,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for getUserByName without sending the request
      */
-    async getUserByNameRequestOpts(requestParameters: UserApiGetUserByNameRequest): Promise<runtime.RequestOpts> {
+    getUserByNameRequestOpts(requestParameters: UserApiGetUserByNameRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -291,7 +291,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for loginUser without sending the request
      */
-    async loginUserRequestOpts(requestParameters: UserApiLoginUserRequest): Promise<runtime.RequestOpts> {
+    loginUserRequestOpts(requestParameters: UserApiLoginUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -354,7 +354,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for logoutUser without sending the request
      */
-    async logoutUserRequestOpts(): Promise<runtime.RequestOpts> {
+    logoutUserRequestOpts(): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -390,7 +390,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for updateUser without sending the request
      */
-    async updateUserRequestOpts(requestParameters: UserApiUpdateUserRequest): Promise<runtime.RequestOpts> {
+    updateUserRequestOpts(requestParameters: UserApiUpdateUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/BehaviorApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/BehaviorApi.ts
@@ -69,7 +69,7 @@ export class BehaviorApi extends runtime.BaseAPI {
      * Get permissions for the behavior
      */
     async getBehaviorPermissionsRaw(requestParameters: GetBehaviorPermissionsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<GetBehaviorPermissionsResponse>> {
-        const requestOptions = await this.getBehaviorPermissionsRequestOpts(requestParameters);
+        const requestOptions = this.getBehaviorPermissionsRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => GetBehaviorPermissionsResponseFromJSON(jsonValue));
@@ -114,7 +114,7 @@ export class BehaviorApi extends runtime.BaseAPI {
      * Get the type of behavior
      */
     async getBehaviorTypeRaw(requestParameters: GetBehaviorTypeRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<GetBehaviorTypeResponse>> {
-        const requestOptions = await this.getBehaviorTypeRequestOpts(requestParameters);
+        const requestOptions = this.getBehaviorTypeRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => GetBehaviorTypeResponseFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/BehaviorApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/BehaviorApi.ts
@@ -41,7 +41,7 @@ export class BehaviorApi extends runtime.BaseAPI {
     /**
      * Creates request options for getBehaviorPermissions without sending the request
      */
-    async getBehaviorPermissionsRequestOpts(requestParameters: GetBehaviorPermissionsRequest): Promise<runtime.RequestOpts> {
+    getBehaviorPermissionsRequestOpts(requestParameters: GetBehaviorPermissionsRequest): runtime.RequestOpts {
         if (requestParameters['behaviorId'] == null) {
             throw new runtime.RequiredError(
                 'behaviorId',
@@ -86,7 +86,7 @@ export class BehaviorApi extends runtime.BaseAPI {
     /**
      * Creates request options for getBehaviorType without sending the request
      */
-    async getBehaviorTypeRequestOpts(requestParameters: GetBehaviorTypeRequest): Promise<runtime.RequestOpts> {
+    getBehaviorTypeRequestOpts(requestParameters: GetBehaviorTypeRequest): runtime.RequestOpts {
         if (requestParameters['behaviorId'] == null) {
             throw new runtime.RequiredError(
                 'behaviorId',

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetApi.ts
@@ -511,7 +511,7 @@ export class PetApi extends runtime.BaseAPI {
      * Gets regions for a single pet.
      */
     async getPetRegionsRaw(requestParameters: GetPetRegionsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<PetRegionsResponse>> {
-        const requestOptions = await this.getPetRegionsRequestOpts(requestParameters);
+        const requestOptions = this.getPetRegionsRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => PetRegionsResponseFromJSON(jsonValue));
@@ -617,7 +617,7 @@ export class PetApi extends runtime.BaseAPI {
      * Updates the pet regions.
      */
     async updatePetRegionsRaw(requestParameters: UpdatePetRegionsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<PetRegionsResponse>> {
-        const requestOptions = await this.updatePetRegionsRequestOpts(requestParameters);
+        const requestOptions = this.updatePetRegionsRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => PetRegionsResponseFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetApi.ts
@@ -483,7 +483,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Creates request options for getPetRegions without sending the request
      */
-    async getPetRegionsRequestOpts(requestParameters: GetPetRegionsRequest): Promise<runtime.RequestOpts> {
+    getPetRegionsRequestOpts(requestParameters: GetPetRegionsRequest): runtime.RequestOpts {
         if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
@@ -579,7 +579,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Creates request options for updatePetRegions without sending the request
      */
-    async updatePetRegionsRequestOpts(requestParameters: UpdatePetRegionsRequest): Promise<runtime.RequestOpts> {
+    updatePetRegionsRequestOpts(requestParameters: UpdatePetRegionsRequest): runtime.RequestOpts {
         if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetPartApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetPartApi.ts
@@ -74,7 +74,7 @@ export class PetPartApi extends runtime.BaseAPI {
      * Returns single pet part type for the petPart id.
      */
     async getFakePetPartTypeRaw(requestParameters: GetFakePetPartTypeRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<GetPetPartTypeResponse>> {
-        const requestOptions = await this.getFakePetPartTypeRequestOpts(requestParameters);
+        const requestOptions = this.getFakePetPartTypeRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => GetPetPartTypeResponseFromJSON(jsonValue));
@@ -160,7 +160,7 @@ export class PetPartApi extends runtime.BaseAPI {
      * Get the matching parts for the given pet part.
      */
     async getMatchingPartsRaw(requestParameters: GetMatchingPartsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<GetMatchingPartsResponse>> {
-        const requestOptions = await this.getMatchingPartsRequestOpts(requestParameters);
+        const requestOptions = this.getMatchingPartsRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => GetMatchingPartsResponseFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetPartApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetPartApi.ts
@@ -46,7 +46,7 @@ export class PetPartApi extends runtime.BaseAPI {
     /**
      * Creates request options for getFakePetPartType without sending the request
      */
-    async getFakePetPartTypeRequestOpts(requestParameters: GetFakePetPartTypeRequest): Promise<runtime.RequestOpts> {
+    getFakePetPartTypeRequestOpts(requestParameters: GetFakePetPartTypeRequest): runtime.RequestOpts {
         if (requestParameters['fakePetPartId'] == null) {
             throw new runtime.RequiredError(
                 'fakePetPartId',
@@ -91,7 +91,7 @@ export class PetPartApi extends runtime.BaseAPI {
     /**
      * Creates request options for getMatchingParts without sending the request
      */
-    async getMatchingPartsRequestOpts(requestParameters: GetMatchingPartsRequest): Promise<runtime.RequestOpts> {
+    getMatchingPartsRequestOpts(requestParameters: GetMatchingPartsRequest): runtime.RequestOpts {
         if (requestParameters['fakePetPartId'] == null) {
             throw new runtime.RequiredError(
                 'fakePetPartId',

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/StoreApi.ts
@@ -71,7 +71,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Delete purchase order by ID
      */
     async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.deleteOrderRequestOpts(requestParameters);
+        const requestOptions = this.deleteOrderRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -160,7 +160,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Find purchase order by ID
      */
     async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        const requestOptions = await this.getOrderByIdRequestOpts(requestParameters);
+        const requestOptions = this.getOrderByIdRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
@@ -208,7 +208,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Place an order for a pet
      */
     async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        const requestOptions = await this.placeOrderRequestOpts(requestParameters);
+        const requestOptions = this.placeOrderRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/StoreApi.ts
@@ -42,7 +42,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for deleteOrder without sending the request
      */
-    async deleteOrderRequestOpts(requestParameters: DeleteOrderRequest): Promise<runtime.RequestOpts> {
+    deleteOrderRequestOpts(requestParameters: DeleteOrderRequest): runtime.RequestOpts {
         if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
@@ -131,7 +131,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for getOrderById without sending the request
      */
-    async getOrderByIdRequestOpts(requestParameters: GetOrderByIdRequest): Promise<runtime.RequestOpts> {
+    getOrderByIdRequestOpts(requestParameters: GetOrderByIdRequest): runtime.RequestOpts {
         if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
@@ -178,7 +178,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for placeOrder without sending the request
      */
-    async placeOrderRequestOpts(requestParameters: PlaceOrderRequest): Promise<runtime.RequestOpts> {
+    placeOrderRequestOpts(requestParameters: PlaceOrderRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/UserApi.ts
@@ -63,7 +63,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUser without sending the request
      */
-    async createUserRequestOpts(requestParameters: CreateUserRequest): Promise<runtime.RequestOpts> {
+    createUserRequestOpts(requestParameters: CreateUserRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -111,7 +111,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUsersWithArrayInput without sending the request
      */
-    async createUsersWithArrayInputRequestOpts(requestParameters: CreateUsersWithArrayInputRequest): Promise<runtime.RequestOpts> {
+    createUsersWithArrayInputRequestOpts(requestParameters: CreateUsersWithArrayInputRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -157,7 +157,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUsersWithListInput without sending the request
      */
-    async createUsersWithListInputRequestOpts(requestParameters: CreateUsersWithListInputRequest): Promise<runtime.RequestOpts> {
+    createUsersWithListInputRequestOpts(requestParameters: CreateUsersWithListInputRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -203,7 +203,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for deleteUser without sending the request
      */
-    async deleteUserRequestOpts(requestParameters: DeleteUserRequest): Promise<runtime.RequestOpts> {
+    deleteUserRequestOpts(requestParameters: DeleteUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -249,7 +249,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for getUserByName without sending the request
      */
-    async getUserByNameRequestOpts(requestParameters: GetUserByNameRequest): Promise<runtime.RequestOpts> {
+    getUserByNameRequestOpts(requestParameters: GetUserByNameRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -294,7 +294,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for loginUser without sending the request
      */
-    async loginUserRequestOpts(requestParameters: LoginUserRequest): Promise<runtime.RequestOpts> {
+    loginUserRequestOpts(requestParameters: LoginUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -357,7 +357,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for logoutUser without sending the request
      */
-    async logoutUserRequestOpts(): Promise<runtime.RequestOpts> {
+    logoutUserRequestOpts(): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -393,7 +393,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for updateUser without sending the request
      */
-    async updateUserRequestOpts(requestParameters: UpdateUserRequest): Promise<runtime.RequestOpts> {
+    updateUserRequestOpts(requestParameters: UpdateUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/UserApi.ts
@@ -94,7 +94,7 @@ export class UserApi extends runtime.BaseAPI {
      * Create user
      */
     async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUserRequestOpts(requestParameters);
+        const requestOptions = this.createUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -141,7 +141,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUsersWithArrayInputRequestOpts(requestParameters);
+        const requestOptions = this.createUsersWithArrayInputRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -187,7 +187,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUsersWithListInputRequestOpts(requestParameters);
+        const requestOptions = this.createUsersWithListInputRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -232,7 +232,7 @@ export class UserApi extends runtime.BaseAPI {
      * Delete user
      */
     async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.deleteUserRequestOpts(requestParameters);
+        const requestOptions = this.deleteUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -277,7 +277,7 @@ export class UserApi extends runtime.BaseAPI {
      * Get user by user name
      */
     async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<User>> {
-        const requestOptions = await this.getUserByNameRequestOpts(requestParameters);
+        const requestOptions = this.getUserByNameRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => UserFromJSON(jsonValue));
@@ -336,7 +336,7 @@ export class UserApi extends runtime.BaseAPI {
      * Logs user into the system
      */
     async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<string>> {
-        const requestOptions = await this.loginUserRequestOpts(requestParameters);
+        const requestOptions = this.loginUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         if (this.isJsonMime(response.headers.get('content-type'))) {
@@ -377,7 +377,7 @@ export class UserApi extends runtime.BaseAPI {
      * Logs out current logged in user session
      */
     async logoutUserRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.logoutUserRequestOpts();
+        const requestOptions = this.logoutUserRequestOpts();
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -432,7 +432,7 @@ export class UserApi extends runtime.BaseAPI {
      * Updated user
      */
     async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<DefaultMetaOnlyResponse>> {
-        const requestOptions = await this.updateUserRequestOpts(requestParameters);
+        const requestOptions = this.updateUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => DefaultMetaOnlyResponseFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/AnotherFakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/AnotherFakeApi.ts
@@ -65,7 +65,7 @@ export class AnotherFakeApi extends runtime.BaseAPI {
      * To test special tags
      */
     async _123testSpecialTagsRaw(requestParameters: 123testSpecialTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Client>> {
-        const requestOptions = await this._123testSpecialTagsRequestOpts(requestParameters);
+        const requestOptions = this._123testSpecialTagsRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ClientFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/AnotherFakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/AnotherFakeApi.ts
@@ -34,7 +34,7 @@ export class AnotherFakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for _123testSpecialTags without sending the request
      */
-    async _123testSpecialTagsRequestOpts(requestParameters: 123testSpecialTagsRequest): Promise<runtime.RequestOpts> {
+    _123testSpecialTagsRequestOpts(requestParameters: 123testSpecialTagsRequest): runtime.RequestOpts {
         if (requestParameters['client'] == null) {
             throw new runtime.RequiredError(
                 'client',

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/DefaultApi.ts
@@ -30,7 +30,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Creates request options for fooGet without sending the request
      */
-    async fooGetRequestOpts(): Promise<runtime.RequestOpts> {
+    fooGetRequestOpts(): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/DefaultApi.ts
@@ -49,7 +49,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      */
     async fooGetRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FooGetDefaultResponse>> {
-        const requestOptions = await this.fooGetRequestOpts();
+        const requestOptions = this.fooGetRequestOpts();
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => FooGetDefaultResponseFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/FakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/FakeApi.ts
@@ -174,7 +174,7 @@ export class FakeApi extends runtime.BaseAPI {
      * for Java apache and Java native, test toUrlQueryString for maps with BegDecimal keys
      */
     async fakeBigDecimalMapRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FakeBigDecimalMap200Response>> {
-        const requestOptions = await this.fakeBigDecimalMapRequestOpts();
+        const requestOptions = this.fakeBigDecimalMapRequestOpts();
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => FakeBigDecimalMap200ResponseFromJSON(jsonValue));
@@ -211,7 +211,7 @@ export class FakeApi extends runtime.BaseAPI {
      * Health check endpoint
      */
     async fakeHealthGetRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<HealthCheckResult>> {
-        const requestOptions = await this.fakeHealthGetRequestOpts();
+        const requestOptions = this.fakeHealthGetRequestOpts();
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => HealthCheckResultFromJSON(jsonValue));
@@ -305,7 +305,7 @@ export class FakeApi extends runtime.BaseAPI {
      * Test serialization of outer boolean types
      */
     async fakeOuterBooleanSerializeRaw(requestParameters: FakeOuterBooleanSerializeRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<boolean>> {
-        const requestOptions = await this.fakeOuterBooleanSerializeRequestOpts(requestParameters);
+        const requestOptions = this.fakeOuterBooleanSerializeRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         if (this.isJsonMime(response.headers.get('content-type'))) {
@@ -349,7 +349,7 @@ export class FakeApi extends runtime.BaseAPI {
      * Test serialization of object with outer number type
      */
     async fakeOuterCompositeSerializeRaw(requestParameters: FakeOuterCompositeSerializeRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<OuterComposite>> {
-        const requestOptions = await this.fakeOuterCompositeSerializeRequestOpts(requestParameters);
+        const requestOptions = this.fakeOuterCompositeSerializeRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OuterCompositeFromJSON(jsonValue));
@@ -389,7 +389,7 @@ export class FakeApi extends runtime.BaseAPI {
      * Test serialization of outer number types
      */
     async fakeOuterNumberSerializeRaw(requestParameters: FakeOuterNumberSerializeRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<number>> {
-        const requestOptions = await this.fakeOuterNumberSerializeRequestOpts(requestParameters);
+        const requestOptions = this.fakeOuterNumberSerializeRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         if (this.isJsonMime(response.headers.get('content-type'))) {
@@ -433,7 +433,7 @@ export class FakeApi extends runtime.BaseAPI {
      * Test serialization of outer string types
      */
     async fakeOuterStringSerializeRaw(requestParameters: FakeOuterStringSerializeRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<string>> {
-        const requestOptions = await this.fakeOuterStringSerializeRequestOpts(requestParameters);
+        const requestOptions = this.fakeOuterStringSerializeRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         if (this.isJsonMime(response.headers.get('content-type'))) {
@@ -484,7 +484,7 @@ export class FakeApi extends runtime.BaseAPI {
      * Test serialization of enum (int) properties with examples
      */
     async fakePropertyEnumIntegerSerializeRaw(requestParameters: FakePropertyEnumIntegerSerializeRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<OuterObjectWithEnumProperty>> {
-        const requestOptions = await this.fakePropertyEnumIntegerSerializeRequestOpts(requestParameters);
+        const requestOptions = this.fakePropertyEnumIntegerSerializeRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OuterObjectWithEnumPropertyFromJSON(jsonValue));
@@ -531,7 +531,7 @@ export class FakeApi extends runtime.BaseAPI {
      * For this test, the body has to be a binary file.
      */
     async testBodyWithBinaryRaw(requestParameters: TestBodyWithBinaryRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.testBodyWithBinaryRequestOpts(requestParameters);
+        const requestOptions = this.testBodyWithBinaryRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -577,7 +577,7 @@ export class FakeApi extends runtime.BaseAPI {
      * For this test, the body for this request must reference a schema named `File`.
      */
     async testBodyWithFileSchemaRaw(requestParameters: TestBodyWithFileSchemaRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.testBodyWithFileSchemaRequestOpts(requestParameters);
+        const requestOptions = this.testBodyWithFileSchemaRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -633,7 +633,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      */
     async testBodyWithQueryParamsRaw(requestParameters: TestBodyWithQueryParamsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.testBodyWithQueryParamsRequestOpts(requestParameters);
+        const requestOptions = this.testBodyWithQueryParamsRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -679,7 +679,7 @@ export class FakeApi extends runtime.BaseAPI {
      * To test \"client\" model
      */
     async testClientModelRaw(requestParameters: TestClientModelRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Client>> {
-        const requestOptions = await this.testClientModelRequestOpts(requestParameters);
+        const requestOptions = this.testClientModelRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ClientFromJSON(jsonValue));
@@ -911,7 +911,7 @@ export class FakeApi extends runtime.BaseAPI {
      * To test enum parameters
      */
     async testEnumParametersRaw(requestParameters: TestEnumParametersRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.testEnumParametersRequestOpts(requestParameters);
+        const requestOptions = this.testEnumParametersRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -1050,7 +1050,7 @@ export class FakeApi extends runtime.BaseAPI {
      * test inline additionalProperties
      */
     async testInlineAdditionalPropertiesRaw(requestParameters: TestInlineAdditionalPropertiesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.testInlineAdditionalPropertiesRequestOpts(requestParameters);
+        const requestOptions = this.testInlineAdditionalPropertiesRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -1125,7 +1125,7 @@ export class FakeApi extends runtime.BaseAPI {
      * test json serialization of form data
      */
     async testJsonFormDataRaw(requestParameters: TestJsonFormDataRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.testJsonFormDataRequestOpts(requestParameters);
+        const requestOptions = this.testJsonFormDataRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -1234,7 +1234,7 @@ export class FakeApi extends runtime.BaseAPI {
      * To test the collection format in query parameters
      */
     async testQueryParameterCollectionFormatRaw(requestParameters: TestQueryParameterCollectionFormatRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.testQueryParameterCollectionFormatRequestOpts(requestParameters);
+        const requestOptions = this.testQueryParameterCollectionFormatRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/FakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/FakeApi.ts
@@ -154,7 +154,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for fakeBigDecimalMap without sending the request
      */
-    async fakeBigDecimalMapRequestOpts(): Promise<runtime.RequestOpts> {
+    fakeBigDecimalMapRequestOpts(): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -191,7 +191,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for fakeHealthGet without sending the request
      */
-    async fakeHealthGetRequestOpts(): Promise<runtime.RequestOpts> {
+    fakeHealthGetRequestOpts(): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -282,7 +282,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for fakeOuterBooleanSerialize without sending the request
      */
-    async fakeOuterBooleanSerializeRequestOpts(requestParameters: FakeOuterBooleanSerializeRequest): Promise<runtime.RequestOpts> {
+    fakeOuterBooleanSerializeRequestOpts(requestParameters: FakeOuterBooleanSerializeRequest): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -326,7 +326,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for fakeOuterCompositeSerialize without sending the request
      */
-    async fakeOuterCompositeSerializeRequestOpts(requestParameters: FakeOuterCompositeSerializeRequest): Promise<runtime.RequestOpts> {
+    fakeOuterCompositeSerializeRequestOpts(requestParameters: FakeOuterCompositeSerializeRequest): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -366,7 +366,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for fakeOuterNumberSerialize without sending the request
      */
-    async fakeOuterNumberSerializeRequestOpts(requestParameters: FakeOuterNumberSerializeRequest): Promise<runtime.RequestOpts> {
+    fakeOuterNumberSerializeRequestOpts(requestParameters: FakeOuterNumberSerializeRequest): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -410,7 +410,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for fakeOuterStringSerialize without sending the request
      */
-    async fakeOuterStringSerializeRequestOpts(requestParameters: FakeOuterStringSerializeRequest): Promise<runtime.RequestOpts> {
+    fakeOuterStringSerializeRequestOpts(requestParameters: FakeOuterStringSerializeRequest): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -454,7 +454,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for fakePropertyEnumIntegerSerialize without sending the request
      */
-    async fakePropertyEnumIntegerSerializeRequestOpts(requestParameters: FakePropertyEnumIntegerSerializeRequest): Promise<runtime.RequestOpts> {
+    fakePropertyEnumIntegerSerializeRequestOpts(requestParameters: FakePropertyEnumIntegerSerializeRequest): runtime.RequestOpts {
         if (requestParameters['outerObjectWithEnumProperty'] == null) {
             throw new runtime.RequiredError(
                 'outerObjectWithEnumProperty',
@@ -501,7 +501,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for testBodyWithBinary without sending the request
      */
-    async testBodyWithBinaryRequestOpts(requestParameters: TestBodyWithBinaryRequest): Promise<runtime.RequestOpts> {
+    testBodyWithBinaryRequestOpts(requestParameters: TestBodyWithBinaryRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -547,7 +547,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for testBodyWithFileSchema without sending the request
      */
-    async testBodyWithFileSchemaRequestOpts(requestParameters: TestBodyWithFileSchemaRequest): Promise<runtime.RequestOpts> {
+    testBodyWithFileSchemaRequestOpts(requestParameters: TestBodyWithFileSchemaRequest): runtime.RequestOpts {
         if (requestParameters['fileSchemaTestClass'] == null) {
             throw new runtime.RequiredError(
                 'fileSchemaTestClass',
@@ -593,7 +593,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for testBodyWithQueryParams without sending the request
      */
-    async testBodyWithQueryParamsRequestOpts(requestParameters: TestBodyWithQueryParamsRequest): Promise<runtime.RequestOpts> {
+    testBodyWithQueryParamsRequestOpts(requestParameters: TestBodyWithQueryParamsRequest): runtime.RequestOpts {
         if (requestParameters['query'] == null) {
             throw new runtime.RequiredError(
                 'query',
@@ -648,7 +648,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for testClientModel without sending the request
      */
-    async testClientModelRequestOpts(requestParameters: TestClientModelRequest): Promise<runtime.RequestOpts> {
+    testClientModelRequestOpts(requestParameters: TestClientModelRequest): runtime.RequestOpts {
         if (requestParameters['client'] == null) {
             throw new runtime.RequiredError(
                 'client',
@@ -839,7 +839,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for testEnumParameters without sending the request
      */
-    async testEnumParametersRequestOpts(requestParameters: TestEnumParametersRequest): Promise<runtime.RequestOpts> {
+    testEnumParametersRequestOpts(requestParameters: TestEnumParametersRequest): runtime.RequestOpts {
         const queryParameters: any = {};
 
         if (requestParameters['enumQueryStringArray'] != null) {
@@ -1019,7 +1019,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for testInlineAdditionalProperties without sending the request
      */
-    async testInlineAdditionalPropertiesRequestOpts(requestParameters: TestInlineAdditionalPropertiesRequest): Promise<runtime.RequestOpts> {
+    testInlineAdditionalPropertiesRequestOpts(requestParameters: TestInlineAdditionalPropertiesRequest): runtime.RequestOpts {
         if (requestParameters['requestBody'] == null) {
             throw new runtime.RequiredError(
                 'requestBody',
@@ -1067,7 +1067,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for testJsonFormData without sending the request
      */
-    async testJsonFormDataRequestOpts(requestParameters: TestJsonFormDataRequest): Promise<runtime.RequestOpts> {
+    testJsonFormDataRequestOpts(requestParameters: TestJsonFormDataRequest): runtime.RequestOpts {
         if (requestParameters['param'] == null) {
             throw new runtime.RequiredError(
                 'param',
@@ -1142,7 +1142,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Creates request options for testQueryParameterCollectionFormat without sending the request
      */
-    async testQueryParameterCollectionFormatRequestOpts(requestParameters: TestQueryParameterCollectionFormatRequest): Promise<runtime.RequestOpts> {
+    testQueryParameterCollectionFormatRequestOpts(requestParameters: TestQueryParameterCollectionFormatRequest): runtime.RequestOpts {
         if (requestParameters['pipe'] == null) {
             throw new runtime.RequiredError(
                 'pipe',

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/StoreApi.ts
@@ -71,7 +71,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Delete purchase order by ID
      */
     async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.deleteOrderRequestOpts(requestParameters);
+        const requestOptions = this.deleteOrderRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -160,7 +160,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Find purchase order by ID
      */
     async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        const requestOptions = await this.getOrderByIdRequestOpts(requestParameters);
+        const requestOptions = this.getOrderByIdRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
@@ -209,7 +209,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Place an order for a pet
      */
     async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        const requestOptions = await this.placeOrderRequestOpts(requestParameters);
+        const requestOptions = this.placeOrderRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/StoreApi.ts
@@ -42,7 +42,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for deleteOrder without sending the request
      */
-    async deleteOrderRequestOpts(requestParameters: DeleteOrderRequest): Promise<runtime.RequestOpts> {
+    deleteOrderRequestOpts(requestParameters: DeleteOrderRequest): runtime.RequestOpts {
         if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
@@ -131,7 +131,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for getOrderById without sending the request
      */
-    async getOrderByIdRequestOpts(requestParameters: GetOrderByIdRequest): Promise<runtime.RequestOpts> {
+    getOrderByIdRequestOpts(requestParameters: GetOrderByIdRequest): runtime.RequestOpts {
         if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
@@ -178,7 +178,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for placeOrder without sending the request
      */
-    async placeOrderRequestOpts(requestParameters: PlaceOrderRequest): Promise<runtime.RequestOpts> {
+    placeOrderRequestOpts(requestParameters: PlaceOrderRequest): runtime.RequestOpts {
         if (requestParameters['order'] == null) {
             throw new runtime.RequiredError(
                 'order',

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/UserApi.ts
@@ -60,7 +60,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUser without sending the request
      */
-    async createUserRequestOpts(requestParameters: CreateUserRequest): Promise<runtime.RequestOpts> {
+    createUserRequestOpts(requestParameters: CreateUserRequest): runtime.RequestOpts {
         if (requestParameters['user'] == null) {
             throw new runtime.RequiredError(
                 'user',
@@ -108,7 +108,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUsersWithArrayInput without sending the request
      */
-    async createUsersWithArrayInputRequestOpts(requestParameters: CreateUsersWithArrayInputRequest): Promise<runtime.RequestOpts> {
+    createUsersWithArrayInputRequestOpts(requestParameters: CreateUsersWithArrayInputRequest): runtime.RequestOpts {
         if (requestParameters['user'] == null) {
             throw new runtime.RequiredError(
                 'user',
@@ -156,7 +156,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUsersWithListInput without sending the request
      */
-    async createUsersWithListInputRequestOpts(requestParameters: CreateUsersWithListInputRequest): Promise<runtime.RequestOpts> {
+    createUsersWithListInputRequestOpts(requestParameters: CreateUsersWithListInputRequest): runtime.RequestOpts {
         if (requestParameters['user'] == null) {
             throw new runtime.RequiredError(
                 'user',
@@ -204,7 +204,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for deleteUser without sending the request
      */
-    async deleteUserRequestOpts(requestParameters: DeleteUserRequest): Promise<runtime.RequestOpts> {
+    deleteUserRequestOpts(requestParameters: DeleteUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -250,7 +250,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for getUserByName without sending the request
      */
-    async getUserByNameRequestOpts(requestParameters: GetUserByNameRequest): Promise<runtime.RequestOpts> {
+    getUserByNameRequestOpts(requestParameters: GetUserByNameRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -297,7 +297,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for loginUser without sending the request
      */
-    async loginUserRequestOpts(requestParameters: LoginUserRequest): Promise<runtime.RequestOpts> {
+    loginUserRequestOpts(requestParameters: LoginUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -362,7 +362,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for logoutUser without sending the request
      */
-    async logoutUserRequestOpts(): Promise<runtime.RequestOpts> {
+    logoutUserRequestOpts(): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -400,7 +400,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for updateUser without sending the request
      */
-    async updateUserRequestOpts(requestParameters: UpdateUserRequest): Promise<runtime.RequestOpts> {
+    updateUserRequestOpts(requestParameters: UpdateUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/UserApi.ts
@@ -91,7 +91,7 @@ export class UserApi extends runtime.BaseAPI {
      * Create user
      */
     async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUserRequestOpts(requestParameters);
+        const requestOptions = this.createUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -139,7 +139,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUsersWithArrayInputRequestOpts(requestParameters);
+        const requestOptions = this.createUsersWithArrayInputRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -187,7 +187,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUsersWithListInputRequestOpts(requestParameters);
+        const requestOptions = this.createUsersWithListInputRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -233,7 +233,7 @@ export class UserApi extends runtime.BaseAPI {
      * Delete user
      */
     async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.deleteUserRequestOpts(requestParameters);
+        const requestOptions = this.deleteUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -279,7 +279,7 @@ export class UserApi extends runtime.BaseAPI {
      * Get user by user name
      */
     async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<User>> {
-        const requestOptions = await this.getUserByNameRequestOpts(requestParameters);
+        const requestOptions = this.getUserByNameRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => UserFromJSON(jsonValue));
@@ -340,7 +340,7 @@ export class UserApi extends runtime.BaseAPI {
      * Logs user into the system
      */
     async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<string>> {
-        const requestOptions = await this.loginUserRequestOpts(requestParameters);
+        const requestOptions = this.loginUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         if (this.isJsonMime(response.headers.get('content-type'))) {
@@ -383,7 +383,7 @@ export class UserApi extends runtime.BaseAPI {
      * Logs out current logged in user session
      */
     async logoutUserRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.logoutUserRequestOpts();
+        const requestOptions = this.logoutUserRequestOpts();
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -439,7 +439,7 @@ export class UserApi extends runtime.BaseAPI {
      * Updated user
      */
     async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.updateUserRequestOpts(requestParameters);
+        const requestOptions = this.updateUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/apis/StoreApi.ts
@@ -71,7 +71,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Delete purchase order by ID
      */
     async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.deleteOrderRequestOpts(requestParameters);
+        const requestOptions = this.deleteOrderRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -160,7 +160,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Find purchase order by ID
      */
     async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        const requestOptions = await this.getOrderByIdRequestOpts(requestParameters);
+        const requestOptions = this.getOrderByIdRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
@@ -209,7 +209,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Place an order for a pet
      */
     async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        const requestOptions = await this.placeOrderRequestOpts(requestParameters);
+        const requestOptions = this.placeOrderRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/apis/StoreApi.ts
@@ -42,7 +42,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for deleteOrder without sending the request
      */
-    async deleteOrderRequestOpts(requestParameters: DeleteOrderRequest): Promise<runtime.RequestOpts> {
+    deleteOrderRequestOpts(requestParameters: DeleteOrderRequest): runtime.RequestOpts {
         if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
@@ -131,7 +131,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for getOrderById without sending the request
      */
-    async getOrderByIdRequestOpts(requestParameters: GetOrderByIdRequest): Promise<runtime.RequestOpts> {
+    getOrderByIdRequestOpts(requestParameters: GetOrderByIdRequest): runtime.RequestOpts {
         if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
@@ -178,7 +178,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for placeOrder without sending the request
      */
-    async placeOrderRequestOpts(requestParameters: PlaceOrderRequest): Promise<runtime.RequestOpts> {
+    placeOrderRequestOpts(requestParameters: PlaceOrderRequest): runtime.RequestOpts {
         if (requestParameters['order'] == null) {
             throw new runtime.RequiredError(
                 'order',

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/apis/UserApi.ts
@@ -266,7 +266,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for getUserByName without sending the request
      */
-    async getUserByNameRequestOpts(requestParameters: GetUserByNameRequest): Promise<runtime.RequestOpts> {
+    getUserByNameRequestOpts(requestParameters: GetUserByNameRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -313,7 +313,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for loginUser without sending the request
      */
-    async loginUserRequestOpts(requestParameters: LoginUserRequest): Promise<runtime.RequestOpts> {
+    loginUserRequestOpts(requestParameters: LoginUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/apis/UserApi.ts
@@ -295,7 +295,7 @@ export class UserApi extends runtime.BaseAPI {
      * Get user by user name
      */
     async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<User>> {
-        const requestOptions = await this.getUserByNameRequestOpts(requestParameters);
+        const requestOptions = this.getUserByNameRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => UserFromJSON(jsonValue));
@@ -356,7 +356,7 @@ export class UserApi extends runtime.BaseAPI {
      * Logs user into the system
      */
     async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<string>> {
-        const requestOptions = await this.loginUserRequestOpts(requestParameters);
+        const requestOptions = this.loginUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         if (this.isJsonMime(response.headers.get('content-type'))) {

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/StoreApi.ts
@@ -173,7 +173,7 @@ export class StoreApi extends runtime.BaseAPI implements StoreApiInterface {
      * Delete purchase order by ID
      */
     async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.deleteOrderRequestOpts(requestParameters);
+        const requestOptions = this.deleteOrderRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -262,7 +262,7 @@ export class StoreApi extends runtime.BaseAPI implements StoreApiInterface {
      * Find purchase order by ID
      */
     async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        const requestOptions = await this.getOrderByIdRequestOpts(requestParameters);
+        const requestOptions = this.getOrderByIdRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
@@ -310,7 +310,7 @@ export class StoreApi extends runtime.BaseAPI implements StoreApiInterface {
      * Place an order for a pet
      */
     async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        const requestOptions = await this.placeOrderRequestOpts(requestParameters);
+        const requestOptions = this.placeOrderRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/StoreApi.ts
@@ -47,7 +47,7 @@ export interface StoreApiInterface {
      * @throws {RequiredError}
      * @memberof StoreApiInterface
      */
-    deleteOrderRequestOpts(requestParameters: DeleteOrderRequest): Promise<runtime.RequestOpts>;
+    deleteOrderRequestOpts(requestParameters: DeleteOrderRequest): runtime.RequestOpts;
 
     /**
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
@@ -93,7 +93,7 @@ export interface StoreApiInterface {
      * @throws {RequiredError}
      * @memberof StoreApiInterface
      */
-    getOrderByIdRequestOpts(requestParameters: GetOrderByIdRequest): Promise<runtime.RequestOpts>;
+    getOrderByIdRequestOpts(requestParameters: GetOrderByIdRequest): runtime.RequestOpts;
 
     /**
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
@@ -117,7 +117,7 @@ export interface StoreApiInterface {
      * @throws {RequiredError}
      * @memberof StoreApiInterface
      */
-    placeOrderRequestOpts(requestParameters: PlaceOrderRequest): Promise<runtime.RequestOpts>;
+    placeOrderRequestOpts(requestParameters: PlaceOrderRequest): runtime.RequestOpts;
 
     /**
      * 
@@ -144,7 +144,7 @@ export class StoreApi extends runtime.BaseAPI implements StoreApiInterface {
     /**
      * Creates request options for deleteOrder without sending the request
      */
-    async deleteOrderRequestOpts(requestParameters: DeleteOrderRequest): Promise<runtime.RequestOpts> {
+    deleteOrderRequestOpts(requestParameters: DeleteOrderRequest): runtime.RequestOpts {
         if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
@@ -233,7 +233,7 @@ export class StoreApi extends runtime.BaseAPI implements StoreApiInterface {
     /**
      * Creates request options for getOrderById without sending the request
      */
-    async getOrderByIdRequestOpts(requestParameters: GetOrderByIdRequest): Promise<runtime.RequestOpts> {
+    getOrderByIdRequestOpts(requestParameters: GetOrderByIdRequest): runtime.RequestOpts {
         if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
@@ -280,7 +280,7 @@ export class StoreApi extends runtime.BaseAPI implements StoreApiInterface {
     /**
      * Creates request options for placeOrder without sending the request
      */
-    async placeOrderRequestOpts(requestParameters: PlaceOrderRequest): Promise<runtime.RequestOpts> {
+    placeOrderRequestOpts(requestParameters: PlaceOrderRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/UserApi.ts
@@ -65,7 +65,7 @@ export interface UserApiInterface {
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    createUserRequestOpts(requestParameters: CreateUserRequest): Promise<runtime.RequestOpts>;
+    createUserRequestOpts(requestParameters: CreateUserRequest): runtime.RequestOpts;
 
     /**
      * This can only be done by the logged in user.
@@ -89,7 +89,7 @@ export interface UserApiInterface {
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    createUsersWithArrayInputRequestOpts(requestParameters: CreateUsersWithArrayInputRequest): Promise<runtime.RequestOpts>;
+    createUsersWithArrayInputRequestOpts(requestParameters: CreateUsersWithArrayInputRequest): runtime.RequestOpts;
 
     /**
      * 
@@ -112,7 +112,7 @@ export interface UserApiInterface {
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    createUsersWithListInputRequestOpts(requestParameters: CreateUsersWithListInputRequest): Promise<runtime.RequestOpts>;
+    createUsersWithListInputRequestOpts(requestParameters: CreateUsersWithListInputRequest): runtime.RequestOpts;
 
     /**
      * 
@@ -135,7 +135,7 @@ export interface UserApiInterface {
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    deleteUserRequestOpts(requestParameters: DeleteUserRequest): Promise<runtime.RequestOpts>;
+    deleteUserRequestOpts(requestParameters: DeleteUserRequest): runtime.RequestOpts;
 
     /**
      * This can only be done by the logged in user.
@@ -159,7 +159,7 @@ export interface UserApiInterface {
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    getUserByNameRequestOpts(requestParameters: GetUserByNameRequest): Promise<runtime.RequestOpts>;
+    getUserByNameRequestOpts(requestParameters: GetUserByNameRequest): runtime.RequestOpts;
 
     /**
      * 
@@ -183,7 +183,7 @@ export interface UserApiInterface {
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    loginUserRequestOpts(requestParameters: LoginUserRequest): Promise<runtime.RequestOpts>;
+    loginUserRequestOpts(requestParameters: LoginUserRequest): runtime.RequestOpts;
 
     /**
      * 
@@ -206,7 +206,7 @@ export interface UserApiInterface {
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    logoutUserRequestOpts(): Promise<runtime.RequestOpts>;
+    logoutUserRequestOpts(): runtime.RequestOpts;
 
     /**
      * 
@@ -229,7 +229,7 @@ export interface UserApiInterface {
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    updateUserRequestOpts(requestParameters: UpdateUserRequest): Promise<runtime.RequestOpts>;
+    updateUserRequestOpts(requestParameters: UpdateUserRequest): runtime.RequestOpts;
 
     /**
      * This can only be done by the logged in user.
@@ -258,7 +258,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
     /**
      * Creates request options for createUser without sending the request
      */
-    async createUserRequestOpts(requestParameters: CreateUserRequest): Promise<runtime.RequestOpts> {
+    createUserRequestOpts(requestParameters: CreateUserRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -306,7 +306,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
     /**
      * Creates request options for createUsersWithArrayInput without sending the request
      */
-    async createUsersWithArrayInputRequestOpts(requestParameters: CreateUsersWithArrayInputRequest): Promise<runtime.RequestOpts> {
+    createUsersWithArrayInputRequestOpts(requestParameters: CreateUsersWithArrayInputRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -352,7 +352,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
     /**
      * Creates request options for createUsersWithListInput without sending the request
      */
-    async createUsersWithListInputRequestOpts(requestParameters: CreateUsersWithListInputRequest): Promise<runtime.RequestOpts> {
+    createUsersWithListInputRequestOpts(requestParameters: CreateUsersWithListInputRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -398,7 +398,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
     /**
      * Creates request options for deleteUser without sending the request
      */
-    async deleteUserRequestOpts(requestParameters: DeleteUserRequest): Promise<runtime.RequestOpts> {
+    deleteUserRequestOpts(requestParameters: DeleteUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -444,7 +444,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
     /**
      * Creates request options for getUserByName without sending the request
      */
-    async getUserByNameRequestOpts(requestParameters: GetUserByNameRequest): Promise<runtime.RequestOpts> {
+    getUserByNameRequestOpts(requestParameters: GetUserByNameRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -489,7 +489,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
     /**
      * Creates request options for loginUser without sending the request
      */
-    async loginUserRequestOpts(requestParameters: LoginUserRequest): Promise<runtime.RequestOpts> {
+    loginUserRequestOpts(requestParameters: LoginUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -552,7 +552,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
     /**
      * Creates request options for logoutUser without sending the request
      */
-    async logoutUserRequestOpts(): Promise<runtime.RequestOpts> {
+    logoutUserRequestOpts(): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -588,7 +588,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
     /**
      * Creates request options for updateUser without sending the request
      */
-    async updateUserRequestOpts(requestParameters: UpdateUserRequest): Promise<runtime.RequestOpts> {
+    updateUserRequestOpts(requestParameters: UpdateUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/UserApi.ts
@@ -289,7 +289,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
      * Create user
      */
     async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUserRequestOpts(requestParameters);
+        const requestOptions = this.createUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -336,7 +336,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
      * Creates list of users with given input array
      */
     async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUsersWithArrayInputRequestOpts(requestParameters);
+        const requestOptions = this.createUsersWithArrayInputRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -382,7 +382,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
      * Creates list of users with given input array
      */
     async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUsersWithListInputRequestOpts(requestParameters);
+        const requestOptions = this.createUsersWithListInputRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -427,7 +427,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
      * Delete user
      */
     async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.deleteUserRequestOpts(requestParameters);
+        const requestOptions = this.deleteUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -472,7 +472,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
      * Get user by user name
      */
     async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<User>> {
-        const requestOptions = await this.getUserByNameRequestOpts(requestParameters);
+        const requestOptions = this.getUserByNameRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => UserFromJSON(jsonValue));
@@ -531,7 +531,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
      * Logs user into the system
      */
     async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<string>> {
-        const requestOptions = await this.loginUserRequestOpts(requestParameters);
+        const requestOptions = this.loginUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         if (this.isJsonMime(response.headers.get('content-type'))) {
@@ -572,7 +572,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
      * Logs out current logged in user session
      */
     async logoutUserRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.logoutUserRequestOpts();
+        const requestOptions = this.logoutUserRequestOpts();
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -627,7 +627,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
      * Updated user
      */
     async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.updateUserRequestOpts(requestParameters);
+        const requestOptions = this.updateUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/StoreApi.ts
@@ -71,7 +71,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Delete purchase order by ID
      */
     async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.deleteOrderRequestOpts(requestParameters);
+        const requestOptions = this.deleteOrderRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -160,7 +160,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Find purchase order by ID
      */
     async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        const requestOptions = await this.getOrderByIdRequestOpts(requestParameters);
+        const requestOptions = this.getOrderByIdRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
@@ -208,7 +208,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Place an order for a pet
      */
     async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        const requestOptions = await this.placeOrderRequestOpts(requestParameters);
+        const requestOptions = this.placeOrderRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/StoreApi.ts
@@ -42,7 +42,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for deleteOrder without sending the request
      */
-    async deleteOrderRequestOpts(requestParameters: DeleteOrderRequest): Promise<runtime.RequestOpts> {
+    deleteOrderRequestOpts(requestParameters: DeleteOrderRequest): runtime.RequestOpts {
         if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
@@ -131,7 +131,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for getOrderById without sending the request
      */
-    async getOrderByIdRequestOpts(requestParameters: GetOrderByIdRequest): Promise<runtime.RequestOpts> {
+    getOrderByIdRequestOpts(requestParameters: GetOrderByIdRequest): runtime.RequestOpts {
         if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
@@ -178,7 +178,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for placeOrder without sending the request
      */
-    async placeOrderRequestOpts(requestParameters: PlaceOrderRequest): Promise<runtime.RequestOpts> {
+    placeOrderRequestOpts(requestParameters: PlaceOrderRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/UserApi.ts
@@ -60,7 +60,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUser without sending the request
      */
-    async createUserRequestOpts(requestParameters: CreateUserRequest): Promise<runtime.RequestOpts> {
+    createUserRequestOpts(requestParameters: CreateUserRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -108,7 +108,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUsersWithArrayInput without sending the request
      */
-    async createUsersWithArrayInputRequestOpts(requestParameters: CreateUsersWithArrayInputRequest): Promise<runtime.RequestOpts> {
+    createUsersWithArrayInputRequestOpts(requestParameters: CreateUsersWithArrayInputRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -154,7 +154,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUsersWithListInput without sending the request
      */
-    async createUsersWithListInputRequestOpts(requestParameters: CreateUsersWithListInputRequest): Promise<runtime.RequestOpts> {
+    createUsersWithListInputRequestOpts(requestParameters: CreateUsersWithListInputRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -200,7 +200,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for deleteUser without sending the request
      */
-    async deleteUserRequestOpts(requestParameters: DeleteUserRequest): Promise<runtime.RequestOpts> {
+    deleteUserRequestOpts(requestParameters: DeleteUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -246,7 +246,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for getUserByName without sending the request
      */
-    async getUserByNameRequestOpts(requestParameters: GetUserByNameRequest): Promise<runtime.RequestOpts> {
+    getUserByNameRequestOpts(requestParameters: GetUserByNameRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -291,7 +291,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for loginUser without sending the request
      */
-    async loginUserRequestOpts(requestParameters: LoginUserRequest): Promise<runtime.RequestOpts> {
+    loginUserRequestOpts(requestParameters: LoginUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -354,7 +354,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for logoutUser without sending the request
      */
-    async logoutUserRequestOpts(): Promise<runtime.RequestOpts> {
+    logoutUserRequestOpts(): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -390,7 +390,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for updateUser without sending the request
      */
-    async updateUserRequestOpts(requestParameters: UpdateUserRequest): Promise<runtime.RequestOpts> {
+    updateUserRequestOpts(requestParameters: UpdateUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/UserApi.ts
@@ -91,7 +91,7 @@ export class UserApi extends runtime.BaseAPI {
      * Create user
      */
     async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUserRequestOpts(requestParameters);
+        const requestOptions = this.createUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -138,7 +138,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUsersWithArrayInputRequestOpts(requestParameters);
+        const requestOptions = this.createUsersWithArrayInputRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -184,7 +184,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUsersWithListInputRequestOpts(requestParameters);
+        const requestOptions = this.createUsersWithListInputRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -229,7 +229,7 @@ export class UserApi extends runtime.BaseAPI {
      * Delete user
      */
     async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.deleteUserRequestOpts(requestParameters);
+        const requestOptions = this.deleteUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -274,7 +274,7 @@ export class UserApi extends runtime.BaseAPI {
      * Get user by user name
      */
     async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<User>> {
-        const requestOptions = await this.getUserByNameRequestOpts(requestParameters);
+        const requestOptions = this.getUserByNameRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => UserFromJSON(jsonValue));
@@ -333,7 +333,7 @@ export class UserApi extends runtime.BaseAPI {
      * Logs user into the system
      */
     async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<string>> {
-        const requestOptions = await this.loginUserRequestOpts(requestParameters);
+        const requestOptions = this.loginUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         if (this.isJsonMime(response.headers.get('content-type'))) {
@@ -374,7 +374,7 @@ export class UserApi extends runtime.BaseAPI {
      * Logs out current logged in user session
      */
     async logoutUserRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.logoutUserRequestOpts();
+        const requestOptions = this.logoutUserRequestOpts();
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -429,7 +429,7 @@ export class UserApi extends runtime.BaseAPI {
      * Updated user
      */
     async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.updateUserRequestOpts(requestParameters);
+        const requestOptions = this.updateUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/apis/DefaultApi.ts
@@ -96,7 +96,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      */
     async fakeEnumRequestGetInlineRaw(requestParameters: FakeEnumRequestGetInlineRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FakeEnumRequestGetInline200Response>> {
-        const requestOptions = await this.fakeEnumRequestGetInlineRequestOpts(requestParameters);
+        const requestOptions = this.fakeEnumRequestGetInlineRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => FakeEnumRequestGetInline200ResponseFromJSON(jsonValue));
@@ -147,7 +147,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      */
     async fakeEnumRequestGetRefRaw(requestParameters: FakeEnumRequestGetRefRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<EnumPatternObject>> {
-        const requestOptions = await this.fakeEnumRequestGetRefRequestOpts(requestParameters);
+        const requestOptions = this.fakeEnumRequestGetRefRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => EnumPatternObjectFromJSON(jsonValue));
@@ -185,7 +185,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      */
     async fakeEnumRequestPostInlineRaw(requestParameters: FakeEnumRequestPostInlineRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FakeEnumRequestGetInline200Response>> {
-        const requestOptions = await this.fakeEnumRequestPostInlineRequestOpts(requestParameters);
+        const requestOptions = this.fakeEnumRequestPostInlineRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => FakeEnumRequestGetInline200ResponseFromJSON(jsonValue));
@@ -223,7 +223,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      */
     async fakeEnumRequestPostRefRaw(requestParameters: FakeEnumRequestPostRefRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<EnumPatternObject>> {
-        const requestOptions = await this.fakeEnumRequestPostRefRequestOpts(requestParameters);
+        const requestOptions = this.fakeEnumRequestPostRefRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => EnumPatternObjectFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/apis/DefaultApi.ts
@@ -61,7 +61,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Creates request options for fakeEnumRequestGetInline without sending the request
      */
-    async fakeEnumRequestGetInlineRequestOpts(requestParameters: FakeEnumRequestGetInlineRequest): Promise<runtime.RequestOpts> {
+    fakeEnumRequestGetInlineRequestOpts(requestParameters: FakeEnumRequestGetInlineRequest): runtime.RequestOpts {
         const queryParameters: any = {};
 
         if (requestParameters['stringEnum'] != null) {
@@ -112,7 +112,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Creates request options for fakeEnumRequestGetRef without sending the request
      */
-    async fakeEnumRequestGetRefRequestOpts(requestParameters: FakeEnumRequestGetRefRequest): Promise<runtime.RequestOpts> {
+    fakeEnumRequestGetRefRequestOpts(requestParameters: FakeEnumRequestGetRefRequest): runtime.RequestOpts {
         const queryParameters: any = {};
 
         if (requestParameters['stringEnum'] != null) {
@@ -163,7 +163,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Creates request options for fakeEnumRequestPostInline without sending the request
      */
-    async fakeEnumRequestPostInlineRequestOpts(requestParameters: FakeEnumRequestPostInlineRequest): Promise<runtime.RequestOpts> {
+    fakeEnumRequestPostInlineRequestOpts(requestParameters: FakeEnumRequestPostInlineRequest): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -201,7 +201,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Creates request options for fakeEnumRequestPostRef without sending the request
      */
-    async fakeEnumRequestPostRefRequestOpts(requestParameters: FakeEnumRequestPostRefRequest): Promise<runtime.RequestOpts> {
+    fakeEnumRequestPostRefRequestOpts(requestParameters: FakeEnumRequestPostRefRequest): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/StoreApi.ts
@@ -67,7 +67,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Delete purchase order by ID
      */
     async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.deleteOrderRequestOpts(requestParameters);
+        const requestOptions = this.deleteOrderRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -156,7 +156,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Find purchase order by ID
      */
     async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        const requestOptions = await this.getOrderByIdRequestOpts(requestParameters);
+        const requestOptions = this.getOrderByIdRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response);
@@ -204,7 +204,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Place an order for a pet
      */
     async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        const requestOptions = await this.placeOrderRequestOpts(requestParameters);
+        const requestOptions = this.placeOrderRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response);

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/StoreApi.ts
@@ -38,7 +38,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for deleteOrder without sending the request
      */
-    async deleteOrderRequestOpts(requestParameters: DeleteOrderRequest): Promise<runtime.RequestOpts> {
+    deleteOrderRequestOpts(requestParameters: DeleteOrderRequest): runtime.RequestOpts {
         if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
@@ -127,7 +127,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for getOrderById without sending the request
      */
-    async getOrderByIdRequestOpts(requestParameters: GetOrderByIdRequest): Promise<runtime.RequestOpts> {
+    getOrderByIdRequestOpts(requestParameters: GetOrderByIdRequest): runtime.RequestOpts {
         if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
@@ -174,7 +174,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Creates request options for placeOrder without sending the request
      */
-    async placeOrderRequestOpts(requestParameters: PlaceOrderRequest): Promise<runtime.RequestOpts> {
+    placeOrderRequestOpts(requestParameters: PlaceOrderRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/UserApi.ts
@@ -56,7 +56,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUser without sending the request
      */
-    async createUserRequestOpts(requestParameters: CreateUserRequest): Promise<runtime.RequestOpts> {
+    createUserRequestOpts(requestParameters: CreateUserRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -104,7 +104,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUsersWithArrayInput without sending the request
      */
-    async createUsersWithArrayInputRequestOpts(requestParameters: CreateUsersWithArrayInputRequest): Promise<runtime.RequestOpts> {
+    createUsersWithArrayInputRequestOpts(requestParameters: CreateUsersWithArrayInputRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -150,7 +150,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for createUsersWithListInput without sending the request
      */
-    async createUsersWithListInputRequestOpts(requestParameters: CreateUsersWithListInputRequest): Promise<runtime.RequestOpts> {
+    createUsersWithListInputRequestOpts(requestParameters: CreateUsersWithListInputRequest): runtime.RequestOpts {
         if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
@@ -196,7 +196,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for deleteUser without sending the request
      */
-    async deleteUserRequestOpts(requestParameters: DeleteUserRequest): Promise<runtime.RequestOpts> {
+    deleteUserRequestOpts(requestParameters: DeleteUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -242,7 +242,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for getUserByName without sending the request
      */
-    async getUserByNameRequestOpts(requestParameters: GetUserByNameRequest): Promise<runtime.RequestOpts> {
+    getUserByNameRequestOpts(requestParameters: GetUserByNameRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -287,7 +287,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for loginUser without sending the request
      */
-    async loginUserRequestOpts(requestParameters: LoginUserRequest): Promise<runtime.RequestOpts> {
+    loginUserRequestOpts(requestParameters: LoginUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
@@ -350,7 +350,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for logoutUser without sending the request
      */
-    async logoutUserRequestOpts(): Promise<runtime.RequestOpts> {
+    logoutUserRequestOpts(): runtime.RequestOpts {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -386,7 +386,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates request options for updateUser without sending the request
      */
-    async updateUserRequestOpts(requestParameters: UpdateUserRequest): Promise<runtime.RequestOpts> {
+    updateUserRequestOpts(requestParameters: UpdateUserRequest): runtime.RequestOpts {
         if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/UserApi.ts
@@ -87,7 +87,7 @@ export class UserApi extends runtime.BaseAPI {
      * Create user
      */
     async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUserRequestOpts(requestParameters);
+        const requestOptions = this.createUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -134,7 +134,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUsersWithArrayInputRequestOpts(requestParameters);
+        const requestOptions = this.createUsersWithArrayInputRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -180,7 +180,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.createUsersWithListInputRequestOpts(requestParameters);
+        const requestOptions = this.createUsersWithListInputRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -225,7 +225,7 @@ export class UserApi extends runtime.BaseAPI {
      * Delete user
      */
     async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.deleteUserRequestOpts(requestParameters);
+        const requestOptions = this.deleteUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -270,7 +270,7 @@ export class UserApi extends runtime.BaseAPI {
      * Get user by user name
      */
     async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<User>> {
-        const requestOptions = await this.getUserByNameRequestOpts(requestParameters);
+        const requestOptions = this.getUserByNameRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response);
@@ -329,7 +329,7 @@ export class UserApi extends runtime.BaseAPI {
      * Logs user into the system
      */
     async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<string>> {
-        const requestOptions = await this.loginUserRequestOpts(requestParameters);
+        const requestOptions = this.loginUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         if (this.isJsonMime(response.headers.get('content-type'))) {
@@ -370,7 +370,7 @@ export class UserApi extends runtime.BaseAPI {
      * Logs out current logged in user session
      */
     async logoutUserRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.logoutUserRequestOpts();
+        const requestOptions = this.logoutUserRequestOpts();
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);
@@ -425,7 +425,7 @@ export class UserApi extends runtime.BaseAPI {
      * Updated user
      */
     async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        const requestOptions = await this.updateUserRequestOpts(requestParameters);
+        const requestOptions = this.updateUserRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.VoidApiResponse(response);


### PR DESCRIPTION
## Problem

The `typescript-fetch` generator unconditionally marks all `RequestOpts` functions as `async` and returns `Promise<runtime.RequestOpts>`, even when the endpoint has no authentication methods and the function body is entirely synchronous.

**Generated (current):**
```typescript
// StoreApi -- no auth configured on these endpoints
async deleteOrderRequestOpts(requestParameters: DeleteOrderRequest): Promise<runtime.RequestOpts> {
    // ... purely synchronous body: parameter validation, URL building, header assembly
    return {
        path: urlPath,
        method: 'DELETE',
        headers: headerParameters,
        query: queryParameters,
    };
}
```

The function body only contains `await` expressions inside `{{#authMethods}}` template blocks (bearer tokens, API keys, OAuth). When no auth is configured, there is nothing to await, yet the function is still async and wraps the return value in an unnecessary Promise.

## Solution

Conditionally emit `async` and `Promise<>` on the `RequestOpts` function signature based on `{{#hasAuthMethods}}`:

- **With auth methods**: `async listPrivateItemsRequestOpts(): Promise<runtime.RequestOpts>`
- **Without auth methods**: `listPublicItemsRequestOpts(): runtime.RequestOpts`

This applies to both the interface declaration and the implementation in `apis.mustache`.

**Generated (fixed):**
```typescript
// StoreApi -- no auth: synchronous signature
deleteOrderRequestOpts(requestParameters: DeleteOrderRequest): runtime.RequestOpts {
    return {
        path: urlPath,
        method: 'DELETE',
        headers: headerParameters,
        query: queryParameters,
    };
}

// PetApi -- has OAuth: async signature preserved
async addPetRequestOpts(requestParameters: AddPetRequest): Promise<runtime.RequestOpts> {
    // ... contains: headerParameters["Authorization"] = await this.configuration.accessToken(...)
    return { ... };
}
```

The calling `Raw` method already uses `await this.{{nickname}}RequestOpts(...)`, which works correctly with both sync (returns value directly) and async (awaits the Promise) return types.

## Test plan

- [x] Added `testRequestOptsIsAsyncOnlyWithAuthMethods` test with a new spec (`api-with-and-without-auth.yaml`) that has one endpoint without auth and one with API key auth
- [x] Regenerated all typescript-fetch samples
- [x] All 23 TypeScriptFetchClientCodegenTest tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `typescript-fetch` generator emit synchronous `*RequestOpts` for operations without auth, and keep them `async` only when auth methods are present. `Raw` methods now skip `await` when the corresponding `*RequestOpts` is synchronous, removing unnecessary Promises and awaits.

- **Bug Fixes**
  - Conditionally emit `async`/`Promise` for `*RequestOpts` based on `hasAuthMethods` in `apis.mustache` (interface + class).
  - Conditionally use `await` at `Raw` call sites only when `*RequestOpts` is async.
  - Added test for mixed-auth operations and regenerated samples.

- **Migration**
  - If you call `*RequestOpts` directly, remove `await` for endpoints without auth. Callers of `Raw` methods do not need changes.

<sup>Written for commit 8a37c9cfd192eecf8af0d2f7e5fff5eef35ad91f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

