### PR TITLE
Postman Generator: Format json edge case

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostmanCollectionCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostmanCollectionCodegen.java
@@ -2,6 +2,7 @@ package org.openapitools.codegen.languages;
 
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -332,8 +333,8 @@ public class PostmanCollectionCodegen extends DefaultCodegen implements CodegenC
             }
         }
 
-        tagName = formatDescription(tagName);
-        tagDescription = formatDescription(tagDescription);
+        tagName = escapeJsonString(tagName);
+        tagDescription = escapeJsonString(tagDescription);
 
         PostmanRequestFolder folder = new PostmanRequestFolder(tagName, tagDescription);
         List<CodegenOperation> list = codegenOperationsByTag.get(folder);
@@ -683,6 +684,13 @@ public class PostmanCollectionCodegen extends DefaultCodegen implements CodegenC
         }
 
         return description;
+    }
+
+    String escapeJsonString(String value) {
+        if (value == null) {
+            return null;
+        }
+        return new String(JsonStringEncoder.getInstance().quoteAsString(value));
     }
 
     /**

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
@@ -151,6 +151,38 @@ public class PostmanCollectionCodegenTest {
     }
 
     @Test
+    public void testTagDescriptionControlCharsAreJsonEscaped() throws IOException {
+        File output = Files.createTempDirectory("postmantest_").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("postman-collection")
+                .setInputSpec("src/test/resources/3_0/postman-collection/TagDescriptionControlCharsEscaping.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(clientOptInput).generate();
+
+        files.forEach(File::deleteOnExit);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode root = objectMapper.readTree(new File(output + "/postman.json"));
+        JsonNode folders = root.get("item");
+
+        JsonNode basicFolder = null;
+        for (JsonNode folder : folders) {
+            if ("basic".equals(folder.get("name").asText())) {
+                basicFolder = folder;
+                break;
+            }
+        }
+
+        assertNotNull(basicFolder);
+        assertEquals("desc with \\t tab, \\b backspace, \\f formfeed, \\r carriage-return, \\n line", basicFolder.get("description").asText());
+    }
+
+    @Test
     public void testValidatePostmanJson() throws IOException {
 
         File output = Files.createTempDirectory("postmantest_").toFile();

--- a/modules/openapi-generator/src/test/resources/3_0/postman-collection/TagDescriptionControlCharsEscaping.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/postman-collection/TagDescriptionControlCharsEscaping.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: Tag Description Control Chars Escaping
+  version: '1.0'
+servers:
+  - url: 'http://localhost:5001'
+paths:
+  '/users/{userId}':
+    get:
+      summary: Get User
+      operationId: get-users-userId
+      tags:
+        - basic
+      parameters:
+        - description: Unique identifier of the user
+          name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: User Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+tags:
+  - name: basic
+    description: "desc with \\t tab, \\b backspace, \\f formfeed, \\r carriage-return, \\n line"


### PR DESCRIPTION
Address [edge case](https://github.com/OpenAPITools/openapi-generator/pull/23249#discussion_r2935440696) (JSON formatting) - cubic-dev comment

@wing328 

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures tag names and descriptions in the `postman-collection` generator are properly JSON-escaped, including control characters, to prevent invalid Postman JSON and broken imports.

- **Bug Fixes**
  - Escape control characters in tag names/descriptions using `JsonStringEncoder` in `PostmanCollectionCodegen`.
  - Added test and sample spec to verify escaping for `\t`, `\b`, `\f`, `\r`, and `\n`.

<sup>Written for commit 7f0ba9c7c73e1ea54bc982d3e4c015bcf31e5d03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

