### PR TITLE
[kotlin] Fix jvm-ktor multipart formData for array of file uploads

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-ktor/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-ktor/api.mustache
@@ -63,7 +63,14 @@ import com.fasterxml.jackson.databind.ObjectMapper
                         formData {
                     {{#formParams}}
                         {{#isFile}}
+                        {{#isArray}}
+                        for (x in {{{paramName}}} ?: listOf()) {
+                            append(x)
+                        }
+                        {{/isArray}}
+                        {{^isArray}}
                         {{{paramName}}}?.apply { append({{{paramName}}}) }
+                        {{/isArray}}
                         {{/isFile}}
                         {{^isFile}}
                         {{^isArray}}


### PR DESCRIPTION
## Summary

When a `multipart/form-data` endpoint has an **array of binary file parameters**, the generated jvm-ktor Kotlin client code fails to compile:

```
e: Cannot infer type for this parameter. Please specify it explicitly.
e: Argument type mismatch: actual type is 'List<FormPart<InputProvider>>', but 'FormPart<T>' was expected.
```

### Root cause

The `{{#isFile}}` block in the jvm-ktor `api.mustache` template does not check for `{{#isArray}}`. When `isFile` is true, the template unconditionally emits:

```kotlin
paramName?.apply { append(paramName) }
```

The `{{#isArray}}` iteration block is nested inside `{{^isFile}}` (line 82-86), so it is **never reached** for file parameters.

PR #21056 (v7.13.0) correctly fixed the **data type** in the method signature (`List<FormPart<InputProvider>>`), but did not update the **formData body** to iterate over array file parameters.

### Fix

Add an `{{#isArray}}`/`{{^isArray}}` check inside the `{{#isFile}}` block:

- **Single file**: `paramName?.apply { append(paramName) }` (unchanged)
- **Array of files**: `for (x in paramName ?: listOf()) { append(x) }` (new)

### OpenAPI spec to reproduce

```yaml
openapi: 3.0.0
info:
  version: "1.0.0"
  title: TestAPI
paths:
  /file-upload:
    post:
      operationId: uploadFiles
      requestBody:
        content:
          multipart/form-data:
            schema:
              type: object
              properties:
                files:
                  type: array
                  items:
                    type: string
                    format: binary
      responses:
        '204':
          description: Files uploaded
```

### Generated code

**Before (broken):**
```kotlin
files?.apply { append(files) }  // List<FormPart<InputProvider>> passed to append(FormPart<T>)
```

**After (fixed):**
```kotlin
for (x in files ?: listOf()) {
    append(x)  // Each FormPart<InputProvider> appended individually
}
```

Fixes #18094

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md)
- [x] Checked the issue tracker for related issues
- [x] This is a minimal, focused change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Kotlin `jvm-ktor` client generation for multipart/form-data arrays of binary files. We now iterate and append each `FormPart<InputProvider>` instead of passing the whole list, resolving the compile error and sending files correctly.

- **Bug Fixes**
  - Add `{{#isArray}}` handling inside `{{#isFile}}` in `kotlin-client/libraries/jvm-ktor/api.mustache`.
  - Single file unchanged; arrays use `for (x in param ?: listOf()) { append(x) }`.

<sup>Written for commit 4ac4ae76eee763d656b722efafefde7fecf98e31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

