### PR TITLE
fix(typescript): add trailing commas to as const enums

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/modelEnum.mustache
@@ -22,7 +22,7 @@ export const {{classname}} = {
      * {{.}}
      */
 {{/enumDescription}}
-    {{name}}: {{{value}}}{{^-last}},{{/-last}}
+    {{name}}: {{{value}}},
 {{/enumVars}}
 {{/allowableValues}}
 } as const;

--- a/modules/openapi-generator/src/main/resources/typescript-angular/modelGenericEnums.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/modelGenericEnums.mustache
@@ -18,7 +18,7 @@ export enum {{classname}}{{enumName}} {
     export const {{enumName}} = {
     {{#allowableValues}}
     {{#enumVars}}
-        {{name}}: {{{value}}}{{^-last}},{{/-last}}
+        {{name}}: {{{value}}},
     {{/enumVars}}
     {{/allowableValues}}
     } as const;

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -496,7 +496,7 @@ export enum {{operationIdCamelCase}}{{enumName}} {
 export const {{operationIdCamelCase}}{{enumName}} = {
 {{#allowableValues}}
     {{#enumVars}}
-    {{{name}}}: {{{value}}}{{^-last}},{{/-last}}
+    {{{name}}}: {{{value}}},
     {{/enumVars}}
 {{/allowableValues}}
 } as const;

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnumInterfaces.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnumInterfaces.mustache
@@ -29,7 +29,7 @@ export const {{classname}} = {
     * {{enumDescription}}
     */
     {{/enumDescription}}
-    {{{name}}}: {{{value}}}{{^-last}},{{/-last}}
+    {{{name}}}: {{{value}}},
 {{/enumVars}}
 {{/allowableValues}}
 } as const;

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGenericInterfaces.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGenericInterfaces.mustache
@@ -41,7 +41,7 @@ export enum {{classname}}{{enumName}} {
 export const {{classname}}{{enumName}} = {
 {{#allowableValues}}
     {{#enumVars}}
-    {{{name}}}: {{{value}}}{{^-last}},{{/-last}}
+    {{{name}}}: {{{value}}},
     {{/enumVars}}
 {{/allowableValues}}
 } as const;

--- a/modules/openapi-generator/src/main/resources/typescript-nestjs-server/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs-server/modelEnum.mustache
@@ -22,7 +22,7 @@ export const {{classname}} = {
      * {{.}}
      */
 {{/enumDescription}}
-    {{name}}: {{{value}}}{{^-last}},{{/-last}}
+    {{name}}: {{{value}}},
 {{/enumVars}}
 {{/allowableValues}}
 } as const;

--- a/modules/openapi-generator/src/main/resources/typescript-nestjs-server/modelGenericEnums.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs-server/modelGenericEnums.mustache
@@ -18,7 +18,7 @@ export namespace {{classname}} {
   export const {{enumName}} = {
   {{#allowableValues}}
   {{#enumVars}}
-    {{name}}: {{{value}}}{{^-last}},{{/-last}}
+    {{name}}: {{{value}}},
   {{/enumVars}}
   {{/allowableValues}}
   } as const;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/SharedTypeScriptTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/SharedTypeScriptTest.java
@@ -4,6 +4,7 @@ import static org.openapitools.codegen.typescript.TypeScriptGroups.TYPESCRIPT;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -274,6 +275,32 @@ public class SharedTypeScriptTest {
         }
     }
 
+    @Test(description = "Issue #23275 - as const enum objects should include trailing commas")
+    public void generatesTrailingCommasInAsConstEnumObjectsAcrossTypeScriptGenerators() throws Exception {
+        final String specPath = "src/test/resources/3_0/java/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml";
+        List<String> generators = Arrays.asList(
+                "typescript-angular",
+                "typescript-axios",
+                "typescript-fetch",
+                "typescript-nestjs-server"
+        );
+
+        for (String generatorName : generators) {
+            File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+            output.deleteOnExit();
+
+            CodegenConfigurator configurator = new CodegenConfigurator()
+                    .setGeneratorName(generatorName)
+                    .setInputSpec(specPath)
+                    .setOutputDir(output.getAbsolutePath());
+
+            Generator generator = new DefaultGenerator();
+            generator.opts(configurator.toClientOptInput()).generate();
+
+            assertAsConstObjectsUseTrailingCommas(output.toPath(), generatorName);
+        }
+    }
+
     @Test(description = "Issue #22748 - Inner enums should not be double-prefixed when model has parent")
     public void givenChildModelWithInheritedInnerEnumThenEnumNameIsNotDoublePrefixed() throws Exception {
         // This tests that when a child model inherits from a parent that has an inner enum property,
@@ -308,6 +335,43 @@ public class SharedTypeScriptTest {
         // Should contain correctly prefixed enum name (single prefix with "." separator)
         Assert.assertTrue(fileContents.contains("Employee.ProjectRolesEnum"),
                 "typescript-angular: Should contain 'Employee.ProjectRolesEnum' in " + modelFile);
+    }
+
+    private void assertAsConstObjectsUseTrailingCommas(Path root, String generatorName) throws IOException {
+        final int[] asConstObjectCount = {0};
+
+        try (Stream<Path> paths = Files.walk(root)) {
+            paths.filter(Files::isRegularFile)
+                    .filter(path -> path.toString().endsWith(".ts"))
+                    .forEach(path -> {
+                        try {
+                            List<String> lines = Files.readAllLines(path);
+                            for (int i = 0; i < lines.size(); i++) {
+                                if (!lines.get(i).strip().equals("} as const;")) {
+                                    continue;
+                                }
+
+                                asConstObjectCount[0]++;
+
+                                int previousLineIndex = i - 1;
+                                while (previousLineIndex >= 0 && lines.get(previousLineIndex).isBlank()) {
+                                    previousLineIndex--;
+                                }
+
+                                Assert.assertTrue(
+                                        previousLineIndex >= 0 && lines.get(previousLineIndex).stripTrailing().endsWith(","),
+                                        generatorName + ": Expected trailing comma before '} as const;' in " + path);
+                            }
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    });
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
+        }
+
+        Assert.assertTrue(asConstObjectCount[0] > 0,
+                generatorName + ": Expected generated as const enum objects");
     }
 
 }

--- a/samples/client/others/typescript-angular-v20/builds/query-param-json/model/pageable.ts
+++ b/samples/client/others/typescript-angular-v20/builds/query-param-json/model/pageable.ts
@@ -33,7 +33,7 @@ export interface Pageable {
 export namespace Pageable {
     export const SortDirectionEnum = {
         Asc: 'ASC',
-        Desc: 'DESC'
+        Desc: 'DESC',
     } as const;
     export type SortDirectionEnum = typeof SortDirectionEnum[keyof typeof SortDirectionEnum];
 }

--- a/samples/client/others/typescript-fetch/infinite-recursion-issue/models/TestObjectType.ts
+++ b/samples/client/others/typescript-fetch/infinite-recursion-issue/models/TestObjectType.ts
@@ -20,7 +20,7 @@
 export const TestObjectType = {
     TEST1: 'TEST1',
     TEST2: 'TEST2',
-    unknown_default_open_api: '11184809'
+    unknown_default_open_api: '11184809',
 } as const;
 export type TestObjectType = typeof TestObjectType[keyof typeof TestObjectType];
 

--- a/samples/client/petstore/typescript-angular-v16-provided-in-root/builds/default/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v16-provided-in-root/builds/default/model/order.ts
@@ -27,7 +27,7 @@ export namespace Order {
     export const StatusEnum = {
         Placed: 'placed',
         Approved: 'approved',
-        SHIPPED: 'delivered'
+        SHIPPED: 'delivered',
     } as const;
     export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }

--- a/samples/client/petstore/typescript-angular-v16-provided-in-root/builds/default/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v16-provided-in-root/builds/default/model/pet.ts
@@ -30,7 +30,7 @@ export namespace Pet {
     export const StatusEnum = {
         Available: 'available',
         Pending: 'pending',
-        Sold: 'sold'
+        Sold: 'sold',
     } as const;
     export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }

--- a/samples/client/petstore/typescript-angular-v17-provided-in-root/builds/default/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v17-provided-in-root/builds/default/model/order.ts
@@ -27,7 +27,7 @@ export namespace Order {
     export const StatusEnum = {
         Placed: 'placed',
         Approved: 'approved',
-        Delivered: 'delivered'
+        Delivered: 'delivered',
     } as const;
     export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }

--- a/samples/client/petstore/typescript-angular-v17-provided-in-root/builds/default/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v17-provided-in-root/builds/default/model/pet.ts
@@ -30,7 +30,7 @@ export namespace Pet {
     export const StatusEnum = {
         Available: 'available',
         Pending: 'pending',
-        Sold: 'sold'
+        Sold: 'sold',
     } as const;
     export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }

--- a/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/model/order.ts
@@ -27,7 +27,7 @@ export namespace Order {
     export const StatusEnum = {
         Placed: 'placed',
         Approved: 'approved',
-        Delivered: 'delivered'
+        Delivered: 'delivered',
     } as const;
     export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }

--- a/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/model/pet.ts
@@ -30,7 +30,7 @@ export namespace Pet {
     export const StatusEnum = {
         Available: 'available',
         Pending: 'pending',
-        Sold: 'sold'
+        Sold: 'sold',
     } as const;
     export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }

--- a/samples/client/petstore/typescript-angular-v19-provided-in-root/builds/default/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v19-provided-in-root/builds/default/model/order.ts
@@ -27,7 +27,7 @@ export namespace Order {
     export const StatusEnum = {
         Placed: 'placed',
         Approved: 'approved',
-        SHIPPED: 'delivered'
+        SHIPPED: 'delivered',
     } as const;
     export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }

--- a/samples/client/petstore/typescript-angular-v19-provided-in-root/builds/default/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v19-provided-in-root/builds/default/model/pet.ts
@@ -30,7 +30,7 @@ export namespace Pet {
     export const StatusEnum = {
         Available: 'available',
         Pending: 'pending',
-        Sold: 'sold'
+        Sold: 'sold',
     } as const;
     export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }

--- a/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/model/order.ts
@@ -27,7 +27,7 @@ export namespace Order {
     export const StatusEnum = {
         Placed: 'placed',
         Approved: 'approved',
-        Delivered: 'delivered'
+        Delivered: 'delivered',
     } as const;
     export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }

--- a/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/model/pet.ts
@@ -30,7 +30,7 @@ export namespace Pet {
     export const StatusEnum = {
         Available: 'available',
         Pending: 'pending',
-        Sold: 'sold'
+        Sold: 'sold',
     } as const;
     export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }

--- a/samples/client/petstore/typescript-angular-v19/builds/default/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v19/builds/default/model/order.ts
@@ -27,7 +27,7 @@ export namespace Order {
     export const StatusEnum = {
         Placed: 'placed',
         Approved: 'approved',
-        Delivered: 'delivered'
+        Delivered: 'delivered',
     } as const;
     export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }

--- a/samples/client/petstore/typescript-angular-v19/builds/default/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v19/builds/default/model/pet.ts
@@ -30,7 +30,7 @@ export namespace Pet {
     export const StatusEnum = {
         Available: 'available',
         Pending: 'pending',
-        Sold: 'sold'
+        Sold: 'sold',
     } as const;
     export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }

--- a/samples/client/petstore/typescript-angular-v20-provided-in-root/builds/default/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v20-provided-in-root/builds/default/model/order.ts
@@ -27,7 +27,7 @@ export namespace Order {
     export const StatusEnum = {
         Placed: 'placed',
         Approved: 'approved',
-        SHIPPED: 'delivered'
+        SHIPPED: 'delivered',
     } as const;
     export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }

--- a/samples/client/petstore/typescript-angular-v20-provided-in-root/builds/default/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v20-provided-in-root/builds/default/model/pet.ts
@@ -30,7 +30,7 @@ export namespace Pet {
     export const StatusEnum = {
         Available: 'available',
         Pending: 'pending',
-        Sold: 'sold'
+        Sold: 'sold',
     } as const;
     export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }

--- a/samples/client/petstore/typescript-angular-v20/builds/default/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v20/builds/default/model/order.ts
@@ -27,7 +27,7 @@ export namespace Order {
     export const StatusEnum = {
         Placed: 'placed',
         Approved: 'approved',
-        Delivered: 'delivered'
+        Delivered: 'delivered',
     } as const;
     export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }

--- a/samples/client/petstore/typescript-angular-v20/builds/default/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v20/builds/default/model/pet.ts
@@ -30,7 +30,7 @@ export namespace Pet {
     export const StatusEnum = {
         Available: 'available',
         Pending: 'pending',
-        Sold: 'sold'
+        Sold: 'sold',
     } as const;
     export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }

--- a/samples/client/petstore/typescript-angular-v21-provided-in-root/builds/default/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v21-provided-in-root/builds/default/model/order.ts
@@ -27,7 +27,7 @@ export namespace Order {
     export const StatusEnum = {
         Placed: 'placed',
         Approved: 'approved',
-        SHIPPED: 'delivered'
+        SHIPPED: 'delivered',
     } as const;
     export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }

--- a/samples/client/petstore/typescript-angular-v21-provided-in-root/builds/default/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v21-provided-in-root/builds/default/model/pet.ts
@@ -30,7 +30,7 @@ export namespace Pet {
     export const StatusEnum = {
         Available: 'available',
         Pending: 'pending',
-        Sold: 'sold'
+        Sold: 'sold',
     } as const;
     export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }

--- a/samples/client/petstore/typescript-angular-v21/builds/default/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v21/builds/default/model/order.ts
@@ -27,7 +27,7 @@ export namespace Order {
     export const StatusEnum = {
         Placed: 'placed',
         Approved: 'approved',
-        Delivered: 'delivered'
+        Delivered: 'delivered',
     } as const;
     export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }

--- a/samples/client/petstore/typescript-angular-v21/builds/default/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v21/builds/default/model/pet.ts
@@ -30,7 +30,7 @@ export namespace Pet {
     export const StatusEnum = {
         Available: 'available',
         Pending: 'pending',
-        Sold: 'sold'
+        Sold: 'sold',
     } as const;
     export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
@@ -1468,7 +1468,7 @@ export class FakeApi extends runtime.BaseAPI {
  */
 export const TestEnumParametersEnumHeaderStringArrayEnum = {
     GreaterThan: '>',
-    Dollar: '$'
+    Dollar: '$',
 } as const;
 export type TestEnumParametersEnumHeaderStringArrayEnum = typeof TestEnumParametersEnumHeaderStringArrayEnum[keyof typeof TestEnumParametersEnumHeaderStringArrayEnum];
 /**
@@ -1477,7 +1477,7 @@ export type TestEnumParametersEnumHeaderStringArrayEnum = typeof TestEnumParamet
 export const TestEnumParametersEnumHeaderStringEnum = {
     Abc: '_abc',
     Efg: '-efg',
-    Xyz: '(xyz)'
+    Xyz: '(xyz)',
 } as const;
 export type TestEnumParametersEnumHeaderStringEnum = typeof TestEnumParametersEnumHeaderStringEnum[keyof typeof TestEnumParametersEnumHeaderStringEnum];
 /**
@@ -1485,7 +1485,7 @@ export type TestEnumParametersEnumHeaderStringEnum = typeof TestEnumParametersEn
  */
 export const TestEnumParametersEnumQueryStringArrayEnum = {
     GreaterThan: '>',
-    Dollar: '$'
+    Dollar: '$',
 } as const;
 export type TestEnumParametersEnumQueryStringArrayEnum = typeof TestEnumParametersEnumQueryStringArrayEnum[keyof typeof TestEnumParametersEnumQueryStringArrayEnum];
 /**
@@ -1494,7 +1494,7 @@ export type TestEnumParametersEnumQueryStringArrayEnum = typeof TestEnumParamete
 export const TestEnumParametersEnumQueryStringEnum = {
     Abc: '_abc',
     Efg: '-efg',
-    Xyz: '(xyz)'
+    Xyz: '(xyz)',
 } as const;
 export type TestEnumParametersEnumQueryStringEnum = typeof TestEnumParametersEnumQueryStringEnum[keyof typeof TestEnumParametersEnumQueryStringEnum];
 /**
@@ -1502,7 +1502,7 @@ export type TestEnumParametersEnumQueryStringEnum = typeof TestEnumParametersEnu
  */
 export const TestEnumParametersEnumQueryIntegerEnum = {
     NUMBER_1: 1,
-    NUMBER_MINUS_2: -2
+    NUMBER_MINUS_2: -2,
 } as const;
 export type TestEnumParametersEnumQueryIntegerEnum = typeof TestEnumParametersEnumQueryIntegerEnum[keyof typeof TestEnumParametersEnumQueryIntegerEnum];
 /**
@@ -1510,7 +1510,7 @@ export type TestEnumParametersEnumQueryIntegerEnum = typeof TestEnumParametersEn
  */
 export const TestEnumParametersEnumQueryDoubleEnum = {
     NUMBER_1_DOT_1: 1.1,
-    NUMBER_MINUS_1_DOT_2: -1.2
+    NUMBER_MINUS_1_DOT_2: -1.2,
 } as const;
 export type TestEnumParametersEnumQueryDoubleEnum = typeof TestEnumParametersEnumQueryDoubleEnum[keyof typeof TestEnumParametersEnumQueryDoubleEnum];
 /**
@@ -1518,7 +1518,7 @@ export type TestEnumParametersEnumQueryDoubleEnum = typeof TestEnumParametersEnu
  */
 export const TestEnumParametersEnumFormStringArrayEnum = {
     GreaterThan: '>',
-    Dollar: '$'
+    Dollar: '$',
 } as const;
 export type TestEnumParametersEnumFormStringArrayEnum = typeof TestEnumParametersEnumFormStringArrayEnum[keyof typeof TestEnumParametersEnumFormStringArrayEnum];
 /**
@@ -1527,6 +1527,6 @@ export type TestEnumParametersEnumFormStringArrayEnum = typeof TestEnumParameter
 export const TestEnumParametersEnumFormStringEnum = {
     Abc: '_abc',
     Efg: '-efg',
-    Xyz: '(xyz)'
+    Xyz: '(xyz)',
 } as const;
 export type TestEnumParametersEnumFormStringEnum = typeof TestEnumParametersEnumFormStringEnum[keyof typeof TestEnumParametersEnumFormStringEnum];

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/PetApi.ts
@@ -641,6 +641,6 @@ export class PetApi extends runtime.BaseAPI {
 export const FindPetsByStatusStatusEnum = {
     Available: 'available',
     Pending: 'pending',
-    Sold: 'sold'
+    Sold: 'sold',
 } as const;
 export type FindPetsByStatusStatusEnum = typeof FindPetsByStatusStatusEnum[keyof typeof FindPetsByStatusStatusEnum];

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumArrays.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumArrays.ts
@@ -39,7 +39,7 @@ export interface EnumArrays {
  */
 export const EnumArraysJustSymbolEnum = {
     GreaterThanOrEqualTo: '>=',
-    Dollar: '$'
+    Dollar: '$',
 } as const;
 export type EnumArraysJustSymbolEnum = typeof EnumArraysJustSymbolEnum[keyof typeof EnumArraysJustSymbolEnum];
 
@@ -48,7 +48,7 @@ export type EnumArraysJustSymbolEnum = typeof EnumArraysJustSymbolEnum[keyof typ
  */
 export const EnumArraysArrayEnumEnum = {
     Fish: 'fish',
-    Crab: 'crab'
+    Crab: 'crab',
 } as const;
 export type EnumArraysArrayEnumEnum = typeof EnumArraysArrayEnumEnum[keyof typeof EnumArraysArrayEnumEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumClass.ts
@@ -20,7 +20,7 @@
 export const EnumClass = {
     Abc: '_abc',
     Efg: '-efg',
-    Xyz: '(xyz)'
+    Xyz: '(xyz)',
 } as const;
 export type EnumClass = typeof EnumClass[keyof typeof EnumClass];
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
@@ -105,7 +105,7 @@ export interface EnumTest {
 export const EnumTestEnumStringEnum = {
     Upper: 'UPPER',
     Lower: 'lower',
-    Empty: ''
+    Empty: '',
 } as const;
 export type EnumTestEnumStringEnum = typeof EnumTestEnumStringEnum[keyof typeof EnumTestEnumStringEnum];
 
@@ -115,7 +115,7 @@ export type EnumTestEnumStringEnum = typeof EnumTestEnumStringEnum[keyof typeof 
 export const EnumTestEnumStringRequiredEnum = {
     Upper: 'UPPER',
     Lower: 'lower',
-    Empty: ''
+    Empty: '',
 } as const;
 export type EnumTestEnumStringRequiredEnum = typeof EnumTestEnumStringRequiredEnum[keyof typeof EnumTestEnumStringRequiredEnum];
 
@@ -124,7 +124,7 @@ export type EnumTestEnumStringRequiredEnum = typeof EnumTestEnumStringRequiredEn
  */
 export const EnumTestEnumIntegerEnum = {
     NUMBER_1: 1,
-    NUMBER_MINUS_1: -1
+    NUMBER_MINUS_1: -1,
 } as const;
 export type EnumTestEnumIntegerEnum = typeof EnumTestEnumIntegerEnum[keyof typeof EnumTestEnumIntegerEnum];
 
@@ -133,7 +133,7 @@ export type EnumTestEnumIntegerEnum = typeof EnumTestEnumIntegerEnum[keyof typeo
  */
 export const EnumTestEnumNumberEnum = {
     NUMBER_1_DOT_1: 1.1,
-    NUMBER_MINUS_1_DOT_2: -1.2
+    NUMBER_MINUS_1_DOT_2: -1.2,
 } as const;
 export type EnumTestEnumNumberEnum = typeof EnumTestEnumNumberEnum[keyof typeof EnumTestEnumNumberEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MapTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MapTest.ts
@@ -51,7 +51,7 @@ export interface MapTest {
  */
 export const MapTestMapOfEnumStringEnum = {
     Upper: 'UPPER',
-    Lower: 'lower'
+    Lower: 'lower',
 } as const;
 export type MapTestMapOfEnumStringEnum = typeof MapTestMapOfEnumStringEnum[keyof typeof MapTestMapOfEnumStringEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Order.ts
@@ -64,7 +64,7 @@ export interface Order {
 export const OrderStatusEnum = {
     Placed: 'placed',
     Approved: 'approved',
-    Delivered: 'delivered'
+    Delivered: 'delivered',
 } as const;
 export type OrderStatusEnum = typeof OrderStatusEnum[keyof typeof OrderStatusEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnum.ts
@@ -20,7 +20,7 @@
 export const OuterEnum = {
     Placed: 'placed',
     Approved: 'approved',
-    Delivered: 'delivered'
+    Delivered: 'delivered',
 } as const;
 export type OuterEnum = typeof OuterEnum[keyof typeof OuterEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumDefaultValue.ts
@@ -20,7 +20,7 @@
 export const OuterEnumDefaultValue = {
     Placed: 'placed',
     Approved: 'approved',
-    Delivered: 'delivered'
+    Delivered: 'delivered',
 } as const;
 export type OuterEnumDefaultValue = typeof OuterEnumDefaultValue[keyof typeof OuterEnumDefaultValue];
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumInteger.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumInteger.ts
@@ -20,7 +20,7 @@
 export const OuterEnumInteger = {
     NUMBER_0: 0,
     NUMBER_1: 1,
-    NUMBER_2: 2
+    NUMBER_2: 2,
 } as const;
 export type OuterEnumInteger = typeof OuterEnumInteger[keyof typeof OuterEnumInteger];
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumIntegerDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumIntegerDefaultValue.ts
@@ -20,7 +20,7 @@
 export const OuterEnumIntegerDefaultValue = {
     NUMBER_0: 0,
     NUMBER_1: 1,
-    NUMBER_2: 2
+    NUMBER_2: 2,
 } as const;
 export type OuterEnumIntegerDefaultValue = typeof OuterEnumIntegerDefaultValue[keyof typeof OuterEnumIntegerDefaultValue];
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
@@ -39,7 +39,7 @@ export interface ParentWithNullable {
  * @export
  */
 export const ParentWithNullableTypeEnum = {
-    ChildWithNullable: 'ChildWithNullable'
+    ChildWithNullable: 'ChildWithNullable',
 } as const;
 export type ParentWithNullableTypeEnum = typeof ParentWithNullableTypeEnum[keyof typeof ParentWithNullableTypeEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
@@ -79,7 +79,7 @@ export interface Pet {
 export const PetStatusEnum = {
     Available: 'available',
     Pending: 'pending',
-    Sold: 'sold'
+    Sold: 'sold',
 } as const;
 export type PetStatusEnum = typeof PetStatusEnum[keyof typeof PetStatusEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SingleRefType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SingleRefType.ts
@@ -19,7 +19,7 @@
  */
 export const SingleRefType = {
     Admin: 'admin',
-    User: 'user'
+    User: 'user',
 } as const;
 export type SingleRefType = typeof SingleRefType[keyof typeof SingleRefType];
 

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/PetApi.ts
@@ -541,6 +541,6 @@ export class PetApi extends runtime.BaseAPI {
 export const FindPetsByStatusStatusEnum = {
     Available: 'available',
     Pending: 'pending',
-    Sold: 'sold'
+    Sold: 'sold',
 } as const;
 export type FindPetsByStatusStatusEnum = typeof FindPetsByStatusStatusEnum[keyof typeof FindPetsByStatusStatusEnum];

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Order.ts
@@ -64,7 +64,7 @@ export interface Order {
 export const OrderStatusEnum = {
     Placed: 'placed',
     Approved: 'approved',
-    Delivered: 'delivered'
+    Delivered: 'delivered',
 } as const;
 export type OrderStatusEnum = typeof OrderStatusEnum[keyof typeof OrderStatusEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
@@ -79,7 +79,7 @@ export interface Pet {
 export const PetStatusEnum = {
     Available: 'available',
     Pending: 'pending',
-    Sold: 'sold'
+    Sold: 'sold',
 } as const;
 export type PetStatusEnum = typeof PetStatusEnum[keyof typeof PetStatusEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/apis/DefaultApi.ts
@@ -244,7 +244,7 @@ export class DefaultApi extends runtime.BaseAPI {
 export const FakeEnumRequestGetInlineStringEnumEnum = {
     One: 'one',
     Two: 'two',
-    Three: 'three'
+    Three: 'three',
 } as const;
 export type FakeEnumRequestGetInlineStringEnumEnum = typeof FakeEnumRequestGetInlineStringEnumEnum[keyof typeof FakeEnumRequestGetInlineStringEnumEnum];
 /**
@@ -253,7 +253,7 @@ export type FakeEnumRequestGetInlineStringEnumEnum = typeof FakeEnumRequestGetIn
 export const FakeEnumRequestGetInlineNullableStringEnumEnum = {
     One: 'one',
     Two: 'two',
-    Three: 'three'
+    Three: 'three',
 } as const;
 export type FakeEnumRequestGetInlineNullableStringEnumEnum = typeof FakeEnumRequestGetInlineNullableStringEnumEnum[keyof typeof FakeEnumRequestGetInlineNullableStringEnumEnum];
 /**
@@ -262,7 +262,7 @@ export type FakeEnumRequestGetInlineNullableStringEnumEnum = typeof FakeEnumRequ
 export const FakeEnumRequestGetInlineNumberEnumEnum = {
     NUMBER_1: 1,
     NUMBER_2: 2,
-    NUMBER_3: 3
+    NUMBER_3: 3,
 } as const;
 export type FakeEnumRequestGetInlineNumberEnumEnum = typeof FakeEnumRequestGetInlineNumberEnumEnum[keyof typeof FakeEnumRequestGetInlineNumberEnumEnum];
 /**
@@ -271,6 +271,6 @@ export type FakeEnumRequestGetInlineNumberEnumEnum = typeof FakeEnumRequestGetIn
 export const FakeEnumRequestGetInlineNullableNumberEnumEnum = {
     NUMBER_1: 1,
     NUMBER_2: 2,
-    NUMBER_3: 3
+    NUMBER_3: 3,
 } as const;
 export type FakeEnumRequestGetInlineNullableNumberEnumEnum = typeof FakeEnumRequestGetInlineNullableNumberEnumEnum[keyof typeof FakeEnumRequestGetInlineNullableNumberEnumEnum];

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/FakeEnumRequestGetInline200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/FakeEnumRequestGetInline200Response.ts
@@ -52,7 +52,7 @@ export interface FakeEnumRequestGetInline200Response {
 export const FakeEnumRequestGetInline200ResponseStringEnumEnum = {
     One: 'one',
     Two: 'two',
-    Three: 'three'
+    Three: 'three',
 } as const;
 export type FakeEnumRequestGetInline200ResponseStringEnumEnum = typeof FakeEnumRequestGetInline200ResponseStringEnumEnum[keyof typeof FakeEnumRequestGetInline200ResponseStringEnumEnum];
 
@@ -62,7 +62,7 @@ export type FakeEnumRequestGetInline200ResponseStringEnumEnum = typeof FakeEnumR
 export const FakeEnumRequestGetInline200ResponseNullableStringEnumEnum = {
     One: 'one',
     Two: 'two',
-    Three: 'three'
+    Three: 'three',
 } as const;
 export type FakeEnumRequestGetInline200ResponseNullableStringEnumEnum = typeof FakeEnumRequestGetInline200ResponseNullableStringEnumEnum[keyof typeof FakeEnumRequestGetInline200ResponseNullableStringEnumEnum];
 
@@ -72,7 +72,7 @@ export type FakeEnumRequestGetInline200ResponseNullableStringEnumEnum = typeof F
 export const FakeEnumRequestGetInline200ResponseNumberEnumEnum = {
     NUMBER_1: 1,
     NUMBER_2: 2,
-    NUMBER_3: 3
+    NUMBER_3: 3,
 } as const;
 export type FakeEnumRequestGetInline200ResponseNumberEnumEnum = typeof FakeEnumRequestGetInline200ResponseNumberEnumEnum[keyof typeof FakeEnumRequestGetInline200ResponseNumberEnumEnum];
 
@@ -82,7 +82,7 @@ export type FakeEnumRequestGetInline200ResponseNumberEnumEnum = typeof FakeEnumR
 export const FakeEnumRequestGetInline200ResponseNullableNumberEnumEnum = {
     NUMBER_1: 1,
     NUMBER_2: 2,
-    NUMBER_3: 3
+    NUMBER_3: 3,
 } as const;
 export type FakeEnumRequestGetInline200ResponseNullableNumberEnumEnum = typeof FakeEnumRequestGetInline200ResponseNullableNumberEnumEnum[keyof typeof FakeEnumRequestGetInline200ResponseNullableNumberEnumEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/FakeEnumRequestPostInlineRequest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/FakeEnumRequestPostInlineRequest.ts
@@ -52,7 +52,7 @@ export interface FakeEnumRequestPostInlineRequest {
 export const FakeEnumRequestPostInlineRequestStringEnumEnum = {
     One: 'one',
     Two: 'two',
-    Three: 'three'
+    Three: 'three',
 } as const;
 export type FakeEnumRequestPostInlineRequestStringEnumEnum = typeof FakeEnumRequestPostInlineRequestStringEnumEnum[keyof typeof FakeEnumRequestPostInlineRequestStringEnumEnum];
 
@@ -62,7 +62,7 @@ export type FakeEnumRequestPostInlineRequestStringEnumEnum = typeof FakeEnumRequ
 export const FakeEnumRequestPostInlineRequestNullableStringEnumEnum = {
     One: 'one',
     Two: 'two',
-    Three: 'three'
+    Three: 'three',
 } as const;
 export type FakeEnumRequestPostInlineRequestNullableStringEnumEnum = typeof FakeEnumRequestPostInlineRequestNullableStringEnumEnum[keyof typeof FakeEnumRequestPostInlineRequestNullableStringEnumEnum];
 
@@ -72,7 +72,7 @@ export type FakeEnumRequestPostInlineRequestNullableStringEnumEnum = typeof Fake
 export const FakeEnumRequestPostInlineRequestNumberEnumEnum = {
     NUMBER_1: 1,
     NUMBER_2: 2,
-    NUMBER_3: 3
+    NUMBER_3: 3,
 } as const;
 export type FakeEnumRequestPostInlineRequestNumberEnumEnum = typeof FakeEnumRequestPostInlineRequestNumberEnumEnum[keyof typeof FakeEnumRequestPostInlineRequestNumberEnumEnum];
 
@@ -82,7 +82,7 @@ export type FakeEnumRequestPostInlineRequestNumberEnumEnum = typeof FakeEnumRequ
 export const FakeEnumRequestPostInlineRequestNullableNumberEnumEnum = {
     NUMBER_1: 1,
     NUMBER_2: 2,
-    NUMBER_3: 3
+    NUMBER_3: 3,
 } as const;
 export type FakeEnumRequestPostInlineRequestNullableNumberEnumEnum = typeof FakeEnumRequestPostInlineRequestNullableNumberEnumEnum[keyof typeof FakeEnumRequestPostInlineRequestNullableNumberEnumEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/InlineObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/InlineObject.ts
@@ -52,7 +52,7 @@ export interface InlineObject {
 export const InlineObjectStringEnumEnum = {
     One: 'one',
     Two: 'two',
-    Three: 'three'
+    Three: 'three',
 } as const;
 export type InlineObjectStringEnumEnum = typeof InlineObjectStringEnumEnum[keyof typeof InlineObjectStringEnumEnum];
 
@@ -62,7 +62,7 @@ export type InlineObjectStringEnumEnum = typeof InlineObjectStringEnumEnum[keyof
 export const InlineObjectNumberEnumEnum = {
     NUMBER_1: 1,
     NUMBER_2: 2,
-    NUMBER_3: 3
+    NUMBER_3: 3,
 } as const;
 export type InlineObjectNumberEnumEnum = typeof InlineObjectNumberEnumEnum[keyof typeof InlineObjectNumberEnumEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/InlineResponse200.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/InlineResponse200.ts
@@ -52,7 +52,7 @@ export interface InlineResponse200 {
 export const InlineResponse200StringEnumEnum = {
     One: 'one',
     Two: 'two',
-    Three: 'three'
+    Three: 'three',
 } as const;
 export type InlineResponse200StringEnumEnum = typeof InlineResponse200StringEnumEnum[keyof typeof InlineResponse200StringEnumEnum];
 
@@ -62,7 +62,7 @@ export type InlineResponse200StringEnumEnum = typeof InlineResponse200StringEnum
 export const InlineResponse200NumberEnumEnum = {
     NUMBER_1: 1,
     NUMBER_2: 2,
-    NUMBER_3: 3
+    NUMBER_3: 3,
 } as const;
 export type InlineResponse200NumberEnumEnum = typeof InlineResponse200NumberEnumEnum[keyof typeof InlineResponse200NumberEnumEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/NumberEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/NumberEnum.ts
@@ -20,7 +20,7 @@
 export const NumberEnum = {
     NUMBER_1: 1,
     NUMBER_2: 2,
-    NUMBER_3: 3
+    NUMBER_3: 3,
 } as const;
 export type NumberEnum = typeof NumberEnum[keyof typeof NumberEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/StringEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/StringEnum.ts
@@ -20,7 +20,7 @@
 export const StringEnum = {
     One: 'one',
     Two: 'two',
-    Three: 'three'
+    Three: 'three',
 } as const;
 export type StringEnum = typeof StringEnum[keyof typeof StringEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/PetApi.ts
@@ -541,6 +541,6 @@ export class PetApi extends runtime.BaseAPI {
 export const FindPetsByStatusStatusEnum = {
     Available: 'available',
     Pending: 'pending',
-    Sold: 'sold'
+    Sold: 'sold',
 } as const;
 export type FindPetsByStatusStatusEnum = typeof FindPetsByStatusStatusEnum[keyof typeof FindPetsByStatusStatusEnum];

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Order.ts
@@ -64,7 +64,7 @@ export interface Order {
 export const OrderStatusEnum = {
     Placed: 'placed',
     Approved: 'approved',
-    Delivered: 'delivered'
+    Delivered: 'delivered',
 } as const;
 export type OrderStatusEnum = typeof OrderStatusEnum[keyof typeof OrderStatusEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Pet.ts
@@ -79,7 +79,7 @@ export interface Pet {
 export const PetStatusEnum = {
     Available: 'available',
     Pending: 'pending',
-    Sold: 'sold'
+    Sold: 'sold',
 } as const;
 export type PetStatusEnum = typeof PetStatusEnum[keyof typeof PetStatusEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/PetApi.ts
@@ -541,6 +541,6 @@ export class PetApi extends runtime.BaseAPI {
 export const FindPetsByStatusStatusEnum = {
     Available: 'available',
     Pending: 'pending',
-    Sold: 'sold'
+    Sold: 'sold',
 } as const;
 export type FindPetsByStatusStatusEnum = typeof FindPetsByStatusStatusEnum[keyof typeof FindPetsByStatusStatusEnum];

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Order.ts
@@ -64,7 +64,7 @@ export interface Order {
 export const OrderStatusEnum = {
     Placed: 'placed',
     Approved: 'approved',
-    Delivered: 'delivered'
+    Delivered: 'delivered',
 } as const;
 export type OrderStatusEnum = typeof OrderStatusEnum[keyof typeof OrderStatusEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Pet.ts
@@ -79,7 +79,7 @@ export interface Pet {
 export const PetStatusEnum = {
     Available: 'available',
     Pending: 'pending',
-    Sold: 'sold'
+    Sold: 'sold',
 } as const;
 export type PetStatusEnum = typeof PetStatusEnum[keyof typeof PetStatusEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/OptionOne.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/OptionOne.ts
@@ -32,7 +32,7 @@ export interface OptionOne {
  * @export
  */
 export const OptionOneDiscriminatorFieldEnum = {
-    OptionOne: 'optionOne'
+    OptionOne: 'optionOne',
 } as const;
 export type OptionOneDiscriminatorFieldEnum = typeof OptionOneDiscriminatorFieldEnum[keyof typeof OptionOneDiscriminatorFieldEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/OptionTwo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/OptionTwo.ts
@@ -32,7 +32,7 @@ export interface OptionTwo {
  * @export
  */
 export const OptionTwoDiscriminatorFieldEnum = {
-    OptionTwo: 'optionTwo'
+    OptionTwo: 'optionTwo',
 } as const;
 export type OptionTwoDiscriminatorFieldEnum = typeof OptionTwoDiscriminatorFieldEnum[keyof typeof OptionTwoDiscriminatorFieldEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/PetApi.ts
@@ -541,6 +541,6 @@ export class PetApi extends runtime.BaseAPI {
 export const FindPetsByStatusStatusEnum = {
     Available: 'available',
     Pending: 'pending',
-    Sold: 'sold'
+    Sold: 'sold',
 } as const;
 export type FindPetsByStatusStatusEnum = typeof FindPetsByStatusStatusEnum[keyof typeof FindPetsByStatusStatusEnum];

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Order.ts
@@ -64,7 +64,7 @@ export interface Order {
 export const OrderStatusEnum = {
     Placed: 'placed',
     Approved: 'approved',
-    Delivered: 'delivered'
+    Delivered: 'delivered',
 } as const;
 export type OrderStatusEnum = typeof OrderStatusEnum[keyof typeof OrderStatusEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Pet.ts
@@ -79,7 +79,7 @@ export interface Pet {
 export const PetStatusEnum = {
     Available: 'available',
     Pending: 'pending',
-    Sold: 'sold'
+    Sold: 'sold',
 } as const;
 export type PetStatusEnum = typeof PetStatusEnum[keyof typeof PetStatusEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetApi.ts
@@ -786,6 +786,6 @@ export class PetApi extends runtime.BaseAPI {
 export const FindPetsByStatusStatusEnum = {
     Available: 'available',
     Pending: 'pending',
-    Sold: 'sold'
+    Sold: 'sold',
 } as const;
 export type FindPetsByStatusStatusEnum = typeof FindPetsByStatusStatusEnum[keyof typeof FindPetsByStatusStatusEnum];

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/BehaviorType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/BehaviorType.ts
@@ -20,7 +20,7 @@
 export const BehaviorType = {
     Voluntary: 'Voluntary',
     Involuntary: 'Involuntary',
-    Overt: 'Overt'
+    Overt: 'Overt',
 } as const;
 export type BehaviorType = typeof BehaviorType[keyof typeof BehaviorType];
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DeploymentRequestStatus.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DeploymentRequestStatus.ts
@@ -29,7 +29,7 @@ export const DeploymentRequestStatus = {
     Ready: 'Ready',
     Packaged: 'Packaged',
     Pairing: 'Pairing',
-    Paired: 'Paired'
+    Paired: 'Paired',
 } as const;
 export type DeploymentRequestStatus = typeof DeploymentRequestStatus[keyof typeof DeploymentRequestStatus];
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ErrorCode.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ErrorCode.ts
@@ -35,7 +35,7 @@ export const ErrorCode = {
     MaximumMessageGainHigherThanMaximum: 'Maximum_Message_Gain_Higher_Than_Maximum',
     MaximumMessageGainLowerThanMessageGain: 'Maximum_Message_Gain_Lower_Than_Message_Gain',
     MinimumVolumeBlocksMusicVolumeDecrease: 'Minimum_Volume_Blocks_Music_Volume_Decrease',
-    MaximumVolumeBlocksMusicVolumeIncrease: 'Maximum_Volume_Blocks_Music_Volume_Increase'
+    MaximumVolumeBlocksMusicVolumeIncrease: 'Maximum_Volume_Blocks_Music_Volume_Increase',
 } as const;
 export type ErrorCode = typeof ErrorCode[keyof typeof ErrorCode];
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Order.ts
@@ -64,7 +64,7 @@ export interface Order {
 export const OrderStatusEnum = {
     Placed: 'placed',
     Approved: 'approved',
-    Delivered: 'delivered'
+    Delivered: 'delivered',
 } as const;
 export type OrderStatusEnum = typeof OrderStatusEnum[keyof typeof OrderStatusEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Pet.ts
@@ -183,7 +183,7 @@ export interface Pet {
 export const PetStatusEnum = {
     Available: 'available',
     Pending: 'pending',
-    Sold: 'sold'
+    Sold: 'sold',
 } as const;
 export type PetStatusEnum = typeof PetStatusEnum[keyof typeof PetStatusEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetPartType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetPartType.ts
@@ -20,7 +20,7 @@
 export const PetPartType = {
     Curved: 'Curved',
     Smooth: 'Smooth',
-    Long: 'Long'
+    Long: 'Long',
 } as const;
 export type PetPartType = typeof PetPartType[keyof typeof PetPartType];
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ResponseMeta.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ResponseMeta.ts
@@ -92,7 +92,7 @@ export const ResponseMetaCodeEnum = {
     UserAlreadyHasMultipleGalaxieApiProductsException: 'User_Already_Has_Multiple_Galaxie_Api_Products_Exception',
     RecurlyApiException: 'Recurly_Api_Exception',
     RecurlyTransactionErrorException: 'Recurly_Transaction_Error_Exception',
-    GalaxieApiException: 'Galaxie_Api_Exception'
+    GalaxieApiException: 'Galaxie_Api_Exception',
 } as const;
 export type ResponseMetaCodeEnum = typeof ResponseMetaCodeEnum[keyof typeof ResponseMetaCodeEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/WarningCode.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/WarningCode.ts
@@ -20,7 +20,7 @@
 export const WarningCode = {
     ReduceVolumeRangeToAvoidLargeSteps: 'Reduce_Volume_Range_To_Avoid_Large_Steps',
     RaiseAmplifierVolume: 'Raise_Amplifier_Volume',
-    NoVolumeRangeSpecified: 'No_Volume_Range_Specified'
+    NoVolumeRangeSpecified: 'No_Volume_Range_Specified',
 } as const;
 export type WarningCode = typeof WarningCode[keyof typeof WarningCode];
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/FakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/FakeApi.ts
@@ -1254,7 +1254,7 @@ export class FakeApi extends runtime.BaseAPI {
  */
 export const TestEnumParametersEnumHeaderStringArrayEnum = {
     GreaterThan: '>',
-    Dollar: '$'
+    Dollar: '$',
 } as const;
 export type TestEnumParametersEnumHeaderStringArrayEnum = typeof TestEnumParametersEnumHeaderStringArrayEnum[keyof typeof TestEnumParametersEnumHeaderStringArrayEnum];
 /**
@@ -1263,7 +1263,7 @@ export type TestEnumParametersEnumHeaderStringArrayEnum = typeof TestEnumParamet
 export const TestEnumParametersEnumHeaderStringEnum = {
     Abc: '_abc',
     Efg: '-efg',
-    Xyz: '(xyz)'
+    Xyz: '(xyz)',
 } as const;
 export type TestEnumParametersEnumHeaderStringEnum = typeof TestEnumParametersEnumHeaderStringEnum[keyof typeof TestEnumParametersEnumHeaderStringEnum];
 /**
@@ -1271,7 +1271,7 @@ export type TestEnumParametersEnumHeaderStringEnum = typeof TestEnumParametersEn
  */
 export const TestEnumParametersEnumQueryStringArrayEnum = {
     GreaterThan: '>',
-    Dollar: '$'
+    Dollar: '$',
 } as const;
 export type TestEnumParametersEnumQueryStringArrayEnum = typeof TestEnumParametersEnumQueryStringArrayEnum[keyof typeof TestEnumParametersEnumQueryStringArrayEnum];
 /**
@@ -1280,7 +1280,7 @@ export type TestEnumParametersEnumQueryStringArrayEnum = typeof TestEnumParamete
 export const TestEnumParametersEnumQueryStringEnum = {
     Abc: '_abc',
     Efg: '-efg',
-    Xyz: '(xyz)'
+    Xyz: '(xyz)',
 } as const;
 export type TestEnumParametersEnumQueryStringEnum = typeof TestEnumParametersEnumQueryStringEnum[keyof typeof TestEnumParametersEnumQueryStringEnum];
 /**
@@ -1288,7 +1288,7 @@ export type TestEnumParametersEnumQueryStringEnum = typeof TestEnumParametersEnu
  */
 export const TestEnumParametersEnumQueryIntegerEnum = {
     NUMBER_1: 1,
-    NUMBER_MINUS_2: -2
+    NUMBER_MINUS_2: -2,
 } as const;
 export type TestEnumParametersEnumQueryIntegerEnum = typeof TestEnumParametersEnumQueryIntegerEnum[keyof typeof TestEnumParametersEnumQueryIntegerEnum];
 /**
@@ -1296,7 +1296,7 @@ export type TestEnumParametersEnumQueryIntegerEnum = typeof TestEnumParametersEn
  */
 export const TestEnumParametersEnumQueryDoubleEnum = {
     NUMBER_1_DOT_1: 1.1,
-    NUMBER_MINUS_1_DOT_2: -1.2
+    NUMBER_MINUS_1_DOT_2: -1.2,
 } as const;
 export type TestEnumParametersEnumQueryDoubleEnum = typeof TestEnumParametersEnumQueryDoubleEnum[keyof typeof TestEnumParametersEnumQueryDoubleEnum];
 /**
@@ -1304,7 +1304,7 @@ export type TestEnumParametersEnumQueryDoubleEnum = typeof TestEnumParametersEnu
  */
 export const TestEnumParametersEnumFormStringArrayEnum = {
     GreaterThan: '>',
-    Dollar: '$'
+    Dollar: '$',
 } as const;
 export type TestEnumParametersEnumFormStringArrayEnum = typeof TestEnumParametersEnumFormStringArrayEnum[keyof typeof TestEnumParametersEnumFormStringArrayEnum];
 /**
@@ -1313,6 +1313,6 @@ export type TestEnumParametersEnumFormStringArrayEnum = typeof TestEnumParameter
 export const TestEnumParametersEnumFormStringEnum = {
     Abc: '_abc',
     Efg: '-efg',
-    Xyz: '(xyz)'
+    Xyz: '(xyz)',
 } as const;
 export type TestEnumParametersEnumFormStringEnum = typeof TestEnumParametersEnumFormStringEnum[keyof typeof TestEnumParametersEnumFormStringEnum];

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/PetApi.ts
@@ -641,6 +641,6 @@ export class PetApi extends runtime.BaseAPI {
 export const FindPetsByStatusStatusEnum = {
     Available: 'available',
     Pending: 'pending',
-    Sold: 'sold'
+    Sold: 'sold',
 } as const;
 export type FindPetsByStatusStatusEnum = typeof FindPetsByStatusStatusEnum[keyof typeof FindPetsByStatusStatusEnum];

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumArrays.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumArrays.ts
@@ -39,7 +39,7 @@ export interface EnumArrays {
  */
 export const EnumArraysJustSymbolEnum = {
     GreaterThanOrEqualTo: '>=',
-    Dollar: '$'
+    Dollar: '$',
 } as const;
 export type EnumArraysJustSymbolEnum = typeof EnumArraysJustSymbolEnum[keyof typeof EnumArraysJustSymbolEnum];
 
@@ -48,7 +48,7 @@ export type EnumArraysJustSymbolEnum = typeof EnumArraysJustSymbolEnum[keyof typ
  */
 export const EnumArraysArrayEnumEnum = {
     Fish: 'fish',
-    Crab: 'crab'
+    Crab: 'crab',
 } as const;
 export type EnumArraysArrayEnumEnum = typeof EnumArraysArrayEnumEnum[keyof typeof EnumArraysArrayEnumEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumClass.ts
@@ -20,7 +20,7 @@
 export const EnumClass = {
     Abc: '_abc',
     Efg: '-efg',
-    Xyz: '(xyz)'
+    Xyz: '(xyz)',
 } as const;
 export type EnumClass = typeof EnumClass[keyof typeof EnumClass];
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
@@ -105,7 +105,7 @@ export interface EnumTest {
 export const EnumTestEnumStringEnum = {
     Upper: 'UPPER',
     Lower: 'lower',
-    Empty: ''
+    Empty: '',
 } as const;
 export type EnumTestEnumStringEnum = typeof EnumTestEnumStringEnum[keyof typeof EnumTestEnumStringEnum];
 
@@ -115,7 +115,7 @@ export type EnumTestEnumStringEnum = typeof EnumTestEnumStringEnum[keyof typeof 
 export const EnumTestEnumStringRequiredEnum = {
     Upper: 'UPPER',
     Lower: 'lower',
-    Empty: ''
+    Empty: '',
 } as const;
 export type EnumTestEnumStringRequiredEnum = typeof EnumTestEnumStringRequiredEnum[keyof typeof EnumTestEnumStringRequiredEnum];
 
@@ -124,7 +124,7 @@ export type EnumTestEnumStringRequiredEnum = typeof EnumTestEnumStringRequiredEn
  */
 export const EnumTestEnumIntegerEnum = {
     NUMBER_1: 1,
-    NUMBER_MINUS_1: -1
+    NUMBER_MINUS_1: -1,
 } as const;
 export type EnumTestEnumIntegerEnum = typeof EnumTestEnumIntegerEnum[keyof typeof EnumTestEnumIntegerEnum];
 
@@ -133,7 +133,7 @@ export type EnumTestEnumIntegerEnum = typeof EnumTestEnumIntegerEnum[keyof typeo
  */
 export const EnumTestEnumNumberEnum = {
     NUMBER_1_DOT_1: 1.1,
-    NUMBER_MINUS_1_DOT_2: -1.2
+    NUMBER_MINUS_1_DOT_2: -1.2,
 } as const;
 export type EnumTestEnumNumberEnum = typeof EnumTestEnumNumberEnum[keyof typeof EnumTestEnumNumberEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MapTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MapTest.ts
@@ -51,7 +51,7 @@ export interface MapTest {
  */
 export const MapTestMapOfEnumStringEnum = {
     Upper: 'UPPER',
-    Lower: 'lower'
+    Lower: 'lower',
 } as const;
 export type MapTestMapOfEnumStringEnum = typeof MapTestMapOfEnumStringEnum[keyof typeof MapTestMapOfEnumStringEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Order.ts
@@ -64,7 +64,7 @@ export interface Order {
 export const OrderStatusEnum = {
     Placed: 'placed',
     Approved: 'approved',
-    Delivered: 'delivered'
+    Delivered: 'delivered',
 } as const;
 export type OrderStatusEnum = typeof OrderStatusEnum[keyof typeof OrderStatusEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnum.ts
@@ -20,7 +20,7 @@
 export const OuterEnum = {
     Placed: 'placed',
     Approved: 'approved',
-    Delivered: 'delivered'
+    Delivered: 'delivered',
 } as const;
 export type OuterEnum = typeof OuterEnum[keyof typeof OuterEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumDefaultValue.ts
@@ -20,7 +20,7 @@
 export const OuterEnumDefaultValue = {
     Placed: 'placed',
     Approved: 'approved',
-    Delivered: 'delivered'
+    Delivered: 'delivered',
 } as const;
 export type OuterEnumDefaultValue = typeof OuterEnumDefaultValue[keyof typeof OuterEnumDefaultValue];
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumInteger.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumInteger.ts
@@ -20,7 +20,7 @@
 export const OuterEnumInteger = {
     NUMBER_0: 0,
     NUMBER_1: 1,
-    NUMBER_2: 2
+    NUMBER_2: 2,
 } as const;
 export type OuterEnumInteger = typeof OuterEnumInteger[keyof typeof OuterEnumInteger];
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumIntegerDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumIntegerDefaultValue.ts
@@ -20,7 +20,7 @@
 export const OuterEnumIntegerDefaultValue = {
     NUMBER_0: 0,
     NUMBER_1: 1,
-    NUMBER_2: 2
+    NUMBER_2: 2,
 } as const;
 export type OuterEnumIntegerDefaultValue = typeof OuterEnumIntegerDefaultValue[keyof typeof OuterEnumIntegerDefaultValue];
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Pet.ts
@@ -79,7 +79,7 @@ export interface Pet {
 export const PetStatusEnum = {
     Available: 'available',
     Pending: 'pending',
-    Sold: 'sold'
+    Sold: 'sold',
 } as const;
 export type PetStatusEnum = typeof PetStatusEnum[keyof typeof PetStatusEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SingleRefType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SingleRefType.ts
@@ -19,7 +19,7 @@
  */
 export const SingleRefType = {
     Admin: 'admin',
-    User: 'user'
+    User: 'user',
 } as const;
 export type SingleRefType = typeof SingleRefType[keyof typeof SingleRefType];
 

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/apis/PetApi.ts
@@ -553,6 +553,6 @@ export class PetApi extends runtime.BaseAPI {
 export const FindPetsByStatusStatusEnum = {
     Available: 'available',
     Pending: 'pending',
-    Sold: 'sold'
+    Sold: 'sold',
 } as const;
 export type FindPetsByStatusStatusEnum = typeof FindPetsByStatusStatusEnum[keyof typeof FindPetsByStatusStatusEnum];

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Order.ts
@@ -65,7 +65,7 @@ export interface Order {
 export const OrderStatusEnum = {
     Placed: 'placed',
     Approved: 'approved',
-    Delivered: 'delivered'
+    Delivered: 'delivered',
 } as const;
 export type OrderStatusEnum = typeof OrderStatusEnum[keyof typeof OrderStatusEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Pet.ts
@@ -80,7 +80,7 @@ export interface Pet {
 export const PetStatusEnum = {
     Available: 'available',
     Pending: 'pending',
-    Sold: 'sold'
+    Sold: 'sold',
 } as const;
 export type PetStatusEnum = typeof PetStatusEnum[keyof typeof PetStatusEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/PetApi.ts
@@ -750,6 +750,6 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
 export const FindPetsByStatusStatusEnum = {
     Available: 'available',
     Pending: 'pending',
-    Sold: 'sold'
+    Sold: 'sold',
 } as const;
 export type FindPetsByStatusStatusEnum = typeof FindPetsByStatusStatusEnum[keyof typeof FindPetsByStatusStatusEnum];

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Order.ts
@@ -64,7 +64,7 @@ export interface Order {
 export const OrderStatusEnum = {
     Placed: 'placed',
     Approved: 'approved',
-    Delivered: 'delivered'
+    Delivered: 'delivered',
 } as const;
 export type OrderStatusEnum = typeof OrderStatusEnum[keyof typeof OrderStatusEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
@@ -79,7 +79,7 @@ export interface Pet {
 export const PetStatusEnum = {
     Available: 'available',
     Pending: 'pending',
-    Sold: 'sold'
+    Sold: 'sold',
 } as const;
 export type PetStatusEnum = typeof PetStatusEnum[keyof typeof PetStatusEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/PetApi.ts
@@ -541,6 +541,6 @@ export class PetApi extends runtime.BaseAPI {
 export const FindPetsByStatusStatusEnum = {
     Available: 'available',
     Pending: 'pending',
-    Sold: 'sold'
+    Sold: 'sold',
 } as const;
 export type FindPetsByStatusStatusEnum = typeof FindPetsByStatusStatusEnum[keyof typeof FindPetsByStatusStatusEnum];

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Order.ts
@@ -64,7 +64,7 @@ export interface Order {
 export const OrderStatusEnum = {
     Placed: 'placed',
     Approved: 'approved',
-    Delivered: 'delivered'
+    Delivered: 'delivered',
 } as const;
 export type OrderStatusEnum = typeof OrderStatusEnum[keyof typeof OrderStatusEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Pet.ts
@@ -79,7 +79,7 @@ export interface Pet {
 export const PetStatusEnum = {
     Available: 'available',
     Pending: 'pending',
-    Sold: 'sold'
+    Sold: 'sold',
 } as const;
 export type PetStatusEnum = typeof PetStatusEnum[keyof typeof PetStatusEnum];
 

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/PetApi.ts
@@ -535,6 +535,6 @@ export class PetApi extends runtime.BaseAPI {
 export const FindPetsByStatusStatusEnum = {
     Available: 'available',
     Pending: 'pending',
-    Sold: 'sold'
+    Sold: 'sold',
 } as const;
 export type FindPetsByStatusStatusEnum = typeof FindPetsByStatusStatusEnum[keyof typeof FindPetsByStatusStatusEnum];

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/models/index.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/models/index.ts
@@ -95,7 +95,7 @@ export interface Order {
 export const OrderStatusEnum = {
     Placed: 'placed',
     Approved: 'approved',
-    Delivered: 'delivered'
+    Delivered: 'delivered',
 } as const;
 export type OrderStatusEnum = typeof OrderStatusEnum[keyof typeof OrderStatusEnum];
 
@@ -150,7 +150,7 @@ export interface Pet {
 export const PetStatusEnum = {
     Available: 'available',
     Pending: 'pending',
-    Sold: 'sold'
+    Sold: 'sold',
 } as const;
 export type PetStatusEnum = typeof PetStatusEnum[keyof typeof PetStatusEnum];
 

--- a/samples/server/petstore/typescript-nestjs-server/builds/default/models/order.ts
+++ b/samples/server/petstore/typescript-nestjs-server/builds/default/models/order.ts
@@ -18,7 +18,7 @@ export namespace Order {
   export const StatusEnum = {
     Placed: 'placed',
     Approved: 'approved',
-    Delivered: 'delivered'
+    Delivered: 'delivered',
   } as const;
   export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }

--- a/samples/server/petstore/typescript-nestjs-server/builds/default/models/pet.ts
+++ b/samples/server/petstore/typescript-nestjs-server/builds/default/models/pet.ts
@@ -21,7 +21,7 @@ export namespace Pet {
   export const StatusEnum = {
     Available: 'available',
     Pending: 'pending',
-    Sold: 'sold'
+    Sold: 'sold',
   } as const;
   export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }


### PR DESCRIPTION
## Summary
- add trailing commas to `as const` enum objects in typescript-angular, typescript-fetch, and typescript-nestjs-server
- update generated samples and add shared regression coverage

continuation of #23275

<sup>PR opened by gpt-5.4 xhigh on opencode</sup>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generate `as const` enum objects with trailing commas to reduce diff noise and align with common TS style across generators. Updates templates for `typescript-angular`, `typescript-fetch`, and `typescript-nestjs-server`, and adds shared regression coverage across generators.

- **Bug Fixes**
  - Always emit trailing commas in enum objects in `typescript-angular`, `typescript-fetch`, and `typescript-nestjs-server` templates.
  - Updated generated samples to reflect the new formatting.
  - Added a shared test to enforce trailing commas across `typescript-angular`, `typescript-fetch`, `typescript-nestjs-server`, and `typescript-axios`.

<sup>Written for commit d9cb3b19d8e095227e26612a5c047be9540a3486. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



