### PR TITLE
[Java][Spring] Insert Annotations to be `TYPE_USE` Compatible

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -28,6 +28,7 @@ import io.swagger.v3.parser.core.models.ParseOptions;
 import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.MapAssert;
+import org.junit.jupiter.api.DisplayName;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.config.CodegenConfigurator;
 import org.openapitools.codegen.config.GlobalSettings;
@@ -6637,4 +6638,33 @@ public class SpringCodegenTest {
         JavaFileAssert.assertThat(Paths.get(outputPath + "/src/main/java/org/openapitools/api/PetApi.java"))
                 .assertMethod("addPet").assertParameter("pet").assertParameterAnnotations().doesNotContainWithName("Parameter");
     }
+
+  @Test
+  @DisplayName("Testing Issue #23206: Support JSpecify with SchemaMappings")
+  public void testIssue23206() throws IOException {
+    final SpringCodegen codegen = new SpringCodegen();
+
+    codegen.setLibrary("spring-boot");
+
+    codegen.importMapping().put("org.springframework.lang.Nullable", "org.jspecify.annotations.Nullable");
+    codegen.schemaMapping().put("PersonCountValue", "a.b.c.PersonCountValue");
+
+    codegen.additionalProperties().put(OPENAPI_NULLABLE, "false");
+    codegen.additionalProperties().put(SKIP_DEFAULT_INTERFACE, "true");
+    codegen.additionalProperties().put(USE_SPRING_BOOT4, "true");
+    codegen.additionalProperties().put(USE_JACKSON_3, "true");
+    codegen.additionalProperties().put(USE_TAGS, "true");
+    codegen.additionalProperties().put(USE_BEANVALIDATION, "false");
+
+    final Map<String, File> files = generateFiles(codegen, "src/test/resources/3_0/spring/issue_23206.yaml");
+    final var javaFileAssert = JavaFileAssert.assertThat(files.get("MyDto.java"));
+
+    javaFileAssert
+        .hasImports("org.jspecify.annotations.Nullable")
+        .assertProperty("men");
+
+    // Should Fail without any changes to the mustache templates!
+    javaFileAssert.fileContains("private a.b.c.@Nullable PersonCountValue men;"); // Actual: private @Nullable a.b.c.PersonCountValue men;
+    javaFileAssert.fileContains("private a.b.c.@Nullable PersonCountValue women;"); // Actual: private @Nullable a.b.c.PersonCountValue women;
+  }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/spring/issue_23206.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/spring/issue_23206.yaml
@@ -1,0 +1,28 @@
+openapi: "3.0.3"
+info:
+  title: Move Annotations in Generated POJOs
+  description: "Test Placement of Annotations, to allow TYPE_USE Annotations to compile correctly. See #23206"
+  version: 1.0.0
+
+paths:
+  /some/endpoint:
+    get:
+      responses:
+        "200":
+          description: OK
+
+components:
+  schemas:
+    MyDto:
+      type: object
+      properties:
+        men:
+          nullable: true
+          $ref: '#/components/schemas/PersonCountValue'
+        women:
+          nullable: true
+          $ref: '#/components/schemas/PersonCountValue'
+    PersonCountValue:
+      type: number
+      format: personCountValue
+      example: 1234


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
WIP WIP WIP
Relates to #23206 .

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a test and sample to ensure Java Spring POJOs use TYPE_USE nullability annotations for schema-mapped types, enabling JSpecify compatibility. The test asserts `a.b.c.@Nullable PersonCountValue` (via `importMapping` to `org.jspecify.annotations.Nullable`) instead of `@Nullable a.b.c.PersonCountValue` (relates to #23206).

<sup>Written for commit e05e4a12b9d3dad4dfe860db9bf1a0b7692ff472. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

