### PR TITLE
Fix: Gradle plugin tests failing with Java 23

### DIFF
--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskConfigurationCacheTest.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskConfigurationCacheTest.kt
@@ -20,7 +20,7 @@ class GenerateTaskConfigurationCacheTest : TestBase() {
     }
 
     @DataProvider(name = "gradle_version_provider")
-    private fun gradleVersionProviderWithConfigurationCache(): Array<Array<String>> = arrayOf(arrayOf("8.14.4"), arrayOf("8.5"))
+    private fun gradleVersionProviderWithConfigurationCache(): Array<Array<String>> = arrayOf(arrayOf("8.14.4"), arrayOf("8.10"))
 
     @DataProvider(name = "gradle_version_provider_without_cc")
     private fun gradleVersionProviderWithoutConfigurationCache(): Array<Array<String>> = arrayOf(arrayOf("5.6.1"))

--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskFromCacheTest.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskFromCacheTest.kt
@@ -22,7 +22,7 @@ class GenerateTaskFromCacheTest : TestBase() {
     }
 
     @DataProvider(name = "gradle_version_provider")
-    private fun gradleVersionProvider(): Array<Array<String>> = arrayOf(arrayOf("8.14.4"), arrayOf("8.5"))
+    private fun gradleVersionProvider(): Array<Array<String>> = arrayOf(arrayOf("8.14.4"), arrayOf("8.10"))
 
     // inputSpec tests
 

--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskUpToDateTest.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskUpToDateTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertEquals
 class GenerateTaskUpToDateTest : TestBase() {
 
     @DataProvider(name = "gradle_version_provider")
-    private fun gradleVersionProvider(): Array<Array<String>> = arrayOf(arrayOf("8.14.4"), arrayOf("8.5"))
+    private fun gradleVersionProvider(): Array<Array<String>> = arrayOf(arrayOf("8.14.4"), arrayOf("8.10"))
 
     // inputSpec tests
 

--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/ValidateTaskDslTest.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/ValidateTaskDslTest.kt
@@ -17,7 +17,7 @@ class ValidateTaskDslTest : TestBase() {
     @DataProvider(name = "gradle_version_provider")
     fun gradleVersionProvider(): Array<Array<String?>> = arrayOf(
         arrayOf(null), // uses the version of Gradle used to build the plugin itself
-        arrayOf("8.5")
+        arrayOf("8.10")
     )
 
     private fun getGradleRunner(gradleVersion: String?): GradleRunner {


### PR DESCRIPTION
Fix Gradle plugin tests failing with Java 23

While building the project, the module `openapi-generator-gradle-plugin`
failed with 26 test failures when running tests parameterized with
Gradle 8.5.

Error observed:
BUG! exception in phase 'semantic analysis' in source unit '_BuildScript_'
Unsupported class file major version 67

Root cause:
The tests were executed on Java 23. Gradle 8.5 does not support
running on Java 23, which causes Groovy compilation failures.
According to the Gradle compatibility matrix, Java 23 support
starts with Gradle 8.10.

Solution:
Update the Gradle version used in the test parameter providers
from 8.5 to 8.10 in the following files:

- GenerateTaskUpToDateTest.kt
- GenerateTaskFromCacheTest.kt
- GenerateTaskConfigurationCacheTest.kt
- ValidateTaskDslTest.kt

After the change all tests pass successfully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Gradle versions used in `openapi-generator-gradle-plugin` tests to 8.10 to fix failures on Java 23. Prevents Groovy compile errors seen with Gradle 8.5.

- **Bug Fixes**
  - Switched test DataProviders from 8.5 to 8.10 in GenerateTaskUpToDateTest.kt, GenerateTaskFromCacheTest.kt, GenerateTaskConfigurationCacheTest.kt, and ValidateTaskDslTest.kt.
  - All tests now pass on Java 23.

<sup>Written for commit 1d7a995824ec85d2868b3dd3087b593004267ce5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

