### PR TITLE
[php-nextgen]: Fix array defaults

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpNextgenClientCodegen.java
@@ -251,7 +251,7 @@ public class PhpNextgenClientCodegen extends AbstractPhpCodegen {
             schema = ModelUtils.getReferencedSchema(this.openAPI, schema);
 
             if (schema.getDefault() != null) { // array schema has default value
-                return "[" + schema.getDefault().toString() + "]";
+                return schema.getDefault().toString();
             } else if (schema.getItems().getDefault() != null) { // array item schema has default value
                 return "[" + toDefaultValue(schema.getItems()) + "]";
             } else {

--- a/samples/client/echo_api/php-nextgen-streaming/docs/Model/DefaultValue.md
+++ b/samples/client/echo_api/php-nextgen-streaming/docs/Model/DefaultValue.md
@@ -4,10 +4,10 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**array_string_enum_ref_default** | [**\OpenAPI\Client\Model\StringEnumRef[]**](StringEnumRef.md) |  | [optional] [default to [["success","failure"]]]
-**array_string_enum_default** | **string[]** |  | [optional] [default to [["success","failure"]]]
-**array_string_default** | **string[]** |  | [optional] [default to [["failure","skipped"]]]
-**array_integer_default** | **int[]** |  | [optional] [default to [[1,3]]]
+**array_string_enum_ref_default** | [**\OpenAPI\Client\Model\StringEnumRef[]**](StringEnumRef.md) |  | [optional] [default to ["success","failure"]]
+**array_string_enum_default** | **string[]** |  | [optional] [default to ["success","failure"]]
+**array_string_default** | **string[]** |  | [optional] [default to ["failure","skipped"]]
+**array_integer_default** | **int[]** |  | [optional] [default to [1,3]]
 **array_string** | **string[]** |  | [optional]
 **array_string_nullable** | **string[]** |  | [optional]
 **array_string_extension_nullable** | **string[]** |  | [optional]

--- a/samples/client/echo_api/php-nextgen-streaming/docs/Model/Query.md
+++ b/samples/client/echo_api/php-nextgen-streaming/docs/Model/Query.md
@@ -5,6 +5,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **int** | Query | [optional]
-**outcomes** | **string[]** |  | [optional] [default to [["SUCCESS","FAILURE"]]]
+**outcomes** | **string[]** |  | [optional] [default to ["SUCCESS","FAILURE"]]
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/DefaultValue.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/DefaultValue.php
@@ -303,10 +303,10 @@ class DefaultValue implements ModelInterface, ArrayAccess, JsonSerializable
      */
     public function __construct(?array $data = null)
     {
-        $this->setIfExists('array_string_enum_ref_default', $data ?? [], [["success","failure"]]);
-        $this->setIfExists('array_string_enum_default', $data ?? [], [["success","failure"]]);
-        $this->setIfExists('array_string_default', $data ?? [], [["failure","skipped"]]);
-        $this->setIfExists('array_integer_default', $data ?? [], [[1,3]]);
+        $this->setIfExists('array_string_enum_ref_default', $data ?? [], ["success","failure"]);
+        $this->setIfExists('array_string_enum_default', $data ?? [], ["success","failure"]);
+        $this->setIfExists('array_string_default', $data ?? [], ["failure","skipped"]);
+        $this->setIfExists('array_integer_default', $data ?? [], [1,3]);
         $this->setIfExists('array_string', $data ?? [], null);
         $this->setIfExists('array_string_nullable', $data ?? [], null);
         $this->setIfExists('array_string_extension_nullable', $data ?? [], null);

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/Query.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/Query.php
@@ -267,7 +267,7 @@ class Query implements ModelInterface, ArrayAccess, JsonSerializable
     public function __construct(?array $data = null)
     {
         $this->setIfExists('id', $data ?? [], null);
-        $this->setIfExists('outcomes', $data ?? [], [["SUCCESS","FAILURE"]]);
+        $this->setIfExists('outcomes', $data ?? [], ["SUCCESS","FAILURE"]);
     }
 
     /**

--- a/samples/client/echo_api/php-nextgen/docs/Model/DefaultValue.md
+++ b/samples/client/echo_api/php-nextgen/docs/Model/DefaultValue.md
@@ -4,10 +4,10 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**array_string_enum_ref_default** | [**\OpenAPI\Client\Model\StringEnumRef[]**](StringEnumRef.md) |  | [optional] [default to [["success","failure"]]]
-**array_string_enum_default** | **string[]** |  | [optional] [default to [["success","failure"]]]
-**array_string_default** | **string[]** |  | [optional] [default to [["failure","skipped"]]]
-**array_integer_default** | **int[]** |  | [optional] [default to [[1,3]]]
+**array_string_enum_ref_default** | [**\OpenAPI\Client\Model\StringEnumRef[]**](StringEnumRef.md) |  | [optional] [default to ["success","failure"]]
+**array_string_enum_default** | **string[]** |  | [optional] [default to ["success","failure"]]
+**array_string_default** | **string[]** |  | [optional] [default to ["failure","skipped"]]
+**array_integer_default** | **int[]** |  | [optional] [default to [1,3]]
 **array_string** | **string[]** |  | [optional]
 **array_string_nullable** | **string[]** |  | [optional]
 **array_string_extension_nullable** | **string[]** |  | [optional]

--- a/samples/client/echo_api/php-nextgen/docs/Model/Query.md
+++ b/samples/client/echo_api/php-nextgen/docs/Model/Query.md
@@ -5,6 +5,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **int** | Query | [optional]
-**outcomes** | **string[]** |  | [optional] [default to [["SUCCESS","FAILURE"]]]
+**outcomes** | **string[]** |  | [optional] [default to ["SUCCESS","FAILURE"]]
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/samples/client/echo_api/php-nextgen/src/Model/DefaultValue.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/DefaultValue.php
@@ -303,10 +303,10 @@ class DefaultValue implements ModelInterface, ArrayAccess, JsonSerializable
      */
     public function __construct(?array $data = null)
     {
-        $this->setIfExists('array_string_enum_ref_default', $data ?? [], [["success","failure"]]);
-        $this->setIfExists('array_string_enum_default', $data ?? [], [["success","failure"]]);
-        $this->setIfExists('array_string_default', $data ?? [], [["failure","skipped"]]);
-        $this->setIfExists('array_integer_default', $data ?? [], [[1,3]]);
+        $this->setIfExists('array_string_enum_ref_default', $data ?? [], ["success","failure"]);
+        $this->setIfExists('array_string_enum_default', $data ?? [], ["success","failure"]);
+        $this->setIfExists('array_string_default', $data ?? [], ["failure","skipped"]);
+        $this->setIfExists('array_integer_default', $data ?? [], [1,3]);
         $this->setIfExists('array_string', $data ?? [], null);
         $this->setIfExists('array_string_nullable', $data ?? [], null);
         $this->setIfExists('array_string_extension_nullable', $data ?? [], null);

--- a/samples/client/echo_api/php-nextgen/src/Model/Query.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/Query.php
@@ -267,7 +267,7 @@ class Query implements ModelInterface, ArrayAccess, JsonSerializable
     public function __construct(?array $data = null)
     {
         $this->setIfExists('id', $data ?? [], null);
-        $this->setIfExists('outcomes', $data ?? [], [["SUCCESS","FAILURE"]]);
+        $this->setIfExists('outcomes', $data ?? [], ["SUCCESS","FAILURE"]);
     }
 
     /**


### PR DESCRIPTION
The array default value is double-wrapped in arrays, because the default value is already an array.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes array default handling in the `php-nextgen` generator to avoid double-wrapped defaults (e.g., `[["SUCCESS","FAILURE"]]` -> `["SUCCESS","FAILURE"]`). Regenerated `php-nextgen` and `php-nextgen-streaming` PHP models and docs to reflect correct defaults.

<sup>Written for commit a8f173b999aed2c410b37665bbbbbb2f299cec4b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

