### PR TITLE
fix(java/restclient): avoid IndexOutOfBoundsException for empty multi…

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/ApiClient.mustache
@@ -846,14 +846,14 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
 
         if (MediaType.MULTIPART_FORM_DATA.isCompatibleWith(contentType)) {
             formParams.forEach(
-                    (k, v) -> {
-                        if (v instanceof java.util.ArrayList) {
-                            Object o = v.get(0);
-                            if (o != null && o.getClass().getEnumConstants() != null) {
-                                v.set(0, o.toString());
-                            }
+                (k, v) -> {
+                    if (v instanceof java.util.ArrayList && !v.isEmpty()) {
+                        Object first = v.get(0);
+                        if (first != null && first.getClass().isEnum()) {
+                            v.set(0, first.toString());
                         }
-                    });
+                    }
+            });
         }
 
         var selectedBody = selectBody(body, formParams, contentType);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -4211,4 +4211,30 @@ public class JavaClientCodegenTest {
                 "feign-hc5 must preserve a user-provided templateDir and not overwrite it with 'feign'");
     }
 
+    @Test(description = "Regression test for multipart/form-data list handling in restclient ApiClient to avoid IndexOutOfBoundsException on empty lists")
+    public void testRestClientMultipartFormParamsGuardAgainstEmptyLists() {
+        final Path output = newTempFolder();
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(JAVA_GENERATOR)
+                .setLibrary(JavaClientCodegen.RESTCLIENT)
+                .setAdditionalProperties(Map.of(CodegenConstants.API_PACKAGE, "xyz.abcdef.api"))
+                .setInputSpec("src/test/resources/3_0/form-multipart-binary-array.yaml")
+                .setOutputDir(output.toString().replace("\\", "/"));
+
+        List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+
+        validateJavaSourceFiles(files);
+
+        assertFileContains(
+                output.resolve("src/main/java/xyz/abcdef/ApiClient.java"),
+                "if (v instanceof java.util.ArrayList && !v.isEmpty()) {",
+                "first.getClass().isEnum()"
+        );
+
+        TestUtils.assertFileNotContains(
+                output.resolve("src/main/java/xyz/abcdef/ApiClient.java"),
+                "if (v instanceof java.util.ArrayList) {",
+                "o.getClass().getEnumConstants() != null"
+        );
+    }
 }

--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -724,14 +724,14 @@ public class ApiClient extends JavaTimeFormatter {
 
         if (MediaType.MULTIPART_FORM_DATA.isCompatibleWith(contentType)) {
             formParams.forEach(
-                    (k, v) -> {
-                        if (v instanceof java.util.ArrayList) {
-                            Object o = v.get(0);
-                            if (o != null && o.getClass().getEnumConstants() != null) {
-                                v.set(0, o.toString());
-                            }
+                (k, v) -> {
+                    if (v instanceof java.util.ArrayList && !v.isEmpty()) {
+                        Object first = v.get(0);
+                        if (first != null && first.getClass().isEnum()) {
+                            v.set(0, first.toString());
                         }
-                    });
+                    }
+            });
         }
 
         var selectedBody = selectBody(body, formParams, contentType);

--- a/samples/client/others/java/restclient-enum-in-multipart/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/restclient-enum-in-multipart/src/main/java/org/openapitools/client/ApiClient.java
@@ -723,14 +723,14 @@ public class ApiClient extends JavaTimeFormatter {
 
         if (MediaType.MULTIPART_FORM_DATA.isCompatibleWith(contentType)) {
             formParams.forEach(
-                    (k, v) -> {
-                        if (v instanceof java.util.ArrayList) {
-                            Object o = v.get(0);
-                            if (o != null && o.getClass().getEnumConstants() != null) {
-                                v.set(0, o.toString());
-                            }
+                (k, v) -> {
+                    if (v instanceof java.util.ArrayList && !v.isEmpty()) {
+                        Object first = v.get(0);
+                        if (first != null && first.getClass().isEnum()) {
+                            v.set(0, first.toString());
                         }
-                    });
+                    }
+            });
         }
 
         var selectedBody = selectBody(body, formParams, contentType);

--- a/samples/client/others/java/restclient-sealedInterface/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/restclient-sealedInterface/src/main/java/org/openapitools/client/ApiClient.java
@@ -722,14 +722,14 @@ public class ApiClient extends JavaTimeFormatter {
 
         if (MediaType.MULTIPART_FORM_DATA.isCompatibleWith(contentType)) {
             formParams.forEach(
-                    (k, v) -> {
-                        if (v instanceof java.util.ArrayList) {
-                            Object o = v.get(0);
-                            if (o != null && o.getClass().getEnumConstants() != null) {
-                                v.set(0, o.toString());
-                            }
+                (k, v) -> {
+                    if (v instanceof java.util.ArrayList && !v.isEmpty()) {
+                        Object first = v.get(0);
+                        if (first != null && first.getClass().isEnum()) {
+                            v.set(0, first.toString());
                         }
-                    });
+                    }
+            });
         }
 
         var selectedBody = selectBody(body, formParams, contentType);

--- a/samples/client/others/java/restclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/restclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
@@ -722,14 +722,14 @@ public class ApiClient extends JavaTimeFormatter {
 
         if (MediaType.MULTIPART_FORM_DATA.isCompatibleWith(contentType)) {
             formParams.forEach(
-                    (k, v) -> {
-                        if (v instanceof java.util.ArrayList) {
-                            Object o = v.get(0);
-                            if (o != null && o.getClass().getEnumConstants() != null) {
-                                v.set(0, o.toString());
-                            }
+                (k, v) -> {
+                    if (v instanceof java.util.ArrayList && !v.isEmpty()) {
+                        Object first = v.get(0);
+                        if (first != null && first.getClass().isEnum()) {
+                            v.set(0, first.toString());
                         }
-                    });
+                    }
+            });
         }
 
         var selectedBody = selectBody(body, formParams, contentType);

--- a/samples/client/petstore/java/restclient-nullable-arrays/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-nullable-arrays/src/main/java/org/openapitools/client/ApiClient.java
@@ -722,14 +722,14 @@ public class ApiClient extends JavaTimeFormatter {
 
         if (MediaType.MULTIPART_FORM_DATA.isCompatibleWith(contentType)) {
             formParams.forEach(
-                    (k, v) -> {
-                        if (v instanceof java.util.ArrayList) {
-                            Object o = v.get(0);
-                            if (o != null && o.getClass().getEnumConstants() != null) {
-                                v.set(0, o.toString());
-                            }
+                (k, v) -> {
+                    if (v instanceof java.util.ArrayList && !v.isEmpty()) {
+                        Object first = v.get(0);
+                        if (first != null && first.getClass().isEnum()) {
+                            v.set(0, first.toString());
                         }
-                    });
+                    }
+            });
         }
 
         var selectedBody = selectBody(body, formParams, contentType);

--- a/samples/client/petstore/java/restclient-springBoot4-jackson2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson2/src/main/java/org/openapitools/client/ApiClient.java
@@ -748,14 +748,14 @@ public class ApiClient extends JavaTimeFormatter {
 
         if (MediaType.MULTIPART_FORM_DATA.isCompatibleWith(contentType)) {
             formParams.forEach(
-                    (k, v) -> {
-                        if (v instanceof java.util.ArrayList) {
-                            Object o = v.get(0);
-                            if (o != null && o.getClass().getEnumConstants() != null) {
-                                v.set(0, o.toString());
-                            }
+                (k, v) -> {
+                    if (v instanceof java.util.ArrayList && !v.isEmpty()) {
+                        Object first = v.get(0);
+                        if (first != null && first.getClass().isEnum()) {
+                            v.set(0, first.toString());
                         }
-                    });
+                    }
+            });
         }
 
         var selectedBody = selectBody(body, formParams, contentType);

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3/src/main/java/org/openapitools/client/ApiClient.java
@@ -741,14 +741,14 @@ public class ApiClient extends JavaTimeFormatter {
 
         if (MediaType.MULTIPART_FORM_DATA.isCompatibleWith(contentType)) {
             formParams.forEach(
-                    (k, v) -> {
-                        if (v instanceof java.util.ArrayList) {
-                            Object o = v.get(0);
-                            if (o != null && o.getClass().getEnumConstants() != null) {
-                                v.set(0, o.toString());
-                            }
+                (k, v) -> {
+                    if (v instanceof java.util.ArrayList && !v.isEmpty()) {
+                        Object first = v.get(0);
+                        if (first != null && first.getClass().isEnum()) {
+                            v.set(0, first.toString());
                         }
-                    });
+                    }
+            });
         }
 
         var selectedBody = selectBody(body, formParams, contentType);

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/ApiClient.java
@@ -795,14 +795,14 @@ public class ApiClient extends JavaTimeFormatter {
 
         if (MediaType.MULTIPART_FORM_DATA.isCompatibleWith(contentType)) {
             formParams.forEach(
-                    (k, v) -> {
-                        if (v instanceof java.util.ArrayList) {
-                            Object o = v.get(0);
-                            if (o != null && o.getClass().getEnumConstants() != null) {
-                                v.set(0, o.toString());
-                            }
+                (k, v) -> {
+                    if (v instanceof java.util.ArrayList && !v.isEmpty()) {
+                        Object first = v.get(0);
+                        if (first != null && first.getClass().isEnum()) {
+                            v.set(0, first.toString());
                         }
-                    });
+                    }
+            });
         }
 
         var selectedBody = selectBody(body, formParams, contentType);

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/ApiClient.java
@@ -795,14 +795,14 @@ public class ApiClient extends JavaTimeFormatter {
 
         if (MediaType.MULTIPART_FORM_DATA.isCompatibleWith(contentType)) {
             formParams.forEach(
-                    (k, v) -> {
-                        if (v instanceof java.util.ArrayList) {
-                            Object o = v.get(0);
-                            if (o != null && o.getClass().getEnumConstants() != null) {
-                                v.set(0, o.toString());
-                            }
+                (k, v) -> {
+                    if (v instanceof java.util.ArrayList && !v.isEmpty()) {
+                        Object first = v.get(0);
+                        if (first != null && first.getClass().isEnum()) {
+                            v.set(0, first.toString());
                         }
-                    });
+                    }
+            });
         }
 
         var selectedBody = selectBody(body, formParams, contentType);

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/ApiClient.java
@@ -795,14 +795,14 @@ public class ApiClient extends JavaTimeFormatter {
 
         if (MediaType.MULTIPART_FORM_DATA.isCompatibleWith(contentType)) {
             formParams.forEach(
-                    (k, v) -> {
-                        if (v instanceof java.util.ArrayList) {
-                            Object o = v.get(0);
-                            if (o != null && o.getClass().getEnumConstants() != null) {
-                                v.set(0, o.toString());
-                            }
+                (k, v) -> {
+                    if (v instanceof java.util.ArrayList && !v.isEmpty()) {
+                        Object first = v.get(0);
+                        if (first != null && first.getClass().isEnum()) {
+                            v.set(0, first.toString());
                         }
-                    });
+                    }
+            });
         }
 
         var selectedBody = selectBody(body, formParams, contentType);

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -795,14 +795,14 @@ public class ApiClient extends JavaTimeFormatter {
 
         if (MediaType.MULTIPART_FORM_DATA.isCompatibleWith(contentType)) {
             formParams.forEach(
-                    (k, v) -> {
-                        if (v instanceof java.util.ArrayList) {
-                            Object o = v.get(0);
-                            if (o != null && o.getClass().getEnumConstants() != null) {
-                                v.set(0, o.toString());
-                            }
+                (k, v) -> {
+                    if (v instanceof java.util.ArrayList && !v.isEmpty()) {
+                        Object first = v.get(0);
+                        if (first != null && first.getClass().isEnum()) {
+                            v.set(0, first.toString());
                         }
-                    });
+                    }
+            });
         }
 
         var selectedBody = selectBody(body, formParams, contentType);


### PR DESCRIPTION
…part list params (#23153)

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

### Description

This PR fixes an issue in the `java` generator (`restclient` library) where multipart form parameters containing lists could cause an `IndexOutOfBoundsException`.

#### Root cause

The existing implementation:
- Assumes list-based multipart parameters are non-empty and directly accesses `v.get(0)`
- Uses the first element only as a runtime type probe (due to type erasure)
- Detects enum lists via `getEnumConstants() != null`
- Converts only the first element of the list to `String`, leaving the rest unchanged
- Restricts handling to `ArrayList`, excluding other `List` implementations

This leads to:
- A crash when an empty list is passed

#### Fix

- Add a guard to ensure the list is not empty before accessing elements
- Replace `getEnumConstants()` with `isEnum()` for clearer intent

Updated logic:

```java
if (MediaType.MULTIPART_FORM_DATA.isCompatibleWith(contentType)) {
    formParams.forEach((k, v) -> {
                    if (v instanceof java.util.ArrayList && !v.isEmpty()) {
                        Object first = v.get(0);
                        if (first != null && first.getClass().isEnum()) {
                            v.set(0, first.toString());
                        }
                    }
    });
}
```
This preserves the original intent (enum list handling) while making it safe and consistent.

#### Tests

Added a regression test in JavaClientCodegenTest to verify that:

Generated ApiClient.java contains the new guarded logic

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an IndexOutOfBoundsException for empty multipart/form-data list params in `java` `restclient` by adding an empty-list guard and safer enum detection.

- **Bug Fixes**
  - Guard against empty `ArrayList` before accessing index 0 in multipart form params.
  - Detect enums with `isEnum()` and convert the first enum item to a string.
  - Added a regression test and regenerated samples.

<sup>Written for commit e0d29aeb325372c59469a853e6efa37cdaa75365. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

