### PR TITLE
[php-nextgen]: Simplify enum type

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpNextgenClientCodegen.java
@@ -167,16 +167,6 @@ public class PhpNextgenClientCodegen extends AbstractPhpCodegen {
 
                 prop.vendorExtensions.putIfAbsent("x-php-prop-type", propType);
             }
-
-            if (model.isEnum) {
-                for (Map<String, Object> enumVars : (List<Map<String, Object>>) model.getAllowableValues().get("enumVars")) {
-                    if ((Boolean) enumVars.get("isString")) {
-                        model.vendorExtensions.putIfAbsent("x-php-enum-type", "string");
-                    } else {
-                        model.vendorExtensions.putIfAbsent("x-php-enum-type", "int");
-                    }
-                }
-            }
         }
         return objs;
     }

--- a/modules/openapi-generator/src/main/resources/php-nextgen/model_enum.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/model_enum.mustache
@@ -1,4 +1,4 @@
-enum {{classname}}: {{exts.x-php-enum-type}}
+enum {{classname}}: {{dataType}}
 {
     {{#allowableValues}}
     {{#enumVars}}


### PR DESCRIPTION
Replace the `x-php-enum-type` with `dataType`

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified PHP Nextgen enum backing types by using `dataType` directly and removing the `x-php-enum-type` vendor extension. This keeps enum types correct (string/int) while reducing custom logic.

- **Refactors**
  - Removed `x-php-enum-type` injection from `PhpNextgenClientCodegen`.
  - Updated `php-nextgen/model_enum.mustache` to use `{{dataType}}` for enum backing type.

- **Migration**
  - If you have custom templates reading `exts.x-php-enum-type`, switch to `dataType`.
  - No changes expected in generated PHP code with default templates.

<sup>Written for commit 3c34304f48003d1203c37d90e01b28d81b4707c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

