### PR TITLE
fix(typescript-axios): add useErasableSyntax support for erasableSyntaxOnly compatibility

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
@@ -53,10 +53,13 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
     public static final String AXIOS_VERSION = "axiosVersion";
     public static final String DEFAULT_AXIOS_VERSION = "^1.13.5";
     public static final String WITH_AWSV4_SIGNATURE = "withAWSV4Signature";
+    public static final String USE_ERASABLE_SYNTAX = "useErasableSyntax";
+    public static final String USE_ERASABLE_SYNTAX_DESC = "Use erasable syntax for the generated code, compatible with TypeScript's erasableSyntaxOnly option.";
 
     @Getter @Setter
     protected String npmRepository = null;
     protected Boolean stringEnums = false;
+    protected Boolean useErasableSyntax = false;
     protected String importFileExtension = "";
 
     @Getter @Setter
@@ -97,6 +100,7 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
         this.cliOptions.add(new CliOption(USE_SQUARE_BRACKETS_IN_ARRAY_NAMES, "Setting this property to true will add brackets to array attribute names, e.g. my_values[].", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
         this.cliOptions.add(new CliOption(AXIOS_VERSION, "Use this property to override the axios version in package.json").defaultValue(DEFAULT_AXIOS_VERSION));
         this.cliOptions.add(new CliOption(WITH_AWSV4_SIGNATURE, "whether to include AWS v4 signature support", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
+        this.cliOptions.add(new CliOption(USE_ERASABLE_SYNTAX, USE_ERASABLE_SYNTAX_DESC, SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
         // Templates have no mapping between formatted property names and original base names so use only "original" and remove this option
         removeOption(CodegenConstants.MODEL_PROPERTY_NAMING);
     }
@@ -175,6 +179,11 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
                 this.importFileExtension = "." + this.importFileExtension;
             }
             additionalProperties.put("importFileExtension", this.importFileExtension);
+        }
+
+        if (additionalProperties.containsKey(USE_ERASABLE_SYNTAX)) {
+            this.useErasableSyntax = Boolean.parseBoolean(additionalProperties.get(USE_ERASABLE_SYNTAX).toString());
+            additionalProperties.put(USE_ERASABLE_SYNTAX, this.useErasableSyntax);
         }
 
         if (additionalProperties.containsKey(NPM_NAME)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
@@ -41,7 +41,7 @@ import java.util.TreeSet;
 
 public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodegen {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(TypeScriptAxiosClientCodegen.class);
+    private final Logger LOGGER = LoggerFactory.getLogger(TypeScriptAxiosClientCodegen.class);
 
     public static final String NPM_REPOSITORY = "npmRepository";
     public static final String WITH_INTERFACES = "withInterfaces";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
@@ -22,6 +22,8 @@ import io.swagger.v3.parser.util.SchemaTypeUtil;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.features.DocumentationFeature;
 import org.openapitools.codegen.meta.features.SecurityFeature;
@@ -38,6 +40,8 @@ import java.util.Map;
 import java.util.TreeSet;
 
 public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodegen {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TypeScriptAxiosClientCodegen.class);
 
     public static final String NPM_REPOSITORY = "npmRepository";
     public static final String WITH_INTERFACES = "withInterfaces";
@@ -184,6 +188,13 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
         if (additionalProperties.containsKey(USE_ERASABLE_SYNTAX)) {
             this.useErasableSyntax = Boolean.parseBoolean(additionalProperties.get(USE_ERASABLE_SYNTAX).toString());
             additionalProperties.put(USE_ERASABLE_SYNTAX, this.useErasableSyntax);
+        }
+
+        if (this.useErasableSyntax && this.stringEnums) {
+            LOGGER.warn("useErasableSyntax and stringEnums are both enabled. "
+                    + "TypeScript 'enum' declarations are not erasable syntax and will fail with "
+                    + "erasableSyntaxOnly. Consider disabling stringEnums (the default generates "
+                    + "erasable-compatible const objects instead).");
         }
 
         if (additionalProperties.containsKey(NPM_NAME)) {

--- a/modules/openapi-generator/src/main/resources/typescript-axios/baseApi.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/baseApi.mustache
@@ -25,6 +25,7 @@ export interface RequestArgs {
 
 export class BaseAPI {
     protected configuration: Configuration | undefined;
+{{^useErasableSyntax}}
 
     constructor(configuration?: Configuration, protected basePath: string = BASE_PATH, protected axios: AxiosInstance = globalAxios) {
         if (configuration) {
@@ -32,13 +33,37 @@ export class BaseAPI {
             this.basePath = configuration.basePath ?? basePath;
         }
     }
+{{/useErasableSyntax}}
+{{#useErasableSyntax}}
+    protected basePath: string;
+    protected axios: AxiosInstance;
+
+    constructor(configuration?: Configuration, basePath: string = BASE_PATH, axios: AxiosInstance = globalAxios) {
+        this.basePath = basePath;
+        this.axios = axios;
+        if (configuration) {
+            this.configuration = configuration;
+            this.basePath = configuration.basePath ?? basePath;
+        }
+    }
+{{/useErasableSyntax}}
 };
 
 export class RequiredError extends Error {
+{{^useErasableSyntax}}
     constructor(public field: string, msg?: string) {
         super(msg);
         this.name = "RequiredError"
     }
+{{/useErasableSyntax}}
+{{#useErasableSyntax}}
+    public field: string;
+    constructor(field: string, msg?: string) {
+        super(msg);
+        this.name = "RequiredError"
+        this.field = field;
+    }
+{{/useErasableSyntax}}
 }
 
 interface ServerMap {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/axios/TypeScriptAxiosClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/axios/TypeScriptAxiosClientCodegenTest.java
@@ -11,6 +11,7 @@ import org.openapitools.codegen.typescript.TypeScriptGroups;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -177,5 +178,45 @@ public class TypeScriptAxiosClientCodegenTest {
 
         // Verify the non-deprecated array property 'nicknames' is also present
         TestUtils.assertFileContains(file, "'nicknames'?: Array<string>");
+    }
+
+    @Test(description = "Verify useErasableSyntax generates erasable code in base.ts")
+    public void testUseErasableSyntaxConfig() throws IOException {
+        boolean[] options = {true, false};
+        for (boolean useErasableSyntax : options) {
+            final File output = Files.createTempDirectory("typescript_axios_erasable_").toFile();
+            output.deleteOnExit();
+
+            final CodegenConfigurator configurator = new CodegenConfigurator()
+                    .setGeneratorName("typescript-axios")
+                    .setInputSpec("src/test/resources/3_0/petstore.yaml")
+                    .addAdditionalProperty("useErasableSyntax", useErasableSyntax)
+                    .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+            final ClientOptInput clientOptInput = configurator.toClientOptInput();
+            final DefaultGenerator generator = new DefaultGenerator();
+            final List<File> files = generator.opts(clientOptInput).generate();
+            files.forEach(File::deleteOnExit);
+
+            Path baseTsPath = Paths.get(output + "/base.ts");
+            TestUtils.assertFileExists(baseTsPath);
+            if (useErasableSyntax) {
+                // Erasable syntax: no parameter properties, explicit field declarations and assignments
+                TestUtils.assertFileContains(baseTsPath, "protected basePath: string;");
+                TestUtils.assertFileContains(baseTsPath, "protected axios: AxiosInstance;");
+                TestUtils.assertFileContains(baseTsPath, "this.basePath = basePath;");
+                TestUtils.assertFileContains(baseTsPath, "this.axios = axios;");
+                TestUtils.assertFileContains(baseTsPath, "public field: string;");
+                TestUtils.assertFileContains(baseTsPath, "this.field = field;");
+                // Should NOT contain parameter properties
+                TestUtils.assertFileNotContains(baseTsPath, "protected basePath: string = BASE_PATH,");
+                TestUtils.assertFileNotContains(baseTsPath, "public field: string,");
+            } else {
+                // Non-erasable syntax: uses parameter properties
+                TestUtils.assertFileContains(baseTsPath, "protected basePath: string = BASE_PATH,");
+                TestUtils.assertFileContains(baseTsPath, "protected axios: AxiosInstance = globalAxios");
+                TestUtils.assertFileContains(baseTsPath, "constructor(public field: string,");
+            }
+        }
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/axios/TypeScriptAxiosClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/axios/TypeScriptAxiosClientCodegenTest.java
@@ -210,6 +210,7 @@ public class TypeScriptAxiosClientCodegenTest {
                 TestUtils.assertFileContains(baseTsPath, "this.field = field;");
                 // Should NOT contain parameter properties
                 TestUtils.assertFileNotContains(baseTsPath, "protected basePath: string = BASE_PATH,");
+                TestUtils.assertFileNotContains(baseTsPath, "protected axios: AxiosInstance = globalAxios");
                 TestUtils.assertFileNotContains(baseTsPath, "public field: string,");
             } else {
                 // Non-erasable syntax: uses parameter properties


### PR DESCRIPTION
## Summary

Fixes #22540 — [BUG] Typescript-axios code generated is not compatible with erasableSyntaxOnly

TypeScript 5.8 introduced the `erasableSyntaxOnly` compiler option, which disallows parameter properties (`protected`/`public` in constructor parameters). The `typescript-axios` generator produces code in `base.ts` that uses parameter properties in both `BaseAPI` and `RequiredError` constructors, making the generated code incompatible with this flag.

This PR adds a new `useErasableSyntax` generator option that, when enabled, replaces parameter properties with explicit field declarations and constructor assignments.

## Problem

The generated `base.ts` contains parameter properties like:

```typescript
// BaseAPI
constructor(configuration?: Configuration, protected basePath: string = BASE_PATH, protected axios: AxiosInstance = globalAxios) { ... }

// RequiredError
constructor(public field: string, msg?: string) { ... }
```

These fail compilation when `erasableSyntaxOnly: true` is set in `tsconfig.json` (TypeScript 5.8+).

## Changes

### 1. Java Generator (`TypeScriptAxiosClientCodegen.java`)
- Added `useErasableSyntax` CLI option (boolean, defaults to `false`)
- Parses and passes the option through to Mustache templates via `additionalProperties`

### 2. Mustache Template (`baseApi.mustache`)
- Added conditional blocks using `{{#useErasableSyntax}}` / `{{^useErasableSyntax}}`
- When **enabled**: `BaseAPI` declares `basePath` and `axios` as explicit protected fields, assigns them in the constructor body. `RequiredError` declares `field` as a public field, assigns it in the constructor body.
- When **disabled**: behavior is unchanged (existing parameter property syntax)

### 3. Tests (`TypeScriptAxiosClientCodegenTest.java`)
- Added `testUseErasableSyntaxConfig()` test that generates code with both `useErasableSyntax: true` and `useErasableSyntax: false`
- Verifies erasable mode produces explicit field declarations and assignments
- Verifies non-erasable mode retains parameter property syntax
- Verifies erasable mode does NOT contain parameter properties

## Files Changed

```
 .../languages/TypeScriptAxiosClientCodegen.java    |  9 +++++
 .../resources/typescript-axios/baseApi.mustache    | 25 +++++++++++++
 .../axios/TypeScriptAxiosClientCodegenTest.java    | 41 ++++++++++++++++++++++
 3 files changed, 75 insertions(+)
```

## Usage

```yaml
# In your OpenAPI Generator config
generatorName: typescript-axios
additionalProperties:
  useErasableSyntax: "true"
```

Or via CLI:
```bash
openapi-generator-cli generate -g typescript-axios --additional-properties=useErasableSyntax=true -i spec.yaml -o output/
```

## Test Plan

- [ ] Build passes: `./mvnw clean install -DskipTests`
- [ ] `TypeScriptAxiosClientCodegenTest.testUseErasableSyntaxConfig` passes
- [ ] Generated code with `useErasableSyntax=true` compiles with `erasableSyntaxOnly: true`
- [ ] Generated code without the flag remains unchanged (backward compatible)
- [ ] Affected samples regenerated (if applicable)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `useErasableSyntax` option to the `typescript-axios` generator so `base.ts` compiles with TypeScript 5.8 `erasableSyntaxOnly`. Warns when used with `stringEnums`; tests verify parameter properties (including axios) are removed. Fixes #22540.

- **New Features**
  - Adds `useErasableSyntax` (default `false`).
  - When enabled, `BaseAPI` and `RequiredError` use explicit fields and constructor assignments; disabled keeps existing output.
  - Logs a warning if combined with `stringEnums`.
  - Enable via `--additional-properties=useErasableSyntax=true` or config `additionalProperties`.

- **Refactors**
  - Make the generator logger non-static to align with project ArchUnit rules.

<sup>Written for commit 30f7c22825952f0ba272b1d89b4588cbcd9d23cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

