### PR TITLE
[php-nextgen]: Fix imports for models with parent schema

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/model.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/model.mustache
@@ -21,14 +21,14 @@
 
 namespace {{modelPackage}};
 {{^isEnum}}
-{{^parentSchema}}
 
+{{^parentSchema}}
 use ArrayAccess;
 use JsonSerializable;
+{{/parentSchema}}
 use InvalidArgumentException;
 use ReturnTypeWillChange;
 use {{invokerPackage}}\ObjectSerializer;
-{{/parentSchema}}
 {{/isEnum}}
 
 /**

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/DataQuery.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/DataQuery.php
@@ -28,6 +28,10 @@
 
 namespace OpenAPI\Client\Model;
 
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
+
 /**
  * DataQuery Class Doc Comment
  *

--- a/samples/client/echo_api/php-nextgen/src/Model/DataQuery.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/DataQuery.php
@@ -28,6 +28,10 @@
 
 namespace OpenAPI\Client\Model;
 
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
+
 /**
  * DataQuery Class Doc Comment
  *

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Cat.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Cat.php
@@ -27,6 +27,10 @@
 
 namespace OpenAPI\Client\Model;
 
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
+
 /**
  * Cat Class Doc Comment
  *

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ChildWithNullable.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ChildWithNullable.php
@@ -27,6 +27,10 @@
 
 namespace OpenAPI\Client\Model;
 
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
+
 /**
  * ChildWithNullable Class Doc Comment
  *

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/DiscriminatorChild.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/DiscriminatorChild.php
@@ -27,6 +27,10 @@
 
 namespace OpenAPI\Client\Model;
 
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
+
 /**
  * DiscriminatorChild Class Doc Comment
  *

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Dog.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Dog.php
@@ -27,6 +27,10 @@
 
 namespace OpenAPI\Client\Model;
 
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
+
 /**
  * Dog Class Doc Comment
  *


### PR DESCRIPTION
The models with parent schema are missing imports.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds missing imports to `php-nextgen` models with a parent schema to prevent undefined class errors and improve IDE support.

- **Bug Fixes**
  - Updated `model.mustache` to add `InvalidArgumentException`, `ReturnTypeWillChange`, and `ObjectSerializer` when `parentSchema` is present.
  - Regenerated affected PHP samples (e.g., `DataQuery`, `Cat`, `Dog`) to include the imports.

<sup>Written for commit 140fd451b6229209b2e30c05be9afd1ebc297489. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

