### PR TITLE
fix(java): preserve user templateDir for feign-hc5 library

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -850,7 +850,13 @@ public class JavaClientCodegen extends AbstractJavaCodegen
             additionalProperties.put("feign-okhttp", "true");
         } else if (isLibrary(FEIGN_HC5)) {
             additionalProperties.put("feign-hc5", "true");
-            setTemplateDir(FEIGN);
+            // Only fall back to the built-in "feign" template directory when the user has not
+            // provided a custom template directory.  super.processOpts() already wrote any
+            // user-supplied templateDir back into additionalProperties, so checking for the
+            // key's presence reliably distinguishes "user provided" from "not provided".
+            if (!additionalProperties.containsKey(CodegenConstants.TEMPLATE_DIR)) {
+                setTemplateDir(FEIGN);
+            }
             setLibrary(FEIGN);
         }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -4180,4 +4180,35 @@ public class JavaClientCodegenTest {
                 .fileContains("public FruitType getFruitType()");
     }
 
+    /**
+     * Regression: without a user-provided template dir, feign-hc5 should still resolve
+     * built-in templates from the "feign" folder (same behaviour as before the fix).
+     */
+    @Test
+    public void testFeignHc5TemplateDirDefaultsToFeign() {
+        final JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.setLibrary(FEIGN_HC5);
+        codegen.processOpts();
+
+        assertEquals(codegen.templateDir(), FEIGN,
+                "feign-hc5 without a custom templateDir should use the 'feign' built-in template directory");
+    }
+
+    /**
+     * Bug fix: a user-provided templateDir must not be overwritten when library=feign-hc5.
+     * Previously setTemplateDir(FEIGN) was called unconditionally and silently replaced the
+     * user's path.
+     */
+    @Test
+    public void testFeignHc5CustomTemplateDirIsPreserved() {
+        final String customTemplateDir = "/custom/templates";
+        final JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.setLibrary(FEIGN_HC5);
+        codegen.additionalProperties().put(CodegenConstants.TEMPLATE_DIR, customTemplateDir);
+        codegen.processOpts();
+
+        assertEquals(codegen.templateDir(), customTemplateDir,
+                "feign-hc5 must preserve a user-provided templateDir and not overwrite it with 'feign'");
+    }
+
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
---
fixes #23139
@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @martin-mfg
Can one of you take a look pls?

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the user’s `templateDir` for Java `feign-hc5` clients; only fall back to built-in `feign` templates when no custom dir is set. Fixes #23139.

- **Bug Fixes**
  - Guarded `setTemplateDir(FEIGN)` in `JavaClientCodegen.processOpts` with a `CodegenConstants.TEMPLATE_DIR` check.
  - Added tests to confirm defaulting to `feign` and preserving a custom `templateDir`.

<sup>Written for commit efc4b45ae156356c46b0fa33654a7a282025efe0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

