### PR TITLE
[Kotlin] Replace deprecated Ktor base64 encoding with Kotlin std library call

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-ktor/auth/HttpBasicAuth.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-ktor/auth/HttpBasicAuth.kt.mustache
@@ -1,6 +1,6 @@
 package {{packageName}}.auth
 
-import io.ktor.util.encodeBase64
+import kotlin.io.encoding.Base64
 
 {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}class HttpBasicAuth : Authentication {
     {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}var username: String? = null
@@ -9,7 +9,7 @@ import io.ktor.util.encodeBase64
     override fun apply(query: MutableMap<String, List<String>>, headers: MutableMap<String, String>) {
         if (username == null && password == null) return
         val str = (username ?: "") + ":" + (password ?: "")
-        val auth = str.encodeBase64()
+        val auth = Base64.encode(str.encodeToByteArray())
         headers["Authorization"] = "Basic $auth"
     }
 }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/auth/HttpBasicAuth.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/auth/HttpBasicAuth.kt.mustache
@@ -1,6 +1,6 @@
 package {{packageName}}.auth
 
-import io.ktor.util.encodeBase64
+import kotlin.io.encoding.Base64
 
 {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}class HttpBasicAuth : Authentication {
     {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}var username: String? = null
@@ -9,7 +9,7 @@ import io.ktor.util.encodeBase64
     override fun apply(query: MutableMap<String, List<String>>, headers: MutableMap<String, String>) {
         if (username == null && password == null) return
         val str = (username ?: "") + ":" + (password ?: "")
-        val auth = str.encodeBase64()
+        val auth = Base64.encode(str.encodeToByteArray())
         headers["Authorization"] = "Basic $auth"
     }
 }


### PR DESCRIPTION
This pull request fixes the usage of the Base64 encoding coming from Ktor with a call to the Kotlin standard library. The old method was marked deprecated with Ktor 3.4.0.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06) @e5l (2024/10) @dennisameling (2026/02)

fixes #22808

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace deprecated Ktor Base64 encoding (`io.ktor.util.encodeBase64`) with Kotlin stdlib `kotlin.io.encoding.Base64.encode` in `HttpBasicAuth` for Ktor JVM and Multiplatform clients. Removes deprecation warnings and ensures compatibility with Ktor 3.4.0 with no behavior change, fixing #22808.

<sup>Written for commit 9acac9f182817ea4cbabbe3cd69eb988c10e5e63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

