### PR TITLE
[php-nextgen]: Fix ArrayAccess parameter types

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/model_generic.mustache
@@ -463,7 +463,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -475,7 +475,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -488,7 +488,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -505,7 +505,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/Bird.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/Bird.php
@@ -327,7 +327,7 @@ class Bird implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -339,7 +339,7 @@ class Bird implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -352,7 +352,7 @@ class Bird implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -369,7 +369,7 @@ class Bird implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/Category.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/Category.php
@@ -327,7 +327,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -339,7 +339,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -352,7 +352,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -369,7 +369,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/DataQuery.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/DataQuery.php
@@ -351,7 +351,7 @@ class DataQuery extends Query
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -363,7 +363,7 @@ class DataQuery extends Query
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -376,7 +376,7 @@ class DataQuery extends Query
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -393,7 +393,7 @@ class DataQuery extends Query
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/DefaultValue.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/DefaultValue.php
@@ -579,7 +579,7 @@ class DefaultValue implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -591,7 +591,7 @@ class DefaultValue implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -604,7 +604,7 @@ class DefaultValue implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -621,7 +621,7 @@ class DefaultValue implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/NumberPropertiesOnly.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/NumberPropertiesOnly.php
@@ -377,7 +377,7 @@ class NumberPropertiesOnly implements ModelInterface, ArrayAccess, JsonSerializa
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -389,7 +389,7 @@ class NumberPropertiesOnly implements ModelInterface, ArrayAccess, JsonSerializa
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -402,7 +402,7 @@ class NumberPropertiesOnly implements ModelInterface, ArrayAccess, JsonSerializa
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -419,7 +419,7 @@ class NumberPropertiesOnly implements ModelInterface, ArrayAccess, JsonSerializa
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/Pet.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/Pet.php
@@ -505,7 +505,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -517,7 +517,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -530,7 +530,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -547,7 +547,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/Query.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/Query.php
@@ -353,7 +353,7 @@ class Query implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -365,7 +365,7 @@ class Query implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -378,7 +378,7 @@ class Query implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -395,7 +395,7 @@ class Query implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/Tag.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/Tag.php
@@ -327,7 +327,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -339,7 +339,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -352,7 +352,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -369,7 +369,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/TestFormObjectMultipartRequestMarker.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/TestFormObjectMultipartRequestMarker.php
@@ -293,7 +293,7 @@ class TestFormObjectMultipartRequestMarker implements ModelInterface, ArrayAcces
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -305,7 +305,7 @@ class TestFormObjectMultipartRequestMarker implements ModelInterface, ArrayAcces
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -318,7 +318,7 @@ class TestFormObjectMultipartRequestMarker implements ModelInterface, ArrayAcces
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -335,7 +335,7 @@ class TestFormObjectMultipartRequestMarker implements ModelInterface, ArrayAcces
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter.php
@@ -395,7 +395,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter impleme
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -407,7 +407,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter impleme
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -420,7 +420,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter impleme
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -437,7 +437,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter impleme
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.php
@@ -293,7 +293,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter implements Mo
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -305,7 +305,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter implements Mo
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -318,7 +318,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter implements Mo
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -335,7 +335,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter implements Mo
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen/src/Model/Bird.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/Bird.php
@@ -327,7 +327,7 @@ class Bird implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -339,7 +339,7 @@ class Bird implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -352,7 +352,7 @@ class Bird implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -369,7 +369,7 @@ class Bird implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen/src/Model/Category.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/Category.php
@@ -327,7 +327,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -339,7 +339,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -352,7 +352,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -369,7 +369,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen/src/Model/DataQuery.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/DataQuery.php
@@ -351,7 +351,7 @@ class DataQuery extends Query
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -363,7 +363,7 @@ class DataQuery extends Query
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -376,7 +376,7 @@ class DataQuery extends Query
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -393,7 +393,7 @@ class DataQuery extends Query
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen/src/Model/DefaultValue.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/DefaultValue.php
@@ -579,7 +579,7 @@ class DefaultValue implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -591,7 +591,7 @@ class DefaultValue implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -604,7 +604,7 @@ class DefaultValue implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -621,7 +621,7 @@ class DefaultValue implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen/src/Model/NumberPropertiesOnly.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/NumberPropertiesOnly.php
@@ -377,7 +377,7 @@ class NumberPropertiesOnly implements ModelInterface, ArrayAccess, JsonSerializa
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -389,7 +389,7 @@ class NumberPropertiesOnly implements ModelInterface, ArrayAccess, JsonSerializa
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -402,7 +402,7 @@ class NumberPropertiesOnly implements ModelInterface, ArrayAccess, JsonSerializa
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -419,7 +419,7 @@ class NumberPropertiesOnly implements ModelInterface, ArrayAccess, JsonSerializa
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen/src/Model/Pet.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/Pet.php
@@ -505,7 +505,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -517,7 +517,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -530,7 +530,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -547,7 +547,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen/src/Model/Query.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/Query.php
@@ -353,7 +353,7 @@ class Query implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -365,7 +365,7 @@ class Query implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -378,7 +378,7 @@ class Query implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -395,7 +395,7 @@ class Query implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen/src/Model/Tag.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/Tag.php
@@ -327,7 +327,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -339,7 +339,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -352,7 +352,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -369,7 +369,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen/src/Model/TestFormObjectMultipartRequestMarker.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/TestFormObjectMultipartRequestMarker.php
@@ -293,7 +293,7 @@ class TestFormObjectMultipartRequestMarker implements ModelInterface, ArrayAcces
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -305,7 +305,7 @@ class TestFormObjectMultipartRequestMarker implements ModelInterface, ArrayAcces
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -318,7 +318,7 @@ class TestFormObjectMultipartRequestMarker implements ModelInterface, ArrayAcces
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -335,7 +335,7 @@ class TestFormObjectMultipartRequestMarker implements ModelInterface, ArrayAcces
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen/src/Model/TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter.php
@@ -395,7 +395,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter impleme
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -407,7 +407,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter impleme
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -420,7 +420,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter impleme
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -437,7 +437,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter impleme
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/echo_api/php-nextgen/src/Model/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.php
@@ -293,7 +293,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter implements Mo
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -305,7 +305,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter implements Mo
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -318,7 +318,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter implements Mo
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -335,7 +335,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter implements Mo
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AdditionalPropertiesClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AdditionalPropertiesClass.php
@@ -326,7 +326,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, JsonSeri
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -338,7 +338,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, JsonSeri
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -351,7 +351,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, JsonSeri
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -368,7 +368,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, JsonSeri
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AllOfWithSingleRef.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AllOfWithSingleRef.php
@@ -326,7 +326,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, JsonSerializabl
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -338,7 +338,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, JsonSerializabl
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -351,7 +351,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, JsonSerializabl
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -368,7 +368,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, JsonSerializabl
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Animal.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Animal.php
@@ -334,7 +334,7 @@ class Animal implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -346,7 +346,7 @@ class Animal implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -359,7 +359,7 @@ class Animal implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -376,7 +376,7 @@ class Animal implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ApiResponse.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ApiResponse.php
@@ -360,7 +360,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -372,7 +372,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -385,7 +385,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -402,7 +402,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayOfArrayOfNumberOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayOfArrayOfNumberOnly.php
@@ -292,7 +292,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, JsonSeria
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -304,7 +304,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, JsonSeria
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -317,7 +317,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, JsonSeria
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -334,7 +334,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, JsonSeria
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayOfNumberOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayOfNumberOnly.php
@@ -292,7 +292,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -304,7 +304,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -317,7 +317,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -334,7 +334,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayTest.php
@@ -375,7 +375,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -387,7 +387,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -400,7 +400,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -417,7 +417,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Capitalization.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Capitalization.php
@@ -462,7 +462,7 @@ class Capitalization implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -474,7 +474,7 @@ class Capitalization implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -487,7 +487,7 @@ class Capitalization implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -504,7 +504,7 @@ class Capitalization implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Cat.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Cat.php
@@ -282,7 +282,7 @@ class Cat extends Animal
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -294,7 +294,7 @@ class Cat extends Animal
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -307,7 +307,7 @@ class Cat extends Animal
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -324,7 +324,7 @@ class Cat extends Animal
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Category.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Category.php
@@ -329,7 +329,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -341,7 +341,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -354,7 +354,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -371,7 +371,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ChildWithNullable.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ChildWithNullable.php
@@ -282,7 +282,7 @@ class ChildWithNullable extends ParentWithNullable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -294,7 +294,7 @@ class ChildWithNullable extends ParentWithNullable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -307,7 +307,7 @@ class ChildWithNullable extends ParentWithNullable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -324,7 +324,7 @@ class ChildWithNullable extends ParentWithNullable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ClassModel.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ClassModel.php
@@ -293,7 +293,7 @@ class ClassModel implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -305,7 +305,7 @@ class ClassModel implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -318,7 +318,7 @@ class ClassModel implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -335,7 +335,7 @@ class ClassModel implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Client.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Client.php
@@ -292,7 +292,7 @@ class Client implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -304,7 +304,7 @@ class Client implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -317,7 +317,7 @@ class Client implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -334,7 +334,7 @@ class Client implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/DeprecatedObject.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/DeprecatedObject.php
@@ -292,7 +292,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -304,7 +304,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -317,7 +317,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -334,7 +334,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/DiscriminatorBase.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/DiscriminatorBase.php
@@ -299,7 +299,7 @@ class DiscriminatorBase implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -311,7 +311,7 @@ class DiscriminatorBase implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -324,7 +324,7 @@ class DiscriminatorBase implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -341,7 +341,7 @@ class DiscriminatorBase implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/DiscriminatorChild.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/DiscriminatorChild.php
@@ -282,7 +282,7 @@ class DiscriminatorChild extends DiscriminatorBase
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -294,7 +294,7 @@ class DiscriminatorChild extends DiscriminatorBase
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -307,7 +307,7 @@ class DiscriminatorChild extends DiscriminatorBase
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -324,7 +324,7 @@ class DiscriminatorChild extends DiscriminatorBase
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Dog.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Dog.php
@@ -282,7 +282,7 @@ class Dog extends Animal
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -294,7 +294,7 @@ class Dog extends Animal
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -307,7 +307,7 @@ class Dog extends Animal
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -324,7 +324,7 @@ class Dog extends Animal
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumArrays.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumArrays.php
@@ -384,7 +384,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -396,7 +396,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -409,7 +409,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -426,7 +426,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumTest.php
@@ -680,7 +680,7 @@ class EnumTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -692,7 +692,7 @@ class EnumTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -705,7 +705,7 @@ class EnumTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -722,7 +722,7 @@ class EnumTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Error.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Error.php
@@ -330,7 +330,7 @@ class Error implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -342,7 +342,7 @@ class Error implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -355,7 +355,7 @@ class Error implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -372,7 +372,7 @@ class Error implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ErrorResponse.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ErrorResponse.php
@@ -326,7 +326,7 @@ class ErrorResponse implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -338,7 +338,7 @@ class ErrorResponse implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -351,7 +351,7 @@ class ErrorResponse implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -368,7 +368,7 @@ class ErrorResponse implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FakeBigDecimalMap200Response.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FakeBigDecimalMap200Response.php
@@ -326,7 +326,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, JsonS
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -338,7 +338,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, JsonS
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -351,7 +351,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, JsonS
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -368,7 +368,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, JsonS
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/File.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/File.php
@@ -293,7 +293,7 @@ class File implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -305,7 +305,7 @@ class File implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -318,7 +318,7 @@ class File implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -335,7 +335,7 @@ class File implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FileSchemaTestClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FileSchemaTestClass.php
@@ -326,7 +326,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, JsonSerializab
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -338,7 +338,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, JsonSerializab
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -351,7 +351,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, JsonSerializab
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -368,7 +368,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, JsonSerializab
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Foo.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Foo.php
@@ -292,7 +292,7 @@ class Foo implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -304,7 +304,7 @@ class Foo implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -317,7 +317,7 @@ class Foo implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -334,7 +334,7 @@ class Foo implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FooGetDefaultResponse.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FooGetDefaultResponse.php
@@ -292,7 +292,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, JsonSerializ
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -304,7 +304,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, JsonSerializ
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -317,7 +317,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, JsonSerializ
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -334,7 +334,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, JsonSerializ
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FormatTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FormatTest.php
@@ -970,7 +970,7 @@ class FormatTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -982,7 +982,7 @@ class FormatTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -995,7 +995,7 @@ class FormatTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -1012,7 +1012,7 @@ class FormatTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HasOnlyReadOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HasOnlyReadOnly.php
@@ -326,7 +326,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -338,7 +338,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -351,7 +351,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -368,7 +368,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HealthCheckResult.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HealthCheckResult.php
@@ -300,7 +300,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -312,7 +312,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -325,7 +325,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -342,7 +342,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MapTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MapTest.php
@@ -418,7 +418,7 @@ class MapTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -430,7 +430,7 @@ class MapTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -443,7 +443,7 @@ class MapTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -460,7 +460,7 @@ class MapTest implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -360,7 +360,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -372,7 +372,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -385,7 +385,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -402,7 +402,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Model200Response.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Model200Response.php
@@ -327,7 +327,7 @@ class Model200Response implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -339,7 +339,7 @@ class Model200Response implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -352,7 +352,7 @@ class Model200Response implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -369,7 +369,7 @@ class Model200Response implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelList.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelList.php
@@ -292,7 +292,7 @@ class ModelList implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -304,7 +304,7 @@ class ModelList implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -317,7 +317,7 @@ class ModelList implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -334,7 +334,7 @@ class ModelList implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelReturn.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelReturn.php
@@ -293,7 +293,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -305,7 +305,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -318,7 +318,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -335,7 +335,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Name.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Name.php
@@ -398,7 +398,7 @@ class Name implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -410,7 +410,7 @@ class Name implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -423,7 +423,7 @@ class Name implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -440,7 +440,7 @@ class Name implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NullableClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NullableClass.php
@@ -736,7 +736,7 @@ class NullableClass implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -748,7 +748,7 @@ class NullableClass implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -761,7 +761,7 @@ class NullableClass implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -778,7 +778,7 @@ class NullableClass implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NumberOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NumberOnly.php
@@ -292,7 +292,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -304,7 +304,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -317,7 +317,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -334,7 +334,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ObjectWithDeprecatedFields.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ObjectWithDeprecatedFields.php
@@ -400,7 +400,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, JsonSer
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -412,7 +412,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, JsonSer
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -425,7 +425,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, JsonSer
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -442,7 +442,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, JsonSer
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Order.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Order.php
@@ -498,7 +498,7 @@ class Order implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -510,7 +510,7 @@ class Order implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -523,7 +523,7 @@ class Order implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -540,7 +540,7 @@ class Order implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterComposite.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterComposite.php
@@ -360,7 +360,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -372,7 +372,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -385,7 +385,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -402,7 +402,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterObjectWithEnumProperty.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterObjectWithEnumProperty.php
@@ -295,7 +295,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, JsonSe
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -307,7 +307,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, JsonSe
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -320,7 +320,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, JsonSe
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -337,7 +337,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, JsonSe
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ParentWithNullable.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ParentWithNullable.php
@@ -368,7 +368,7 @@ class ParentWithNullable implements ModelInterface, ArrayAccess, JsonSerializabl
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -380,7 +380,7 @@ class ParentWithNullable implements ModelInterface, ArrayAccess, JsonSerializabl
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -393,7 +393,7 @@ class ParentWithNullable implements ModelInterface, ArrayAccess, JsonSerializabl
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -410,7 +410,7 @@ class ParentWithNullable implements ModelInterface, ArrayAccess, JsonSerializabl
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Pet.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Pet.php
@@ -506,7 +506,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -518,7 +518,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -531,7 +531,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -548,7 +548,7 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ReadOnlyFirst.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ReadOnlyFirst.php
@@ -326,7 +326,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -338,7 +338,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -351,7 +351,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -368,7 +368,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/SpecialModelName.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/SpecialModelName.php
@@ -292,7 +292,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -304,7 +304,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -317,7 +317,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -334,7 +334,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Tag.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Tag.php
@@ -326,7 +326,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -338,7 +338,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -351,7 +351,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -368,7 +368,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/TestInlineFreeformAdditionalPropertiesRequest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/TestInlineFreeformAdditionalPropertiesRequest.php
@@ -292,7 +292,7 @@ class TestInlineFreeformAdditionalPropertiesRequest implements ModelInterface, A
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -304,7 +304,7 @@ class TestInlineFreeformAdditionalPropertiesRequest implements ModelInterface, A
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -317,7 +317,7 @@ class TestInlineFreeformAdditionalPropertiesRequest implements ModelInterface, A
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -334,7 +334,7 @@ class TestInlineFreeformAdditionalPropertiesRequest implements ModelInterface, A
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/User.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/User.php
@@ -530,7 +530,7 @@ class User implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return boolean
      */
@@ -542,7 +542,7 @@ class User implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return mixed|null
      */
@@ -555,7 +555,7 @@ class User implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets value based on offset.
      *
-     * @param int|null $offset Offset
+     * @param int|string|null $offset Offset
      * @param mixed    $value  Value to be set
      *
      * @return void
@@ -572,7 +572,7 @@ class User implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param int|string $offset Offset
      *
      * @return void
      */


### PR DESCRIPTION
The model classes implement the `ArrayAccess` interface. The phpdoc specifies the key type to be a string. In the methods, the key type is defined as `int` in the PHPDoc. This PR changes it to `int|string`. I'm not 100% sure what the correct type would be, but including string is correct for sure.

Also I think maybe the methods to access the fields could be moved to the `ModelInterface`, with stronger typing than the `ArrayAccess` interface. 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects `ArrayAccess` offset PHPDoc types in `php-nextgen` models to accept both strings and integers, matching PHP behavior and reducing IDE/static analysis warnings. Updates the generator template and regenerates samples.

- **Bug Fixes**
  - Updated `modules/openapi-generator/src/main/resources/php-nextgen/model_generic.mustache` to use `int|string` for offset parameters (`offsetExists`, `offsetGet`, `offsetUnset`) and `int|string|null` for `offsetSet`.
  - Regenerated `php-nextgen` and `php-nextgen-streaming` sample models to reflect the new PHPDoc types.

<sup>Written for commit a5f65430fbdd0f0dac40706bc638be2adfa507c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

