### PR TITLE
[php-symfony] use baseName for query param lookup in generated controllers

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/api_controller.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/api_controller.mustache
@@ -114,7 +114,7 @@ class {{controllerName}} extends Controller
 
         // Read out all input parameter values into variables
         {{#queryParams}}
-        ${{paramName}} = $request->query->get('{{paramName}}'{{#defaultValue}}, {{{.}}}{{/defaultValue}});
+        ${{paramName}} = $request->query->get('{{baseName}}'{{#defaultValue}}, {{{.}}}{{/defaultValue}});
         {{/queryParams}}
         {{#headerParams}}
         ${{paramName}} = $request->headers->get('{{baseName}}'{{#defaultValue}}, {{{.}}}{{/defaultValue}});


### PR DESCRIPTION

What does this PR change?

This PR fixes PHP Symfony server/controller code generation for query parameters: the generated controller currently reads query parameters using {{paramName}} (language-specific variable name), but it must use {{baseName}} (the actual OpenAPI parameter name). This leads to incorrect behavior whenever paramName and baseName differ (e.g., dateFrom vs date_from), causing query parameters to be ignored at runtime.
Patch:
Diff
- ${{paramName}} = $request->query->get('{{paramName}}'{{#defaultValue}}, {{{.}}}{{/defaultValue}});
+ ${{paramName}} = $request->query->get('{{baseName}}'{{#defaultValue}}, {{{.}}}{{/defaultValue}});

Why is this needed?

OpenAPI defines the external contract parameter name (e.g., date_from in the query string). paramName is only an internal code identifier. Using paramName to access $request->query->get() breaks request parsing for snake_case query params and other naming transformations. The PHP generator is expected to conform to the OpenAPI contract. 

Actual output vs expected output

Actual (broken):
$dateFrom = $request->query->get('dateFrom');

Expected (correct):
$dateFrom = $request->query->get('date_from');

Tests

Regenerated samples and verified the change in the generated controller code.
Added/updated unit tests (if applicable) to ensure query lookup uses baseName and not paramName.

Fixes
fixes #23217
Technical committee mention
@OpenAPITools/openapi-generator-technical-committee

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 

- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PHP Symfony controller codegen to read query params by `baseName` (OpenAPI name) instead of `paramName`, so generated controllers correctly parse requests (e.g., `date_from` -> `$request->query->get('date_from')`).

- **Bug Fixes**
  - In `api_controller.mustache`, use `$request->query->get('{{baseName}}', ...)` instead of `'{{paramName}}'`.
  - Prevents missing query params when names are transformed (snake_case vs camelCase); samples regenerated and tests updated.
  - Fixes #23217.

<sup>Written for commit 7404298206d18f1e253e63a6b918970dd37f77b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

