### PR TITLE
Update undici to newer version

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/package.mustache
@@ -44,7 +44,7 @@
       {{#fetch-api}}
         {{#platforms}}
           {{#node}}
-    "undici": "^7.18.2",
+    "undici": "^7.24.0",
           {{/node}}
           {{#browser}}
     "whatwg-fetch": "^3.0.0",

--- a/samples/client/echo_api/typescript/build/package.json
+++ b/samples/client/echo_api/typescript/build/package.json
@@ -32,7 +32,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "undici": "^7.18.2",
+    "undici": "^7.24.0",
     "@types/node": "^20.17.10",
     "form-data": "^4.0.4",
     "es6-promise": "^4.2.4"

--- a/samples/client/others/typescript/encode-decode/build/package.json
+++ b/samples/client/others/typescript/encode-decode/build/package.json
@@ -32,7 +32,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "undici": "^7.18.2",
+    "undici": "^7.24.0",
     "@types/node": "^20.17.10",
     "form-data": "^4.0.4",
     "es6-promise": "^4.2.4"

--- a/samples/openapi3/client/petstore/typescript/builds/default/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/default/package.json
@@ -32,7 +32,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "undici": "^7.18.2",
+    "undici": "^7.24.0",
     "@types/node": "^20.17.10",
     "form-data": "^4.0.4",
     "es6-promise": "^4.2.4"

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/package.json
@@ -32,7 +32,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "undici": "^7.18.2",
+    "undici": "^7.24.0",
     "@types/node": "^20.17.10",
     "form-data": "^4.0.4",
     "es6-promise": "^4.2.4"

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/package.json
@@ -32,7 +32,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "undici": "^7.18.2",
+    "undici": "^7.24.0",
     "@types/node": "^20.17.10",
     "form-data": "^4.0.4",
     "inversify": "^6.0.1",

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/package.json
@@ -32,7 +32,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "undici": "^7.18.2",
+    "undici": "^7.24.0",
     "@types/node": "^20.17.10",
     "form-data": "^4.0.4",
     "es6-promise": "^4.2.4"


### PR DESCRIPTION
to close https://github.com/OpenAPITools/openapi-generator/pull/23235

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `undici` from ^7.18.2 to ^7.24.0 in the TypeScript generator and sample clients. This keeps the Node fetch runtime current and pulls in the latest 7.x fixes.

- **Dependencies**
  - Bumped `undici` to ^7.24.0 in `modules/openapi-generator/src/main/resources/typescript/package.mustache`.
  - Updated sample TypeScript client `package.json` files (echo_api and petstore builds) to use `undici` ^7.24.0.

<sup>Written for commit ac1b50559eb4ab9e06cba817950435bba27826db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

