### PR TITLE
[ALL-GENS] Utility - add open and close brace placeholders to additionalProperties for all mustache templates in all code gens

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -391,6 +391,10 @@ public class DefaultCodegen implements CodegenConfig {
 
     @Override
     public void processOpts() {
+        // add open brace {{openbrace}} and close brace {{closebrace}} to additionalProperties for all mustache templates
+        // to use when needed to use them where mustache would prevent plaintext
+        additionalProperties.put("openbrace", "{");
+        additionalProperties.put("closebrace", "}");
 
         if (!additionalProperties.containsKey(CodegenConstants.MUSTACHE_PARENT_CONTEXT)) {
             // by default empty parent context

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -391,10 +391,6 @@ public class DefaultCodegen implements CodegenConfig {
 
     @Override
     public void processOpts() {
-        // add open brace {{openbrace}} and close brace {{closebrace}} to additionalProperties for all mustache templates
-        // to use when needed to use them where mustache would prevent plaintext
-        additionalProperties.put("openbrace", "{");
-        additionalProperties.put("closebrace", "}");
 
         if (!additionalProperties.containsKey(CodegenConstants.MUSTACHE_PARENT_CONTEXT)) {
             // by default empty parent context
@@ -1865,6 +1861,10 @@ public class DefaultCodegen implements CodegenConfig {
 
         // Register common Mustache lambdas.
         registerMustacheLambdas();
+
+        // Initialize mustache braces placeholders for all generators
+        additionalProperties.putIfAbsent("openbrace", "{");
+        additionalProperties.putIfAbsent("closebrace", "}");
     }
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaMicronautAbstractCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaMicronautAbstractCodegen.java
@@ -133,10 +133,6 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
                 ))
         );
 
-        // Set additional properties
-        additionalProperties.put("openbrace", "{");
-        additionalProperties.put("closebrace", "}");
-
         // Set client options that will be presented to user
         updateOption(INVOKER_PACKAGE, this.getInvokerPackage());
         updateOption(CodegenConstants.ARTIFACT_ID, this.getArtifactId());

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
@@ -63,9 +63,6 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
                     "ApiResponse"
             ));
 
-    public static final String OPEN_BRACE = "{";
-    public static final String CLOSE_BRACE = "}";
-
     public static final String TITLE = "title";
     public static final String SERVER_PORT = "serverPort";
     public static final String CONFIG_PACKAGE = "configPackage";
@@ -221,9 +218,6 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
 
         // cliOptions default redefinition need to be updated
         updateOption(CodegenConstants.ARTIFACT_ID, this.artifactId);
-
-        additionalProperties.put("openbrace", OPEN_BRACE);
-        additionalProperties.put("closebrace", CLOSE_BRACE);
 
         // Use lists instead of arrays
         typeMapping.put("array", "kotlin.collections.List");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -123,9 +123,6 @@ public class SpringCodegen extends AbstractJavaCodegen
         }
     }
 
-    public static final String OPEN_BRACE = "{";
-    public static final String CLOSE_BRACE = "}";
-
     @Setter protected String title = "OpenAPI Spring";
     @Getter @Setter
     protected String configPackage = "org.openapitools.configuration";
@@ -222,8 +219,6 @@ public class SpringCodegen extends AbstractJavaCodegen
 
         // spring uses the jackson lib
         jackson = true;
-        additionalProperties.put("openbrace", OPEN_BRACE);
-        additionalProperties.put("closebrace", CLOSE_BRACE);
 
         cliOptions.add(new CliOption(TITLE, "server title name or client service name").defaultValue(title));
         cliOptions.add(new CliOption(CONFIG_PACKAGE, "configuration package for generated code")


### PR DESCRIPTION
Make `{{openbrace}}` and `{{closebrace}}` available in all the mustache templates to solve issues when one needs to use `{` or `}`.

E.g. `<version>{abc.version}</version>`
can now be easily encoded as:
 `<version>{{openbrace}}{{service}}.version{{closebrace}}</version>`.

Fixes #23109

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `{{openbrace}}` and `{{closebrace}}` available in all Mustache templates by adding `openbrace` and `closebrace` to `additionalProperties` in `DefaultCodegen`’s constructor (using `putIfAbsent` to preserve overrides). Removes per-generator definitions from `SpringCodegen`, `KotlinSpringServerCodegen`, and `JavaMicronautAbstractCodegen`.

<sup>Written for commit c60de82f1681b358ea7694ed09c382ceb49dbba3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



