### PR TITLE
Improve consumption of primitive types as body

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
@@ -325,7 +325,7 @@ import com.squareup.moshi.adapter
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
                 val textualContent = when (content) {
-                    is CharSequence -> content.toString()
+                    is Char, is CharSequence -> content.toString()
                     is Number -> content.toString()
                     is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")

--- a/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -271,10 +271,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/others/kotlin-integer-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/others/kotlin-integer-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -271,10 +271,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -271,10 +271,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/others/kotlin-jvm-okhttp-parameter-tests/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-parameter-tests/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -271,10 +271,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/others/kotlin-jvm-okhttp-path-comments/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-path-comments/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -271,10 +271,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/petstore/kotlin-allOf-discriminator-kotlinx-serialization/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-allOf-discriminator-kotlinx-serialization/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -274,10 +274,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/petstore/kotlin-allOf-discriminator/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-allOf-discriminator/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -271,10 +271,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/petstore/kotlin-array-integer-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-array-integer-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -271,10 +271,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -271,10 +271,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -271,10 +271,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -271,10 +271,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -271,10 +271,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -271,10 +271,10 @@ public open class ApiClient(public val baseUrl: String, public val client: Call.
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -271,10 +271,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -271,10 +271,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -275,10 +275,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -274,10 +274,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -271,10 +271,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -271,10 +271,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -271,10 +271,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/petstore/kotlin-name-parameter-mappings/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-name-parameter-mappings/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -271,10 +271,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -271,10 +271,10 @@ internal open class ApiClient(val baseUrl: String, val client: Call.Factory = de
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -271,10 +271,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -271,10 +271,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -271,10 +271,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -274,10 +274,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -271,10 +271,10 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
                 }
             mediaType == XML_MEDIA_TYPE -> throw UnsupportedOperationException("xml not currently supported.")
             mediaType == TEXT_MEDIA_TYPE -> {
-                val textualContent = when {
-                    content is CharSequence -> content.toString()
-                    content is Number -> content.toString()
-                    content is Boolean -> content.toString()
+                val textualContent = when (content) {
+                    is Char, is CharSequence -> content.toString()
+                    is Number -> content.toString()
+                    is Boolean -> content.toString()
                     else -> throw UnsupportedOperationException("requestBody currently only supports text body containing primitive types: characters, numbers, or booleans.")
                 }
                 textualContent.toRequestBody(mediaType.toMediaTypeOrNull())


### PR DESCRIPTION
Currently, the `ApiClient` for OkHttp allows sending textual body payloads (MIME=`text/plain`) only for Strings, but it can be easily adapted to send primitive types too: any character sequence, numbers, and booleans.

This small PR allows doing just that. If the content is not a primitive, then a suitable error is thrown instead.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06) @e5l (2024/10) @dennisameling (2026/02)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend the Kotlin JVM OkHttp `ApiClient` to support `text/plain` bodies from primitive values (Char/CharSequence, Number, Boolean via toString); non-primitives now error clearly, logic is consolidated into a single `when`, and samples are regenerated.

<sup>Written for commit 40b7d40ca03a69c3b7d4aa3e6e07f0d7fcc6a0e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

