### PR TITLE
[php-nextgen]: Fix offsetGet/offsetExists/offsetSet parameter

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/model_generic.mustache
@@ -487,7 +487,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -499,7 +499,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -512,7 +512,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -529,7 +529,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/Bird.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/Bird.php
@@ -351,7 +351,7 @@ class Bird implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -363,7 +363,7 @@ class Bird implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -376,7 +376,7 @@ class Bird implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -393,7 +393,7 @@ class Bird implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/Category.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/Category.php
@@ -351,7 +351,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -363,7 +363,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -376,7 +376,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -393,7 +393,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/DataQuery.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/DataQuery.php
@@ -375,7 +375,7 @@ class DataQuery extends Query
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -387,7 +387,7 @@ class DataQuery extends Query
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -400,7 +400,7 @@ class DataQuery extends Query
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -417,7 +417,7 @@ class DataQuery extends Query
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/DefaultValue.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/DefaultValue.php
@@ -603,7 +603,7 @@ class DefaultValue implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -615,7 +615,7 @@ class DefaultValue implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -628,7 +628,7 @@ class DefaultValue implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -645,7 +645,7 @@ class DefaultValue implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/NumberPropertiesOnly.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/NumberPropertiesOnly.php
@@ -401,7 +401,7 @@ class NumberPropertiesOnly implements ModelInterface, ArrayAccess, JsonSerializa
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -413,7 +413,7 @@ class NumberPropertiesOnly implements ModelInterface, ArrayAccess, JsonSerializa
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -426,7 +426,7 @@ class NumberPropertiesOnly implements ModelInterface, ArrayAccess, JsonSerializa
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -443,7 +443,7 @@ class NumberPropertiesOnly implements ModelInterface, ArrayAccess, JsonSerializa
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/Pet.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/Pet.php
@@ -529,7 +529,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -541,7 +541,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -554,7 +554,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -571,7 +571,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/Query.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/Query.php
@@ -377,7 +377,7 @@ class Query implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -389,7 +389,7 @@ class Query implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -402,7 +402,7 @@ class Query implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -419,7 +419,7 @@ class Query implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/Tag.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/Tag.php
@@ -351,7 +351,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -363,7 +363,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -376,7 +376,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -393,7 +393,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/TestFormObjectMultipartRequestMarker.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/TestFormObjectMultipartRequestMarker.php
@@ -317,7 +317,7 @@ class TestFormObjectMultipartRequestMarker implements ModelInterface, ArrayAcces
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -329,7 +329,7 @@ class TestFormObjectMultipartRequestMarker implements ModelInterface, ArrayAcces
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -342,7 +342,7 @@ class TestFormObjectMultipartRequestMarker implements ModelInterface, ArrayAcces
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -359,7 +359,7 @@ class TestFormObjectMultipartRequestMarker implements ModelInterface, ArrayAcces
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter.php
@@ -419,7 +419,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter impleme
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -431,7 +431,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter impleme
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -444,7 +444,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter impleme
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -461,7 +461,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter impleme
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.php
@@ -317,7 +317,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter implements Mo
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -329,7 +329,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter implements Mo
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -342,7 +342,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter implements Mo
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -359,7 +359,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter implements Mo
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen/src/Model/Bird.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/Bird.php
@@ -351,7 +351,7 @@ class Bird implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -363,7 +363,7 @@ class Bird implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -376,7 +376,7 @@ class Bird implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -393,7 +393,7 @@ class Bird implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen/src/Model/Category.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/Category.php
@@ -351,7 +351,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -363,7 +363,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -376,7 +376,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -393,7 +393,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen/src/Model/DataQuery.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/DataQuery.php
@@ -375,7 +375,7 @@ class DataQuery extends Query
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -387,7 +387,7 @@ class DataQuery extends Query
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -400,7 +400,7 @@ class DataQuery extends Query
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -417,7 +417,7 @@ class DataQuery extends Query
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen/src/Model/DefaultValue.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/DefaultValue.php
@@ -603,7 +603,7 @@ class DefaultValue implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -615,7 +615,7 @@ class DefaultValue implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -628,7 +628,7 @@ class DefaultValue implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -645,7 +645,7 @@ class DefaultValue implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen/src/Model/NumberPropertiesOnly.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/NumberPropertiesOnly.php
@@ -401,7 +401,7 @@ class NumberPropertiesOnly implements ModelInterface, ArrayAccess, JsonSerializa
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -413,7 +413,7 @@ class NumberPropertiesOnly implements ModelInterface, ArrayAccess, JsonSerializa
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -426,7 +426,7 @@ class NumberPropertiesOnly implements ModelInterface, ArrayAccess, JsonSerializa
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -443,7 +443,7 @@ class NumberPropertiesOnly implements ModelInterface, ArrayAccess, JsonSerializa
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen/src/Model/Pet.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/Pet.php
@@ -529,7 +529,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -541,7 +541,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -554,7 +554,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -571,7 +571,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen/src/Model/Query.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/Query.php
@@ -377,7 +377,7 @@ class Query implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -389,7 +389,7 @@ class Query implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -402,7 +402,7 @@ class Query implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -419,7 +419,7 @@ class Query implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen/src/Model/Tag.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/Tag.php
@@ -351,7 +351,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -363,7 +363,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -376,7 +376,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -393,7 +393,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen/src/Model/TestFormObjectMultipartRequestMarker.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/TestFormObjectMultipartRequestMarker.php
@@ -317,7 +317,7 @@ class TestFormObjectMultipartRequestMarker implements ModelInterface, ArrayAcces
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -329,7 +329,7 @@ class TestFormObjectMultipartRequestMarker implements ModelInterface, ArrayAcces
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -342,7 +342,7 @@ class TestFormObjectMultipartRequestMarker implements ModelInterface, ArrayAcces
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -359,7 +359,7 @@ class TestFormObjectMultipartRequestMarker implements ModelInterface, ArrayAcces
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen/src/Model/TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter.php
@@ -419,7 +419,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter impleme
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -431,7 +431,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter impleme
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -444,7 +444,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter impleme
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -461,7 +461,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter impleme
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen/src/Model/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.php
@@ -317,7 +317,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter implements Mo
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -329,7 +329,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter implements Mo
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -342,7 +342,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter implements Mo
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -359,7 +359,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter implements Mo
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AdditionalPropertiesClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AdditionalPropertiesClass.php
@@ -350,7 +350,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, JsonSeri
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -362,7 +362,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, JsonSeri
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -375,7 +375,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, JsonSeri
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -392,7 +392,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, JsonSeri
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AllOfWithSingleRef.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AllOfWithSingleRef.php
@@ -350,7 +350,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, JsonSerializabl
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -362,7 +362,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, JsonSerializabl
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -375,7 +375,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, JsonSerializabl
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -392,7 +392,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, JsonSerializabl
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Animal.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Animal.php
@@ -358,7 +358,7 @@ class Animal implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -370,7 +370,7 @@ class Animal implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -383,7 +383,7 @@ class Animal implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -400,7 +400,7 @@ class Animal implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ApiResponse.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ApiResponse.php
@@ -384,7 +384,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -396,7 +396,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -409,7 +409,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -426,7 +426,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayOfArrayOfNumberOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayOfArrayOfNumberOnly.php
@@ -316,7 +316,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, JsonSeria
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -328,7 +328,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, JsonSeria
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -341,7 +341,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, JsonSeria
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -358,7 +358,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, JsonSeria
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayOfNumberOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayOfNumberOnly.php
@@ -316,7 +316,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -328,7 +328,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -341,7 +341,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -358,7 +358,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayTest.php
@@ -399,7 +399,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -411,7 +411,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -424,7 +424,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -441,7 +441,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Capitalization.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Capitalization.php
@@ -486,7 +486,7 @@ class Capitalization implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -498,7 +498,7 @@ class Capitalization implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -511,7 +511,7 @@ class Capitalization implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -528,7 +528,7 @@ class Capitalization implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Cat.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Cat.php
@@ -306,7 +306,7 @@ class Cat extends Animal
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -318,7 +318,7 @@ class Cat extends Animal
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -331,7 +331,7 @@ class Cat extends Animal
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -348,7 +348,7 @@ class Cat extends Animal
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Category.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Category.php
@@ -353,7 +353,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -365,7 +365,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -378,7 +378,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -395,7 +395,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ChildWithNullable.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ChildWithNullable.php
@@ -306,7 +306,7 @@ class ChildWithNullable extends ParentWithNullable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -318,7 +318,7 @@ class ChildWithNullable extends ParentWithNullable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -331,7 +331,7 @@ class ChildWithNullable extends ParentWithNullable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -348,7 +348,7 @@ class ChildWithNullable extends ParentWithNullable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ClassModel.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ClassModel.php
@@ -317,7 +317,7 @@ class ClassModel implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -329,7 +329,7 @@ class ClassModel implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -342,7 +342,7 @@ class ClassModel implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -359,7 +359,7 @@ class ClassModel implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Client.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Client.php
@@ -316,7 +316,7 @@ class Client implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -328,7 +328,7 @@ class Client implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -341,7 +341,7 @@ class Client implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -358,7 +358,7 @@ class Client implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/DeprecatedObject.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/DeprecatedObject.php
@@ -316,7 +316,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -328,7 +328,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -341,7 +341,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -358,7 +358,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Dog.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Dog.php
@@ -306,7 +306,7 @@ class Dog extends Animal
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -318,7 +318,7 @@ class Dog extends Animal
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -331,7 +331,7 @@ class Dog extends Animal
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -348,7 +348,7 @@ class Dog extends Animal
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumArrays.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumArrays.php
@@ -408,7 +408,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -420,7 +420,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -433,7 +433,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -450,7 +450,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumTest.php
@@ -704,7 +704,7 @@ class EnumTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -716,7 +716,7 @@ class EnumTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -729,7 +729,7 @@ class EnumTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -746,7 +746,7 @@ class EnumTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Error.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Error.php
@@ -354,7 +354,7 @@ class Error implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -366,7 +366,7 @@ class Error implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -379,7 +379,7 @@ class Error implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -396,7 +396,7 @@ class Error implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ErrorResponse.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ErrorResponse.php
@@ -350,7 +350,7 @@ class ErrorResponse implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -362,7 +362,7 @@ class ErrorResponse implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -375,7 +375,7 @@ class ErrorResponse implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -392,7 +392,7 @@ class ErrorResponse implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FakeBigDecimalMap200Response.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FakeBigDecimalMap200Response.php
@@ -350,7 +350,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, JsonS
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -362,7 +362,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, JsonS
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -375,7 +375,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, JsonS
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -392,7 +392,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, JsonS
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/File.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/File.php
@@ -317,7 +317,7 @@ class File implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -329,7 +329,7 @@ class File implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -342,7 +342,7 @@ class File implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -359,7 +359,7 @@ class File implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FileSchemaTestClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FileSchemaTestClass.php
@@ -350,7 +350,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, JsonSerializab
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -362,7 +362,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, JsonSerializab
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -375,7 +375,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, JsonSerializab
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -392,7 +392,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, JsonSerializab
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Foo.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Foo.php
@@ -316,7 +316,7 @@ class Foo implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -328,7 +328,7 @@ class Foo implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -341,7 +341,7 @@ class Foo implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -358,7 +358,7 @@ class Foo implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FooGetDefaultResponse.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FooGetDefaultResponse.php
@@ -316,7 +316,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, JsonSerializ
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -328,7 +328,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, JsonSerializ
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -341,7 +341,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, JsonSerializ
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -358,7 +358,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, JsonSerializ
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FormatTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FormatTest.php
@@ -994,7 +994,7 @@ class FormatTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -1006,7 +1006,7 @@ class FormatTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -1019,7 +1019,7 @@ class FormatTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -1036,7 +1036,7 @@ class FormatTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HasOnlyReadOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HasOnlyReadOnly.php
@@ -350,7 +350,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -362,7 +362,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -375,7 +375,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -392,7 +392,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HealthCheckResult.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HealthCheckResult.php
@@ -324,7 +324,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -336,7 +336,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -349,7 +349,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -366,7 +366,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MapTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MapTest.php
@@ -442,7 +442,7 @@ class MapTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -454,7 +454,7 @@ class MapTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -467,7 +467,7 @@ class MapTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -484,7 +484,7 @@ class MapTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -384,7 +384,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -396,7 +396,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -409,7 +409,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -426,7 +426,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Model200Response.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Model200Response.php
@@ -351,7 +351,7 @@ class Model200Response implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -363,7 +363,7 @@ class Model200Response implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -376,7 +376,7 @@ class Model200Response implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -393,7 +393,7 @@ class Model200Response implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelList.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelList.php
@@ -316,7 +316,7 @@ class ModelList implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -328,7 +328,7 @@ class ModelList implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -341,7 +341,7 @@ class ModelList implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -358,7 +358,7 @@ class ModelList implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelReturn.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelReturn.php
@@ -317,7 +317,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -329,7 +329,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -342,7 +342,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -359,7 +359,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Name.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Name.php
@@ -422,7 +422,7 @@ class Name implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -434,7 +434,7 @@ class Name implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -447,7 +447,7 @@ class Name implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -464,7 +464,7 @@ class Name implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NullableClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NullableClass.php
@@ -760,7 +760,7 @@ class NullableClass implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -772,7 +772,7 @@ class NullableClass implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -785,7 +785,7 @@ class NullableClass implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -802,7 +802,7 @@ class NullableClass implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NumberOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NumberOnly.php
@@ -316,7 +316,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -328,7 +328,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -341,7 +341,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -358,7 +358,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ObjectWithDeprecatedFields.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ObjectWithDeprecatedFields.php
@@ -424,7 +424,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, JsonSer
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -436,7 +436,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, JsonSer
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -449,7 +449,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, JsonSer
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -466,7 +466,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, JsonSer
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Order.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Order.php
@@ -522,7 +522,7 @@ class Order implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -534,7 +534,7 @@ class Order implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -547,7 +547,7 @@ class Order implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -564,7 +564,7 @@ class Order implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterComposite.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterComposite.php
@@ -384,7 +384,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -396,7 +396,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -409,7 +409,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -426,7 +426,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterObjectWithEnumProperty.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterObjectWithEnumProperty.php
@@ -319,7 +319,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, JsonSe
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -331,7 +331,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, JsonSe
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -344,7 +344,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, JsonSe
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -361,7 +361,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, JsonSe
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ParentWithNullable.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ParentWithNullable.php
@@ -392,7 +392,7 @@ class ParentWithNullable implements ModelInterface, ArrayAccess, JsonSerializabl
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -404,7 +404,7 @@ class ParentWithNullable implements ModelInterface, ArrayAccess, JsonSerializabl
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -417,7 +417,7 @@ class ParentWithNullable implements ModelInterface, ArrayAccess, JsonSerializabl
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -434,7 +434,7 @@ class ParentWithNullable implements ModelInterface, ArrayAccess, JsonSerializabl
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Pet.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Pet.php
@@ -530,7 +530,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -542,7 +542,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -555,7 +555,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -572,7 +572,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ReadOnlyFirst.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ReadOnlyFirst.php
@@ -350,7 +350,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -362,7 +362,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -375,7 +375,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -392,7 +392,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/SpecialModelName.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/SpecialModelName.php
@@ -316,7 +316,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -328,7 +328,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -341,7 +341,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -358,7 +358,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Tag.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Tag.php
@@ -350,7 +350,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -362,7 +362,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -375,7 +375,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -392,7 +392,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/TestInlineFreeformAdditionalPropertiesRequest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/TestInlineFreeformAdditionalPropertiesRequest.php
@@ -316,7 +316,7 @@ class TestInlineFreeformAdditionalPropertiesRequest implements ModelInterface, A
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -328,7 +328,7 @@ class TestInlineFreeformAdditionalPropertiesRequest implements ModelInterface, A
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -341,7 +341,7 @@ class TestInlineFreeformAdditionalPropertiesRequest implements ModelInterface, A
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -358,7 +358,7 @@ class TestInlineFreeformAdditionalPropertiesRequest implements ModelInterface, A
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/User.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/User.php
@@ -554,7 +554,7 @@ class User implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return boolean
      */
@@ -566,7 +566,7 @@ class User implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return mixed|null
      */
@@ -579,7 +579,7 @@ class User implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param integer|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -596,7 +596,7 @@ class User implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param integer|string $offset Offset
      *
      * @return void
      */


### PR DESCRIPTION
The parameter is defined as integer. However the offset on the container is probably a string in most of the time. This fix is very similar to #21583 for `php`.

@jebentier  @dkarlovi @mandrean @jfastnacht (2017/09) @ybelenko @renepardon


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ArrayAccess typing in `php-nextgen` models so offsets accept strings and `offsetGet` can return null. Regenerates affected `php-nextgen` and `php-nextgen-streaming` PHP samples.

- **Bug Fixes**
  - Update phpdoc for `offsetExists`, `offsetGet`, `offsetSet`, and `offsetUnset` to accept `integer|string` offsets; allow `null` for `offsetSet`.
  - Make `offsetGet` return type nullable and return `null` when the key is missing.

<sup>Written for commit 454b199fd5d60e4eafe269441ac35d840cfd5229. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



