### PR TITLE
feature: add profile to skip Gradle tests when Maven tests are skipped. Use same java version for the gradle task as for the maven

### DIFF
--- a/modules/openapi-generator-gradle-plugin/pom.xml
+++ b/modules/openapi-generator-gradle-plugin/pom.xml
@@ -143,14 +143,20 @@
                         <groupId>org.fortasoft</groupId>
                         <artifactId>gradle-maven-plugin</artifactId>
                         <executions>
-                            <!-- Override the gradle-build execution: swap `build` (assemble + test)
-                                 for `assemble` (no tests) when -Dmaven.test.skip=true is set. -->
+                            <!-- Override the gradle-build execution: keep `build` (so checkstyle,
+                                 spotbugs, and other check-lifecycle tasks still run) but add
+                                 `-x test` to exclude only the Gradle test task, mirroring
+                                 Maven's maven.test.skip behaviour which does not skip quality checks. -->
                             <execution>
                                 <id>gradle-build</id>
                                 <configuration>
+                                    <args combine.children="append">
+                                        <arg>-x</arg>
+                                        <arg>test</arg>
+                                    </args>
                                     <tasks>
                                         <task>clean</task>
-                                        <task>assemble</task>
+                                        <task>build</task>
                                         <task>publishToMavenLocal</task>
                                     </tasks>
                                 </configuration>
@@ -165,6 +171,9 @@
             <activation>
                 <property>
                     <name>skipTests</name>
+                    <!-- Maven maps bare -DskipTests to the string "true", so this matches
+                         both -DskipTests and -DskipTests=true but NOT -DskipTests=false. -->
+                    <value>true</value>
                 </property>
             </activation>
             <build>
@@ -173,14 +182,21 @@
                         <groupId>org.fortasoft</groupId>
                         <artifactId>gradle-maven-plugin</artifactId>
                         <executions>
-                            <!-- Override the gradle-build execution: swap `build` (assemble + test)
-                                 for `assemble` (no tests) when -DskipTests is set. -->
+                            <!-- Override the gradle-build execution: keep `build` (so checkstyle,
+                                 spotbugs, and other check-lifecycle tasks still run) but add
+                                 `-x test` to exclude only the Gradle test task.
+                                 combine.children="append" appends to the plugin-level <args>
+                                 instead of replacing them, preserving -P openApiGeneratorVersion. -->
                             <execution>
                                 <id>gradle-build</id>
                                 <configuration>
+                                    <args combine.children="append">
+                                        <arg>-x</arg>
+                                        <arg>test</arg>
+                                    </args>
                                     <tasks>
                                         <task>clean</task>
-                                        <task>assemble</task>
+                                        <task>build</task>
                                         <task>publishToMavenLocal</task>
                                     </tasks>
                                 </configuration>


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Sometimes I just want to quickly rebuild the project and skip tests. However the tests in gradle maven wrapper still execute. This changes the behavior. Also the gradle inherits jdk from the parent maven task when executed as part of the maven build. This makes it possible to e.g. set a specific jdk version for maven in IDEA and have the gradle task also use it instead to falling back to the default OS JDK

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.  - Tagging: @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06) @e5l (2024/10) @dennisameling (2026/02), @cachescrubber (2022/02) @welshm (2022/02) @MelleD (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02) @borsch (2022/02) @banlevente (2022/02) @Zomzog (2022/09) @martin-mfg (2023/08), @wing328



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Gradle plugin build with Maven: Gradle now runs on Maven’s JVM and mirrors Maven test-skip flags while keeping quality checks.

Adds `skip-gradle-tests` and `skip-gradle-tests-skipTests` Maven profiles that append `-x test` to the Gradle `build` when `-Dmaven.test.skip=true` or `-DskipTests` is set; sets `-Dorg.gradle.java.home=${java.home}` so the Gradle daemon uses the same JDK.

<sup>Written for commit 95cd659477349da2e5976657c722c491c2c53972. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



