### PR TITLE
Add scalafmt (plugin) to scala-http4s client generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaHttp4sClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaHttp4sClientCodegen.java
@@ -274,6 +274,8 @@ public class ScalaHttp4sClientCodegen extends AbstractScalaCodegen implements Co
         if (!excludeSbt) {
             supportingFiles.add(new SupportingFile("build.sbt.mustache", "", "build.sbt"));
             supportingFiles.add(new SupportingFile("project/build.properties.mustache", "project", "build.properties"));
+            supportingFiles.add(new SupportingFile("project/plugins.mustache", "project", "plugins.sbt"));
+            supportingFiles.add(new SupportingFile("scalafmt.mustache", "", ".scalafmt.conf"));
         } else {
             supportingFiles.remove(new SupportingFile("build.sbt.mustache", "", "build.sbt"));
             supportingFiles.remove(new SupportingFile("project/build.properties.mustache", "project", "build.properties"));

--- a/modules/openapi-generator/src/main/resources/scala-http4s/project/plugins.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-http4s/project/plugins.mustache
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")

--- a/modules/openapi-generator/src/main/resources/scala-http4s/scalafmt.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-http4s/scalafmt.mustache
@@ -1,0 +1,58 @@
+version=3.10.6
+runner.dialect = scala3
+project {
+  git = false
+  excludeFilters = [
+    scalafmt-benchmarks/src/resources,
+    sbt-test
+    bin/issue
+  ]
+  layout = StandardConvention
+}
+align {
+  preset = none
+  stripMargin = true
+}
+binPack {
+  importSelectors = fold
+}
+newlines {
+  avoidForSimpleOverflow = all
+  ignoreInSyntax = false
+  source = fold
+}
+rewrite {
+  rules = [
+    AvoidInfix,
+    Imports,
+    RedundantBraces,
+    RedundantParens,
+    SortModifiers,
+  ]
+  imports {
+    selectors = fold
+    removeRedundantSelectors = true
+    sort = ascii
+    groups = [
+      ["org\\.scalafmt\\..*"],
+      ["scala\\.meta\\..*", "org\\.scalameta\\..*"],
+      ["sbt\\..*"],
+      ["java.?\\..*"],
+      ["scala\\..*"],
+      ["org\\..*"],
+      ["com\\..*"],
+    ]
+  }
+  redundantBraces {
+    preset = all
+    oneStatApply {
+      parensMaxSpan = 300
+      bracesMinSpan = 300
+    }
+  }
+  redundantParens {
+    preset = all
+  }
+  sortModifiers.preset = styleGuide
+  trailingCommas.style = "always"
+}

--- a/samples/client/petstore/scala-http4s/.openapi-generator/FILES
+++ b/samples/client/petstore/scala-http4s/.openapi-generator/FILES
@@ -1,5 +1,7 @@
+.scalafmt.conf
 build.sbt
 project/build.properties
+project/plugins.sbt
 src/main/scala/org/openapitools/client/apis/BaseClient.scala
 src/main/scala/org/openapitools/client/apis/JsonSupports.scala
 src/main/scala/org/openapitools/client/apis/PetApi.scala

--- a/samples/client/petstore/scala-http4s/.scalafmt.conf
+++ b/samples/client/petstore/scala-http4s/.scalafmt.conf
@@ -1,0 +1,58 @@
+version=3.10.6
+runner.dialect = scala3
+project {
+  git = false
+  excludeFilters = [
+    scalafmt-benchmarks/src/resources,
+    sbt-test
+    bin/issue
+  ]
+  layout = StandardConvention
+}
+align {
+  preset = none
+  stripMargin = true
+}
+binPack {
+  importSelectors = fold
+}
+newlines {
+  avoidForSimpleOverflow = all
+  ignoreInSyntax = false
+  source = fold
+}
+rewrite {
+  rules = [
+    AvoidInfix,
+    Imports,
+    RedundantBraces,
+    RedundantParens,
+    SortModifiers,
+  ]
+  imports {
+    selectors = fold
+    removeRedundantSelectors = true
+    sort = ascii
+    groups = [
+      ["org\\.scalafmt\\..*"],
+      ["scala\\.meta\\..*", "org\\.scalameta\\..*"],
+      ["sbt\\..*"],
+      ["java.?\\..*"],
+      ["scala\\..*"],
+      ["org\\..*"],
+      ["com\\..*"],
+    ]
+  }
+  redundantBraces {
+    preset = all
+    oneStatApply {
+      parensMaxSpan = 300
+      bracesMinSpan = 300
+    }
+  }
+  redundantParens {
+    preset = all
+  }
+  sortModifiers.preset = styleGuide
+  trailingCommas.style = "always"
+}

--- a/samples/client/petstore/scala-http4s/project/plugins.sbt
+++ b/samples/client/petstore/scala-http4s/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")


### PR DESCRIPTION
Summary
- Adds `scalafmt.conf` and `sbt-scalafmt` plugin to the `scala-http4s` client generator for consistent code formatting
- Uses `runner.dialect = scala3` to match the generator's Scala 3.6.4 target
- Follows the pattern established in #23273 for `scala-sttp4`

Refs #23274

## PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/scala-http4s.yaml || exit
  ```
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Scalafmt support to the `scala-http4s` client generator for consistent formatting of generated Scala 3 code. Generates the plugin and config so users can run formatting out of the box.

- **New Features**
  - Generate `.scalafmt.conf` and `project/plugins.sbt` for `scala-http4s` clients.
  - Include `sbt-scalafmt` plugin `2.5.6` and Scalafmt `version=3.10.6` with `runner.dialect = scala3` (matches Scala 3.6.4 target).
  - Only added when SBT files are generated (skipped if `excludeSbt` is true).

<sup>Written for commit 5bdd29753a50f8308e9b5345d211d53697691ed0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

