### PR TITLE
Add scalafmt (plugin) to scala-akka client generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaAkkaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaAkkaClientCodegen.java
@@ -179,6 +179,8 @@ public class ScalaAkkaClientCodegen extends AbstractScalaCodegen implements Code
         supportingFiles.add(new SupportingFile("apiSettings.mustache", invokerFolder, "ApiSettings.scala"));
         final String apiFolder = (sourceFolder + File.separator + apiPackage).replace(".", File.separator);
         supportingFiles.add(new SupportingFile("project/build.properties.mustache", "project", "build.properties"));
+        supportingFiles.add(new SupportingFile("project/plugins.mustache", "project", "plugins.sbt"));
+        supportingFiles.add(new SupportingFile("scalafmt.mustache", "", ".scalafmt.conf"));
         supportingFiles.add(new SupportingFile("enumsSerializers.mustache", apiFolder, "EnumsSerializers.scala"));
         supportingFiles.add(new SupportingFile("serializers.mustache", invokerFolder, "Serializers.scala"));
     }

--- a/modules/openapi-generator/src/main/resources/scala-akka-client/project/plugins.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/project/plugins.mustache
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")

--- a/modules/openapi-generator/src/main/resources/scala-akka-client/scalafmt.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/scalafmt.mustache
@@ -1,0 +1,58 @@
+version=3.10.6
+runner.dialect = scala213
+project {
+  git = false
+  excludeFilters = [
+    scalafmt-benchmarks/src/resources,
+    sbt-test
+    bin/issue
+  ]
+  layout = StandardConvention
+}
+align {
+  preset = none
+  stripMargin = true
+}
+binPack {
+  importSelectors = fold
+}
+newlines {
+  avoidForSimpleOverflow = all
+  ignoreInSyntax = false
+  source = fold
+}
+rewrite {
+  rules = [
+    AvoidInfix,
+    Imports,
+    RedundantBraces,
+    RedundantParens,
+    SortModifiers,
+  ]
+  imports {
+    selectors = fold
+    removeRedundantSelectors = true
+    sort = ascii
+    groups = [
+      ["org\\.scalafmt\\..*"],
+      ["scala\\.meta\\..*", "org\\.scalameta\\..*"],
+      ["sbt\\..*"],
+      ["java.?\\..*"],
+      ["scala\\..*"],
+      ["org\\..*"],
+      ["com\\..*"],
+    ]
+  }
+  redundantBraces {
+    preset = all
+    oneStatApply {
+      parensMaxSpan = 300
+      bracesMinSpan = 300
+    }
+  }
+  redundantParens {
+    preset = all
+  }
+  sortModifiers.preset = styleGuide
+  trailingCommas.style = "always"
+}

--- a/samples/client/petstore/scala-akka/.openapi-generator/FILES
+++ b/samples/client/petstore/scala-akka/.openapi-generator/FILES
@@ -1,3 +1,4 @@
+.scalafmt.conf
 README.md
 build.sbt
 docs/ApiResponse.md
@@ -10,6 +11,7 @@ docs/Tag.md
 docs/User.md
 docs/UserApi.md
 project/build.properties
+project/plugins.sbt
 src/main/resources/reference.conf
 src/main/scala/org/openapitools/client/api/EnumsSerializers.scala
 src/main/scala/org/openapitools/client/api/PetApi.scala

--- a/samples/client/petstore/scala-akka/.scalafmt.conf
+++ b/samples/client/petstore/scala-akka/.scalafmt.conf
@@ -1,0 +1,58 @@
+version=3.10.6
+runner.dialect = scala213
+project {
+  git = false
+  excludeFilters = [
+    scalafmt-benchmarks/src/resources,
+    sbt-test
+    bin/issue
+  ]
+  layout = StandardConvention
+}
+align {
+  preset = none
+  stripMargin = true
+}
+binPack {
+  importSelectors = fold
+}
+newlines {
+  avoidForSimpleOverflow = all
+  ignoreInSyntax = false
+  source = fold
+}
+rewrite {
+  rules = [
+    AvoidInfix,
+    Imports,
+    RedundantBraces,
+    RedundantParens,
+    SortModifiers,
+  ]
+  imports {
+    selectors = fold
+    removeRedundantSelectors = true
+    sort = ascii
+    groups = [
+      ["org\\.scalafmt\\..*"],
+      ["scala\\.meta\\..*", "org\\.scalameta\\..*"],
+      ["sbt\\..*"],
+      ["java.?\\..*"],
+      ["scala\\..*"],
+      ["org\\..*"],
+      ["com\\..*"],
+    ]
+  }
+  redundantBraces {
+    preset = all
+    oneStatApply {
+      parensMaxSpan = 300
+      bracesMinSpan = 300
+    }
+  }
+  redundantParens {
+    preset = all
+  }
+  sortModifiers.preset = styleGuide
+  trailingCommas.style = "always"
+}

--- a/samples/client/petstore/scala-akka/project/plugins.sbt
+++ b/samples/client/petstore/scala-akka/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")


### PR DESCRIPTION
Adds scalafmt (`.scalafmt.conf`) and `sbt-scalafmt` plugin to the `scala-akka` client generator for consistent code formatting.

Follows the pattern established in #23273 for `scala-sttp4`.

Refs #23274

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/scala-akka.yaml || exit
  ``` 
  Commit all changed files. 
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Scalafmt to the `scala-akka` client generator to ensure consistent formatting by generating a `.scalafmt.conf` and enabling the `sbt-scalafmt` plugin.

- **New Features**
  - Generate `project/plugins.sbt` with `sbt-scalafmt` version `2.5.6`.
  - Generate `.scalafmt.conf` (Scalafmt `3.10.6`, Scala 2.13 dialect) via template.
  - Register both files in `ScalaAkkaClientCodegen` supporting files.
  - Update Scala Akka sample to include the new files.

<sup>Written for commit 6171846de4f3f7d1633cd52250995a9f3aa5ad4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

