### PR TITLE
[csharp][generichost] Fix invalid implicit cast

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/modelGeneric.mustache
@@ -240,7 +240,7 @@
         {{#deprecated}}
         [Obsolete]
         {{/deprecated}}
-        public {{{datatypeWithEnum}}}{{#lambda.first}}{{#isNullable}}{{>NullConditionalProperty}}  {{/isNullable}}{{^required}}{{nrt?}}{{^nrt}}{{#vendorExtensions.x-is-value-type}}?{{/vendorExtensions.x-is-value-type}}{{/nrt}}  {{/required}}{{/lambda.first}} {{name}} {{#required}}{ get; {{^isReadOnly}}set; {{/isReadOnly}}}{{/required}}{{^required}}{ get { return this.{{name}}Option; } {{^isReadOnly}}set { this.{{name}}Option = new{{^net70OrLater}} Option<{{{datatypeWithEnum}}}{{>NullConditionalProperty}}>{{/net70OrLater}}(value); } {{/isReadOnly}}}{{/required}}
+        public {{{datatypeWithEnum}}}{{#lambda.first}}{{#isNullable}}{{>NullConditionalProperty}}  {{/isNullable}}{{^required}}{{nrt?}}{{^nrt}}{{#vendorExtensions.x-is-value-type}}?{{/vendorExtensions.x-is-value-type}}{{/nrt}}  {{/required}}{{/lambda.first}} {{name}} {{#required}}{ get; {{^isReadOnly}}set; {{/isReadOnly}}}{{/required}}{{^required}}{ get { return this.{{name}}Option.Value; } {{^isReadOnly}}set { this.{{name}}Option = new{{^net70OrLater}} Option<{{{datatypeWithEnum}}}{{>NullConditionalProperty}}>{{/net70OrLater}}(value); } {{/isReadOnly}}}{{/required}}
 
         {{/isInherited}}
         {{/isEnum}}

--- a/samples/client/petstore/csharp/generichost/latest/HelloWorld/src/Org.OpenAPITools/Model/HelloWorldPostRequest.cs
+++ b/samples/client/petstore/csharp/generichost/latest/HelloWorld/src/Org.OpenAPITools/Model/HelloWorldPostRequest.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Message
         /// </summary>
         [JsonPropertyName("message")]
-        public string? Message { get { return this.MessageOption; } set { this.MessageOption = new(value); } }
+        public string? Message { get { return this.MessageOption.Value; } set { this.MessageOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Model/Foo.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string? Bar { get { return this.BarOption; } set { this.BarOption = new(value); } }
+        public string? Bar { get { return this.BarOption.Value; } set { this.BarOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Model/IconsDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Model/IconsDefaultResponse.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public Foo? String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public Foo? String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Model/TestObject.cs
+++ b/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Model/TestObject.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Model/Adult.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Model/Adult.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Children
         /// </summary>
         [JsonPropertyName("children")]
-        public List<Child>? Children { get { return this.ChildrenOption; } set { this.ChildrenOption = new(value); } }
+        public List<Child>? Children { get { return this.ChildrenOption.Value; } set { this.ChildrenOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Age
         /// </summary>
         [JsonPropertyName("age")]
-        public int? Age { get { return this.AgeOption; } set { this.AgeOption = new(value); } }
+        public int? Age { get { return this.AgeOption.Value; } set { this.AgeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of BoosterSeat
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BoosterSeat
         /// </summary>
         [JsonPropertyName("boosterSeat")]
-        public bool? BoosterSeat { get { return this.BoosterSeatOption; } set { this.BoosterSeatOption = new(value); } }
+        public bool? BoosterSeat { get { return this.BoosterSeatOption.Value; } set { this.BoosterSeatOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Model/Person.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Model/Person.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets FirstName
         /// </summary>
         [JsonPropertyName("firstName")]
-        public string? FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new(value); } }
+        public string? FirstName { get { return this.FirstNameOption.Value; } set { this.FirstNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of LastName
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LastName
         /// </summary>
         [JsonPropertyName("lastName")]
-        public string? LastName { get { return this.LastNameOption; } set { this.LastNameOption = new(value); } }
+        public string? LastName { get { return this.LastNameOption.Value; } set { this.LastNameOption = new(value); } }
 
         /// <summary>
         /// The discriminator

--- a/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Kind
         /// </summary>
         [JsonPropertyName("kind")]
-        public string? Kind { get { return this.KindOption; } set { this.KindOption = new(value); } }
+        public string? Kind { get { return this.KindOption.Value; } set { this.KindOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Count
         /// </summary>
         [JsonPropertyName("count")]
-        public decimal? Count { get { return this.CountOption; } set { this.CountOption = new(value); } }
+        public decimal? Count { get { return this.CountOption.Value; } set { this.CountOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -82,7 +82,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Kind
         /// </summary>
         [JsonPropertyName("kind")]
-        public string? Kind { get { return this.KindOption; } set { this.KindOption = new(value); } }
+        public string? Kind { get { return this.KindOption.Value; } set { this.KindOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Count
         /// </summary>
         [JsonPropertyName("count")]
-        public decimal? Count { get { return this.CountOption; } set { this.CountOption = new(value); } }
+        public decimal? Count { get { return this.CountOption.Value; } set { this.CountOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
@@ -81,7 +81,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Activity.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ActivityOutputs
         /// </summary>
         [JsonPropertyName("activity_outputs")]
-        public Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs { get { return this.ActivityOutputsOption; } set { this.ActivityOutputsOption = new(value); } }
+        public Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs { get { return this.ActivityOutputsOption.Value; } set { this.ActivityOutputsOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop1
         /// </summary>
         [JsonPropertyName("prop1")]
-        public string Prop1 { get { return this.Prop1Option; } set { this.Prop1Option = new(value); } }
+        public string Prop1 { get { return this.Prop1Option.Value; } set { this.Prop1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Prop2
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop2
         /// </summary>
         [JsonPropertyName("prop2")]
-        public Object Prop2 { get { return this.Prop2Option; } set { this.Prop2Option = new(value); } }
+        public Object Prop2 { get { return this.Prop2Option.Value; } set { this.Prop2Option = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Anytype1
         /// </summary>
         [JsonPropertyName("anytype_1")]
-        public Object Anytype1 { get { return this.Anytype1Option; } set { this.Anytype1Option = new(value); } }
+        public Object Anytype1 { get { return this.Anytype1Option.Value; } set { this.Anytype1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of EmptyMap
@@ -81,7 +81,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>an object with no declared properties and no undeclared properties, hence it&#39;s an empty map.</value>
         [JsonPropertyName("empty_map")]
-        public Object EmptyMap { get { return this.EmptyMapOption; } set { this.EmptyMapOption = new(value); } }
+        public Object EmptyMap { get { return this.EmptyMapOption.Value; } set { this.EmptyMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfMapProperty
@@ -94,7 +94,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfMapProperty
         /// </summary>
         [JsonPropertyName("map_of_map_property")]
-        public Dictionary<string, Dictionary<string, string>> MapOfMapProperty { get { return this.MapOfMapPropertyOption; } set { this.MapOfMapPropertyOption = new(value); } }
+        public Dictionary<string, Dictionary<string, string>> MapOfMapProperty { get { return this.MapOfMapPropertyOption.Value; } set { this.MapOfMapPropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapProperty
@@ -107,7 +107,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapProperty
         /// </summary>
         [JsonPropertyName("map_property")]
-        public Dictionary<string, string> MapProperty { get { return this.MapPropertyOption; } set { this.MapPropertyOption = new(value); } }
+        public Dictionary<string, string> MapProperty { get { return this.MapPropertyOption.Value; } set { this.MapPropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype1
@@ -120,7 +120,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype1
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_1")]
-        public Object MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new(value); } }
+        public Object MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype2
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype2
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_2")]
-        public Object MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new(value); } }
+        public Object MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype3
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype3
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_3")]
-        public Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new(value); } }
+        public Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesString
@@ -159,7 +159,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesString
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_string")]
-        public Dictionary<string, string> MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption; } set { this.MapWithUndeclaredPropertiesStringOption = new(value); } }
+        public Dictionary<string, string> MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption.Value; } set { this.MapWithUndeclaredPropertiesStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Animal.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [JsonPropertyName("code")]
-        public int? Code { get { return this.CodeOption; } set { this.CodeOption = new(value); } }
+        public int? Code { get { return this.CodeOption.Value; } set { this.CodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Message
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Message
         /// </summary>
         [JsonPropertyName("message")]
-        public string Message { get { return this.MessageOption; } set { this.MessageOption = new(value); } }
+        public string Message { get { return this.MessageOption.Value; } set { this.MessageOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Type
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Type
         /// </summary>
         [JsonPropertyName("type")]
-        public string Type { get { return this.TypeOption; } set { this.TypeOption = new(value); } }
+        public string Type { get { return this.TypeOption.Value; } set { this.TypeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Apple.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ColorCode
         /// </summary>
         [JsonPropertyName("color_code")]
-        public string ColorCode { get { return this.ColorCodeOption; } set { this.ColorCodeOption = new(value); } }
+        public string ColorCode { get { return this.ColorCodeOption.Value; } set { this.ColorCodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Cultivar
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Cultivar
         /// </summary>
         [JsonPropertyName("cultivar")]
-        public string Cultivar { get { return this.CultivarOption; } set { this.CultivarOption = new(value); } }
+        public string Cultivar { get { return this.CultivarOption.Value; } set { this.CultivarOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Origin
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Origin
         /// </summary>
         [JsonPropertyName("origin")]
-        public string Origin { get { return this.OriginOption; } set { this.OriginOption = new(value); } }
+        public string Origin { get { return this.OriginOption.Value; } set { this.OriginOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [JsonPropertyName("mealy")]
-        public bool? Mealy { get { return this.MealyOption; } set { this.MealyOption = new(value); } }
+        public bool? Mealy { get { return this.MealyOption.Value; } set { this.MealyOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayArrayNumber")]
-        public List<List<decimal>> ArrayArrayNumber { get { return this.ArrayArrayNumberOption; } set { this.ArrayArrayNumberOption = new(value); } }
+        public List<List<decimal>> ArrayArrayNumber { get { return this.ArrayArrayNumberOption.Value; } set { this.ArrayArrayNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayNumber")]
-        public List<decimal> ArrayNumber { get { return this.ArrayNumberOption; } set { this.ArrayNumberOption = new(value); } }
+        public List<decimal> ArrayNumber { get { return this.ArrayNumberOption.Value; } set { this.ArrayNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfInteger
         /// </summary>
         [JsonPropertyName("array_array_of_integer")]
-        public List<List<long>> ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption; } set { this.ArrayArrayOfIntegerOption = new(value); } }
+        public List<List<long>> ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption.Value; } set { this.ArrayArrayOfIntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayArrayOfModel
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfModel
         /// </summary>
         [JsonPropertyName("array_array_of_model")]
-        public List<List<ReadOnlyFirst>> ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption; } set { this.ArrayArrayOfModelOption = new(value); } }
+        public List<List<ReadOnlyFirst>> ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption.Value; } set { this.ArrayArrayOfModelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayOfString
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayOfString
         /// </summary>
         [JsonPropertyName("array_of_string")]
-        public List<string> ArrayOfString { get { return this.ArrayOfStringOption; } set { this.ArrayOfStringOption = new(value); } }
+        public List<string> ArrayOfString { get { return this.ArrayOfStringOption.Value; } set { this.ArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Banana.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [JsonPropertyName("lengthCm")]
-        public decimal? LengthCm { get { return this.LengthCmOption; } set { this.LengthCmOption = new(value); } }
+        public decimal? LengthCm { get { return this.LengthCmOption.Value; } set { this.LengthCmOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [JsonPropertyName("sweet")]
-        public bool? Sweet { get { return this.SweetOption; } set { this.SweetOption = new(value); } }
+        public bool? Sweet { get { return this.SweetOption.Value; } set { this.SweetOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -64,7 +64,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Name of the pet </value>
         [JsonPropertyName("ATT_NAME")]
-        public string ATT_NAME { get { return this.ATT_NAMEOption; } set { this.ATT_NAMEOption = new(value); } }
+        public string ATT_NAME { get { return this.ATT_NAMEOption.Value; } set { this.ATT_NAMEOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalCamel
@@ -77,7 +77,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalCamel
         /// </summary>
         [JsonPropertyName("CapitalCamel")]
-        public string CapitalCamel { get { return this.CapitalCamelOption; } set { this.CapitalCamelOption = new(value); } }
+        public string CapitalCamel { get { return this.CapitalCamelOption.Value; } set { this.CapitalCamelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalSnake
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalSnake
         /// </summary>
         [JsonPropertyName("Capital_Snake")]
-        public string CapitalSnake { get { return this.CapitalSnakeOption; } set { this.CapitalSnakeOption = new(value); } }
+        public string CapitalSnake { get { return this.CapitalSnakeOption.Value; } set { this.CapitalSnakeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SCAETHFlowPoints
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SCAETHFlowPoints
         /// </summary>
         [JsonPropertyName("SCA_ETH_Flow_Points")]
-        public string SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption; } set { this.SCAETHFlowPointsOption = new(value); } }
+        public string SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption.Value; } set { this.SCAETHFlowPointsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SmallCamel
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallCamel
         /// </summary>
         [JsonPropertyName("smallCamel")]
-        public string SmallCamel { get { return this.SmallCamelOption; } set { this.SmallCamelOption = new(value); } }
+        public string SmallCamel { get { return this.SmallCamelOption.Value; } set { this.SmallCamelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SmallSnake
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallSnake
         /// </summary>
         [JsonPropertyName("small_Snake")]
-        public string SmallSnake { get { return this.SmallSnakeOption; } set { this.SmallSnakeOption = new(value); } }
+        public string SmallSnake { get { return this.SmallSnakeOption.Value; } set { this.SmallSnakeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Cat.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [JsonPropertyName("declawed")]
-        public bool? Declawed { get { return this.DeclawedOption; } set { this.DeclawedOption = new(value); } }
+        public bool? Declawed { get { return this.DeclawedOption.Value; } set { this.DeclawedOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Category.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("_class")]
-        public string Class { get { return this.ClassOption; } set { this.ClassOption = new(value); } }
+        public string Class { get { return this.ClassOption.Value; } set { this.ClassOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>Fri Jul 21 00:00:00 UTC 2017</example> */
         [JsonPropertyName("dateOnlyProperty")]
-        public DateOnly? DateOnlyProperty { get { return this.DateOnlyPropertyOption; } set { this.DateOnlyPropertyOption = new(value); } }
+        public DateOnly? DateOnlyProperty { get { return this.DateOnlyPropertyOption.Value; } set { this.DateOnlyPropertyOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Dog.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Breed
         /// </summary>
         [JsonPropertyName("breed")]
-        public string Breed { get { return this.BreedOption; } set { this.BreedOption = new(value); } }
+        public string Breed { get { return this.BreedOption.Value; } set { this.BreedOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MainShape
         /// </summary>
         [JsonPropertyName("mainShape")]
-        public Shape MainShape { get { return this.MainShapeOption; } set { this.MainShapeOption = new(value); } }
+        public Shape MainShape { get { return this.MainShapeOption.Value; } set { this.MainShapeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NullableShape
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableShape
         /// </summary>
         [JsonPropertyName("nullableShape")]
-        public NullableShape NullableShape { get { return this.NullableShapeOption; } set { this.NullableShapeOption = new(value); } }
+        public NullableShape NullableShape { get { return this.NullableShapeOption.Value; } set { this.NullableShapeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ShapeOrNull
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ShapeOrNull
         /// </summary>
         [JsonPropertyName("shapeOrNull")]
-        public ShapeOrNull ShapeOrNull { get { return this.ShapeOrNullOption; } set { this.ShapeOrNullOption = new(value); } }
+        public ShapeOrNull ShapeOrNull { get { return this.ShapeOrNullOption.Value; } set { this.ShapeOrNullOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Shapes
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Shapes
         /// </summary>
         [JsonPropertyName("shapes")]
-        public List<Shape> Shapes { get { return this.ShapesOption; } set { this.ShapesOption = new(value); } }
+        public List<Shape> Shapes { get { return this.ShapesOption.Value; } set { this.ShapesOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayEnum
         /// </summary>
         [JsonPropertyName("array_enum")]
-        public List<EnumArraysArrayEnumInner> ArrayEnum { get { return this.ArrayEnumOption; } set { this.ArrayEnumOption = new(value); } }
+        public List<EnumArraysArrayEnumInner> ArrayEnum { get { return this.ArrayEnumOption.Value; } set { this.ArrayEnumOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/File.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Test capitalization</value>
         [JsonPropertyName("sourceURI")]
-        public string SourceURI { get { return this.SourceURIOption; } set { this.SourceURIOption = new(value); } }
+        public string SourceURI { get { return this.SourceURIOption.Value; } set { this.SourceURIOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets File
         /// </summary>
         [JsonPropertyName("file")]
-        public File File { get { return this.FileOption; } set { this.FileOption = new(value); } }
+        public File File { get { return this.FileOption.Value; } set { this.FileOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Files
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Files
         /// </summary>
         [JsonPropertyName("files")]
-        public List<File> Files { get { return this.FilesOption; } set { this.FilesOption = new(value); } }
+        public List<File> Files { get { return this.FilesOption.Value; } set { this.FilesOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Foo.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } set { this.BarOption = new(value); } }
+        public string Bar { get { return this.BarOption.Value; } set { this.BarOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public Foo String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public Foo String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -138,7 +138,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Binary
         /// </summary>
         [JsonPropertyName("binary")]
-        public System.IO.Stream Binary { get { return this.BinaryOption; } set { this.BinaryOption = new(value); } }
+        public System.IO.Stream Binary { get { return this.BinaryOption.Value; } set { this.BinaryOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DateTime
@@ -152,7 +152,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2007-12-03T10:15:30+01:00</example> */
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Decimal
@@ -165,7 +165,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Decimal
         /// </summary>
         [JsonPropertyName("decimal")]
-        public decimal? Decimal { get { return this.DecimalOption; } set { this.DecimalOption = new(value); } }
+        public decimal? Decimal { get { return this.DecimalOption.Value; } set { this.DecimalOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Double
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Double
         /// </summary>
         [JsonPropertyName("double")]
-        public double? Double { get { return this.DoubleOption; } set { this.DoubleOption = new(value); } }
+        public double? Double { get { return this.DoubleOption.Value; } set { this.DoubleOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName2
@@ -191,7 +191,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName2
         /// </summary>
         [JsonPropertyName("duplicate_property_name")]
-        public string DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option; } set { this.DuplicatePropertyName2Option = new(value); } }
+        public string DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option.Value; } set { this.DuplicatePropertyName2Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName
@@ -204,7 +204,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName
         /// </summary>
         [JsonPropertyName("@duplicate_property_name")]
-        public string DuplicatePropertyName { get { return this.DuplicatePropertyNameOption; } set { this.DuplicatePropertyNameOption = new(value); } }
+        public string DuplicatePropertyName { get { return this.DuplicatePropertyNameOption.Value; } set { this.DuplicatePropertyNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Float
@@ -217,7 +217,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Float
         /// </summary>
         [JsonPropertyName("float")]
-        public float? Float { get { return this.FloatOption; } set { this.FloatOption = new(value); } }
+        public float? Float { get { return this.FloatOption.Value; } set { this.FloatOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int32
@@ -230,7 +230,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32
         /// </summary>
         [JsonPropertyName("int32")]
-        public int? Int32 { get { return this.Int32Option; } set { this.Int32Option = new(value); } }
+        public int? Int32 { get { return this.Int32Option.Value; } set { this.Int32Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int32Range
@@ -243,7 +243,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32Range
         /// </summary>
         [JsonPropertyName("int32Range")]
-        public int? Int32Range { get { return this.Int32RangeOption; } set { this.Int32RangeOption = new(value); } }
+        public int? Int32Range { get { return this.Int32RangeOption.Value; } set { this.Int32RangeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64
@@ -256,7 +256,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64
         /// </summary>
         [JsonPropertyName("int64")]
-        public long? Int64 { get { return this.Int64Option; } set { this.Int64Option = new(value); } }
+        public long? Int64 { get { return this.Int64Option.Value; } set { this.Int64Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Negative
@@ -269,7 +269,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Negative
         /// </summary>
         [JsonPropertyName("int64Negative")]
-        public long? Int64Negative { get { return this.Int64NegativeOption; } set { this.Int64NegativeOption = new(value); } }
+        public long? Int64Negative { get { return this.Int64NegativeOption.Value; } set { this.Int64NegativeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64NegativeExclusive
@@ -282,7 +282,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64NegativeExclusive
         /// </summary>
         [JsonPropertyName("int64NegativeExclusive")]
-        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption; } set { this.Int64NegativeExclusiveOption = new(value); } }
+        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption.Value; } set { this.Int64NegativeExclusiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Positive
@@ -295,7 +295,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Positive
         /// </summary>
         [JsonPropertyName("int64Positive")]
-        public long? Int64Positive { get { return this.Int64PositiveOption; } set { this.Int64PositiveOption = new(value); } }
+        public long? Int64Positive { get { return this.Int64PositiveOption.Value; } set { this.Int64PositiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64PositiveExclusive
@@ -308,7 +308,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64PositiveExclusive
         /// </summary>
         [JsonPropertyName("int64PositiveExclusive")]
-        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption; } set { this.Int64PositiveExclusiveOption = new(value); } }
+        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption.Value; } set { this.Int64PositiveExclusiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Integer
@@ -321,7 +321,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [JsonPropertyName("integer")]
-        public int? Integer { get { return this.IntegerOption; } set { this.IntegerOption = new(value); } }
+        public int? Integer { get { return this.IntegerOption.Value; } set { this.IntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithBackslash
@@ -335,7 +335,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>None</value>
         [JsonPropertyName("pattern_with_backslash")]
-        public string PatternWithBackslash { get { return this.PatternWithBackslashOption; } set { this.PatternWithBackslashOption = new(value); } }
+        public string PatternWithBackslash { get { return this.PatternWithBackslashOption.Value; } set { this.PatternWithBackslashOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigits
@@ -349,7 +349,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string that is a 10 digit number. Can have leading zeros.</value>
         [JsonPropertyName("pattern_with_digits")]
-        public string PatternWithDigits { get { return this.PatternWithDigitsOption; } set { this.PatternWithDigitsOption = new(value); } }
+        public string PatternWithDigits { get { return this.PatternWithDigitsOption.Value; } set { this.PatternWithDigitsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigitsAndDelimiter
@@ -363,7 +363,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.</value>
         [JsonPropertyName("pattern_with_digits_and_delimiter")]
-        public string PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption; } set { this.PatternWithDigitsAndDelimiterOption = new(value); } }
+        public string PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption.Value; } set { this.PatternWithDigitsAndDelimiterOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of String
@@ -376,7 +376,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public string String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public string String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of StringFormattedAsDecimal
@@ -389,7 +389,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringFormattedAsDecimal
         /// </summary>
         [JsonPropertyName("string_formatted_as_decimal")]
-        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption; } set { this.StringFormattedAsDecimalOption = new(value); } }
+        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption.Value; } set { this.StringFormattedAsDecimalOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedInteger
@@ -402,7 +402,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [JsonPropertyName("unsigned_integer")]
-        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption; } set { this.UnsignedIntegerOption = new(value); } }
+        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption.Value; } set { this.UnsignedIntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedLong
@@ -415,7 +415,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedLong
         /// </summary>
         [JsonPropertyName("unsigned_long")]
-        public ulong? UnsignedLong { get { return this.UnsignedLongOption; } set { this.UnsignedLongOption = new(value); } }
+        public ulong? UnsignedLong { get { return this.UnsignedLongOption.Value; } set { this.UnsignedLongOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -429,7 +429,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -80,7 +80,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } }
+        public string Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Foo
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Foo
         /// </summary>
         [JsonPropertyName("foo")]
-        public string Foo { get { return this.FooOption; } }
+        public string Foo { get { return this.FooOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableMessage
         /// </summary>
         [JsonPropertyName("NullableMessage")]
-        public string NullableMessage { get { return this.NullableMessageOption; } set { this.NullableMessageOption = new(value); } }
+        public string NullableMessage { get { return this.NullableMessageOption.Value; } set { this.NullableMessageOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/List.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123List
         /// </summary>
         [JsonPropertyName("123-list")]
-        public string Var123List { get { return this.Var123ListOption; } set { this.Var123ListOption = new(value); } }
+        public string Var123List { get { return this.Var123ListOption.Value; } set { this.Var123ListOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets EscapedLiteralString
         /// </summary>
         [JsonPropertyName("escapedLiteralString")]
-        public string EscapedLiteralString { get { return this.EscapedLiteralStringOption; } set { this.EscapedLiteralStringOption = new(value); } }
+        public string EscapedLiteralString { get { return this.EscapedLiteralStringOption.Value; } set { this.EscapedLiteralStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnescapedLiteralString
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnescapedLiteralString
         /// </summary>
         [JsonPropertyName("unescapedLiteralString")]
-        public string UnescapedLiteralString { get { return this.UnescapedLiteralStringOption; } set { this.UnescapedLiteralStringOption = new(value); } }
+        public string UnescapedLiteralString { get { return this.UnescapedLiteralStringOption.Value; } set { this.UnescapedLiteralStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DirectMap
         /// </summary>
         [JsonPropertyName("direct_map")]
-        public Dictionary<string, bool> DirectMap { get { return this.DirectMapOption; } set { this.DirectMapOption = new(value); } }
+        public Dictionary<string, bool> DirectMap { get { return this.DirectMapOption.Value; } set { this.DirectMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of IndirectMap
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IndirectMap
         /// </summary>
         [JsonPropertyName("indirect_map")]
-        public Dictionary<string, bool> IndirectMap { get { return this.IndirectMapOption; } set { this.IndirectMapOption = new(value); } }
+        public Dictionary<string, bool> IndirectMap { get { return this.IndirectMapOption.Value; } set { this.IndirectMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapMapOfString
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapMapOfString
         /// </summary>
         [JsonPropertyName("map_map_of_string")]
-        public Dictionary<string, Dictionary<string, string>> MapMapOfString { get { return this.MapMapOfStringOption; } set { this.MapMapOfStringOption = new(value); } }
+        public Dictionary<string, Dictionary<string, string>> MapMapOfString { get { return this.MapMapOfStringOption.Value; } set { this.MapMapOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfEnumString
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfEnumString
         /// </summary>
         [JsonPropertyName("map_of_enum_string")]
-        public Dictionary<string, MapTestMapOfEnumStringValue> MapOfEnumString { get { return this.MapOfEnumStringOption; } set { this.MapOfEnumStringOption = new(value); } }
+        public Dictionary<string, MapTestMapOfEnumStringValue> MapOfEnumString { get { return this.MapOfEnumStringOption.Value; } set { this.MapOfEnumStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedAnyOfContent Content { get { return this.ContentOption; } set { this.ContentOption = new(value); } }
+        public MixedAnyOfContent Content { get { return this.ContentOption.Value; } set { this.ContentOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedOneOfContent Content { get { return this.ContentOption; } set { this.ContentOption = new(value); } }
+        public MixedOneOfContent Content { get { return this.ContentOption.Value; } set { this.ContentOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateTime
         /// </summary>
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Map
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Map
         /// </summary>
         [JsonPropertyName("map")]
-        public Dictionary<string, Animal> Map { get { return this.MapOption; } set { this.MapOption = new(value); } }
+        public Dictionary<string, Animal> Map { get { return this.MapOption.Value; } set { this.MapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UuidWithPattern
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [JsonPropertyName("uuid_with_pattern")]
-        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption; } set { this.UuidWithPatternOption = new(value); } }
+        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption.Value; } set { this.UuidWithPatternOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public string Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public string Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("class")]
-        public string Class { get { return this.ClassOption; } set { this.ClassOption = new(value); } }
+        public string Class { get { return this.ClassOption.Value; } set { this.ClassOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public int? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public int? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarClient
         /// </summary>
         [JsonPropertyName("client")]
-        public string VarClient { get { return this.VarClientOption; } set { this.VarClientOption = new(value); } }
+        public string VarClient { get { return this.VarClientOption.Value; } set { this.VarClientOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Name.cs
@@ -65,7 +65,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Property
         /// </summary>
         [JsonPropertyName("property")]
-        public string Property { get { return this.PropertyOption; } set { this.PropertyOption = new(value); } }
+        public string Property { get { return this.PropertyOption.Value; } set { this.PropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SnakeCase
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [JsonPropertyName("snake_case")]
-        public int? SnakeCase { get { return this.SnakeCaseOption; } }
+        public int? SnakeCase { get { return this.SnakeCaseOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Var123Number
@@ -91,7 +91,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123Number
         /// </summary>
         [JsonPropertyName("123Number")]
-        public int? Var123Number { get { return this.Var123NumberOption; } }
+        public int? Var123Number { get { return this.Var123NumberOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -75,7 +75,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("array_and_items_nullable_prop")]
-        public List<Object> ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption; } set { this.ArrayAndItemsNullablePropOption = new(value); } }
+        public List<Object> ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption.Value; } set { this.ArrayAndItemsNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayItemsNullable
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayItemsNullable
         /// </summary>
         [JsonPropertyName("array_items_nullable")]
-        public List<Object> ArrayItemsNullable { get { return this.ArrayItemsNullableOption; } set { this.ArrayItemsNullableOption = new(value); } }
+        public List<Object> ArrayItemsNullable { get { return this.ArrayItemsNullableOption.Value; } set { this.ArrayItemsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayNullableProp
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNullableProp
         /// </summary>
         [JsonPropertyName("array_nullable_prop")]
-        public List<Object> ArrayNullableProp { get { return this.ArrayNullablePropOption; } set { this.ArrayNullablePropOption = new(value); } }
+        public List<Object> ArrayNullableProp { get { return this.ArrayNullablePropOption.Value; } set { this.ArrayNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of BooleanProp
@@ -114,7 +114,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BooleanProp
         /// </summary>
         [JsonPropertyName("boolean_prop")]
-        public bool? BooleanProp { get { return this.BooleanPropOption; } set { this.BooleanPropOption = new(value); } }
+        public bool? BooleanProp { get { return this.BooleanPropOption.Value; } set { this.BooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DateProp
@@ -127,7 +127,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateProp
         /// </summary>
         [JsonPropertyName("date_prop")]
-        public DateOnly? DateProp { get { return this.DatePropOption; } set { this.DatePropOption = new(value); } }
+        public DateOnly? DateProp { get { return this.DatePropOption.Value; } set { this.DatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DatetimeProp
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DatetimeProp
         /// </summary>
         [JsonPropertyName("datetime_prop")]
-        public DateTime? DatetimeProp { get { return this.DatetimePropOption; } set { this.DatetimePropOption = new(value); } }
+        public DateTime? DatetimeProp { get { return this.DatetimePropOption.Value; } set { this.DatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of IntegerProp
@@ -153,7 +153,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IntegerProp
         /// </summary>
         [JsonPropertyName("integer_prop")]
-        public int? IntegerProp { get { return this.IntegerPropOption; } set { this.IntegerPropOption = new(value); } }
+        public int? IntegerProp { get { return this.IntegerPropOption.Value; } set { this.IntegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NumberProp
@@ -166,7 +166,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NumberProp
         /// </summary>
         [JsonPropertyName("number_prop")]
-        public decimal? NumberProp { get { return this.NumberPropOption; } set { this.NumberPropOption = new(value); } }
+        public decimal? NumberProp { get { return this.NumberPropOption.Value; } set { this.NumberPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectAndItemsNullableProp
@@ -179,7 +179,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("object_and_items_nullable_prop")]
-        public Dictionary<string, Object> ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption; } set { this.ObjectAndItemsNullablePropOption = new(value); } }
+        public Dictionary<string, Object> ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption.Value; } set { this.ObjectAndItemsNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectItemsNullable
@@ -192,7 +192,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectItemsNullable
         /// </summary>
         [JsonPropertyName("object_items_nullable")]
-        public Dictionary<string, Object> ObjectItemsNullable { get { return this.ObjectItemsNullableOption; } set { this.ObjectItemsNullableOption = new(value); } }
+        public Dictionary<string, Object> ObjectItemsNullable { get { return this.ObjectItemsNullableOption.Value; } set { this.ObjectItemsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectNullableProp
@@ -205,7 +205,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectNullableProp
         /// </summary>
         [JsonPropertyName("object_nullable_prop")]
-        public Dictionary<string, Object> ObjectNullableProp { get { return this.ObjectNullablePropOption; } set { this.ObjectNullablePropOption = new(value); } }
+        public Dictionary<string, Object> ObjectNullableProp { get { return this.ObjectNullablePropOption.Value; } set { this.ObjectNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of StringProp
@@ -218,7 +218,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringProp
         /// </summary>
         [JsonPropertyName("string_prop")]
-        public string StringProp { get { return this.StringPropOption; } set { this.StringPropOption = new(value); } }
+        public string StringProp { get { return this.StringPropOption.Value; } set { this.StringPropOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [JsonPropertyName("JustNumber")]
-        public decimal? JustNumber { get { return this.JustNumberOption; } set { this.JustNumberOption = new(value); } }
+        public decimal? JustNumber { get { return this.JustNumberOption.Value; } set { this.JustNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("bars")]
         [Obsolete]
-        public List<string> Bars { get { return this.BarsOption; } set { this.BarsOption = new(value); } }
+        public List<string> Bars { get { return this.BarsOption.Value; } set { this.BarsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DeprecatedRef
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("deprecatedRef")]
         [Obsolete]
-        public DeprecatedObject DeprecatedRef { get { return this.DeprecatedRefOption; } set { this.DeprecatedRefOption = new(value); } }
+        public DeprecatedObject DeprecatedRef { get { return this.DeprecatedRefOption.Value; } set { this.DeprecatedRefOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("id")]
         [Obsolete]
-        public decimal? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public decimal? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Order.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Complete
         /// </summary>
         [JsonPropertyName("complete")]
-        public bool? Complete { get { return this.CompleteOption; } set { this.CompleteOption = new(value); } }
+        public bool? Complete { get { return this.CompleteOption.Value; } set { this.CompleteOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -89,7 +89,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PetId
@@ -102,7 +102,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets PetId
         /// </summary>
         [JsonPropertyName("petId")]
-        public long? PetId { get { return this.PetIdOption; } set { this.PetIdOption = new(value); } }
+        public long? PetId { get { return this.PetIdOption.Value; } set { this.PetIdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Quantity
@@ -115,7 +115,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Quantity
         /// </summary>
         [JsonPropertyName("quantity")]
-        public int? Quantity { get { return this.QuantityOption; } set { this.QuantityOption = new(value); } }
+        public int? Quantity { get { return this.QuantityOption.Value; } set { this.QuantityOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ShipDate
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2020-02-02T20:20:20.000222Z</example> */
         [JsonPropertyName("shipDate")]
-        public DateTime? ShipDate { get { return this.ShipDateOption; } set { this.ShipDateOption = new(value); } }
+        public DateTime? ShipDate { get { return this.ShipDateOption.Value; } set { this.ShipDateOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyBoolean
         /// </summary>
         [JsonPropertyName("my_boolean")]
-        public bool? MyBoolean { get { return this.MyBooleanOption; } set { this.MyBooleanOption = new(value); } }
+        public bool? MyBoolean { get { return this.MyBooleanOption.Value; } set { this.MyBooleanOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MyNumber
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [JsonPropertyName("my_number")]
-        public decimal? MyNumber { get { return this.MyNumberOption; } set { this.MyNumberOption = new(value); } }
+        public decimal? MyNumber { get { return this.MyNumberOption.Value; } set { this.MyNumberOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MyString
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyString
         /// </summary>
         [JsonPropertyName("my_string")]
-        public string MyString { get { return this.MyStringOption; } set { this.MyStringOption = new(value); } }
+        public string MyString { get { return this.MyStringOption.Value; } set { this.MyStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Pet.cs
@@ -89,7 +89,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Category
         /// </summary>
         [JsonPropertyName("category")]
-        public Category Category { get { return this.CategoryOption; } set { this.CategoryOption = new(value); } }
+        public Category Category { get { return this.CategoryOption.Value; } set { this.CategoryOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -102,7 +102,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Tags
@@ -115,7 +115,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Tags
         /// </summary>
         [JsonPropertyName("tags")]
-        public List<Tag> Tags { get { return this.TagsOption; } set { this.TagsOption = new(value); } }
+        public List<Tag> Tags { get { return this.TagsOption.Value; } set { this.TagsOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } }
+        public string Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Baz
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Baz
         /// </summary>
         [JsonPropertyName("baz")]
-        public string Baz { get { return this.BazOption; } set { this.BazOption = new(value); } }
+        public string Baz { get { return this.BazOption.Value; } set { this.BazOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -334,7 +334,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_notnullable_date_prop")]
-        public DateOnly? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption; } set { this.NotRequiredNotnullableDatePropOption = new(value); } }
+        public DateOnly? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption.Value; } set { this.NotRequiredNotnullableDatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNotnullableintegerProp
@@ -347,7 +347,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [JsonPropertyName("not_required_notnullableinteger_prop")]
-        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption; } set { this.NotRequiredNotnullableintegerPropOption = new(value); } }
+        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption.Value; } set { this.NotRequiredNotnullableintegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableDateProp
@@ -360,7 +360,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_date_prop")]
-        public DateOnly? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption; } set { this.NotRequiredNullableDatePropOption = new(value); } }
+        public DateOnly? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption.Value; } set { this.NotRequiredNullableDatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableIntegerProp
@@ -373,7 +373,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableIntegerProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_integer_prop")]
-        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption; } set { this.NotRequiredNullableIntegerPropOption = new(value); } }
+        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption.Value; } set { this.NotRequiredNullableIntegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableArrayOfString
@@ -386,7 +386,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_array_of_string")]
-        public List<string> NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption; } set { this.NotrequiredNotnullableArrayOfStringOption = new(value); } }
+        public List<string> NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption.Value; } set { this.NotrequiredNotnullableArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableBooleanProp
@@ -399,7 +399,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_boolean_prop")]
-        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption; } set { this.NotrequiredNotnullableBooleanPropOption = new(value); } }
+        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption.Value; } set { this.NotrequiredNotnullableBooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableDatetimeProp
@@ -412,7 +412,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_datetime_prop")]
-        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption; } set { this.NotrequiredNotnullableDatetimePropOption = new(value); } }
+        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption.Value; } set { this.NotrequiredNotnullableDatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableStringProp
@@ -425,7 +425,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_string_prop")]
-        public string NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption; } set { this.NotrequiredNotnullableStringPropOption = new(value); } }
+        public string NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption.Value; } set { this.NotrequiredNotnullableStringPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableUuid
@@ -439,7 +439,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_notnullable_uuid")]
-        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption; } set { this.NotrequiredNotnullableUuidOption = new(value); } }
+        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption.Value; } set { this.NotrequiredNotnullableUuidOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableArrayOfString
@@ -452,7 +452,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_nullable_array_of_string")]
-        public List<string> NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption; } set { this.NotrequiredNullableArrayOfStringOption = new(value); } }
+        public List<string> NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption.Value; } set { this.NotrequiredNullableArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableBooleanProp
@@ -465,7 +465,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_boolean_prop")]
-        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption; } set { this.NotrequiredNullableBooleanPropOption = new(value); } }
+        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption.Value; } set { this.NotrequiredNullableBooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableDatetimeProp
@@ -478,7 +478,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_datetime_prop")]
-        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption; } set { this.NotrequiredNullableDatetimePropOption = new(value); } }
+        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption.Value; } set { this.NotrequiredNullableDatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableStringProp
@@ -491,7 +491,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_string_prop")]
-        public string NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption; } set { this.NotrequiredNullableStringPropOption = new(value); } }
+        public string NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption.Value; } set { this.NotrequiredNullableStringPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableUuid
@@ -505,7 +505,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_nullable_uuid")]
-        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption; } set { this.NotrequiredNullableUuidOption = new(value); } }
+        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption.Value; } set { this.NotrequiredNullableUuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets RequiredNullableArrayOfString

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Result.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result code</value>
         [JsonPropertyName("code")]
-        public string Code { get { return this.CodeOption; } set { this.CodeOption = new(value); } }
+        public string Code { get { return this.CodeOption.Value; } set { this.CodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Data
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string> Data { get { return this.DataOption; } set { this.DataOption = new(value); } }
+        public Dictionary<string, string> Data { get { return this.DataOption.Value; } set { this.DataOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Return.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [JsonPropertyName("return")]
-        public int? VarReturn { get { return this.VarReturnOption; } set { this.VarReturnOption = new(value); } }
+        public int? VarReturn { get { return this.VarReturnOption.Value; } set { this.VarReturnOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Unsafe
@@ -84,7 +84,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Unsafe
         /// </summary>
         [JsonPropertyName("unsafe")]
-        public string Unsafe { get { return this.UnsafeOption; } set { this.UnsafeOption = new(value); } }
+        public string Unsafe { get { return this.UnsafeOption.Value; } set { this.UnsafeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Role
         /// </summary>
         [JsonPropertyName("role")]
-        public RolesReportsHashRole Role { get { return this.RoleOption; } set { this.RoleOption = new(value); } }
+        public RolesReportsHashRole Role { get { return this.RoleOption.Value; } set { this.RoleOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of RoleUuid
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [JsonPropertyName("role_uuid")]
-        public Guid? RoleUuid { get { return this.RoleUuidOption; } set { this.RoleUuidOption = new(value); } }
+        public Guid? RoleUuid { get { return this.RoleUuidOption.Value; } set { this.RoleUuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarSpecialModelName
         /// </summary>
         [JsonPropertyName("_special_model.name_")]
-        public string VarSpecialModelName { get { return this.VarSpecialModelNameOption; } set { this.VarSpecialModelNameOption = new(value); } }
+        public string VarSpecialModelName { get { return this.VarSpecialModelNameOption.Value; } set { this.VarSpecialModelNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SpecialPropertyName
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [JsonPropertyName("$special[property.name]")]
-        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption; } set { this.SpecialPropertyNameOption = new(value); } }
+        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption.Value; } set { this.SpecialPropertyNameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Tag.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Value
         /// </summary>
         [JsonPropertyName("value")]
-        public string Value { get { return this.ValueOption; } set { this.ValueOption = new(value); } }
+        public string Value { get { return this.ValueOption.Value; } set { this.ValueOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets TestCollectionEndingWithWordList
         /// </summary>
         [JsonPropertyName("TestCollectionEndingWithWordList")]
-        public List<TestCollectionEndingWithWordList> TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption; } set { this.TestCollectionEndingWithWordListOption = new(value); } }
+        public List<TestCollectionEndingWithWordList> TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption.Value; } set { this.TestCollectionEndingWithWordListOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SomeProperty
         /// </summary>
         [JsonPropertyName("someProperty")]
-        public string SomeProperty { get { return this.SomePropertyOption; } set { this.SomePropertyOption = new(value); } }
+        public string SomeProperty { get { return this.SomePropertyOption.Value; } set { this.SomePropertyOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string> Data { get { return this.DataOption; } set { this.DataOption = new(value); } }
+        public Dictionary<string, string> Data { get { return this.DataOption.Value; } set { this.DataOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/User.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
         [JsonPropertyName("anyTypeProp")]
-        public Object AnyTypeProp { get { return this.AnyTypePropOption; } set { this.AnyTypePropOption = new(value); } }
+        public Object AnyTypeProp { get { return this.AnyTypePropOption.Value; } set { this.AnyTypePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of AnyTypePropNullable
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values.</value>
         [JsonPropertyName("anyTypePropNullable")]
-        public Object AnyTypePropNullable { get { return this.AnyTypePropNullableOption; } set { this.AnyTypePropNullableOption = new(value); } }
+        public Object AnyTypePropNullable { get { return this.AnyTypePropNullableOption.Value; } set { this.AnyTypePropNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Email
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Email
         /// </summary>
         [JsonPropertyName("email")]
-        public string Email { get { return this.EmailOption; } set { this.EmailOption = new(value); } }
+        public string Email { get { return this.EmailOption.Value; } set { this.EmailOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of FirstName
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets FirstName
         /// </summary>
         [JsonPropertyName("firstName")]
-        public string FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new(value); } }
+        public string FirstName { get { return this.FirstNameOption.Value; } set { this.FirstNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of LastName
@@ -142,7 +142,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LastName
         /// </summary>
         [JsonPropertyName("lastName")]
-        public string LastName { get { return this.LastNameOption; } set { this.LastNameOption = new(value); } }
+        public string LastName { get { return this.LastNameOption.Value; } set { this.LastNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredProps
@@ -156,7 +156,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredProps")]
-        public Object ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption; } set { this.ObjectWithNoDeclaredPropsOption = new(value); } }
+        public Object ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption.Value; } set { this.ObjectWithNoDeclaredPropsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredPropsNullable
@@ -170,7 +170,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredPropsNullable")]
-        public Object ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption; } set { this.ObjectWithNoDeclaredPropsNullableOption = new(value); } }
+        public Object ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption.Value; } set { this.ObjectWithNoDeclaredPropsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Password
@@ -183,7 +183,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Password
         /// </summary>
         [JsonPropertyName("password")]
-        public string Password { get { return this.PasswordOption; } set { this.PasswordOption = new(value); } }
+        public string Password { get { return this.PasswordOption.Value; } set { this.PasswordOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Phone
@@ -196,7 +196,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Phone
         /// </summary>
         [JsonPropertyName("phone")]
-        public string Phone { get { return this.PhoneOption; } set { this.PhoneOption = new(value); } }
+        public string Phone { get { return this.PhoneOption.Value; } set { this.PhoneOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UserStatus
@@ -210,7 +210,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [JsonPropertyName("userStatus")]
-        public int? UserStatus { get { return this.UserStatusOption; } set { this.UserStatusOption = new(value); } }
+        public int? UserStatus { get { return this.UserStatusOption.Value; } set { this.UserStatusOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Username
@@ -223,7 +223,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Username
         /// </summary>
         [JsonPropertyName("username")]
-        public string Username { get { return this.UsernameOption; } set { this.UsernameOption = new(value); } }
+        public string Username { get { return this.UsernameOption.Value; } set { this.UsernameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/Whale.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [JsonPropertyName("hasBaleen")]
-        public bool? HasBaleen { get { return this.HasBaleenOption; } set { this.HasBaleenOption = new(value); } }
+        public bool? HasBaleen { get { return this.HasBaleenOption.Value; } set { this.HasBaleenOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of HasTeeth
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasTeeth
         /// </summary>
         [JsonPropertyName("hasTeeth")]
-        public bool? HasTeeth { get { return this.HasTeethOption; } set { this.HasTeethOption = new(value); } }
+        public bool? HasTeeth { get { return this.HasTeethOption.Value; } set { this.HasTeethOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Activity.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ActivityOutputs
         /// </summary>
         [JsonPropertyName("activity_outputs")]
-        public Dictionary<string, List<ActivityOutputElementRepresentation>>? ActivityOutputs { get { return this.ActivityOutputsOption; } set { this.ActivityOutputsOption = new(value); } }
+        public Dictionary<string, List<ActivityOutputElementRepresentation>>? ActivityOutputs { get { return this.ActivityOutputsOption.Value; } set { this.ActivityOutputsOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop1
         /// </summary>
         [JsonPropertyName("prop1")]
-        public string? Prop1 { get { return this.Prop1Option; } set { this.Prop1Option = new(value); } }
+        public string? Prop1 { get { return this.Prop1Option.Value; } set { this.Prop1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Prop2
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop2
         /// </summary>
         [JsonPropertyName("prop2")]
-        public Object? Prop2 { get { return this.Prop2Option; } set { this.Prop2Option = new(value); } }
+        public Object? Prop2 { get { return this.Prop2Option.Value; } set { this.Prop2Option = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -69,7 +69,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Anytype1
         /// </summary>
         [JsonPropertyName("anytype_1")]
-        public Object? Anytype1 { get { return this.Anytype1Option; } set { this.Anytype1Option = new(value); } }
+        public Object? Anytype1 { get { return this.Anytype1Option.Value; } set { this.Anytype1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of EmptyMap
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>an object with no declared properties and no undeclared properties, hence it&#39;s an empty map.</value>
         [JsonPropertyName("empty_map")]
-        public Object? EmptyMap { get { return this.EmptyMapOption; } set { this.EmptyMapOption = new(value); } }
+        public Object? EmptyMap { get { return this.EmptyMapOption.Value; } set { this.EmptyMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfMapProperty
@@ -96,7 +96,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfMapProperty
         /// </summary>
         [JsonPropertyName("map_of_map_property")]
-        public Dictionary<string, Dictionary<string, string>>? MapOfMapProperty { get { return this.MapOfMapPropertyOption; } set { this.MapOfMapPropertyOption = new(value); } }
+        public Dictionary<string, Dictionary<string, string>>? MapOfMapProperty { get { return this.MapOfMapPropertyOption.Value; } set { this.MapOfMapPropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapProperty
@@ -109,7 +109,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapProperty
         /// </summary>
         [JsonPropertyName("map_property")]
-        public Dictionary<string, string>? MapProperty { get { return this.MapPropertyOption; } set { this.MapPropertyOption = new(value); } }
+        public Dictionary<string, string>? MapProperty { get { return this.MapPropertyOption.Value; } set { this.MapPropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype1
@@ -122,7 +122,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype1
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_1")]
-        public Object? MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new(value); } }
+        public Object? MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype2
@@ -135,7 +135,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype2
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_2")]
-        public Object? MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new(value); } }
+        public Object? MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype3
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype3
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_3")]
-        public Dictionary<string, Object>? MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new(value); } }
+        public Dictionary<string, Object>? MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesString
@@ -161,7 +161,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesString
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_string")]
-        public Dictionary<string, string>? MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption; } set { this.MapWithUndeclaredPropertiesStringOption = new(value); } }
+        public Dictionary<string, string>? MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption.Value; } set { this.MapWithUndeclaredPropertiesStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Animal.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [JsonPropertyName("code")]
-        public int? Code { get { return this.CodeOption; } set { this.CodeOption = new(value); } }
+        public int? Code { get { return this.CodeOption.Value; } set { this.CodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Message
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Message
         /// </summary>
         [JsonPropertyName("message")]
-        public string? Message { get { return this.MessageOption; } set { this.MessageOption = new(value); } }
+        public string? Message { get { return this.MessageOption.Value; } set { this.MessageOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Type
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Type
         /// </summary>
         [JsonPropertyName("type")]
-        public string? Type { get { return this.TypeOption; } set { this.TypeOption = new(value); } }
+        public string? Type { get { return this.TypeOption.Value; } set { this.TypeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Apple.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ColorCode
         /// </summary>
         [JsonPropertyName("color_code")]
-        public string? ColorCode { get { return this.ColorCodeOption; } set { this.ColorCodeOption = new(value); } }
+        public string? ColorCode { get { return this.ColorCodeOption.Value; } set { this.ColorCodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Cultivar
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Cultivar
         /// </summary>
         [JsonPropertyName("cultivar")]
-        public string? Cultivar { get { return this.CultivarOption; } set { this.CultivarOption = new(value); } }
+        public string? Cultivar { get { return this.CultivarOption.Value; } set { this.CultivarOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Origin
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Origin
         /// </summary>
         [JsonPropertyName("origin")]
-        public string? Origin { get { return this.OriginOption; } set { this.OriginOption = new(value); } }
+        public string? Origin { get { return this.OriginOption.Value; } set { this.OriginOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [JsonPropertyName("mealy")]
-        public bool? Mealy { get { return this.MealyOption; } set { this.MealyOption = new(value); } }
+        public bool? Mealy { get { return this.MealyOption.Value; } set { this.MealyOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayArrayNumber")]
-        public List<List<decimal>>? ArrayArrayNumber { get { return this.ArrayArrayNumberOption; } set { this.ArrayArrayNumberOption = new(value); } }
+        public List<List<decimal>>? ArrayArrayNumber { get { return this.ArrayArrayNumberOption.Value; } set { this.ArrayArrayNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayNumber")]
-        public List<decimal>? ArrayNumber { get { return this.ArrayNumberOption; } set { this.ArrayNumberOption = new(value); } }
+        public List<decimal>? ArrayNumber { get { return this.ArrayNumberOption.Value; } set { this.ArrayNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfInteger
         /// </summary>
         [JsonPropertyName("array_array_of_integer")]
-        public List<List<long>>? ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption; } set { this.ArrayArrayOfIntegerOption = new(value); } }
+        public List<List<long>>? ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption.Value; } set { this.ArrayArrayOfIntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayArrayOfModel
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfModel
         /// </summary>
         [JsonPropertyName("array_array_of_model")]
-        public List<List<ReadOnlyFirst>>? ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption; } set { this.ArrayArrayOfModelOption = new(value); } }
+        public List<List<ReadOnlyFirst>>? ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption.Value; } set { this.ArrayArrayOfModelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayOfString
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayOfString
         /// </summary>
         [JsonPropertyName("array_of_string")]
-        public List<string>? ArrayOfString { get { return this.ArrayOfStringOption; } set { this.ArrayOfStringOption = new(value); } }
+        public List<string>? ArrayOfString { get { return this.ArrayOfStringOption.Value; } set { this.ArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Banana.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [JsonPropertyName("lengthCm")]
-        public decimal? LengthCm { get { return this.LengthCmOption; } set { this.LengthCmOption = new(value); } }
+        public decimal? LengthCm { get { return this.LengthCmOption.Value; } set { this.LengthCmOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [JsonPropertyName("sweet")]
-        public bool? Sweet { get { return this.SweetOption; } set { this.SweetOption = new(value); } }
+        public bool? Sweet { get { return this.SweetOption.Value; } set { this.SweetOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -66,7 +66,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Name of the pet </value>
         [JsonPropertyName("ATT_NAME")]
-        public string? ATT_NAME { get { return this.ATT_NAMEOption; } set { this.ATT_NAMEOption = new(value); } }
+        public string? ATT_NAME { get { return this.ATT_NAMEOption.Value; } set { this.ATT_NAMEOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalCamel
@@ -79,7 +79,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalCamel
         /// </summary>
         [JsonPropertyName("CapitalCamel")]
-        public string? CapitalCamel { get { return this.CapitalCamelOption; } set { this.CapitalCamelOption = new(value); } }
+        public string? CapitalCamel { get { return this.CapitalCamelOption.Value; } set { this.CapitalCamelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalSnake
@@ -92,7 +92,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalSnake
         /// </summary>
         [JsonPropertyName("Capital_Snake")]
-        public string? CapitalSnake { get { return this.CapitalSnakeOption; } set { this.CapitalSnakeOption = new(value); } }
+        public string? CapitalSnake { get { return this.CapitalSnakeOption.Value; } set { this.CapitalSnakeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SCAETHFlowPoints
@@ -105,7 +105,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SCAETHFlowPoints
         /// </summary>
         [JsonPropertyName("SCA_ETH_Flow_Points")]
-        public string? SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption; } set { this.SCAETHFlowPointsOption = new(value); } }
+        public string? SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption.Value; } set { this.SCAETHFlowPointsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SmallCamel
@@ -118,7 +118,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallCamel
         /// </summary>
         [JsonPropertyName("smallCamel")]
-        public string? SmallCamel { get { return this.SmallCamelOption; } set { this.SmallCamelOption = new(value); } }
+        public string? SmallCamel { get { return this.SmallCamelOption.Value; } set { this.SmallCamelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SmallSnake
@@ -131,7 +131,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallSnake
         /// </summary>
         [JsonPropertyName("small_Snake")]
-        public string? SmallSnake { get { return this.SmallSnakeOption; } set { this.SmallSnakeOption = new(value); } }
+        public string? SmallSnake { get { return this.SmallSnakeOption.Value; } set { this.SmallSnakeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [JsonPropertyName("declawed")]
-        public bool? Declawed { get { return this.DeclawedOption; } set { this.DeclawedOption = new(value); } }
+        public bool? Declawed { get { return this.DeclawedOption.Value; } set { this.DeclawedOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -108,7 +108,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// The discriminator

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("_class")]
-        public string? Class { get { return this.ClassOption; } set { this.ClassOption = new(value); } }
+        public string? Class { get { return this.ClassOption.Value; } set { this.ClassOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>Fri Jul 21 00:00:00 UTC 2017</example> */
         [JsonPropertyName("dateOnlyProperty")]
-        public DateOnly? DateOnlyProperty { get { return this.DateOnlyPropertyOption; } set { this.DateOnlyPropertyOption = new(value); } }
+        public DateOnly? DateOnlyProperty { get { return this.DateOnlyPropertyOption.Value; } set { this.DateOnlyPropertyOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Dog.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Breed
         /// </summary>
         [JsonPropertyName("breed")]
-        public string? Breed { get { return this.BreedOption; } set { this.BreedOption = new(value); } }
+        public string? Breed { get { return this.BreedOption.Value; } set { this.BreedOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Drawing.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MainShape
         /// </summary>
         [JsonPropertyName("mainShape")]
-        public Shape? MainShape { get { return this.MainShapeOption; } set { this.MainShapeOption = new(value); } }
+        public Shape? MainShape { get { return this.MainShapeOption.Value; } set { this.MainShapeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NullableShape
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableShape
         /// </summary>
         [JsonPropertyName("nullableShape")]
-        public NullableShape? NullableShape { get { return this.NullableShapeOption; } set { this.NullableShapeOption = new(value); } }
+        public NullableShape? NullableShape { get { return this.NullableShapeOption.Value; } set { this.NullableShapeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ShapeOrNull
@@ -87,7 +87,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ShapeOrNull
         /// </summary>
         [JsonPropertyName("shapeOrNull")]
-        public ShapeOrNull? ShapeOrNull { get { return this.ShapeOrNullOption; } set { this.ShapeOrNullOption = new(value); } }
+        public ShapeOrNull? ShapeOrNull { get { return this.ShapeOrNullOption.Value; } set { this.ShapeOrNullOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Shapes
@@ -100,7 +100,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Shapes
         /// </summary>
         [JsonPropertyName("shapes")]
-        public List<Shape>? Shapes { get { return this.ShapesOption; } set { this.ShapesOption = new(value); } }
+        public List<Shape>? Shapes { get { return this.ShapesOption.Value; } set { this.ShapesOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -202,7 +202,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayEnum
         /// </summary>
         [JsonPropertyName("array_enum")]
-        public List<EnumArrays.ArrayEnumEnum>? ArrayEnum { get { return this.ArrayEnumOption; } set { this.ArrayEnumOption = new(value); } }
+        public List<EnumArrays.ArrayEnumEnum>? ArrayEnum { get { return this.ArrayEnumOption.Value; } set { this.ArrayEnumOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/File.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Test capitalization</value>
         [JsonPropertyName("sourceURI")]
-        public string? SourceURI { get { return this.SourceURIOption; } set { this.SourceURIOption = new(value); } }
+        public string? SourceURI { get { return this.SourceURIOption.Value; } set { this.SourceURIOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets File
         /// </summary>
         [JsonPropertyName("file")]
-        public File? File { get { return this.FileOption; } set { this.FileOption = new(value); } }
+        public File? File { get { return this.FileOption.Value; } set { this.FileOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Files
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Files
         /// </summary>
         [JsonPropertyName("files")]
-        public List<File>? Files { get { return this.FilesOption; } set { this.FilesOption = new(value); } }
+        public List<File>? Files { get { return this.FilesOption.Value; } set { this.FilesOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Foo.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string? Bar { get { return this.BarOption; } set { this.BarOption = new(value); } }
+        public string? Bar { get { return this.BarOption.Value; } set { this.BarOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public Foo? String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public Foo? String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Binary
         /// </summary>
         [JsonPropertyName("binary")]
-        public System.IO.Stream? Binary { get { return this.BinaryOption; } set { this.BinaryOption = new(value); } }
+        public System.IO.Stream? Binary { get { return this.BinaryOption.Value; } set { this.BinaryOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DateTime
@@ -154,7 +154,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2007-12-03T10:15:30+01:00</example> */
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Decimal
@@ -167,7 +167,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Decimal
         /// </summary>
         [JsonPropertyName("decimal")]
-        public decimal? Decimal { get { return this.DecimalOption; } set { this.DecimalOption = new(value); } }
+        public decimal? Decimal { get { return this.DecimalOption.Value; } set { this.DecimalOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Double
@@ -180,7 +180,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Double
         /// </summary>
         [JsonPropertyName("double")]
-        public double? Double { get { return this.DoubleOption; } set { this.DoubleOption = new(value); } }
+        public double? Double { get { return this.DoubleOption.Value; } set { this.DoubleOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName2
@@ -193,7 +193,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName2
         /// </summary>
         [JsonPropertyName("duplicate_property_name")]
-        public string? DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option; } set { this.DuplicatePropertyName2Option = new(value); } }
+        public string? DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option.Value; } set { this.DuplicatePropertyName2Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName
@@ -206,7 +206,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName
         /// </summary>
         [JsonPropertyName("@duplicate_property_name")]
-        public string? DuplicatePropertyName { get { return this.DuplicatePropertyNameOption; } set { this.DuplicatePropertyNameOption = new(value); } }
+        public string? DuplicatePropertyName { get { return this.DuplicatePropertyNameOption.Value; } set { this.DuplicatePropertyNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Float
@@ -219,7 +219,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Float
         /// </summary>
         [JsonPropertyName("float")]
-        public float? Float { get { return this.FloatOption; } set { this.FloatOption = new(value); } }
+        public float? Float { get { return this.FloatOption.Value; } set { this.FloatOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int32
@@ -232,7 +232,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32
         /// </summary>
         [JsonPropertyName("int32")]
-        public int? Int32 { get { return this.Int32Option; } set { this.Int32Option = new(value); } }
+        public int? Int32 { get { return this.Int32Option.Value; } set { this.Int32Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int32Range
@@ -245,7 +245,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32Range
         /// </summary>
         [JsonPropertyName("int32Range")]
-        public int? Int32Range { get { return this.Int32RangeOption; } set { this.Int32RangeOption = new(value); } }
+        public int? Int32Range { get { return this.Int32RangeOption.Value; } set { this.Int32RangeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64
@@ -258,7 +258,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64
         /// </summary>
         [JsonPropertyName("int64")]
-        public long? Int64 { get { return this.Int64Option; } set { this.Int64Option = new(value); } }
+        public long? Int64 { get { return this.Int64Option.Value; } set { this.Int64Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Negative
@@ -271,7 +271,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Negative
         /// </summary>
         [JsonPropertyName("int64Negative")]
-        public long? Int64Negative { get { return this.Int64NegativeOption; } set { this.Int64NegativeOption = new(value); } }
+        public long? Int64Negative { get { return this.Int64NegativeOption.Value; } set { this.Int64NegativeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64NegativeExclusive
@@ -284,7 +284,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64NegativeExclusive
         /// </summary>
         [JsonPropertyName("int64NegativeExclusive")]
-        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption; } set { this.Int64NegativeExclusiveOption = new(value); } }
+        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption.Value; } set { this.Int64NegativeExclusiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Positive
@@ -297,7 +297,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Positive
         /// </summary>
         [JsonPropertyName("int64Positive")]
-        public long? Int64Positive { get { return this.Int64PositiveOption; } set { this.Int64PositiveOption = new(value); } }
+        public long? Int64Positive { get { return this.Int64PositiveOption.Value; } set { this.Int64PositiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64PositiveExclusive
@@ -310,7 +310,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64PositiveExclusive
         /// </summary>
         [JsonPropertyName("int64PositiveExclusive")]
-        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption; } set { this.Int64PositiveExclusiveOption = new(value); } }
+        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption.Value; } set { this.Int64PositiveExclusiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Integer
@@ -323,7 +323,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [JsonPropertyName("integer")]
-        public int? Integer { get { return this.IntegerOption; } set { this.IntegerOption = new(value); } }
+        public int? Integer { get { return this.IntegerOption.Value; } set { this.IntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithBackslash
@@ -337,7 +337,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>None</value>
         [JsonPropertyName("pattern_with_backslash")]
-        public string? PatternWithBackslash { get { return this.PatternWithBackslashOption; } set { this.PatternWithBackslashOption = new(value); } }
+        public string? PatternWithBackslash { get { return this.PatternWithBackslashOption.Value; } set { this.PatternWithBackslashOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigits
@@ -351,7 +351,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string that is a 10 digit number. Can have leading zeros.</value>
         [JsonPropertyName("pattern_with_digits")]
-        public string? PatternWithDigits { get { return this.PatternWithDigitsOption; } set { this.PatternWithDigitsOption = new(value); } }
+        public string? PatternWithDigits { get { return this.PatternWithDigitsOption.Value; } set { this.PatternWithDigitsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigitsAndDelimiter
@@ -365,7 +365,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.</value>
         [JsonPropertyName("pattern_with_digits_and_delimiter")]
-        public string? PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption; } set { this.PatternWithDigitsAndDelimiterOption = new(value); } }
+        public string? PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption.Value; } set { this.PatternWithDigitsAndDelimiterOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of String
@@ -378,7 +378,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public string? String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public string? String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of StringFormattedAsDecimal
@@ -391,7 +391,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringFormattedAsDecimal
         /// </summary>
         [JsonPropertyName("string_formatted_as_decimal")]
-        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption; } set { this.StringFormattedAsDecimalOption = new(value); } }
+        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption.Value; } set { this.StringFormattedAsDecimalOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedInteger
@@ -404,7 +404,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [JsonPropertyName("unsigned_integer")]
-        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption; } set { this.UnsignedIntegerOption = new(value); } }
+        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption.Value; } set { this.UnsignedIntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedLong
@@ -417,7 +417,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedLong
         /// </summary>
         [JsonPropertyName("unsigned_long")]
-        public ulong? UnsignedLong { get { return this.UnsignedLongOption; } set { this.UnsignedLongOption = new(value); } }
+        public ulong? UnsignedLong { get { return this.UnsignedLongOption.Value; } set { this.UnsignedLongOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -431,7 +431,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -82,7 +82,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string? Bar { get { return this.BarOption; } }
+        public string? Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Foo
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Foo
         /// </summary>
         [JsonPropertyName("foo")]
-        public string? Foo { get { return this.FooOption; } }
+        public string? Foo { get { return this.FooOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableMessage
         /// </summary>
         [JsonPropertyName("NullableMessage")]
-        public string? NullableMessage { get { return this.NullableMessageOption; } set { this.NullableMessageOption = new(value); } }
+        public string? NullableMessage { get { return this.NullableMessageOption.Value; } set { this.NullableMessageOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/List.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123List
         /// </summary>
         [JsonPropertyName("123-list")]
-        public string? Var123List { get { return this.Var123ListOption; } set { this.Var123ListOption = new(value); } }
+        public string? Var123List { get { return this.Var123ListOption.Value; } set { this.Var123ListOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets EscapedLiteralString
         /// </summary>
         [JsonPropertyName("escapedLiteralString")]
-        public string? EscapedLiteralString { get { return this.EscapedLiteralStringOption; } set { this.EscapedLiteralStringOption = new(value); } }
+        public string? EscapedLiteralString { get { return this.EscapedLiteralStringOption.Value; } set { this.EscapedLiteralStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnescapedLiteralString
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnescapedLiteralString
         /// </summary>
         [JsonPropertyName("unescapedLiteralString")]
-        public string? UnescapedLiteralString { get { return this.UnescapedLiteralStringOption; } set { this.UnescapedLiteralStringOption = new(value); } }
+        public string? UnescapedLiteralString { get { return this.UnescapedLiteralStringOption.Value; } set { this.UnescapedLiteralStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MapTest.cs
@@ -127,7 +127,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DirectMap
         /// </summary>
         [JsonPropertyName("direct_map")]
-        public Dictionary<string, bool>? DirectMap { get { return this.DirectMapOption; } set { this.DirectMapOption = new(value); } }
+        public Dictionary<string, bool>? DirectMap { get { return this.DirectMapOption.Value; } set { this.DirectMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of IndirectMap
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IndirectMap
         /// </summary>
         [JsonPropertyName("indirect_map")]
-        public Dictionary<string, bool>? IndirectMap { get { return this.IndirectMapOption; } set { this.IndirectMapOption = new(value); } }
+        public Dictionary<string, bool>? IndirectMap { get { return this.IndirectMapOption.Value; } set { this.IndirectMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapMapOfString
@@ -153,7 +153,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapMapOfString
         /// </summary>
         [JsonPropertyName("map_map_of_string")]
-        public Dictionary<string, Dictionary<string, string>>? MapMapOfString { get { return this.MapMapOfStringOption; } set { this.MapMapOfStringOption = new(value); } }
+        public Dictionary<string, Dictionary<string, string>>? MapMapOfString { get { return this.MapMapOfStringOption.Value; } set { this.MapMapOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfEnumString
@@ -166,7 +166,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfEnumString
         /// </summary>
         [JsonPropertyName("map_of_enum_string")]
-        public Dictionary<string, MapTest.InnerEnum>? MapOfEnumString { get { return this.MapOfEnumStringOption; } set { this.MapOfEnumStringOption = new(value); } }
+        public Dictionary<string, MapTest.InnerEnum>? MapOfEnumString { get { return this.MapOfEnumStringOption.Value; } set { this.MapOfEnumStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedAnyOfContent? Content { get { return this.ContentOption; } set { this.ContentOption = new(value); } }
+        public MixedAnyOfContent? Content { get { return this.ContentOption.Value; } set { this.ContentOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedOneOfContent? Content { get { return this.ContentOption; } set { this.ContentOption = new(value); } }
+        public MixedOneOfContent? Content { get { return this.ContentOption.Value; } set { this.ContentOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateTime
         /// </summary>
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Map
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Map
         /// </summary>
         [JsonPropertyName("map")]
-        public Dictionary<string, Animal>? Map { get { return this.MapOption; } set { this.MapOption = new(value); } }
+        public Dictionary<string, Animal>? Map { get { return this.MapOption.Value; } set { this.MapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -87,7 +87,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UuidWithPattern
@@ -100,7 +100,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [JsonPropertyName("uuid_with_pattern")]
-        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption; } set { this.UuidWithPatternOption = new(value); } }
+        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption.Value; } set { this.UuidWithPatternOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public string? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public string? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("class")]
-        public string? Class { get { return this.ClassOption; } set { this.ClassOption = new(value); } }
+        public string? Class { get { return this.ClassOption.Value; } set { this.ClassOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public int? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public int? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarClient
         /// </summary>
         [JsonPropertyName("client")]
-        public string? VarClient { get { return this.VarClientOption; } set { this.VarClientOption = new(value); } }
+        public string? VarClient { get { return this.VarClientOption.Value; } set { this.VarClientOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Property
         /// </summary>
         [JsonPropertyName("property")]
-        public string? Property { get { return this.PropertyOption; } set { this.PropertyOption = new(value); } }
+        public string? Property { get { return this.PropertyOption.Value; } set { this.PropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SnakeCase
@@ -80,7 +80,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [JsonPropertyName("snake_case")]
-        public int? SnakeCase { get { return this.SnakeCaseOption; } }
+        public int? SnakeCase { get { return this.SnakeCaseOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Var123Number
@@ -93,7 +93,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123Number
         /// </summary>
         [JsonPropertyName("123Number")]
-        public int? Var123Number { get { return this.Var123NumberOption; } }
+        public int? Var123Number { get { return this.Var123NumberOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -77,7 +77,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("array_and_items_nullable_prop")]
-        public List<Object>? ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption; } set { this.ArrayAndItemsNullablePropOption = new(value); } }
+        public List<Object>? ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption.Value; } set { this.ArrayAndItemsNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayItemsNullable
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayItemsNullable
         /// </summary>
         [JsonPropertyName("array_items_nullable")]
-        public List<Object>? ArrayItemsNullable { get { return this.ArrayItemsNullableOption; } set { this.ArrayItemsNullableOption = new(value); } }
+        public List<Object>? ArrayItemsNullable { get { return this.ArrayItemsNullableOption.Value; } set { this.ArrayItemsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayNullableProp
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNullableProp
         /// </summary>
         [JsonPropertyName("array_nullable_prop")]
-        public List<Object>? ArrayNullableProp { get { return this.ArrayNullablePropOption; } set { this.ArrayNullablePropOption = new(value); } }
+        public List<Object>? ArrayNullableProp { get { return this.ArrayNullablePropOption.Value; } set { this.ArrayNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of BooleanProp
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BooleanProp
         /// </summary>
         [JsonPropertyName("boolean_prop")]
-        public bool? BooleanProp { get { return this.BooleanPropOption; } set { this.BooleanPropOption = new(value); } }
+        public bool? BooleanProp { get { return this.BooleanPropOption.Value; } set { this.BooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DateProp
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateProp
         /// </summary>
         [JsonPropertyName("date_prop")]
-        public DateOnly? DateProp { get { return this.DatePropOption; } set { this.DatePropOption = new(value); } }
+        public DateOnly? DateProp { get { return this.DatePropOption.Value; } set { this.DatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DatetimeProp
@@ -142,7 +142,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DatetimeProp
         /// </summary>
         [JsonPropertyName("datetime_prop")]
-        public DateTime? DatetimeProp { get { return this.DatetimePropOption; } set { this.DatetimePropOption = new(value); } }
+        public DateTime? DatetimeProp { get { return this.DatetimePropOption.Value; } set { this.DatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of IntegerProp
@@ -155,7 +155,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IntegerProp
         /// </summary>
         [JsonPropertyName("integer_prop")]
-        public int? IntegerProp { get { return this.IntegerPropOption; } set { this.IntegerPropOption = new(value); } }
+        public int? IntegerProp { get { return this.IntegerPropOption.Value; } set { this.IntegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NumberProp
@@ -168,7 +168,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NumberProp
         /// </summary>
         [JsonPropertyName("number_prop")]
-        public decimal? NumberProp { get { return this.NumberPropOption; } set { this.NumberPropOption = new(value); } }
+        public decimal? NumberProp { get { return this.NumberPropOption.Value; } set { this.NumberPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectAndItemsNullableProp
@@ -181,7 +181,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("object_and_items_nullable_prop")]
-        public Dictionary<string, Object>? ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption; } set { this.ObjectAndItemsNullablePropOption = new(value); } }
+        public Dictionary<string, Object>? ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption.Value; } set { this.ObjectAndItemsNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectItemsNullable
@@ -194,7 +194,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectItemsNullable
         /// </summary>
         [JsonPropertyName("object_items_nullable")]
-        public Dictionary<string, Object>? ObjectItemsNullable { get { return this.ObjectItemsNullableOption; } set { this.ObjectItemsNullableOption = new(value); } }
+        public Dictionary<string, Object>? ObjectItemsNullable { get { return this.ObjectItemsNullableOption.Value; } set { this.ObjectItemsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectNullableProp
@@ -207,7 +207,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectNullableProp
         /// </summary>
         [JsonPropertyName("object_nullable_prop")]
-        public Dictionary<string, Object>? ObjectNullableProp { get { return this.ObjectNullablePropOption; } set { this.ObjectNullablePropOption = new(value); } }
+        public Dictionary<string, Object>? ObjectNullableProp { get { return this.ObjectNullablePropOption.Value; } set { this.ObjectNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of StringProp
@@ -220,7 +220,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringProp
         /// </summary>
         [JsonPropertyName("string_prop")]
-        public string? StringProp { get { return this.StringPropOption; } set { this.StringPropOption = new(value); } }
+        public string? StringProp { get { return this.StringPropOption.Value; } set { this.StringPropOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [JsonPropertyName("JustNumber")]
-        public decimal? JustNumber { get { return this.JustNumberOption; } set { this.JustNumberOption = new(value); } }
+        public decimal? JustNumber { get { return this.JustNumberOption.Value; } set { this.JustNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("bars")]
         [Obsolete]
-        public List<string>? Bars { get { return this.BarsOption; } set { this.BarsOption = new(value); } }
+        public List<string>? Bars { get { return this.BarsOption.Value; } set { this.BarsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DeprecatedRef
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("deprecatedRef")]
         [Obsolete]
-        public DeprecatedObject? DeprecatedRef { get { return this.DeprecatedRefOption; } set { this.DeprecatedRefOption = new(value); } }
+        public DeprecatedObject? DeprecatedRef { get { return this.DeprecatedRefOption.Value; } set { this.DeprecatedRefOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("id")]
         [Obsolete]
-        public decimal? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public decimal? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public string? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Order.cs
@@ -160,7 +160,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Complete
         /// </summary>
         [JsonPropertyName("complete")]
-        public bool? Complete { get { return this.CompleteOption; } set { this.CompleteOption = new(value); } }
+        public bool? Complete { get { return this.CompleteOption.Value; } set { this.CompleteOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -173,7 +173,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PetId
@@ -186,7 +186,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets PetId
         /// </summary>
         [JsonPropertyName("petId")]
-        public long? PetId { get { return this.PetIdOption; } set { this.PetIdOption = new(value); } }
+        public long? PetId { get { return this.PetIdOption.Value; } set { this.PetIdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Quantity
@@ -199,7 +199,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Quantity
         /// </summary>
         [JsonPropertyName("quantity")]
-        public int? Quantity { get { return this.QuantityOption; } set { this.QuantityOption = new(value); } }
+        public int? Quantity { get { return this.QuantityOption.Value; } set { this.QuantityOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ShipDate
@@ -213,7 +213,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2020-02-02T20:20:20.000222Z</example> */
         [JsonPropertyName("shipDate")]
-        public DateTime? ShipDate { get { return this.ShipDateOption; } set { this.ShipDateOption = new(value); } }
+        public DateTime? ShipDate { get { return this.ShipDateOption.Value; } set { this.ShipDateOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyBoolean
         /// </summary>
         [JsonPropertyName("my_boolean")]
-        public bool? MyBoolean { get { return this.MyBooleanOption; } set { this.MyBooleanOption = new(value); } }
+        public bool? MyBoolean { get { return this.MyBooleanOption.Value; } set { this.MyBooleanOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MyNumber
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [JsonPropertyName("my_number")]
-        public decimal? MyNumber { get { return this.MyNumberOption; } set { this.MyNumberOption = new(value); } }
+        public decimal? MyNumber { get { return this.MyNumberOption.Value; } set { this.MyNumberOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MyString
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyString
         /// </summary>
         [JsonPropertyName("my_string")]
-        public string? MyString { get { return this.MyStringOption; } set { this.MyStringOption = new(value); } }
+        public string? MyString { get { return this.MyStringOption.Value; } set { this.MyStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
@@ -173,7 +173,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Category
         /// </summary>
         [JsonPropertyName("category")]
-        public Category? Category { get { return this.CategoryOption; } set { this.CategoryOption = new(value); } }
+        public Category? Category { get { return this.CategoryOption.Value; } set { this.CategoryOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -186,7 +186,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Tags
@@ -199,7 +199,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Tags
         /// </summary>
         [JsonPropertyName("tags")]
-        public List<Tag>? Tags { get { return this.TagsOption; } set { this.TagsOption = new(value); } }
+        public List<Tag>? Tags { get { return this.TagsOption.Value; } set { this.TagsOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string? Bar { get { return this.BarOption; } }
+        public string? Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Baz
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Baz
         /// </summary>
         [JsonPropertyName("baz")]
-        public string? Baz { get { return this.BazOption; } set { this.BazOption = new(value); } }
+        public string? Baz { get { return this.BazOption.Value; } set { this.BazOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -1414,7 +1414,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_notnullable_date_prop")]
-        public DateOnly? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption; } set { this.NotRequiredNotnullableDatePropOption = new(value); } }
+        public DateOnly? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption.Value; } set { this.NotRequiredNotnullableDatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNotnullableintegerProp
@@ -1427,7 +1427,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [JsonPropertyName("not_required_notnullableinteger_prop")]
-        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption; } set { this.NotRequiredNotnullableintegerPropOption = new(value); } }
+        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption.Value; } set { this.NotRequiredNotnullableintegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableDateProp
@@ -1440,7 +1440,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_date_prop")]
-        public DateOnly? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption; } set { this.NotRequiredNullableDatePropOption = new(value); } }
+        public DateOnly? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption.Value; } set { this.NotRequiredNullableDatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableIntegerProp
@@ -1453,7 +1453,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableIntegerProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_integer_prop")]
-        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption; } set { this.NotRequiredNullableIntegerPropOption = new(value); } }
+        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption.Value; } set { this.NotRequiredNullableIntegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableArrayOfString
@@ -1466,7 +1466,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_array_of_string")]
-        public List<string>? NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption; } set { this.NotrequiredNotnullableArrayOfStringOption = new(value); } }
+        public List<string>? NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption.Value; } set { this.NotrequiredNotnullableArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableBooleanProp
@@ -1479,7 +1479,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_boolean_prop")]
-        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption; } set { this.NotrequiredNotnullableBooleanPropOption = new(value); } }
+        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption.Value; } set { this.NotrequiredNotnullableBooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableDatetimeProp
@@ -1492,7 +1492,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_datetime_prop")]
-        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption; } set { this.NotrequiredNotnullableDatetimePropOption = new(value); } }
+        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption.Value; } set { this.NotrequiredNotnullableDatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableStringProp
@@ -1505,7 +1505,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_string_prop")]
-        public string? NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption; } set { this.NotrequiredNotnullableStringPropOption = new(value); } }
+        public string? NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption.Value; } set { this.NotrequiredNotnullableStringPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableUuid
@@ -1519,7 +1519,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_notnullable_uuid")]
-        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption; } set { this.NotrequiredNotnullableUuidOption = new(value); } }
+        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption.Value; } set { this.NotrequiredNotnullableUuidOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableArrayOfString
@@ -1532,7 +1532,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_nullable_array_of_string")]
-        public List<string>? NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption; } set { this.NotrequiredNullableArrayOfStringOption = new(value); } }
+        public List<string>? NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption.Value; } set { this.NotrequiredNullableArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableBooleanProp
@@ -1545,7 +1545,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_boolean_prop")]
-        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption; } set { this.NotrequiredNullableBooleanPropOption = new(value); } }
+        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption.Value; } set { this.NotrequiredNullableBooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableDatetimeProp
@@ -1558,7 +1558,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_datetime_prop")]
-        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption; } set { this.NotrequiredNullableDatetimePropOption = new(value); } }
+        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption.Value; } set { this.NotrequiredNullableDatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableStringProp
@@ -1571,7 +1571,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_string_prop")]
-        public string? NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption; } set { this.NotrequiredNullableStringPropOption = new(value); } }
+        public string? NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption.Value; } set { this.NotrequiredNullableStringPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableUuid
@@ -1585,7 +1585,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_nullable_uuid")]
-        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption; } set { this.NotrequiredNullableUuidOption = new(value); } }
+        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption.Value; } set { this.NotrequiredNullableUuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets RequiredNullableArrayOfString

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Result.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result code</value>
         [JsonPropertyName("code")]
-        public string? Code { get { return this.CodeOption; } set { this.CodeOption = new(value); } }
+        public string? Code { get { return this.CodeOption.Value; } set { this.CodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Data
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string>? Data { get { return this.DataOption; } set { this.DataOption = new(value); } }
+        public Dictionary<string, string>? Data { get { return this.DataOption.Value; } set { this.DataOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
@@ -73,7 +73,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [JsonPropertyName("return")]
-        public int? VarReturn { get { return this.VarReturnOption; } set { this.VarReturnOption = new(value); } }
+        public int? VarReturn { get { return this.VarReturnOption.Value; } set { this.VarReturnOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Unsafe
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Unsafe
         /// </summary>
         [JsonPropertyName("unsafe")]
-        public string? Unsafe { get { return this.UnsafeOption; } set { this.UnsafeOption = new(value); } }
+        public string? Unsafe { get { return this.UnsafeOption.Value; } set { this.UnsafeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Role
         /// </summary>
         [JsonPropertyName("role")]
-        public RolesReportsHashRole? Role { get { return this.RoleOption; } set { this.RoleOption = new(value); } }
+        public RolesReportsHashRole? Role { get { return this.RoleOption.Value; } set { this.RoleOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of RoleUuid
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [JsonPropertyName("role_uuid")]
-        public Guid? RoleUuid { get { return this.RoleUuidOption; } set { this.RoleUuidOption = new(value); } }
+        public Guid? RoleUuid { get { return this.RoleUuidOption.Value; } set { this.RoleUuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarSpecialModelName
         /// </summary>
         [JsonPropertyName("_special_model.name_")]
-        public string? VarSpecialModelName { get { return this.VarSpecialModelNameOption; } set { this.VarSpecialModelNameOption = new(value); } }
+        public string? VarSpecialModelName { get { return this.VarSpecialModelNameOption.Value; } set { this.VarSpecialModelNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SpecialPropertyName
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [JsonPropertyName("$special[property.name]")]
-        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption; } set { this.SpecialPropertyNameOption = new(value); } }
+        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption.Value; } set { this.SpecialPropertyNameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Value
         /// </summary>
         [JsonPropertyName("value")]
-        public string? Value { get { return this.ValueOption; } set { this.ValueOption = new(value); } }
+        public string? Value { get { return this.ValueOption.Value; } set { this.ValueOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets TestCollectionEndingWithWordList
         /// </summary>
         [JsonPropertyName("TestCollectionEndingWithWordList")]
-        public List<TestCollectionEndingWithWordList>? TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption; } set { this.TestCollectionEndingWithWordListOption = new(value); } }
+        public List<TestCollectionEndingWithWordList>? TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption.Value; } set { this.TestCollectionEndingWithWordListOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SomeProperty
         /// </summary>
         [JsonPropertyName("someProperty")]
-        public string? SomeProperty { get { return this.SomePropertyOption; } set { this.SomePropertyOption = new(value); } }
+        public string? SomeProperty { get { return this.SomePropertyOption.Value; } set { this.SomePropertyOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
@@ -73,7 +73,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string>? Data { get { return this.DataOption; } set { this.DataOption = new(value); } }
+        public Dictionary<string, string>? Data { get { return this.DataOption.Value; } set { this.DataOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -87,7 +87,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
         [JsonPropertyName("anyTypeProp")]
-        public Object? AnyTypeProp { get { return this.AnyTypePropOption; } set { this.AnyTypePropOption = new(value); } }
+        public Object? AnyTypeProp { get { return this.AnyTypePropOption.Value; } set { this.AnyTypePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of AnyTypePropNullable
@@ -92,7 +92,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values.</value>
         [JsonPropertyName("anyTypePropNullable")]
-        public Object? AnyTypePropNullable { get { return this.AnyTypePropNullableOption; } set { this.AnyTypePropNullableOption = new(value); } }
+        public Object? AnyTypePropNullable { get { return this.AnyTypePropNullableOption.Value; } set { this.AnyTypePropNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Email
@@ -105,7 +105,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Email
         /// </summary>
         [JsonPropertyName("email")]
-        public string? Email { get { return this.EmailOption; } set { this.EmailOption = new(value); } }
+        public string? Email { get { return this.EmailOption.Value; } set { this.EmailOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of FirstName
@@ -118,7 +118,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets FirstName
         /// </summary>
         [JsonPropertyName("firstName")]
-        public string? FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new(value); } }
+        public string? FirstName { get { return this.FirstNameOption.Value; } set { this.FirstNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -131,7 +131,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of LastName
@@ -144,7 +144,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LastName
         /// </summary>
         [JsonPropertyName("lastName")]
-        public string? LastName { get { return this.LastNameOption; } set { this.LastNameOption = new(value); } }
+        public string? LastName { get { return this.LastNameOption.Value; } set { this.LastNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredProps
@@ -158,7 +158,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredProps")]
-        public Object? ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption; } set { this.ObjectWithNoDeclaredPropsOption = new(value); } }
+        public Object? ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption.Value; } set { this.ObjectWithNoDeclaredPropsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredPropsNullable
@@ -172,7 +172,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredPropsNullable")]
-        public Object? ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption; } set { this.ObjectWithNoDeclaredPropsNullableOption = new(value); } }
+        public Object? ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption.Value; } set { this.ObjectWithNoDeclaredPropsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Password
@@ -185,7 +185,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Password
         /// </summary>
         [JsonPropertyName("password")]
-        public string? Password { get { return this.PasswordOption; } set { this.PasswordOption = new(value); } }
+        public string? Password { get { return this.PasswordOption.Value; } set { this.PasswordOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Phone
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Phone
         /// </summary>
         [JsonPropertyName("phone")]
-        public string? Phone { get { return this.PhoneOption; } set { this.PhoneOption = new(value); } }
+        public string? Phone { get { return this.PhoneOption.Value; } set { this.PhoneOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UserStatus
@@ -212,7 +212,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [JsonPropertyName("userStatus")]
-        public int? UserStatus { get { return this.UserStatusOption; } set { this.UserStatusOption = new(value); } }
+        public int? UserStatus { get { return this.UserStatusOption.Value; } set { this.UserStatusOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Username
@@ -225,7 +225,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Username
         /// </summary>
         [JsonPropertyName("username")]
-        public string? Username { get { return this.UsernameOption; } set { this.UsernameOption = new(value); } }
+        public string? Username { get { return this.UsernameOption.Value; } set { this.UsernameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
@@ -65,7 +65,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [JsonPropertyName("hasBaleen")]
-        public bool? HasBaleen { get { return this.HasBaleenOption; } set { this.HasBaleenOption = new(value); } }
+        public bool? HasBaleen { get { return this.HasBaleenOption.Value; } set { this.HasBaleenOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of HasTeeth
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasTeeth
         /// </summary>
         [JsonPropertyName("hasTeeth")]
-        public bool? HasTeeth { get { return this.HasTeethOption; } set { this.HasTeethOption = new(value); } }
+        public bool? HasTeeth { get { return this.HasTeethOption.Value; } set { this.HasTeethOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Kind
         /// </summary>
         [JsonPropertyName("kind")]
-        public string? Kind { get { return this.KindOption; } set { this.KindOption = new(value); } }
+        public string? Kind { get { return this.KindOption.Value; } set { this.KindOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Count
         /// </summary>
         [JsonPropertyName("count")]
-        public decimal? Count { get { return this.CountOption; } set { this.CountOption = new(value); } }
+        public decimal? Count { get { return this.CountOption.Value; } set { this.CountOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -95,7 +95,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Orange.cs
+++ b/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Model/Orange.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [JsonPropertyName("sweet")]
-        public bool? Sweet { get { return this.SweetOption; } set { this.SweetOption = new(value); } }
+        public bool? Sweet { get { return this.SweetOption.Value; } set { this.SweetOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Activity.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ActivityOutputs
         /// </summary>
         [JsonPropertyName("activity_outputs")]
-        public Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs { get { return this.ActivityOutputsOption; } set { this.ActivityOutputsOption = new(value); } }
+        public Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs { get { return this.ActivityOutputsOption.Value; } set { this.ActivityOutputsOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop1
         /// </summary>
         [JsonPropertyName("prop1")]
-        public string Prop1 { get { return this.Prop1Option; } set { this.Prop1Option = new(value); } }
+        public string Prop1 { get { return this.Prop1Option.Value; } set { this.Prop1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Prop2
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop2
         /// </summary>
         [JsonPropertyName("prop2")]
-        public Object Prop2 { get { return this.Prop2Option; } set { this.Prop2Option = new(value); } }
+        public Object Prop2 { get { return this.Prop2Option.Value; } set { this.Prop2Option = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Anytype1
         /// </summary>
         [JsonPropertyName("anytype_1")]
-        public Object Anytype1 { get { return this.Anytype1Option; } set { this.Anytype1Option = new(value); } }
+        public Object Anytype1 { get { return this.Anytype1Option.Value; } set { this.Anytype1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of EmptyMap
@@ -81,7 +81,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>an object with no declared properties and no undeclared properties, hence it&#39;s an empty map.</value>
         [JsonPropertyName("empty_map")]
-        public Object EmptyMap { get { return this.EmptyMapOption; } set { this.EmptyMapOption = new(value); } }
+        public Object EmptyMap { get { return this.EmptyMapOption.Value; } set { this.EmptyMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfMapProperty
@@ -94,7 +94,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfMapProperty
         /// </summary>
         [JsonPropertyName("map_of_map_property")]
-        public Dictionary<string, Dictionary<string, string>> MapOfMapProperty { get { return this.MapOfMapPropertyOption; } set { this.MapOfMapPropertyOption = new(value); } }
+        public Dictionary<string, Dictionary<string, string>> MapOfMapProperty { get { return this.MapOfMapPropertyOption.Value; } set { this.MapOfMapPropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapProperty
@@ -107,7 +107,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapProperty
         /// </summary>
         [JsonPropertyName("map_property")]
-        public Dictionary<string, string> MapProperty { get { return this.MapPropertyOption; } set { this.MapPropertyOption = new(value); } }
+        public Dictionary<string, string> MapProperty { get { return this.MapPropertyOption.Value; } set { this.MapPropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype1
@@ -120,7 +120,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype1
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_1")]
-        public Object MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new(value); } }
+        public Object MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype2
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype2
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_2")]
-        public Object MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new(value); } }
+        public Object MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype3
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype3
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_3")]
-        public Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new(value); } }
+        public Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesString
@@ -159,7 +159,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesString
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_string")]
-        public Dictionary<string, string> MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption; } set { this.MapWithUndeclaredPropertiesStringOption = new(value); } }
+        public Dictionary<string, string> MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption.Value; } set { this.MapWithUndeclaredPropertiesStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Animal.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [JsonPropertyName("code")]
-        public int? Code { get { return this.CodeOption; } set { this.CodeOption = new(value); } }
+        public int? Code { get { return this.CodeOption.Value; } set { this.CodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Message
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Message
         /// </summary>
         [JsonPropertyName("message")]
-        public string Message { get { return this.MessageOption; } set { this.MessageOption = new(value); } }
+        public string Message { get { return this.MessageOption.Value; } set { this.MessageOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Type
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Type
         /// </summary>
         [JsonPropertyName("type")]
-        public string Type { get { return this.TypeOption; } set { this.TypeOption = new(value); } }
+        public string Type { get { return this.TypeOption.Value; } set { this.TypeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Apple.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ColorCode
         /// </summary>
         [JsonPropertyName("color_code")]
-        public string ColorCode { get { return this.ColorCodeOption; } set { this.ColorCodeOption = new(value); } }
+        public string ColorCode { get { return this.ColorCodeOption.Value; } set { this.ColorCodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Cultivar
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Cultivar
         /// </summary>
         [JsonPropertyName("cultivar")]
-        public string Cultivar { get { return this.CultivarOption; } set { this.CultivarOption = new(value); } }
+        public string Cultivar { get { return this.CultivarOption.Value; } set { this.CultivarOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Origin
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Origin
         /// </summary>
         [JsonPropertyName("origin")]
-        public string Origin { get { return this.OriginOption; } set { this.OriginOption = new(value); } }
+        public string Origin { get { return this.OriginOption.Value; } set { this.OriginOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [JsonPropertyName("mealy")]
-        public bool? Mealy { get { return this.MealyOption; } set { this.MealyOption = new(value); } }
+        public bool? Mealy { get { return this.MealyOption.Value; } set { this.MealyOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayArrayNumber")]
-        public List<List<decimal>> ArrayArrayNumber { get { return this.ArrayArrayNumberOption; } set { this.ArrayArrayNumberOption = new(value); } }
+        public List<List<decimal>> ArrayArrayNumber { get { return this.ArrayArrayNumberOption.Value; } set { this.ArrayArrayNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayNumber")]
-        public List<decimal> ArrayNumber { get { return this.ArrayNumberOption; } set { this.ArrayNumberOption = new(value); } }
+        public List<decimal> ArrayNumber { get { return this.ArrayNumberOption.Value; } set { this.ArrayNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfInteger
         /// </summary>
         [JsonPropertyName("array_array_of_integer")]
-        public List<List<long>> ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption; } set { this.ArrayArrayOfIntegerOption = new(value); } }
+        public List<List<long>> ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption.Value; } set { this.ArrayArrayOfIntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayArrayOfModel
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfModel
         /// </summary>
         [JsonPropertyName("array_array_of_model")]
-        public List<List<ReadOnlyFirst>> ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption; } set { this.ArrayArrayOfModelOption = new(value); } }
+        public List<List<ReadOnlyFirst>> ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption.Value; } set { this.ArrayArrayOfModelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayOfString
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayOfString
         /// </summary>
         [JsonPropertyName("array_of_string")]
-        public List<string> ArrayOfString { get { return this.ArrayOfStringOption; } set { this.ArrayOfStringOption = new(value); } }
+        public List<string> ArrayOfString { get { return this.ArrayOfStringOption.Value; } set { this.ArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Banana.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [JsonPropertyName("lengthCm")]
-        public decimal? LengthCm { get { return this.LengthCmOption; } set { this.LengthCmOption = new(value); } }
+        public decimal? LengthCm { get { return this.LengthCmOption.Value; } set { this.LengthCmOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [JsonPropertyName("sweet")]
-        public bool? Sweet { get { return this.SweetOption; } set { this.SweetOption = new(value); } }
+        public bool? Sweet { get { return this.SweetOption.Value; } set { this.SweetOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -64,7 +64,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Name of the pet </value>
         [JsonPropertyName("ATT_NAME")]
-        public string ATT_NAME { get { return this.ATT_NAMEOption; } set { this.ATT_NAMEOption = new(value); } }
+        public string ATT_NAME { get { return this.ATT_NAMEOption.Value; } set { this.ATT_NAMEOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalCamel
@@ -77,7 +77,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalCamel
         /// </summary>
         [JsonPropertyName("CapitalCamel")]
-        public string CapitalCamel { get { return this.CapitalCamelOption; } set { this.CapitalCamelOption = new(value); } }
+        public string CapitalCamel { get { return this.CapitalCamelOption.Value; } set { this.CapitalCamelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalSnake
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalSnake
         /// </summary>
         [JsonPropertyName("Capital_Snake")]
-        public string CapitalSnake { get { return this.CapitalSnakeOption; } set { this.CapitalSnakeOption = new(value); } }
+        public string CapitalSnake { get { return this.CapitalSnakeOption.Value; } set { this.CapitalSnakeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SCAETHFlowPoints
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SCAETHFlowPoints
         /// </summary>
         [JsonPropertyName("SCA_ETH_Flow_Points")]
-        public string SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption; } set { this.SCAETHFlowPointsOption = new(value); } }
+        public string SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption.Value; } set { this.SCAETHFlowPointsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SmallCamel
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallCamel
         /// </summary>
         [JsonPropertyName("smallCamel")]
-        public string SmallCamel { get { return this.SmallCamelOption; } set { this.SmallCamelOption = new(value); } }
+        public string SmallCamel { get { return this.SmallCamelOption.Value; } set { this.SmallCamelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SmallSnake
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallSnake
         /// </summary>
         [JsonPropertyName("small_Snake")]
-        public string SmallSnake { get { return this.SmallSnakeOption; } set { this.SmallSnakeOption = new(value); } }
+        public string SmallSnake { get { return this.SmallSnakeOption.Value; } set { this.SmallSnakeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [JsonPropertyName("declawed")]
-        public bool? Declawed { get { return this.DeclawedOption; } set { this.DeclawedOption = new(value); } }
+        public bool? Declawed { get { return this.DeclawedOption.Value; } set { this.DeclawedOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -106,7 +106,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// The discriminator

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("_class")]
-        public string Class { get { return this.ClassOption; } set { this.ClassOption = new(value); } }
+        public string Class { get { return this.ClassOption.Value; } set { this.ClassOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>Fri Jul 21 00:00:00 UTC 2017</example> */
         [JsonPropertyName("dateOnlyProperty")]
-        public DateOnly? DateOnlyProperty { get { return this.DateOnlyPropertyOption; } set { this.DateOnlyPropertyOption = new(value); } }
+        public DateOnly? DateOnlyProperty { get { return this.DateOnlyPropertyOption.Value; } set { this.DateOnlyPropertyOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Breed
         /// </summary>
         [JsonPropertyName("breed")]
-        public string Breed { get { return this.BreedOption; } set { this.BreedOption = new(value); } }
+        public string Breed { get { return this.BreedOption.Value; } set { this.BreedOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MainShape
         /// </summary>
         [JsonPropertyName("mainShape")]
-        public Shape MainShape { get { return this.MainShapeOption; } set { this.MainShapeOption = new(value); } }
+        public Shape MainShape { get { return this.MainShapeOption.Value; } set { this.MainShapeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NullableShape
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableShape
         /// </summary>
         [JsonPropertyName("nullableShape")]
-        public NullableShape NullableShape { get { return this.NullableShapeOption; } set { this.NullableShapeOption = new(value); } }
+        public NullableShape NullableShape { get { return this.NullableShapeOption.Value; } set { this.NullableShapeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ShapeOrNull
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ShapeOrNull
         /// </summary>
         [JsonPropertyName("shapeOrNull")]
-        public ShapeOrNull ShapeOrNull { get { return this.ShapeOrNullOption; } set { this.ShapeOrNullOption = new(value); } }
+        public ShapeOrNull ShapeOrNull { get { return this.ShapeOrNullOption.Value; } set { this.ShapeOrNullOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Shapes
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Shapes
         /// </summary>
         [JsonPropertyName("shapes")]
-        public List<Shape> Shapes { get { return this.ShapesOption; } set { this.ShapesOption = new(value); } }
+        public List<Shape> Shapes { get { return this.ShapesOption.Value; } set { this.ShapesOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayEnum
         /// </summary>
         [JsonPropertyName("array_enum")]
-        public List<EnumArrays.ArrayEnumEnum> ArrayEnum { get { return this.ArrayEnumOption; } set { this.ArrayEnumOption = new(value); } }
+        public List<EnumArrays.ArrayEnumEnum> ArrayEnum { get { return this.ArrayEnumOption.Value; } set { this.ArrayEnumOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/File.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Test capitalization</value>
         [JsonPropertyName("sourceURI")]
-        public string SourceURI { get { return this.SourceURIOption; } set { this.SourceURIOption = new(value); } }
+        public string SourceURI { get { return this.SourceURIOption.Value; } set { this.SourceURIOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets File
         /// </summary>
         [JsonPropertyName("file")]
-        public File File { get { return this.FileOption; } set { this.FileOption = new(value); } }
+        public File File { get { return this.FileOption.Value; } set { this.FileOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Files
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Files
         /// </summary>
         [JsonPropertyName("files")]
-        public List<File> Files { get { return this.FilesOption; } set { this.FilesOption = new(value); } }
+        public List<File> Files { get { return this.FilesOption.Value; } set { this.FilesOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Foo.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } set { this.BarOption = new(value); } }
+        public string Bar { get { return this.BarOption.Value; } set { this.BarOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public Foo String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public Foo String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -138,7 +138,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Binary
         /// </summary>
         [JsonPropertyName("binary")]
-        public System.IO.Stream Binary { get { return this.BinaryOption; } set { this.BinaryOption = new(value); } }
+        public System.IO.Stream Binary { get { return this.BinaryOption.Value; } set { this.BinaryOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DateTime
@@ -152,7 +152,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2007-12-03T10:15:30+01:00</example> */
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Decimal
@@ -165,7 +165,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Decimal
         /// </summary>
         [JsonPropertyName("decimal")]
-        public decimal? Decimal { get { return this.DecimalOption; } set { this.DecimalOption = new(value); } }
+        public decimal? Decimal { get { return this.DecimalOption.Value; } set { this.DecimalOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Double
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Double
         /// </summary>
         [JsonPropertyName("double")]
-        public double? Double { get { return this.DoubleOption; } set { this.DoubleOption = new(value); } }
+        public double? Double { get { return this.DoubleOption.Value; } set { this.DoubleOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName2
@@ -191,7 +191,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName2
         /// </summary>
         [JsonPropertyName("duplicate_property_name")]
-        public string DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option; } set { this.DuplicatePropertyName2Option = new(value); } }
+        public string DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option.Value; } set { this.DuplicatePropertyName2Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName
@@ -204,7 +204,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName
         /// </summary>
         [JsonPropertyName("@duplicate_property_name")]
-        public string DuplicatePropertyName { get { return this.DuplicatePropertyNameOption; } set { this.DuplicatePropertyNameOption = new(value); } }
+        public string DuplicatePropertyName { get { return this.DuplicatePropertyNameOption.Value; } set { this.DuplicatePropertyNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Float
@@ -217,7 +217,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Float
         /// </summary>
         [JsonPropertyName("float")]
-        public float? Float { get { return this.FloatOption; } set { this.FloatOption = new(value); } }
+        public float? Float { get { return this.FloatOption.Value; } set { this.FloatOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int32
@@ -230,7 +230,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32
         /// </summary>
         [JsonPropertyName("int32")]
-        public int? Int32 { get { return this.Int32Option; } set { this.Int32Option = new(value); } }
+        public int? Int32 { get { return this.Int32Option.Value; } set { this.Int32Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int32Range
@@ -243,7 +243,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32Range
         /// </summary>
         [JsonPropertyName("int32Range")]
-        public int? Int32Range { get { return this.Int32RangeOption; } set { this.Int32RangeOption = new(value); } }
+        public int? Int32Range { get { return this.Int32RangeOption.Value; } set { this.Int32RangeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64
@@ -256,7 +256,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64
         /// </summary>
         [JsonPropertyName("int64")]
-        public long? Int64 { get { return this.Int64Option; } set { this.Int64Option = new(value); } }
+        public long? Int64 { get { return this.Int64Option.Value; } set { this.Int64Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Negative
@@ -269,7 +269,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Negative
         /// </summary>
         [JsonPropertyName("int64Negative")]
-        public long? Int64Negative { get { return this.Int64NegativeOption; } set { this.Int64NegativeOption = new(value); } }
+        public long? Int64Negative { get { return this.Int64NegativeOption.Value; } set { this.Int64NegativeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64NegativeExclusive
@@ -282,7 +282,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64NegativeExclusive
         /// </summary>
         [JsonPropertyName("int64NegativeExclusive")]
-        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption; } set { this.Int64NegativeExclusiveOption = new(value); } }
+        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption.Value; } set { this.Int64NegativeExclusiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Positive
@@ -295,7 +295,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Positive
         /// </summary>
         [JsonPropertyName("int64Positive")]
-        public long? Int64Positive { get { return this.Int64PositiveOption; } set { this.Int64PositiveOption = new(value); } }
+        public long? Int64Positive { get { return this.Int64PositiveOption.Value; } set { this.Int64PositiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64PositiveExclusive
@@ -308,7 +308,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64PositiveExclusive
         /// </summary>
         [JsonPropertyName("int64PositiveExclusive")]
-        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption; } set { this.Int64PositiveExclusiveOption = new(value); } }
+        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption.Value; } set { this.Int64PositiveExclusiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Integer
@@ -321,7 +321,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [JsonPropertyName("integer")]
-        public int? Integer { get { return this.IntegerOption; } set { this.IntegerOption = new(value); } }
+        public int? Integer { get { return this.IntegerOption.Value; } set { this.IntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithBackslash
@@ -335,7 +335,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>None</value>
         [JsonPropertyName("pattern_with_backslash")]
-        public string PatternWithBackslash { get { return this.PatternWithBackslashOption; } set { this.PatternWithBackslashOption = new(value); } }
+        public string PatternWithBackslash { get { return this.PatternWithBackslashOption.Value; } set { this.PatternWithBackslashOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigits
@@ -349,7 +349,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string that is a 10 digit number. Can have leading zeros.</value>
         [JsonPropertyName("pattern_with_digits")]
-        public string PatternWithDigits { get { return this.PatternWithDigitsOption; } set { this.PatternWithDigitsOption = new(value); } }
+        public string PatternWithDigits { get { return this.PatternWithDigitsOption.Value; } set { this.PatternWithDigitsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigitsAndDelimiter
@@ -363,7 +363,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.</value>
         [JsonPropertyName("pattern_with_digits_and_delimiter")]
-        public string PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption; } set { this.PatternWithDigitsAndDelimiterOption = new(value); } }
+        public string PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption.Value; } set { this.PatternWithDigitsAndDelimiterOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of String
@@ -376,7 +376,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public string String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public string String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of StringFormattedAsDecimal
@@ -389,7 +389,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringFormattedAsDecimal
         /// </summary>
         [JsonPropertyName("string_formatted_as_decimal")]
-        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption; } set { this.StringFormattedAsDecimalOption = new(value); } }
+        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption.Value; } set { this.StringFormattedAsDecimalOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedInteger
@@ -402,7 +402,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [JsonPropertyName("unsigned_integer")]
-        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption; } set { this.UnsignedIntegerOption = new(value); } }
+        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption.Value; } set { this.UnsignedIntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedLong
@@ -415,7 +415,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedLong
         /// </summary>
         [JsonPropertyName("unsigned_long")]
-        public ulong? UnsignedLong { get { return this.UnsignedLongOption; } set { this.UnsignedLongOption = new(value); } }
+        public ulong? UnsignedLong { get { return this.UnsignedLongOption.Value; } set { this.UnsignedLongOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -429,7 +429,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -80,7 +80,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } }
+        public string Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Foo
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Foo
         /// </summary>
         [JsonPropertyName("foo")]
-        public string Foo { get { return this.FooOption; } }
+        public string Foo { get { return this.FooOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableMessage
         /// </summary>
         [JsonPropertyName("NullableMessage")]
-        public string NullableMessage { get { return this.NullableMessageOption; } set { this.NullableMessageOption = new(value); } }
+        public string NullableMessage { get { return this.NullableMessageOption.Value; } set { this.NullableMessageOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/List.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123List
         /// </summary>
         [JsonPropertyName("123-list")]
-        public string Var123List { get { return this.Var123ListOption; } set { this.Var123ListOption = new(value); } }
+        public string Var123List { get { return this.Var123ListOption.Value; } set { this.Var123ListOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets EscapedLiteralString
         /// </summary>
         [JsonPropertyName("escapedLiteralString")]
-        public string EscapedLiteralString { get { return this.EscapedLiteralStringOption; } set { this.EscapedLiteralStringOption = new(value); } }
+        public string EscapedLiteralString { get { return this.EscapedLiteralStringOption.Value; } set { this.EscapedLiteralStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnescapedLiteralString
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnescapedLiteralString
         /// </summary>
         [JsonPropertyName("unescapedLiteralString")]
-        public string UnescapedLiteralString { get { return this.UnescapedLiteralStringOption; } set { this.UnescapedLiteralStringOption = new(value); } }
+        public string UnescapedLiteralString { get { return this.UnescapedLiteralStringOption.Value; } set { this.UnescapedLiteralStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -125,7 +125,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DirectMap
         /// </summary>
         [JsonPropertyName("direct_map")]
-        public Dictionary<string, bool> DirectMap { get { return this.DirectMapOption; } set { this.DirectMapOption = new(value); } }
+        public Dictionary<string, bool> DirectMap { get { return this.DirectMapOption.Value; } set { this.DirectMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of IndirectMap
@@ -138,7 +138,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IndirectMap
         /// </summary>
         [JsonPropertyName("indirect_map")]
-        public Dictionary<string, bool> IndirectMap { get { return this.IndirectMapOption; } set { this.IndirectMapOption = new(value); } }
+        public Dictionary<string, bool> IndirectMap { get { return this.IndirectMapOption.Value; } set { this.IndirectMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapMapOfString
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapMapOfString
         /// </summary>
         [JsonPropertyName("map_map_of_string")]
-        public Dictionary<string, Dictionary<string, string>> MapMapOfString { get { return this.MapMapOfStringOption; } set { this.MapMapOfStringOption = new(value); } }
+        public Dictionary<string, Dictionary<string, string>> MapMapOfString { get { return this.MapMapOfStringOption.Value; } set { this.MapMapOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfEnumString
@@ -164,7 +164,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfEnumString
         /// </summary>
         [JsonPropertyName("map_of_enum_string")]
-        public Dictionary<string, MapTest.InnerEnum> MapOfEnumString { get { return this.MapOfEnumStringOption; } set { this.MapOfEnumStringOption = new(value); } }
+        public Dictionary<string, MapTest.InnerEnum> MapOfEnumString { get { return this.MapOfEnumStringOption.Value; } set { this.MapOfEnumStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedAnyOfContent Content { get { return this.ContentOption; } set { this.ContentOption = new(value); } }
+        public MixedAnyOfContent Content { get { return this.ContentOption.Value; } set { this.ContentOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedOneOfContent Content { get { return this.ContentOption; } set { this.ContentOption = new(value); } }
+        public MixedOneOfContent Content { get { return this.ContentOption.Value; } set { this.ContentOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateTime
         /// </summary>
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Map
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Map
         /// </summary>
         [JsonPropertyName("map")]
-        public Dictionary<string, Animal> Map { get { return this.MapOption; } set { this.MapOption = new(value); } }
+        public Dictionary<string, Animal> Map { get { return this.MapOption.Value; } set { this.MapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UuidWithPattern
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [JsonPropertyName("uuid_with_pattern")]
-        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption; } set { this.UuidWithPatternOption = new(value); } }
+        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption.Value; } set { this.UuidWithPatternOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public string Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public string Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("class")]
-        public string Class { get { return this.ClassOption; } set { this.ClassOption = new(value); } }
+        public string Class { get { return this.ClassOption.Value; } set { this.ClassOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public int? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public int? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarClient
         /// </summary>
         [JsonPropertyName("client")]
-        public string VarClient { get { return this.VarClientOption; } set { this.VarClientOption = new(value); } }
+        public string VarClient { get { return this.VarClientOption.Value; } set { this.VarClientOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -65,7 +65,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Property
         /// </summary>
         [JsonPropertyName("property")]
-        public string Property { get { return this.PropertyOption; } set { this.PropertyOption = new(value); } }
+        public string Property { get { return this.PropertyOption.Value; } set { this.PropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SnakeCase
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [JsonPropertyName("snake_case")]
-        public int? SnakeCase { get { return this.SnakeCaseOption; } }
+        public int? SnakeCase { get { return this.SnakeCaseOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Var123Number
@@ -91,7 +91,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123Number
         /// </summary>
         [JsonPropertyName("123Number")]
-        public int? Var123Number { get { return this.Var123NumberOption; } }
+        public int? Var123Number { get { return this.Var123NumberOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -75,7 +75,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("array_and_items_nullable_prop")]
-        public List<Object> ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption; } set { this.ArrayAndItemsNullablePropOption = new(value); } }
+        public List<Object> ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption.Value; } set { this.ArrayAndItemsNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayItemsNullable
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayItemsNullable
         /// </summary>
         [JsonPropertyName("array_items_nullable")]
-        public List<Object> ArrayItemsNullable { get { return this.ArrayItemsNullableOption; } set { this.ArrayItemsNullableOption = new(value); } }
+        public List<Object> ArrayItemsNullable { get { return this.ArrayItemsNullableOption.Value; } set { this.ArrayItemsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayNullableProp
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNullableProp
         /// </summary>
         [JsonPropertyName("array_nullable_prop")]
-        public List<Object> ArrayNullableProp { get { return this.ArrayNullablePropOption; } set { this.ArrayNullablePropOption = new(value); } }
+        public List<Object> ArrayNullableProp { get { return this.ArrayNullablePropOption.Value; } set { this.ArrayNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of BooleanProp
@@ -114,7 +114,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BooleanProp
         /// </summary>
         [JsonPropertyName("boolean_prop")]
-        public bool? BooleanProp { get { return this.BooleanPropOption; } set { this.BooleanPropOption = new(value); } }
+        public bool? BooleanProp { get { return this.BooleanPropOption.Value; } set { this.BooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DateProp
@@ -127,7 +127,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateProp
         /// </summary>
         [JsonPropertyName("date_prop")]
-        public DateOnly? DateProp { get { return this.DatePropOption; } set { this.DatePropOption = new(value); } }
+        public DateOnly? DateProp { get { return this.DatePropOption.Value; } set { this.DatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DatetimeProp
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DatetimeProp
         /// </summary>
         [JsonPropertyName("datetime_prop")]
-        public DateTime? DatetimeProp { get { return this.DatetimePropOption; } set { this.DatetimePropOption = new(value); } }
+        public DateTime? DatetimeProp { get { return this.DatetimePropOption.Value; } set { this.DatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of IntegerProp
@@ -153,7 +153,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IntegerProp
         /// </summary>
         [JsonPropertyName("integer_prop")]
-        public int? IntegerProp { get { return this.IntegerPropOption; } set { this.IntegerPropOption = new(value); } }
+        public int? IntegerProp { get { return this.IntegerPropOption.Value; } set { this.IntegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NumberProp
@@ -166,7 +166,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NumberProp
         /// </summary>
         [JsonPropertyName("number_prop")]
-        public decimal? NumberProp { get { return this.NumberPropOption; } set { this.NumberPropOption = new(value); } }
+        public decimal? NumberProp { get { return this.NumberPropOption.Value; } set { this.NumberPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectAndItemsNullableProp
@@ -179,7 +179,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("object_and_items_nullable_prop")]
-        public Dictionary<string, Object> ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption; } set { this.ObjectAndItemsNullablePropOption = new(value); } }
+        public Dictionary<string, Object> ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption.Value; } set { this.ObjectAndItemsNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectItemsNullable
@@ -192,7 +192,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectItemsNullable
         /// </summary>
         [JsonPropertyName("object_items_nullable")]
-        public Dictionary<string, Object> ObjectItemsNullable { get { return this.ObjectItemsNullableOption; } set { this.ObjectItemsNullableOption = new(value); } }
+        public Dictionary<string, Object> ObjectItemsNullable { get { return this.ObjectItemsNullableOption.Value; } set { this.ObjectItemsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectNullableProp
@@ -205,7 +205,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectNullableProp
         /// </summary>
         [JsonPropertyName("object_nullable_prop")]
-        public Dictionary<string, Object> ObjectNullableProp { get { return this.ObjectNullablePropOption; } set { this.ObjectNullablePropOption = new(value); } }
+        public Dictionary<string, Object> ObjectNullableProp { get { return this.ObjectNullablePropOption.Value; } set { this.ObjectNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of StringProp
@@ -218,7 +218,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringProp
         /// </summary>
         [JsonPropertyName("string_prop")]
-        public string StringProp { get { return this.StringPropOption; } set { this.StringPropOption = new(value); } }
+        public string StringProp { get { return this.StringPropOption.Value; } set { this.StringPropOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [JsonPropertyName("JustNumber")]
-        public decimal? JustNumber { get { return this.JustNumberOption; } set { this.JustNumberOption = new(value); } }
+        public decimal? JustNumber { get { return this.JustNumberOption.Value; } set { this.JustNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("bars")]
         [Obsolete]
-        public List<string> Bars { get { return this.BarsOption; } set { this.BarsOption = new(value); } }
+        public List<string> Bars { get { return this.BarsOption.Value; } set { this.BarsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DeprecatedRef
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("deprecatedRef")]
         [Obsolete]
-        public DeprecatedObject DeprecatedRef { get { return this.DeprecatedRefOption; } set { this.DeprecatedRefOption = new(value); } }
+        public DeprecatedObject DeprecatedRef { get { return this.DeprecatedRefOption.Value; } set { this.DeprecatedRefOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("id")]
         [Obsolete]
-        public decimal? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public decimal? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Order.cs
@@ -158,7 +158,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Complete
         /// </summary>
         [JsonPropertyName("complete")]
-        public bool? Complete { get { return this.CompleteOption; } set { this.CompleteOption = new(value); } }
+        public bool? Complete { get { return this.CompleteOption.Value; } set { this.CompleteOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -171,7 +171,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PetId
@@ -184,7 +184,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets PetId
         /// </summary>
         [JsonPropertyName("petId")]
-        public long? PetId { get { return this.PetIdOption; } set { this.PetIdOption = new(value); } }
+        public long? PetId { get { return this.PetIdOption.Value; } set { this.PetIdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Quantity
@@ -197,7 +197,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Quantity
         /// </summary>
         [JsonPropertyName("quantity")]
-        public int? Quantity { get { return this.QuantityOption; } set { this.QuantityOption = new(value); } }
+        public int? Quantity { get { return this.QuantityOption.Value; } set { this.QuantityOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ShipDate
@@ -211,7 +211,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2020-02-02T20:20:20.000222Z</example> */
         [JsonPropertyName("shipDate")]
-        public DateTime? ShipDate { get { return this.ShipDateOption; } set { this.ShipDateOption = new(value); } }
+        public DateTime? ShipDate { get { return this.ShipDateOption.Value; } set { this.ShipDateOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyBoolean
         /// </summary>
         [JsonPropertyName("my_boolean")]
-        public bool? MyBoolean { get { return this.MyBooleanOption; } set { this.MyBooleanOption = new(value); } }
+        public bool? MyBoolean { get { return this.MyBooleanOption.Value; } set { this.MyBooleanOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MyNumber
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [JsonPropertyName("my_number")]
-        public decimal? MyNumber { get { return this.MyNumberOption; } set { this.MyNumberOption = new(value); } }
+        public decimal? MyNumber { get { return this.MyNumberOption.Value; } set { this.MyNumberOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MyString
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyString
         /// </summary>
         [JsonPropertyName("my_string")]
-        public string MyString { get { return this.MyStringOption; } set { this.MyStringOption = new(value); } }
+        public string MyString { get { return this.MyStringOption.Value; } set { this.MyStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -171,7 +171,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Category
         /// </summary>
         [JsonPropertyName("category")]
-        public Category Category { get { return this.CategoryOption; } set { this.CategoryOption = new(value); } }
+        public Category Category { get { return this.CategoryOption.Value; } set { this.CategoryOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -184,7 +184,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Tags
@@ -197,7 +197,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Tags
         /// </summary>
         [JsonPropertyName("tags")]
-        public List<Tag> Tags { get { return this.TagsOption; } set { this.TagsOption = new(value); } }
+        public List<Tag> Tags { get { return this.TagsOption.Value; } set { this.TagsOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } }
+        public string Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Baz
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Baz
         /// </summary>
         [JsonPropertyName("baz")]
-        public string Baz { get { return this.BazOption; } set { this.BazOption = new(value); } }
+        public string Baz { get { return this.BazOption.Value; } set { this.BazOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -1412,7 +1412,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_notnullable_date_prop")]
-        public DateOnly? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption; } set { this.NotRequiredNotnullableDatePropOption = new(value); } }
+        public DateOnly? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption.Value; } set { this.NotRequiredNotnullableDatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNotnullableintegerProp
@@ -1425,7 +1425,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [JsonPropertyName("not_required_notnullableinteger_prop")]
-        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption; } set { this.NotRequiredNotnullableintegerPropOption = new(value); } }
+        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption.Value; } set { this.NotRequiredNotnullableintegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableDateProp
@@ -1438,7 +1438,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_date_prop")]
-        public DateOnly? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption; } set { this.NotRequiredNullableDatePropOption = new(value); } }
+        public DateOnly? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption.Value; } set { this.NotRequiredNullableDatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableIntegerProp
@@ -1451,7 +1451,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableIntegerProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_integer_prop")]
-        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption; } set { this.NotRequiredNullableIntegerPropOption = new(value); } }
+        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption.Value; } set { this.NotRequiredNullableIntegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableArrayOfString
@@ -1464,7 +1464,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_array_of_string")]
-        public List<string> NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption; } set { this.NotrequiredNotnullableArrayOfStringOption = new(value); } }
+        public List<string> NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption.Value; } set { this.NotrequiredNotnullableArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableBooleanProp
@@ -1477,7 +1477,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_boolean_prop")]
-        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption; } set { this.NotrequiredNotnullableBooleanPropOption = new(value); } }
+        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption.Value; } set { this.NotrequiredNotnullableBooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableDatetimeProp
@@ -1490,7 +1490,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_datetime_prop")]
-        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption; } set { this.NotrequiredNotnullableDatetimePropOption = new(value); } }
+        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption.Value; } set { this.NotrequiredNotnullableDatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableStringProp
@@ -1503,7 +1503,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_string_prop")]
-        public string NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption; } set { this.NotrequiredNotnullableStringPropOption = new(value); } }
+        public string NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption.Value; } set { this.NotrequiredNotnullableStringPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableUuid
@@ -1517,7 +1517,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_notnullable_uuid")]
-        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption; } set { this.NotrequiredNotnullableUuidOption = new(value); } }
+        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption.Value; } set { this.NotrequiredNotnullableUuidOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableArrayOfString
@@ -1530,7 +1530,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_nullable_array_of_string")]
-        public List<string> NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption; } set { this.NotrequiredNullableArrayOfStringOption = new(value); } }
+        public List<string> NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption.Value; } set { this.NotrequiredNullableArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableBooleanProp
@@ -1543,7 +1543,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_boolean_prop")]
-        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption; } set { this.NotrequiredNullableBooleanPropOption = new(value); } }
+        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption.Value; } set { this.NotrequiredNullableBooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableDatetimeProp
@@ -1556,7 +1556,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_datetime_prop")]
-        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption; } set { this.NotrequiredNullableDatetimePropOption = new(value); } }
+        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption.Value; } set { this.NotrequiredNullableDatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableStringProp
@@ -1569,7 +1569,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_string_prop")]
-        public string NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption; } set { this.NotrequiredNullableStringPropOption = new(value); } }
+        public string NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption.Value; } set { this.NotrequiredNullableStringPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableUuid
@@ -1583,7 +1583,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_nullable_uuid")]
-        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption; } set { this.NotrequiredNullableUuidOption = new(value); } }
+        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption.Value; } set { this.NotrequiredNullableUuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets RequiredNullableArrayOfString

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Result.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result code</value>
         [JsonPropertyName("code")]
-        public string Code { get { return this.CodeOption; } set { this.CodeOption = new(value); } }
+        public string Code { get { return this.CodeOption.Value; } set { this.CodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Data
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string> Data { get { return this.DataOption; } set { this.DataOption = new(value); } }
+        public Dictionary<string, string> Data { get { return this.DataOption.Value; } set { this.DataOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [JsonPropertyName("return")]
-        public int? VarReturn { get { return this.VarReturnOption; } set { this.VarReturnOption = new(value); } }
+        public int? VarReturn { get { return this.VarReturnOption.Value; } set { this.VarReturnOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Unsafe
@@ -84,7 +84,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Unsafe
         /// </summary>
         [JsonPropertyName("unsafe")]
-        public string Unsafe { get { return this.UnsafeOption; } set { this.UnsafeOption = new(value); } }
+        public string Unsafe { get { return this.UnsafeOption.Value; } set { this.UnsafeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Role
         /// </summary>
         [JsonPropertyName("role")]
-        public RolesReportsHashRole Role { get { return this.RoleOption; } set { this.RoleOption = new(value); } }
+        public RolesReportsHashRole Role { get { return this.RoleOption.Value; } set { this.RoleOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of RoleUuid
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [JsonPropertyName("role_uuid")]
-        public Guid? RoleUuid { get { return this.RoleUuidOption; } set { this.RoleUuidOption = new(value); } }
+        public Guid? RoleUuid { get { return this.RoleUuidOption.Value; } set { this.RoleUuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarSpecialModelName
         /// </summary>
         [JsonPropertyName("_special_model.name_")]
-        public string VarSpecialModelName { get { return this.VarSpecialModelNameOption; } set { this.VarSpecialModelNameOption = new(value); } }
+        public string VarSpecialModelName { get { return this.VarSpecialModelNameOption.Value; } set { this.VarSpecialModelNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SpecialPropertyName
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [JsonPropertyName("$special[property.name]")]
-        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption; } set { this.SpecialPropertyNameOption = new(value); } }
+        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption.Value; } set { this.SpecialPropertyNameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Value
         /// </summary>
         [JsonPropertyName("value")]
-        public string Value { get { return this.ValueOption; } set { this.ValueOption = new(value); } }
+        public string Value { get { return this.ValueOption.Value; } set { this.ValueOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets TestCollectionEndingWithWordList
         /// </summary>
         [JsonPropertyName("TestCollectionEndingWithWordList")]
-        public List<TestCollectionEndingWithWordList> TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption; } set { this.TestCollectionEndingWithWordListOption = new(value); } }
+        public List<TestCollectionEndingWithWordList> TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption.Value; } set { this.TestCollectionEndingWithWordListOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SomeProperty
         /// </summary>
         [JsonPropertyName("someProperty")]
-        public string SomeProperty { get { return this.SomePropertyOption; } set { this.SomePropertyOption = new(value); } }
+        public string SomeProperty { get { return this.SomePropertyOption.Value; } set { this.SomePropertyOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string> Data { get { return this.DataOption; } set { this.DataOption = new(value); } }
+        public Dictionary<string, string> Data { get { return this.DataOption.Value; } set { this.DataOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
         [JsonPropertyName("anyTypeProp")]
-        public Object AnyTypeProp { get { return this.AnyTypePropOption; } set { this.AnyTypePropOption = new(value); } }
+        public Object AnyTypeProp { get { return this.AnyTypePropOption.Value; } set { this.AnyTypePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of AnyTypePropNullable
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values.</value>
         [JsonPropertyName("anyTypePropNullable")]
-        public Object AnyTypePropNullable { get { return this.AnyTypePropNullableOption; } set { this.AnyTypePropNullableOption = new(value); } }
+        public Object AnyTypePropNullable { get { return this.AnyTypePropNullableOption.Value; } set { this.AnyTypePropNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Email
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Email
         /// </summary>
         [JsonPropertyName("email")]
-        public string Email { get { return this.EmailOption; } set { this.EmailOption = new(value); } }
+        public string Email { get { return this.EmailOption.Value; } set { this.EmailOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of FirstName
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets FirstName
         /// </summary>
         [JsonPropertyName("firstName")]
-        public string FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new(value); } }
+        public string FirstName { get { return this.FirstNameOption.Value; } set { this.FirstNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of LastName
@@ -142,7 +142,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LastName
         /// </summary>
         [JsonPropertyName("lastName")]
-        public string LastName { get { return this.LastNameOption; } set { this.LastNameOption = new(value); } }
+        public string LastName { get { return this.LastNameOption.Value; } set { this.LastNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredProps
@@ -156,7 +156,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredProps")]
-        public Object ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption; } set { this.ObjectWithNoDeclaredPropsOption = new(value); } }
+        public Object ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption.Value; } set { this.ObjectWithNoDeclaredPropsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredPropsNullable
@@ -170,7 +170,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredPropsNullable")]
-        public Object ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption; } set { this.ObjectWithNoDeclaredPropsNullableOption = new(value); } }
+        public Object ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption.Value; } set { this.ObjectWithNoDeclaredPropsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Password
@@ -183,7 +183,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Password
         /// </summary>
         [JsonPropertyName("password")]
-        public string Password { get { return this.PasswordOption; } set { this.PasswordOption = new(value); } }
+        public string Password { get { return this.PasswordOption.Value; } set { this.PasswordOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Phone
@@ -196,7 +196,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Phone
         /// </summary>
         [JsonPropertyName("phone")]
-        public string Phone { get { return this.PhoneOption; } set { this.PhoneOption = new(value); } }
+        public string Phone { get { return this.PhoneOption.Value; } set { this.PhoneOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UserStatus
@@ -210,7 +210,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [JsonPropertyName("userStatus")]
-        public int? UserStatus { get { return this.UserStatusOption; } set { this.UserStatusOption = new(value); } }
+        public int? UserStatus { get { return this.UserStatusOption.Value; } set { this.UserStatusOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Username
@@ -223,7 +223,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Username
         /// </summary>
         [JsonPropertyName("username")]
-        public string Username { get { return this.UsernameOption; } set { this.UsernameOption = new(value); } }
+        public string Username { get { return this.UsernameOption.Value; } set { this.UsernameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [JsonPropertyName("hasBaleen")]
-        public bool? HasBaleen { get { return this.HasBaleenOption; } set { this.HasBaleenOption = new(value); } }
+        public bool? HasBaleen { get { return this.HasBaleenOption.Value; } set { this.HasBaleenOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of HasTeeth
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasTeeth
         /// </summary>
         [JsonPropertyName("hasTeeth")]
-        public bool? HasTeeth { get { return this.HasTeethOption; } set { this.HasTeethOption = new(value); } }
+        public bool? HasTeeth { get { return this.HasTeethOption.Value; } set { this.HasTeethOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Activity.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ActivityOutputs
         /// </summary>
         [JsonPropertyName("activity_outputs")]
-        public Dictionary<string, List<ActivityOutputElementRepresentation>>? ActivityOutputs { get { return this.ActivityOutputsOption; } set { this.ActivityOutputsOption = new(value); } }
+        public Dictionary<string, List<ActivityOutputElementRepresentation>>? ActivityOutputs { get { return this.ActivityOutputsOption.Value; } set { this.ActivityOutputsOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop1
         /// </summary>
         [JsonPropertyName("prop1")]
-        public string? Prop1 { get { return this.Prop1Option; } set { this.Prop1Option = new(value); } }
+        public string? Prop1 { get { return this.Prop1Option.Value; } set { this.Prop1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Prop2
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop2
         /// </summary>
         [JsonPropertyName("prop2")]
-        public Object? Prop2 { get { return this.Prop2Option; } set { this.Prop2Option = new(value); } }
+        public Object? Prop2 { get { return this.Prop2Option.Value; } set { this.Prop2Option = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Anytype1
         /// </summary>
         [JsonPropertyName("anytype_1")]
-        public Object? Anytype1 { get { return this.Anytype1Option; } set { this.Anytype1Option = new(value); } }
+        public Object? Anytype1 { get { return this.Anytype1Option.Value; } set { this.Anytype1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of EmptyMap
@@ -84,7 +84,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>an object with no declared properties and no undeclared properties, hence it&#39;s an empty map.</value>
         [JsonPropertyName("empty_map")]
-        public Object? EmptyMap { get { return this.EmptyMapOption; } set { this.EmptyMapOption = new(value); } }
+        public Object? EmptyMap { get { return this.EmptyMapOption.Value; } set { this.EmptyMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfMapProperty
@@ -97,7 +97,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfMapProperty
         /// </summary>
         [JsonPropertyName("map_of_map_property")]
-        public Dictionary<string, Dictionary<string, string>>? MapOfMapProperty { get { return this.MapOfMapPropertyOption; } set { this.MapOfMapPropertyOption = new(value); } }
+        public Dictionary<string, Dictionary<string, string>>? MapOfMapProperty { get { return this.MapOfMapPropertyOption.Value; } set { this.MapOfMapPropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapProperty
@@ -110,7 +110,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapProperty
         /// </summary>
         [JsonPropertyName("map_property")]
-        public Dictionary<string, string>? MapProperty { get { return this.MapPropertyOption; } set { this.MapPropertyOption = new(value); } }
+        public Dictionary<string, string>? MapProperty { get { return this.MapPropertyOption.Value; } set { this.MapPropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype1
@@ -123,7 +123,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype1
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_1")]
-        public Object? MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new(value); } }
+        public Object? MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype2
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype2
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_2")]
-        public Object? MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new(value); } }
+        public Object? MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype3
@@ -149,7 +149,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype3
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_3")]
-        public Dictionary<string, Object>? MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new(value); } }
+        public Dictionary<string, Object>? MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesString
@@ -162,7 +162,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesString
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_string")]
-        public Dictionary<string, string>? MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption; } set { this.MapWithUndeclaredPropertiesStringOption = new(value); } }
+        public Dictionary<string, string>? MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption.Value; } set { this.MapWithUndeclaredPropertiesStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Animal.cs
@@ -64,7 +64,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [JsonPropertyName("code")]
-        public int? Code { get { return this.CodeOption; } set { this.CodeOption = new(value); } }
+        public int? Code { get { return this.CodeOption.Value; } set { this.CodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Message
@@ -73,7 +73,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Message
         /// </summary>
         [JsonPropertyName("message")]
-        public string? Message { get { return this.MessageOption; } set { this.MessageOption = new(value); } }
+        public string? Message { get { return this.MessageOption.Value; } set { this.MessageOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Type
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Type
         /// </summary>
         [JsonPropertyName("type")]
-        public string? Type { get { return this.TypeOption; } set { this.TypeOption = new(value); } }
+        public string? Type { get { return this.TypeOption.Value; } set { this.TypeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Apple.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ColorCode
         /// </summary>
         [JsonPropertyName("color_code")]
-        public string? ColorCode { get { return this.ColorCodeOption; } set { this.ColorCodeOption = new(value); } }
+        public string? ColorCode { get { return this.ColorCodeOption.Value; } set { this.ColorCodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Cultivar
@@ -73,7 +73,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Cultivar
         /// </summary>
         [JsonPropertyName("cultivar")]
-        public string? Cultivar { get { return this.CultivarOption; } set { this.CultivarOption = new(value); } }
+        public string? Cultivar { get { return this.CultivarOption.Value; } set { this.CultivarOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Origin
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Origin
         /// </summary>
         [JsonPropertyName("origin")]
-        public string? Origin { get { return this.OriginOption; } set { this.OriginOption = new(value); } }
+        public string? Origin { get { return this.OriginOption.Value; } set { this.OriginOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -64,7 +64,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [JsonPropertyName("mealy")]
-        public bool? Mealy { get { return this.MealyOption; } set { this.MealyOption = new(value); } }
+        public bool? Mealy { get { return this.MealyOption.Value; } set { this.MealyOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayArrayNumber")]
-        public List<List<decimal>>? ArrayArrayNumber { get { return this.ArrayArrayNumberOption; } set { this.ArrayArrayNumberOption = new(value); } }
+        public List<List<decimal>>? ArrayArrayNumber { get { return this.ArrayArrayNumberOption.Value; } set { this.ArrayArrayNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayNumber")]
-        public List<decimal>? ArrayNumber { get { return this.ArrayNumberOption; } set { this.ArrayNumberOption = new(value); } }
+        public List<decimal>? ArrayNumber { get { return this.ArrayNumberOption.Value; } set { this.ArrayNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfInteger
         /// </summary>
         [JsonPropertyName("array_array_of_integer")]
-        public List<List<long>>? ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption; } set { this.ArrayArrayOfIntegerOption = new(value); } }
+        public List<List<long>>? ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption.Value; } set { this.ArrayArrayOfIntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayArrayOfModel
@@ -73,7 +73,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfModel
         /// </summary>
         [JsonPropertyName("array_array_of_model")]
-        public List<List<ReadOnlyFirst>>? ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption; } set { this.ArrayArrayOfModelOption = new(value); } }
+        public List<List<ReadOnlyFirst>>? ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption.Value; } set { this.ArrayArrayOfModelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayOfString
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayOfString
         /// </summary>
         [JsonPropertyName("array_of_string")]
-        public List<string>? ArrayOfString { get { return this.ArrayOfStringOption; } set { this.ArrayOfStringOption = new(value); } }
+        public List<string>? ArrayOfString { get { return this.ArrayOfStringOption.Value; } set { this.ArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Banana.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [JsonPropertyName("lengthCm")]
-        public decimal? LengthCm { get { return this.LengthCmOption; } set { this.LengthCmOption = new(value); } }
+        public decimal? LengthCm { get { return this.LengthCmOption.Value; } set { this.LengthCmOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -64,7 +64,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [JsonPropertyName("sweet")]
-        public bool? Sweet { get { return this.SweetOption; } set { this.SweetOption = new(value); } }
+        public bool? Sweet { get { return this.SweetOption.Value; } set { this.SweetOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Name of the pet </value>
         [JsonPropertyName("ATT_NAME")]
-        public string? ATT_NAME { get { return this.ATT_NAMEOption; } set { this.ATT_NAMEOption = new(value); } }
+        public string? ATT_NAME { get { return this.ATT_NAMEOption.Value; } set { this.ATT_NAMEOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalCamel
@@ -80,7 +80,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalCamel
         /// </summary>
         [JsonPropertyName("CapitalCamel")]
-        public string? CapitalCamel { get { return this.CapitalCamelOption; } set { this.CapitalCamelOption = new(value); } }
+        public string? CapitalCamel { get { return this.CapitalCamelOption.Value; } set { this.CapitalCamelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalSnake
@@ -93,7 +93,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalSnake
         /// </summary>
         [JsonPropertyName("Capital_Snake")]
-        public string? CapitalSnake { get { return this.CapitalSnakeOption; } set { this.CapitalSnakeOption = new(value); } }
+        public string? CapitalSnake { get { return this.CapitalSnakeOption.Value; } set { this.CapitalSnakeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SCAETHFlowPoints
@@ -106,7 +106,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SCAETHFlowPoints
         /// </summary>
         [JsonPropertyName("SCA_ETH_Flow_Points")]
-        public string? SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption; } set { this.SCAETHFlowPointsOption = new(value); } }
+        public string? SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption.Value; } set { this.SCAETHFlowPointsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SmallCamel
@@ -119,7 +119,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallCamel
         /// </summary>
         [JsonPropertyName("smallCamel")]
-        public string? SmallCamel { get { return this.SmallCamelOption; } set { this.SmallCamelOption = new(value); } }
+        public string? SmallCamel { get { return this.SmallCamelOption.Value; } set { this.SmallCamelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SmallSnake
@@ -132,7 +132,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallSnake
         /// </summary>
         [JsonPropertyName("small_Snake")]
-        public string? SmallSnake { get { return this.SmallSnakeOption; } set { this.SmallSnakeOption = new(value); } }
+        public string? SmallSnake { get { return this.SmallSnakeOption.Value; } set { this.SmallSnakeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [JsonPropertyName("declawed")]
-        public bool? Declawed { get { return this.DeclawedOption; } set { this.DeclawedOption = new(value); } }
+        public bool? Declawed { get { return this.DeclawedOption.Value; } set { this.DeclawedOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -109,7 +109,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// The discriminator

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("_class")]
-        public string? Class { get { return this.ClassOption; } set { this.ClassOption = new(value); } }
+        public string? Class { get { return this.ClassOption.Value; } set { this.ClassOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>Fri Jul 21 00:00:00 UTC 2017</example> */
         [JsonPropertyName("dateOnlyProperty")]
-        public DateOnly? DateOnlyProperty { get { return this.DateOnlyPropertyOption; } set { this.DateOnlyPropertyOption = new(value); } }
+        public DateOnly? DateOnlyProperty { get { return this.DateOnlyPropertyOption.Value; } set { this.DateOnlyPropertyOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Dog.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Breed
         /// </summary>
         [JsonPropertyName("breed")]
-        public string? Breed { get { return this.BreedOption; } set { this.BreedOption = new(value); } }
+        public string? Breed { get { return this.BreedOption.Value; } set { this.BreedOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Drawing.cs
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MainShape
         /// </summary>
         [JsonPropertyName("mainShape")]
-        public Shape? MainShape { get { return this.MainShapeOption; } set { this.MainShapeOption = new(value); } }
+        public Shape? MainShape { get { return this.MainShapeOption.Value; } set { this.MainShapeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NullableShape
@@ -75,7 +75,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableShape
         /// </summary>
         [JsonPropertyName("nullableShape")]
-        public NullableShape? NullableShape { get { return this.NullableShapeOption; } set { this.NullableShapeOption = new(value); } }
+        public NullableShape? NullableShape { get { return this.NullableShapeOption.Value; } set { this.NullableShapeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ShapeOrNull
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ShapeOrNull
         /// </summary>
         [JsonPropertyName("shapeOrNull")]
-        public ShapeOrNull? ShapeOrNull { get { return this.ShapeOrNullOption; } set { this.ShapeOrNullOption = new(value); } }
+        public ShapeOrNull? ShapeOrNull { get { return this.ShapeOrNullOption.Value; } set { this.ShapeOrNullOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Shapes
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Shapes
         /// </summary>
         [JsonPropertyName("shapes")]
-        public List<Shape>? Shapes { get { return this.ShapesOption; } set { this.ShapesOption = new(value); } }
+        public List<Shape>? Shapes { get { return this.ShapesOption.Value; } set { this.ShapesOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -203,7 +203,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayEnum
         /// </summary>
         [JsonPropertyName("array_enum")]
-        public List<EnumArrays.ArrayEnumEnum>? ArrayEnum { get { return this.ArrayEnumOption; } set { this.ArrayEnumOption = new(value); } }
+        public List<EnumArrays.ArrayEnumEnum>? ArrayEnum { get { return this.ArrayEnumOption.Value; } set { this.ArrayEnumOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/File.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Test capitalization</value>
         [JsonPropertyName("sourceURI")]
-        public string? SourceURI { get { return this.SourceURIOption; } set { this.SourceURIOption = new(value); } }
+        public string? SourceURI { get { return this.SourceURIOption.Value; } set { this.SourceURIOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets File
         /// </summary>
         [JsonPropertyName("file")]
-        public File? File { get { return this.FileOption; } set { this.FileOption = new(value); } }
+        public File? File { get { return this.FileOption.Value; } set { this.FileOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Files
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Files
         /// </summary>
         [JsonPropertyName("files")]
-        public List<File>? Files { get { return this.FilesOption; } set { this.FilesOption = new(value); } }
+        public List<File>? Files { get { return this.FilesOption.Value; } set { this.FilesOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Foo.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string? Bar { get { return this.BarOption; } set { this.BarOption = new(value); } }
+        public string? Bar { get { return this.BarOption.Value; } set { this.BarOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public Foo? String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public Foo? String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -141,7 +141,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Binary
         /// </summary>
         [JsonPropertyName("binary")]
-        public System.IO.Stream? Binary { get { return this.BinaryOption; } set { this.BinaryOption = new(value); } }
+        public System.IO.Stream? Binary { get { return this.BinaryOption.Value; } set { this.BinaryOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DateTime
@@ -155,7 +155,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2007-12-03T10:15:30+01:00</example> */
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Decimal
@@ -168,7 +168,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Decimal
         /// </summary>
         [JsonPropertyName("decimal")]
-        public decimal? Decimal { get { return this.DecimalOption; } set { this.DecimalOption = new(value); } }
+        public decimal? Decimal { get { return this.DecimalOption.Value; } set { this.DecimalOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Double
@@ -181,7 +181,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Double
         /// </summary>
         [JsonPropertyName("double")]
-        public double? Double { get { return this.DoubleOption; } set { this.DoubleOption = new(value); } }
+        public double? Double { get { return this.DoubleOption.Value; } set { this.DoubleOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName2
@@ -194,7 +194,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName2
         /// </summary>
         [JsonPropertyName("duplicate_property_name")]
-        public string? DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option; } set { this.DuplicatePropertyName2Option = new(value); } }
+        public string? DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option.Value; } set { this.DuplicatePropertyName2Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName
@@ -207,7 +207,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName
         /// </summary>
         [JsonPropertyName("@duplicate_property_name")]
-        public string? DuplicatePropertyName { get { return this.DuplicatePropertyNameOption; } set { this.DuplicatePropertyNameOption = new(value); } }
+        public string? DuplicatePropertyName { get { return this.DuplicatePropertyNameOption.Value; } set { this.DuplicatePropertyNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Float
@@ -220,7 +220,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Float
         /// </summary>
         [JsonPropertyName("float")]
-        public float? Float { get { return this.FloatOption; } set { this.FloatOption = new(value); } }
+        public float? Float { get { return this.FloatOption.Value; } set { this.FloatOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int32
@@ -233,7 +233,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32
         /// </summary>
         [JsonPropertyName("int32")]
-        public int? Int32 { get { return this.Int32Option; } set { this.Int32Option = new(value); } }
+        public int? Int32 { get { return this.Int32Option.Value; } set { this.Int32Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int32Range
@@ -246,7 +246,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32Range
         /// </summary>
         [JsonPropertyName("int32Range")]
-        public int? Int32Range { get { return this.Int32RangeOption; } set { this.Int32RangeOption = new(value); } }
+        public int? Int32Range { get { return this.Int32RangeOption.Value; } set { this.Int32RangeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64
@@ -259,7 +259,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64
         /// </summary>
         [JsonPropertyName("int64")]
-        public long? Int64 { get { return this.Int64Option; } set { this.Int64Option = new(value); } }
+        public long? Int64 { get { return this.Int64Option.Value; } set { this.Int64Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Negative
@@ -272,7 +272,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Negative
         /// </summary>
         [JsonPropertyName("int64Negative")]
-        public long? Int64Negative { get { return this.Int64NegativeOption; } set { this.Int64NegativeOption = new(value); } }
+        public long? Int64Negative { get { return this.Int64NegativeOption.Value; } set { this.Int64NegativeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64NegativeExclusive
@@ -285,7 +285,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64NegativeExclusive
         /// </summary>
         [JsonPropertyName("int64NegativeExclusive")]
-        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption; } set { this.Int64NegativeExclusiveOption = new(value); } }
+        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption.Value; } set { this.Int64NegativeExclusiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Positive
@@ -298,7 +298,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Positive
         /// </summary>
         [JsonPropertyName("int64Positive")]
-        public long? Int64Positive { get { return this.Int64PositiveOption; } set { this.Int64PositiveOption = new(value); } }
+        public long? Int64Positive { get { return this.Int64PositiveOption.Value; } set { this.Int64PositiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64PositiveExclusive
@@ -311,7 +311,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64PositiveExclusive
         /// </summary>
         [JsonPropertyName("int64PositiveExclusive")]
-        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption; } set { this.Int64PositiveExclusiveOption = new(value); } }
+        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption.Value; } set { this.Int64PositiveExclusiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Integer
@@ -324,7 +324,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [JsonPropertyName("integer")]
-        public int? Integer { get { return this.IntegerOption; } set { this.IntegerOption = new(value); } }
+        public int? Integer { get { return this.IntegerOption.Value; } set { this.IntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithBackslash
@@ -338,7 +338,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>None</value>
         [JsonPropertyName("pattern_with_backslash")]
-        public string? PatternWithBackslash { get { return this.PatternWithBackslashOption; } set { this.PatternWithBackslashOption = new(value); } }
+        public string? PatternWithBackslash { get { return this.PatternWithBackslashOption.Value; } set { this.PatternWithBackslashOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigits
@@ -352,7 +352,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string that is a 10 digit number. Can have leading zeros.</value>
         [JsonPropertyName("pattern_with_digits")]
-        public string? PatternWithDigits { get { return this.PatternWithDigitsOption; } set { this.PatternWithDigitsOption = new(value); } }
+        public string? PatternWithDigits { get { return this.PatternWithDigitsOption.Value; } set { this.PatternWithDigitsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigitsAndDelimiter
@@ -366,7 +366,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.</value>
         [JsonPropertyName("pattern_with_digits_and_delimiter")]
-        public string? PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption; } set { this.PatternWithDigitsAndDelimiterOption = new(value); } }
+        public string? PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption.Value; } set { this.PatternWithDigitsAndDelimiterOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of String
@@ -379,7 +379,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public string? String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public string? String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of StringFormattedAsDecimal
@@ -392,7 +392,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringFormattedAsDecimal
         /// </summary>
         [JsonPropertyName("string_formatted_as_decimal")]
-        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption; } set { this.StringFormattedAsDecimalOption = new(value); } }
+        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption.Value; } set { this.StringFormattedAsDecimalOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedInteger
@@ -405,7 +405,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [JsonPropertyName("unsigned_integer")]
-        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption; } set { this.UnsignedIntegerOption = new(value); } }
+        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption.Value; } set { this.UnsignedIntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedLong
@@ -418,7 +418,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedLong
         /// </summary>
         [JsonPropertyName("unsigned_long")]
-        public ulong? UnsignedLong { get { return this.UnsignedLongOption; } set { this.UnsignedLongOption = new(value); } }
+        public ulong? UnsignedLong { get { return this.UnsignedLongOption.Value; } set { this.UnsignedLongOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -432,7 +432,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
@@ -79,7 +79,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string? Bar { get { return this.BarOption; } }
+        public string? Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Foo
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Foo
         /// </summary>
         [JsonPropertyName("foo")]
-        public string? Foo { get { return this.FooOption; } }
+        public string? Foo { get { return this.FooOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableMessage
         /// </summary>
         [JsonPropertyName("NullableMessage")]
-        public string? NullableMessage { get { return this.NullableMessageOption; } set { this.NullableMessageOption = new(value); } }
+        public string? NullableMessage { get { return this.NullableMessageOption.Value; } set { this.NullableMessageOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/List.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123List
         /// </summary>
         [JsonPropertyName("123-list")]
-        public string? Var123List { get { return this.Var123ListOption; } set { this.Var123ListOption = new(value); } }
+        public string? Var123List { get { return this.Var123ListOption.Value; } set { this.Var123ListOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets EscapedLiteralString
         /// </summary>
         [JsonPropertyName("escapedLiteralString")]
-        public string? EscapedLiteralString { get { return this.EscapedLiteralStringOption; } set { this.EscapedLiteralStringOption = new(value); } }
+        public string? EscapedLiteralString { get { return this.EscapedLiteralStringOption.Value; } set { this.EscapedLiteralStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnescapedLiteralString
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnescapedLiteralString
         /// </summary>
         [JsonPropertyName("unescapedLiteralString")]
-        public string? UnescapedLiteralString { get { return this.UnescapedLiteralStringOption; } set { this.UnescapedLiteralStringOption = new(value); } }
+        public string? UnescapedLiteralString { get { return this.UnescapedLiteralStringOption.Value; } set { this.UnescapedLiteralStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MapTest.cs
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DirectMap
         /// </summary>
         [JsonPropertyName("direct_map")]
-        public Dictionary<string, bool>? DirectMap { get { return this.DirectMapOption; } set { this.DirectMapOption = new(value); } }
+        public Dictionary<string, bool>? DirectMap { get { return this.DirectMapOption.Value; } set { this.DirectMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of IndirectMap
@@ -141,7 +141,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IndirectMap
         /// </summary>
         [JsonPropertyName("indirect_map")]
-        public Dictionary<string, bool>? IndirectMap { get { return this.IndirectMapOption; } set { this.IndirectMapOption = new(value); } }
+        public Dictionary<string, bool>? IndirectMap { get { return this.IndirectMapOption.Value; } set { this.IndirectMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapMapOfString
@@ -154,7 +154,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapMapOfString
         /// </summary>
         [JsonPropertyName("map_map_of_string")]
-        public Dictionary<string, Dictionary<string, string>>? MapMapOfString { get { return this.MapMapOfStringOption; } set { this.MapMapOfStringOption = new(value); } }
+        public Dictionary<string, Dictionary<string, string>>? MapMapOfString { get { return this.MapMapOfStringOption.Value; } set { this.MapMapOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfEnumString
@@ -167,7 +167,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfEnumString
         /// </summary>
         [JsonPropertyName("map_of_enum_string")]
-        public Dictionary<string, MapTest.InnerEnum>? MapOfEnumString { get { return this.MapOfEnumStringOption; } set { this.MapOfEnumStringOption = new(value); } }
+        public Dictionary<string, MapTest.InnerEnum>? MapOfEnumString { get { return this.MapOfEnumStringOption.Value; } set { this.MapOfEnumStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedAnyOfContent? Content { get { return this.ContentOption; } set { this.ContentOption = new(value); } }
+        public MixedAnyOfContent? Content { get { return this.ContentOption.Value; } set { this.ContentOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedOneOfContent? Content { get { return this.ContentOption; } set { this.ContentOption = new(value); } }
+        public MixedOneOfContent? Content { get { return this.ContentOption.Value; } set { this.ContentOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateTime
         /// </summary>
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Map
@@ -75,7 +75,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Map
         /// </summary>
         [JsonPropertyName("map")]
-        public Dictionary<string, Animal>? Map { get { return this.MapOption; } set { this.MapOption = new(value); } }
+        public Dictionary<string, Animal>? Map { get { return this.MapOption.Value; } set { this.MapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UuidWithPattern
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [JsonPropertyName("uuid_with_pattern")]
-        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption; } set { this.UuidWithPatternOption = new(value); } }
+        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption.Value; } set { this.UuidWithPatternOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public string? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public string? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("class")]
-        public string? Class { get { return this.ClassOption; } set { this.ClassOption = new(value); } }
+        public string? Class { get { return this.ClassOption.Value; } set { this.ClassOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public int? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public int? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarClient
         /// </summary>
         [JsonPropertyName("client")]
-        public string? VarClient { get { return this.VarClientOption; } set { this.VarClientOption = new(value); } }
+        public string? VarClient { get { return this.VarClientOption.Value; } set { this.VarClientOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Property
         /// </summary>
         [JsonPropertyName("property")]
-        public string? Property { get { return this.PropertyOption; } set { this.PropertyOption = new(value); } }
+        public string? Property { get { return this.PropertyOption.Value; } set { this.PropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SnakeCase
@@ -81,7 +81,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [JsonPropertyName("snake_case")]
-        public int? SnakeCase { get { return this.SnakeCaseOption; } }
+        public int? SnakeCase { get { return this.SnakeCaseOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Var123Number
@@ -94,7 +94,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123Number
         /// </summary>
         [JsonPropertyName("123Number")]
-        public int? Var123Number { get { return this.Var123NumberOption; } }
+        public int? Var123Number { get { return this.Var123NumberOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("array_and_items_nullable_prop")]
-        public List<Object>? ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption; } set { this.ArrayAndItemsNullablePropOption = new(value); } }
+        public List<Object>? ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption.Value; } set { this.ArrayAndItemsNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayItemsNullable
@@ -91,7 +91,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayItemsNullable
         /// </summary>
         [JsonPropertyName("array_items_nullable")]
-        public List<Object>? ArrayItemsNullable { get { return this.ArrayItemsNullableOption; } set { this.ArrayItemsNullableOption = new(value); } }
+        public List<Object>? ArrayItemsNullable { get { return this.ArrayItemsNullableOption.Value; } set { this.ArrayItemsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayNullableProp
@@ -104,7 +104,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNullableProp
         /// </summary>
         [JsonPropertyName("array_nullable_prop")]
-        public List<Object>? ArrayNullableProp { get { return this.ArrayNullablePropOption; } set { this.ArrayNullablePropOption = new(value); } }
+        public List<Object>? ArrayNullableProp { get { return this.ArrayNullablePropOption.Value; } set { this.ArrayNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of BooleanProp
@@ -117,7 +117,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BooleanProp
         /// </summary>
         [JsonPropertyName("boolean_prop")]
-        public bool? BooleanProp { get { return this.BooleanPropOption; } set { this.BooleanPropOption = new(value); } }
+        public bool? BooleanProp { get { return this.BooleanPropOption.Value; } set { this.BooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DateProp
@@ -130,7 +130,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateProp
         /// </summary>
         [JsonPropertyName("date_prop")]
-        public DateOnly? DateProp { get { return this.DatePropOption; } set { this.DatePropOption = new(value); } }
+        public DateOnly? DateProp { get { return this.DatePropOption.Value; } set { this.DatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DatetimeProp
@@ -143,7 +143,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DatetimeProp
         /// </summary>
         [JsonPropertyName("datetime_prop")]
-        public DateTime? DatetimeProp { get { return this.DatetimePropOption; } set { this.DatetimePropOption = new(value); } }
+        public DateTime? DatetimeProp { get { return this.DatetimePropOption.Value; } set { this.DatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of IntegerProp
@@ -156,7 +156,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IntegerProp
         /// </summary>
         [JsonPropertyName("integer_prop")]
-        public int? IntegerProp { get { return this.IntegerPropOption; } set { this.IntegerPropOption = new(value); } }
+        public int? IntegerProp { get { return this.IntegerPropOption.Value; } set { this.IntegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NumberProp
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NumberProp
         /// </summary>
         [JsonPropertyName("number_prop")]
-        public decimal? NumberProp { get { return this.NumberPropOption; } set { this.NumberPropOption = new(value); } }
+        public decimal? NumberProp { get { return this.NumberPropOption.Value; } set { this.NumberPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectAndItemsNullableProp
@@ -182,7 +182,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("object_and_items_nullable_prop")]
-        public Dictionary<string, Object>? ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption; } set { this.ObjectAndItemsNullablePropOption = new(value); } }
+        public Dictionary<string, Object>? ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption.Value; } set { this.ObjectAndItemsNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectItemsNullable
@@ -195,7 +195,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectItemsNullable
         /// </summary>
         [JsonPropertyName("object_items_nullable")]
-        public Dictionary<string, Object>? ObjectItemsNullable { get { return this.ObjectItemsNullableOption; } set { this.ObjectItemsNullableOption = new(value); } }
+        public Dictionary<string, Object>? ObjectItemsNullable { get { return this.ObjectItemsNullableOption.Value; } set { this.ObjectItemsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectNullableProp
@@ -208,7 +208,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectNullableProp
         /// </summary>
         [JsonPropertyName("object_nullable_prop")]
-        public Dictionary<string, Object>? ObjectNullableProp { get { return this.ObjectNullablePropOption; } set { this.ObjectNullablePropOption = new(value); } }
+        public Dictionary<string, Object>? ObjectNullableProp { get { return this.ObjectNullablePropOption.Value; } set { this.ObjectNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of StringProp
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringProp
         /// </summary>
         [JsonPropertyName("string_prop")]
-        public string? StringProp { get { return this.StringPropOption; } set { this.StringPropOption = new(value); } }
+        public string? StringProp { get { return this.StringPropOption.Value; } set { this.StringPropOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [JsonPropertyName("JustNumber")]
-        public decimal? JustNumber { get { return this.JustNumberOption; } set { this.JustNumberOption = new(value); } }
+        public decimal? JustNumber { get { return this.JustNumberOption.Value; } set { this.JustNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("bars")]
         [Obsolete]
-        public List<string>? Bars { get { return this.BarsOption; } set { this.BarsOption = new(value); } }
+        public List<string>? Bars { get { return this.BarsOption.Value; } set { this.BarsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DeprecatedRef
@@ -77,7 +77,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("deprecatedRef")]
         [Obsolete]
-        public DeprecatedObject? DeprecatedRef { get { return this.DeprecatedRefOption; } set { this.DeprecatedRefOption = new(value); } }
+        public DeprecatedObject? DeprecatedRef { get { return this.DeprecatedRefOption.Value; } set { this.DeprecatedRefOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -91,7 +91,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("id")]
         [Obsolete]
-        public decimal? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public decimal? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -104,7 +104,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public string? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Order.cs
@@ -161,7 +161,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Complete
         /// </summary>
         [JsonPropertyName("complete")]
-        public bool? Complete { get { return this.CompleteOption; } set { this.CompleteOption = new(value); } }
+        public bool? Complete { get { return this.CompleteOption.Value; } set { this.CompleteOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -174,7 +174,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PetId
@@ -187,7 +187,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets PetId
         /// </summary>
         [JsonPropertyName("petId")]
-        public long? PetId { get { return this.PetIdOption; } set { this.PetIdOption = new(value); } }
+        public long? PetId { get { return this.PetIdOption.Value; } set { this.PetIdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Quantity
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Quantity
         /// </summary>
         [JsonPropertyName("quantity")]
-        public int? Quantity { get { return this.QuantityOption; } set { this.QuantityOption = new(value); } }
+        public int? Quantity { get { return this.QuantityOption.Value; } set { this.QuantityOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ShipDate
@@ -214,7 +214,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2020-02-02T20:20:20.000222Z</example> */
         [JsonPropertyName("shipDate")]
-        public DateTime? ShipDate { get { return this.ShipDateOption; } set { this.ShipDateOption = new(value); } }
+        public DateTime? ShipDate { get { return this.ShipDateOption.Value; } set { this.ShipDateOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyBoolean
         /// </summary>
         [JsonPropertyName("my_boolean")]
-        public bool? MyBoolean { get { return this.MyBooleanOption; } set { this.MyBooleanOption = new(value); } }
+        public bool? MyBoolean { get { return this.MyBooleanOption.Value; } set { this.MyBooleanOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MyNumber
@@ -73,7 +73,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [JsonPropertyName("my_number")]
-        public decimal? MyNumber { get { return this.MyNumberOption; } set { this.MyNumberOption = new(value); } }
+        public decimal? MyNumber { get { return this.MyNumberOption.Value; } set { this.MyNumberOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MyString
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyString
         /// </summary>
         [JsonPropertyName("my_string")]
-        public string? MyString { get { return this.MyStringOption; } set { this.MyStringOption = new(value); } }
+        public string? MyString { get { return this.MyStringOption.Value; } set { this.MyStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
@@ -174,7 +174,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Category
         /// </summary>
         [JsonPropertyName("category")]
-        public Category? Category { get { return this.CategoryOption; } set { this.CategoryOption = new(value); } }
+        public Category? Category { get { return this.CategoryOption.Value; } set { this.CategoryOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -187,7 +187,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Tags
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Tags
         /// </summary>
         [JsonPropertyName("tags")]
-        public List<Tag>? Tags { get { return this.TagsOption; } set { this.TagsOption = new(value); } }
+        public List<Tag>? Tags { get { return this.TagsOption.Value; } set { this.TagsOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string? Bar { get { return this.BarOption; } }
+        public string? Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Baz
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Baz
         /// </summary>
         [JsonPropertyName("baz")]
-        public string? Baz { get { return this.BazOption; } set { this.BazOption = new(value); } }
+        public string? Baz { get { return this.BazOption.Value; } set { this.BazOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -1415,7 +1415,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_notnullable_date_prop")]
-        public DateOnly? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption; } set { this.NotRequiredNotnullableDatePropOption = new(value); } }
+        public DateOnly? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption.Value; } set { this.NotRequiredNotnullableDatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNotnullableintegerProp
@@ -1428,7 +1428,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [JsonPropertyName("not_required_notnullableinteger_prop")]
-        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption; } set { this.NotRequiredNotnullableintegerPropOption = new(value); } }
+        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption.Value; } set { this.NotRequiredNotnullableintegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableDateProp
@@ -1441,7 +1441,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_date_prop")]
-        public DateOnly? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption; } set { this.NotRequiredNullableDatePropOption = new(value); } }
+        public DateOnly? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption.Value; } set { this.NotRequiredNullableDatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableIntegerProp
@@ -1454,7 +1454,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableIntegerProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_integer_prop")]
-        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption; } set { this.NotRequiredNullableIntegerPropOption = new(value); } }
+        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption.Value; } set { this.NotRequiredNullableIntegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableArrayOfString
@@ -1467,7 +1467,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_array_of_string")]
-        public List<string>? NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption; } set { this.NotrequiredNotnullableArrayOfStringOption = new(value); } }
+        public List<string>? NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption.Value; } set { this.NotrequiredNotnullableArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableBooleanProp
@@ -1480,7 +1480,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_boolean_prop")]
-        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption; } set { this.NotrequiredNotnullableBooleanPropOption = new(value); } }
+        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption.Value; } set { this.NotrequiredNotnullableBooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableDatetimeProp
@@ -1493,7 +1493,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_datetime_prop")]
-        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption; } set { this.NotrequiredNotnullableDatetimePropOption = new(value); } }
+        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption.Value; } set { this.NotrequiredNotnullableDatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableStringProp
@@ -1506,7 +1506,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_string_prop")]
-        public string? NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption; } set { this.NotrequiredNotnullableStringPropOption = new(value); } }
+        public string? NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption.Value; } set { this.NotrequiredNotnullableStringPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableUuid
@@ -1520,7 +1520,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_notnullable_uuid")]
-        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption; } set { this.NotrequiredNotnullableUuidOption = new(value); } }
+        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption.Value; } set { this.NotrequiredNotnullableUuidOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableArrayOfString
@@ -1533,7 +1533,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_nullable_array_of_string")]
-        public List<string>? NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption; } set { this.NotrequiredNullableArrayOfStringOption = new(value); } }
+        public List<string>? NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption.Value; } set { this.NotrequiredNullableArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableBooleanProp
@@ -1546,7 +1546,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_boolean_prop")]
-        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption; } set { this.NotrequiredNullableBooleanPropOption = new(value); } }
+        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption.Value; } set { this.NotrequiredNullableBooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableDatetimeProp
@@ -1559,7 +1559,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_datetime_prop")]
-        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption; } set { this.NotrequiredNullableDatetimePropOption = new(value); } }
+        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption.Value; } set { this.NotrequiredNullableDatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableStringProp
@@ -1572,7 +1572,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_string_prop")]
-        public string? NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption; } set { this.NotrequiredNullableStringPropOption = new(value); } }
+        public string? NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption.Value; } set { this.NotrequiredNullableStringPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableUuid
@@ -1586,7 +1586,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_nullable_uuid")]
-        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption; } set { this.NotrequiredNullableUuidOption = new(value); } }
+        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption.Value; } set { this.NotrequiredNullableUuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets RequiredNullableArrayOfString

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Result.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result code</value>
         [JsonPropertyName("code")]
-        public string? Code { get { return this.CodeOption; } set { this.CodeOption = new(value); } }
+        public string? Code { get { return this.CodeOption.Value; } set { this.CodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Data
@@ -75,7 +75,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string>? Data { get { return this.DataOption; } set { this.DataOption = new(value); } }
+        public Dictionary<string, string>? Data { get { return this.DataOption.Value; } set { this.DataOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -89,7 +89,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [JsonPropertyName("return")]
-        public int? VarReturn { get { return this.VarReturnOption; } set { this.VarReturnOption = new(value); } }
+        public int? VarReturn { get { return this.VarReturnOption.Value; } set { this.VarReturnOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Unsafe
@@ -87,7 +87,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Unsafe
         /// </summary>
         [JsonPropertyName("unsafe")]
-        public string? Unsafe { get { return this.UnsafeOption; } set { this.UnsafeOption = new(value); } }
+        public string? Unsafe { get { return this.UnsafeOption.Value; } set { this.UnsafeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Role
         /// </summary>
         [JsonPropertyName("role")]
-        public RolesReportsHashRole? Role { get { return this.RoleOption; } set { this.RoleOption = new(value); } }
+        public RolesReportsHashRole? Role { get { return this.RoleOption.Value; } set { this.RoleOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of RoleUuid
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [JsonPropertyName("role_uuid")]
-        public Guid? RoleUuid { get { return this.RoleUuidOption; } set { this.RoleUuidOption = new(value); } }
+        public Guid? RoleUuid { get { return this.RoleUuidOption.Value; } set { this.RoleUuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarSpecialModelName
         /// </summary>
         [JsonPropertyName("_special_model.name_")]
-        public string? VarSpecialModelName { get { return this.VarSpecialModelNameOption; } set { this.VarSpecialModelNameOption = new(value); } }
+        public string? VarSpecialModelName { get { return this.VarSpecialModelNameOption.Value; } set { this.VarSpecialModelNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SpecialPropertyName
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [JsonPropertyName("$special[property.name]")]
-        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption; } set { this.SpecialPropertyNameOption = new(value); } }
+        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption.Value; } set { this.SpecialPropertyNameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Value
         /// </summary>
         [JsonPropertyName("value")]
-        public string? Value { get { return this.ValueOption; } set { this.ValueOption = new(value); } }
+        public string? Value { get { return this.ValueOption.Value; } set { this.ValueOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets TestCollectionEndingWithWordList
         /// </summary>
         [JsonPropertyName("TestCollectionEndingWithWordList")]
-        public List<TestCollectionEndingWithWordList>? TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption; } set { this.TestCollectionEndingWithWordListOption = new(value); } }
+        public List<TestCollectionEndingWithWordList>? TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption.Value; } set { this.TestCollectionEndingWithWordListOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SomeProperty
         /// </summary>
         [JsonPropertyName("someProperty")]
-        public string? SomeProperty { get { return this.SomePropertyOption; } set { this.SomePropertyOption = new(value); } }
+        public string? SomeProperty { get { return this.SomePropertyOption.Value; } set { this.SomePropertyOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string>? Data { get { return this.DataOption; } set { this.DataOption = new(value); } }
+        public Dictionary<string, string>? Data { get { return this.DataOption.Value; } set { this.DataOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
@@ -79,7 +79,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
         [JsonPropertyName("anyTypeProp")]
-        public Object? AnyTypeProp { get { return this.AnyTypePropOption; } set { this.AnyTypePropOption = new(value); } }
+        public Object? AnyTypeProp { get { return this.AnyTypePropOption.Value; } set { this.AnyTypePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of AnyTypePropNullable
@@ -93,7 +93,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values.</value>
         [JsonPropertyName("anyTypePropNullable")]
-        public Object? AnyTypePropNullable { get { return this.AnyTypePropNullableOption; } set { this.AnyTypePropNullableOption = new(value); } }
+        public Object? AnyTypePropNullable { get { return this.AnyTypePropNullableOption.Value; } set { this.AnyTypePropNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Email
@@ -106,7 +106,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Email
         /// </summary>
         [JsonPropertyName("email")]
-        public string? Email { get { return this.EmailOption; } set { this.EmailOption = new(value); } }
+        public string? Email { get { return this.EmailOption.Value; } set { this.EmailOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of FirstName
@@ -119,7 +119,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets FirstName
         /// </summary>
         [JsonPropertyName("firstName")]
-        public string? FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new(value); } }
+        public string? FirstName { get { return this.FirstNameOption.Value; } set { this.FirstNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -132,7 +132,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of LastName
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LastName
         /// </summary>
         [JsonPropertyName("lastName")]
-        public string? LastName { get { return this.LastNameOption; } set { this.LastNameOption = new(value); } }
+        public string? LastName { get { return this.LastNameOption.Value; } set { this.LastNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredProps
@@ -159,7 +159,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredProps")]
-        public Object? ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption; } set { this.ObjectWithNoDeclaredPropsOption = new(value); } }
+        public Object? ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption.Value; } set { this.ObjectWithNoDeclaredPropsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredPropsNullable
@@ -173,7 +173,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredPropsNullable")]
-        public Object? ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption; } set { this.ObjectWithNoDeclaredPropsNullableOption = new(value); } }
+        public Object? ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption.Value; } set { this.ObjectWithNoDeclaredPropsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Password
@@ -186,7 +186,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Password
         /// </summary>
         [JsonPropertyName("password")]
-        public string? Password { get { return this.PasswordOption; } set { this.PasswordOption = new(value); } }
+        public string? Password { get { return this.PasswordOption.Value; } set { this.PasswordOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Phone
@@ -199,7 +199,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Phone
         /// </summary>
         [JsonPropertyName("phone")]
-        public string? Phone { get { return this.PhoneOption; } set { this.PhoneOption = new(value); } }
+        public string? Phone { get { return this.PhoneOption.Value; } set { this.PhoneOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UserStatus
@@ -213,7 +213,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [JsonPropertyName("userStatus")]
-        public int? UserStatus { get { return this.UserStatusOption; } set { this.UserStatusOption = new(value); } }
+        public int? UserStatus { get { return this.UserStatusOption.Value; } set { this.UserStatusOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Username
@@ -226,7 +226,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Username
         /// </summary>
         [JsonPropertyName("username")]
-        public string? Username { get { return this.UsernameOption; } set { this.UsernameOption = new(value); } }
+        public string? Username { get { return this.UsernameOption.Value; } set { this.UsernameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
@@ -66,7 +66,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [JsonPropertyName("hasBaleen")]
-        public bool? HasBaleen { get { return this.HasBaleenOption; } set { this.HasBaleenOption = new(value); } }
+        public bool? HasBaleen { get { return this.HasBaleenOption.Value; } set { this.HasBaleenOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of HasTeeth
@@ -79,7 +79,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasTeeth
         /// </summary>
         [JsonPropertyName("hasTeeth")]
-        public bool? HasTeeth { get { return this.HasTeethOption; } set { this.HasTeethOption = new(value); } }
+        public bool? HasTeeth { get { return this.HasTeethOption.Value; } set { this.HasTeethOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net10/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net10/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Now
         /// </summary>
         [JsonPropertyName("now")]
-        public DateTime? Now { get { return this.NowOption; } set { this.NowOption = new(value); } }
+        public DateTime? Now { get { return this.NowOption.Value; } set { this.NowOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Today
@@ -69,7 +69,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Today
         /// </summary>
         [JsonPropertyName("today")]
-        public DateTime? Today { get { return this.TodayOption; } set { this.TodayOption = new(value); } }
+        public DateTime? Today { get { return this.TodayOption.Value; } set { this.TodayOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Adult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Adult.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Children
         /// </summary>
         [JsonPropertyName("children")]
-        public List<Child> Children { get { return this.ChildrenOption; } set { this.ChildrenOption = new Option<List<Child>>(value); } }
+        public List<Child> Children { get { return this.ChildrenOption.Value; } set { this.ChildrenOption = new Option<List<Child>>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Age
         /// </summary>
         [JsonPropertyName("age")]
-        public int? Age { get { return this.AgeOption; } set { this.AgeOption = new Option<int?>(value); } }
+        public int? Age { get { return this.AgeOption.Value; } set { this.AgeOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of BoosterSeat
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BoosterSeat
         /// </summary>
         [JsonPropertyName("boosterSeat")]
-        public bool? BoosterSeat { get { return this.BoosterSeatOption; } set { this.BoosterSeatOption = new Option<bool?>(value); } }
+        public bool? BoosterSeat { get { return this.BoosterSeatOption.Value; } set { this.BoosterSeatOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Person.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Person.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets FirstName
         /// </summary>
         [JsonPropertyName("firstName")]
-        public string FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new Option<string>(value); } }
+        public string FirstName { get { return this.FirstNameOption.Value; } set { this.FirstNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of LastName
@@ -69,7 +69,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LastName
         /// </summary>
         [JsonPropertyName("lastName")]
-        public string LastName { get { return this.LastNameOption; } set { this.LastNameOption = new Option<string>(value); } }
+        public string LastName { get { return this.LastNameOption.Value; } set { this.LastNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// The discriminator

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Kind
         /// </summary>
         [JsonPropertyName("kind")]
-        public string Kind { get { return this.KindOption; } set { this.KindOption = new Option<string>(value); } }
+        public string Kind { get { return this.KindOption.Value; } set { this.KindOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Count
         /// </summary>
         [JsonPropertyName("count")]
-        public decimal? Count { get { return this.CountOption; } set { this.CountOption = new Option<decimal?>(value); } }
+        public decimal? Count { get { return this.CountOption.Value; } set { this.CountOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -80,7 +80,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new Option<string>(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
@@ -52,7 +52,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Kind
         /// </summary>
         [JsonPropertyName("kind")]
-        public string Kind { get { return this.KindOption; } set { this.KindOption = new Option<string>(value); } }
+        public string Kind { get { return this.KindOption.Value; } set { this.KindOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
@@ -52,7 +52,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Count
         /// </summary>
         [JsonPropertyName("count")]
-        public decimal? Count { get { return this.CountOption; } set { this.CountOption = new Option<decimal?>(value); } }
+        public decimal? Count { get { return this.CountOption.Value; } set { this.CountOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
@@ -79,7 +79,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new Option<string>(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Activity.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ActivityOutputs
         /// </summary>
         [JsonPropertyName("activity_outputs")]
-        public Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs { get { return this.ActivityOutputsOption; } set { this.ActivityOutputsOption = new Option<Dictionary<string, List<ActivityOutputElementRepresentation>>>(value); } }
+        public Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs { get { return this.ActivityOutputsOption.Value; } set { this.ActivityOutputsOption = new Option<Dictionary<string, List<ActivityOutputElementRepresentation>>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop1
         /// </summary>
         [JsonPropertyName("prop1")]
-        public string Prop1 { get { return this.Prop1Option; } set { this.Prop1Option = new Option<string>(value); } }
+        public string Prop1 { get { return this.Prop1Option.Value; } set { this.Prop1Option = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Prop2
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop2
         /// </summary>
         [JsonPropertyName("prop2")]
-        public Object Prop2 { get { return this.Prop2Option; } set { this.Prop2Option = new Option<Object>(value); } }
+        public Object Prop2 { get { return this.Prop2Option.Value; } set { this.Prop2Option = new Option<Object>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Anytype1
         /// </summary>
         [JsonPropertyName("anytype_1")]
-        public Object Anytype1 { get { return this.Anytype1Option; } set { this.Anytype1Option = new Option<Object>(value); } }
+        public Object Anytype1 { get { return this.Anytype1Option.Value; } set { this.Anytype1Option = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of EmptyMap
@@ -81,7 +81,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>an object with no declared properties and no undeclared properties, hence it&#39;s an empty map.</value>
         [JsonPropertyName("empty_map")]
-        public Object EmptyMap { get { return this.EmptyMapOption; } set { this.EmptyMapOption = new Option<Object>(value); } }
+        public Object EmptyMap { get { return this.EmptyMapOption.Value; } set { this.EmptyMapOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfMapProperty
@@ -94,7 +94,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfMapProperty
         /// </summary>
         [JsonPropertyName("map_of_map_property")]
-        public Dictionary<string, Dictionary<string, string>> MapOfMapProperty { get { return this.MapOfMapPropertyOption; } set { this.MapOfMapPropertyOption = new Option<Dictionary<string, Dictionary<string, string>>>(value); } }
+        public Dictionary<string, Dictionary<string, string>> MapOfMapProperty { get { return this.MapOfMapPropertyOption.Value; } set { this.MapOfMapPropertyOption = new Option<Dictionary<string, Dictionary<string, string>>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapProperty
@@ -107,7 +107,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapProperty
         /// </summary>
         [JsonPropertyName("map_property")]
-        public Dictionary<string, string> MapProperty { get { return this.MapPropertyOption; } set { this.MapPropertyOption = new Option<Dictionary<string, string>>(value); } }
+        public Dictionary<string, string> MapProperty { get { return this.MapPropertyOption.Value; } set { this.MapPropertyOption = new Option<Dictionary<string, string>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype1
@@ -120,7 +120,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype1
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_1")]
-        public Object MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new Option<Object>(value); } }
+        public Object MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype2
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype2
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_2")]
-        public Object MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new Option<Object>(value); } }
+        public Object MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype3
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype3
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_3")]
-        public Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new Option<Dictionary<string, Object>>(value); } }
+        public Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new Option<Dictionary<string, Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesString
@@ -159,7 +159,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesString
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_string")]
-        public Dictionary<string, string> MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption; } set { this.MapWithUndeclaredPropertiesStringOption = new Option<Dictionary<string, string>>(value); } }
+        public Dictionary<string, string> MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption.Value; } set { this.MapWithUndeclaredPropertiesStringOption = new Option<Dictionary<string, string>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Animal.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new Option<string>(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [JsonPropertyName("code")]
-        public int? Code { get { return this.CodeOption; } set { this.CodeOption = new Option<int?>(value); } }
+        public int? Code { get { return this.CodeOption.Value; } set { this.CodeOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Message
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Message
         /// </summary>
         [JsonPropertyName("message")]
-        public string Message { get { return this.MessageOption; } set { this.MessageOption = new Option<string>(value); } }
+        public string Message { get { return this.MessageOption.Value; } set { this.MessageOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Type
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Type
         /// </summary>
         [JsonPropertyName("type")]
-        public string Type { get { return this.TypeOption; } set { this.TypeOption = new Option<string>(value); } }
+        public string Type { get { return this.TypeOption.Value; } set { this.TypeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Apple.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ColorCode
         /// </summary>
         [JsonPropertyName("color_code")]
-        public string ColorCode { get { return this.ColorCodeOption; } set { this.ColorCodeOption = new Option<string>(value); } }
+        public string ColorCode { get { return this.ColorCodeOption.Value; } set { this.ColorCodeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Cultivar
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Cultivar
         /// </summary>
         [JsonPropertyName("cultivar")]
-        public string Cultivar { get { return this.CultivarOption; } set { this.CultivarOption = new Option<string>(value); } }
+        public string Cultivar { get { return this.CultivarOption.Value; } set { this.CultivarOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Origin
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Origin
         /// </summary>
         [JsonPropertyName("origin")]
-        public string Origin { get { return this.OriginOption; } set { this.OriginOption = new Option<string>(value); } }
+        public string Origin { get { return this.OriginOption.Value; } set { this.OriginOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [JsonPropertyName("mealy")]
-        public bool? Mealy { get { return this.MealyOption; } set { this.MealyOption = new Option<bool?>(value); } }
+        public bool? Mealy { get { return this.MealyOption.Value; } set { this.MealyOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayArrayNumber")]
-        public List<List<decimal>> ArrayArrayNumber { get { return this.ArrayArrayNumberOption; } set { this.ArrayArrayNumberOption = new Option<List<List<decimal>>>(value); } }
+        public List<List<decimal>> ArrayArrayNumber { get { return this.ArrayArrayNumberOption.Value; } set { this.ArrayArrayNumberOption = new Option<List<List<decimal>>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayNumber")]
-        public List<decimal> ArrayNumber { get { return this.ArrayNumberOption; } set { this.ArrayNumberOption = new Option<List<decimal>>(value); } }
+        public List<decimal> ArrayNumber { get { return this.ArrayNumberOption.Value; } set { this.ArrayNumberOption = new Option<List<decimal>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfInteger
         /// </summary>
         [JsonPropertyName("array_array_of_integer")]
-        public List<List<long>> ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption; } set { this.ArrayArrayOfIntegerOption = new Option<List<List<long>>>(value); } }
+        public List<List<long>> ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption.Value; } set { this.ArrayArrayOfIntegerOption = new Option<List<List<long>>>(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayArrayOfModel
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfModel
         /// </summary>
         [JsonPropertyName("array_array_of_model")]
-        public List<List<ReadOnlyFirst>> ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption; } set { this.ArrayArrayOfModelOption = new Option<List<List<ReadOnlyFirst>>>(value); } }
+        public List<List<ReadOnlyFirst>> ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption.Value; } set { this.ArrayArrayOfModelOption = new Option<List<List<ReadOnlyFirst>>>(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayOfString
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayOfString
         /// </summary>
         [JsonPropertyName("array_of_string")]
-        public List<string> ArrayOfString { get { return this.ArrayOfStringOption; } set { this.ArrayOfStringOption = new Option<List<string>>(value); } }
+        public List<string> ArrayOfString { get { return this.ArrayOfStringOption.Value; } set { this.ArrayOfStringOption = new Option<List<string>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Banana.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [JsonPropertyName("lengthCm")]
-        public decimal? LengthCm { get { return this.LengthCmOption; } set { this.LengthCmOption = new Option<decimal?>(value); } }
+        public decimal? LengthCm { get { return this.LengthCmOption.Value; } set { this.LengthCmOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [JsonPropertyName("sweet")]
-        public bool? Sweet { get { return this.SweetOption; } set { this.SweetOption = new Option<bool?>(value); } }
+        public bool? Sweet { get { return this.SweetOption.Value; } set { this.SweetOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -64,7 +64,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Name of the pet </value>
         [JsonPropertyName("ATT_NAME")]
-        public string ATT_NAME { get { return this.ATT_NAMEOption; } set { this.ATT_NAMEOption = new Option<string>(value); } }
+        public string ATT_NAME { get { return this.ATT_NAMEOption.Value; } set { this.ATT_NAMEOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalCamel
@@ -77,7 +77,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalCamel
         /// </summary>
         [JsonPropertyName("CapitalCamel")]
-        public string CapitalCamel { get { return this.CapitalCamelOption; } set { this.CapitalCamelOption = new Option<string>(value); } }
+        public string CapitalCamel { get { return this.CapitalCamelOption.Value; } set { this.CapitalCamelOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalSnake
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalSnake
         /// </summary>
         [JsonPropertyName("Capital_Snake")]
-        public string CapitalSnake { get { return this.CapitalSnakeOption; } set { this.CapitalSnakeOption = new Option<string>(value); } }
+        public string CapitalSnake { get { return this.CapitalSnakeOption.Value; } set { this.CapitalSnakeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SCAETHFlowPoints
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SCAETHFlowPoints
         /// </summary>
         [JsonPropertyName("SCA_ETH_Flow_Points")]
-        public string SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption; } set { this.SCAETHFlowPointsOption = new Option<string>(value); } }
+        public string SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption.Value; } set { this.SCAETHFlowPointsOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SmallCamel
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallCamel
         /// </summary>
         [JsonPropertyName("smallCamel")]
-        public string SmallCamel { get { return this.SmallCamelOption; } set { this.SmallCamelOption = new Option<string>(value); } }
+        public string SmallCamel { get { return this.SmallCamelOption.Value; } set { this.SmallCamelOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SmallSnake
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallSnake
         /// </summary>
         [JsonPropertyName("small_Snake")]
-        public string SmallSnake { get { return this.SmallSnakeOption; } set { this.SmallSnakeOption = new Option<string>(value); } }
+        public string SmallSnake { get { return this.SmallSnakeOption.Value; } set { this.SmallSnakeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Cat.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [JsonPropertyName("declawed")]
-        public bool? Declawed { get { return this.DeclawedOption; } set { this.DeclawedOption = new Option<bool?>(value); } }
+        public bool? Declawed { get { return this.DeclawedOption.Value; } set { this.DeclawedOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Category.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new Option<string>(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("_class")]
-        public string Class { get { return this.ClassOption; } set { this.ClassOption = new Option<string>(value); } }
+        public string Class { get { return this.ClassOption.Value; } set { this.ClassOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>Fri Jul 21 00:00:00 UTC 2017</example> */
         [JsonPropertyName("dateOnlyProperty")]
-        public DateTime? DateOnlyProperty { get { return this.DateOnlyPropertyOption; } set { this.DateOnlyPropertyOption = new Option<DateTime?>(value); } }
+        public DateTime? DateOnlyProperty { get { return this.DateOnlyPropertyOption.Value; } set { this.DateOnlyPropertyOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new Option<string>(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Dog.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Breed
         /// </summary>
         [JsonPropertyName("breed")]
-        public string Breed { get { return this.BreedOption; } set { this.BreedOption = new Option<string>(value); } }
+        public string Breed { get { return this.BreedOption.Value; } set { this.BreedOption = new Option<string>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MainShape
         /// </summary>
         [JsonPropertyName("mainShape")]
-        public Shape MainShape { get { return this.MainShapeOption; } set { this.MainShapeOption = new Option<Shape>(value); } }
+        public Shape MainShape { get { return this.MainShapeOption.Value; } set { this.MainShapeOption = new Option<Shape>(value); } }
 
         /// <summary>
         /// Used to track the state of NullableShape
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableShape
         /// </summary>
         [JsonPropertyName("nullableShape")]
-        public NullableShape NullableShape { get { return this.NullableShapeOption; } set { this.NullableShapeOption = new Option<NullableShape>(value); } }
+        public NullableShape NullableShape { get { return this.NullableShapeOption.Value; } set { this.NullableShapeOption = new Option<NullableShape>(value); } }
 
         /// <summary>
         /// Used to track the state of ShapeOrNull
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ShapeOrNull
         /// </summary>
         [JsonPropertyName("shapeOrNull")]
-        public ShapeOrNull ShapeOrNull { get { return this.ShapeOrNullOption; } set { this.ShapeOrNullOption = new Option<ShapeOrNull>(value); } }
+        public ShapeOrNull ShapeOrNull { get { return this.ShapeOrNullOption.Value; } set { this.ShapeOrNullOption = new Option<ShapeOrNull>(value); } }
 
         /// <summary>
         /// Used to track the state of Shapes
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Shapes
         /// </summary>
         [JsonPropertyName("shapes")]
-        public List<Shape> Shapes { get { return this.ShapesOption; } set { this.ShapesOption = new Option<List<Shape>>(value); } }
+        public List<Shape> Shapes { get { return this.ShapesOption.Value; } set { this.ShapesOption = new Option<List<Shape>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayEnum
         /// </summary>
         [JsonPropertyName("array_enum")]
-        public List<EnumArraysArrayEnumInner> ArrayEnum { get { return this.ArrayEnumOption; } set { this.ArrayEnumOption = new Option<List<EnumArraysArrayEnumInner>>(value); } }
+        public List<EnumArraysArrayEnumInner> ArrayEnum { get { return this.ArrayEnumOption.Value; } set { this.ArrayEnumOption = new Option<List<EnumArraysArrayEnumInner>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/File.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Test capitalization</value>
         [JsonPropertyName("sourceURI")]
-        public string SourceURI { get { return this.SourceURIOption; } set { this.SourceURIOption = new Option<string>(value); } }
+        public string SourceURI { get { return this.SourceURIOption.Value; } set { this.SourceURIOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets File
         /// </summary>
         [JsonPropertyName("file")]
-        public File File { get { return this.FileOption; } set { this.FileOption = new Option<File>(value); } }
+        public File File { get { return this.FileOption.Value; } set { this.FileOption = new Option<File>(value); } }
 
         /// <summary>
         /// Used to track the state of Files
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Files
         /// </summary>
         [JsonPropertyName("files")]
-        public List<File> Files { get { return this.FilesOption; } set { this.FilesOption = new Option<List<File>>(value); } }
+        public List<File> Files { get { return this.FilesOption.Value; } set { this.FilesOption = new Option<List<File>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Foo.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } set { this.BarOption = new Option<string>(value); } }
+        public string Bar { get { return this.BarOption.Value; } set { this.BarOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public Foo String { get { return this.StringOption; } set { this.StringOption = new Option<Foo>(value); } }
+        public Foo String { get { return this.StringOption.Value; } set { this.StringOption = new Option<Foo>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -138,7 +138,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Binary
         /// </summary>
         [JsonPropertyName("binary")]
-        public System.IO.Stream Binary { get { return this.BinaryOption; } set { this.BinaryOption = new Option<System.IO.Stream>(value); } }
+        public System.IO.Stream Binary { get { return this.BinaryOption.Value; } set { this.BinaryOption = new Option<System.IO.Stream>(value); } }
 
         /// <summary>
         /// Used to track the state of DateTime
@@ -152,7 +152,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2007-12-03T10:15:30+01:00</example> */
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new Option<DateTime?>(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of Decimal
@@ -165,7 +165,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Decimal
         /// </summary>
         [JsonPropertyName("decimal")]
-        public decimal? Decimal { get { return this.DecimalOption; } set { this.DecimalOption = new Option<decimal?>(value); } }
+        public decimal? Decimal { get { return this.DecimalOption.Value; } set { this.DecimalOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of Double
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Double
         /// </summary>
         [JsonPropertyName("double")]
-        public double? Double { get { return this.DoubleOption; } set { this.DoubleOption = new Option<double?>(value); } }
+        public double? Double { get { return this.DoubleOption.Value; } set { this.DoubleOption = new Option<double?>(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName2
@@ -191,7 +191,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName2
         /// </summary>
         [JsonPropertyName("duplicate_property_name")]
-        public string DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option; } set { this.DuplicatePropertyName2Option = new Option<string>(value); } }
+        public string DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option.Value; } set { this.DuplicatePropertyName2Option = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName
@@ -204,7 +204,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName
         /// </summary>
         [JsonPropertyName("@duplicate_property_name")]
-        public string DuplicatePropertyName { get { return this.DuplicatePropertyNameOption; } set { this.DuplicatePropertyNameOption = new Option<string>(value); } }
+        public string DuplicatePropertyName { get { return this.DuplicatePropertyNameOption.Value; } set { this.DuplicatePropertyNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Float
@@ -217,7 +217,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Float
         /// </summary>
         [JsonPropertyName("float")]
-        public float? Float { get { return this.FloatOption; } set { this.FloatOption = new Option<float?>(value); } }
+        public float? Float { get { return this.FloatOption.Value; } set { this.FloatOption = new Option<float?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int32
@@ -230,7 +230,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32
         /// </summary>
         [JsonPropertyName("int32")]
-        public int? Int32 { get { return this.Int32Option; } set { this.Int32Option = new Option<int?>(value); } }
+        public int? Int32 { get { return this.Int32Option.Value; } set { this.Int32Option = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int32Range
@@ -243,7 +243,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32Range
         /// </summary>
         [JsonPropertyName("int32Range")]
-        public int? Int32Range { get { return this.Int32RangeOption; } set { this.Int32RangeOption = new Option<int?>(value); } }
+        public int? Int32Range { get { return this.Int32RangeOption.Value; } set { this.Int32RangeOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64
@@ -256,7 +256,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64
         /// </summary>
         [JsonPropertyName("int64")]
-        public long? Int64 { get { return this.Int64Option; } set { this.Int64Option = new Option<long?>(value); } }
+        public long? Int64 { get { return this.Int64Option.Value; } set { this.Int64Option = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Negative
@@ -269,7 +269,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Negative
         /// </summary>
         [JsonPropertyName("int64Negative")]
-        public long? Int64Negative { get { return this.Int64NegativeOption; } set { this.Int64NegativeOption = new Option<long?>(value); } }
+        public long? Int64Negative { get { return this.Int64NegativeOption.Value; } set { this.Int64NegativeOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64NegativeExclusive
@@ -282,7 +282,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64NegativeExclusive
         /// </summary>
         [JsonPropertyName("int64NegativeExclusive")]
-        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption; } set { this.Int64NegativeExclusiveOption = new Option<long?>(value); } }
+        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption.Value; } set { this.Int64NegativeExclusiveOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Positive
@@ -295,7 +295,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Positive
         /// </summary>
         [JsonPropertyName("int64Positive")]
-        public long? Int64Positive { get { return this.Int64PositiveOption; } set { this.Int64PositiveOption = new Option<long?>(value); } }
+        public long? Int64Positive { get { return this.Int64PositiveOption.Value; } set { this.Int64PositiveOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64PositiveExclusive
@@ -308,7 +308,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64PositiveExclusive
         /// </summary>
         [JsonPropertyName("int64PositiveExclusive")]
-        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption; } set { this.Int64PositiveExclusiveOption = new Option<long?>(value); } }
+        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption.Value; } set { this.Int64PositiveExclusiveOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Integer
@@ -321,7 +321,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [JsonPropertyName("integer")]
-        public int? Integer { get { return this.IntegerOption; } set { this.IntegerOption = new Option<int?>(value); } }
+        public int? Integer { get { return this.IntegerOption.Value; } set { this.IntegerOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithBackslash
@@ -335,7 +335,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>None</value>
         [JsonPropertyName("pattern_with_backslash")]
-        public string PatternWithBackslash { get { return this.PatternWithBackslashOption; } set { this.PatternWithBackslashOption = new Option<string>(value); } }
+        public string PatternWithBackslash { get { return this.PatternWithBackslashOption.Value; } set { this.PatternWithBackslashOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigits
@@ -349,7 +349,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string that is a 10 digit number. Can have leading zeros.</value>
         [JsonPropertyName("pattern_with_digits")]
-        public string PatternWithDigits { get { return this.PatternWithDigitsOption; } set { this.PatternWithDigitsOption = new Option<string>(value); } }
+        public string PatternWithDigits { get { return this.PatternWithDigitsOption.Value; } set { this.PatternWithDigitsOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigitsAndDelimiter
@@ -363,7 +363,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.</value>
         [JsonPropertyName("pattern_with_digits_and_delimiter")]
-        public string PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption; } set { this.PatternWithDigitsAndDelimiterOption = new Option<string>(value); } }
+        public string PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption.Value; } set { this.PatternWithDigitsAndDelimiterOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of String
@@ -376,7 +376,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public string String { get { return this.StringOption; } set { this.StringOption = new Option<string>(value); } }
+        public string String { get { return this.StringOption.Value; } set { this.StringOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of StringFormattedAsDecimal
@@ -389,7 +389,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringFormattedAsDecimal
         /// </summary>
         [JsonPropertyName("string_formatted_as_decimal")]
-        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption; } set { this.StringFormattedAsDecimalOption = new Option<decimal?>(value); } }
+        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption.Value; } set { this.StringFormattedAsDecimalOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedInteger
@@ -402,7 +402,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [JsonPropertyName("unsigned_integer")]
-        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption; } set { this.UnsignedIntegerOption = new Option<uint?>(value); } }
+        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption.Value; } set { this.UnsignedIntegerOption = new Option<uint?>(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedLong
@@ -415,7 +415,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedLong
         /// </summary>
         [JsonPropertyName("unsigned_long")]
-        public ulong? UnsignedLong { get { return this.UnsignedLongOption; } set { this.UnsignedLongOption = new Option<ulong?>(value); } }
+        public ulong? UnsignedLong { get { return this.UnsignedLongOption.Value; } set { this.UnsignedLongOption = new Option<ulong?>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -429,7 +429,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<Guid?>(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new Option<string>(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new Option<string>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -80,7 +80,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new Option<string>(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new Option<string>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } }
+        public string Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Foo
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Foo
         /// </summary>
         [JsonPropertyName("foo")]
-        public string Foo { get { return this.FooOption; } }
+        public string Foo { get { return this.FooOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableMessage
         /// </summary>
         [JsonPropertyName("NullableMessage")]
-        public string NullableMessage { get { return this.NullableMessageOption; } set { this.NullableMessageOption = new Option<string>(value); } }
+        public string NullableMessage { get { return this.NullableMessageOption.Value; } set { this.NullableMessageOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/List.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123List
         /// </summary>
         [JsonPropertyName("123-list")]
-        public string Var123List { get { return this.Var123ListOption; } set { this.Var123ListOption = new Option<string>(value); } }
+        public string Var123List { get { return this.Var123ListOption.Value; } set { this.Var123ListOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets EscapedLiteralString
         /// </summary>
         [JsonPropertyName("escapedLiteralString")]
-        public string EscapedLiteralString { get { return this.EscapedLiteralStringOption; } set { this.EscapedLiteralStringOption = new Option<string>(value); } }
+        public string EscapedLiteralString { get { return this.EscapedLiteralStringOption.Value; } set { this.EscapedLiteralStringOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of UnescapedLiteralString
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnescapedLiteralString
         /// </summary>
         [JsonPropertyName("unescapedLiteralString")]
-        public string UnescapedLiteralString { get { return this.UnescapedLiteralStringOption; } set { this.UnescapedLiteralStringOption = new Option<string>(value); } }
+        public string UnescapedLiteralString { get { return this.UnescapedLiteralStringOption.Value; } set { this.UnescapedLiteralStringOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DirectMap
         /// </summary>
         [JsonPropertyName("direct_map")]
-        public Dictionary<string, bool> DirectMap { get { return this.DirectMapOption; } set { this.DirectMapOption = new Option<Dictionary<string, bool>>(value); } }
+        public Dictionary<string, bool> DirectMap { get { return this.DirectMapOption.Value; } set { this.DirectMapOption = new Option<Dictionary<string, bool>>(value); } }
 
         /// <summary>
         /// Used to track the state of IndirectMap
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IndirectMap
         /// </summary>
         [JsonPropertyName("indirect_map")]
-        public Dictionary<string, bool> IndirectMap { get { return this.IndirectMapOption; } set { this.IndirectMapOption = new Option<Dictionary<string, bool>>(value); } }
+        public Dictionary<string, bool> IndirectMap { get { return this.IndirectMapOption.Value; } set { this.IndirectMapOption = new Option<Dictionary<string, bool>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapMapOfString
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapMapOfString
         /// </summary>
         [JsonPropertyName("map_map_of_string")]
-        public Dictionary<string, Dictionary<string, string>> MapMapOfString { get { return this.MapMapOfStringOption; } set { this.MapMapOfStringOption = new Option<Dictionary<string, Dictionary<string, string>>>(value); } }
+        public Dictionary<string, Dictionary<string, string>> MapMapOfString { get { return this.MapMapOfStringOption.Value; } set { this.MapMapOfStringOption = new Option<Dictionary<string, Dictionary<string, string>>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfEnumString
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfEnumString
         /// </summary>
         [JsonPropertyName("map_of_enum_string")]
-        public Dictionary<string, MapTestMapOfEnumStringValue> MapOfEnumString { get { return this.MapOfEnumStringOption; } set { this.MapOfEnumStringOption = new Option<Dictionary<string, MapTestMapOfEnumStringValue>>(value); } }
+        public Dictionary<string, MapTestMapOfEnumStringValue> MapOfEnumString { get { return this.MapOfEnumStringOption.Value; } set { this.MapOfEnumStringOption = new Option<Dictionary<string, MapTestMapOfEnumStringValue>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedAnyOfContent Content { get { return this.ContentOption; } set { this.ContentOption = new Option<MixedAnyOfContent>(value); } }
+        public MixedAnyOfContent Content { get { return this.ContentOption.Value; } set { this.ContentOption = new Option<MixedAnyOfContent>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedOneOfContent Content { get { return this.ContentOption; } set { this.ContentOption = new Option<MixedOneOfContent>(value); } }
+        public MixedOneOfContent Content { get { return this.ContentOption.Value; } set { this.ContentOption = new Option<MixedOneOfContent>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateTime
         /// </summary>
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new Option<DateTime?>(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of Map
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Map
         /// </summary>
         [JsonPropertyName("map")]
-        public Dictionary<string, Animal> Map { get { return this.MapOption; } set { this.MapOption = new Option<Dictionary<string, Animal>>(value); } }
+        public Dictionary<string, Animal> Map { get { return this.MapOption.Value; } set { this.MapOption = new Option<Dictionary<string, Animal>>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<Guid?>(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Used to track the state of UuidWithPattern
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [JsonPropertyName("uuid_with_pattern")]
-        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption; } set { this.UuidWithPatternOption = new Option<Guid?>(value); } }
+        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption.Value; } set { this.UuidWithPatternOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public string Id { get { return this.IdOption; } set { this.IdOption = new Option<string>(value); } }
+        public string Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("class")]
-        public string Class { get { return this.ClassOption; } set { this.ClassOption = new Option<string>(value); } }
+        public string Class { get { return this.ClassOption.Value; } set { this.ClassOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public int? Name { get { return this.NameOption; } set { this.NameOption = new Option<int?>(value); } }
+        public int? Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarClient
         /// </summary>
         [JsonPropertyName("client")]
-        public string VarClient { get { return this.VarClientOption; } set { this.VarClientOption = new Option<string>(value); } }
+        public string VarClient { get { return this.VarClientOption.Value; } set { this.VarClientOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Name.cs
@@ -65,7 +65,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Property
         /// </summary>
         [JsonPropertyName("property")]
-        public string Property { get { return this.PropertyOption; } set { this.PropertyOption = new Option<string>(value); } }
+        public string Property { get { return this.PropertyOption.Value; } set { this.PropertyOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SnakeCase
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [JsonPropertyName("snake_case")]
-        public int? SnakeCase { get { return this.SnakeCaseOption; } }
+        public int? SnakeCase { get { return this.SnakeCaseOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Var123Number
@@ -91,7 +91,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123Number
         /// </summary>
         [JsonPropertyName("123Number")]
-        public int? Var123Number { get { return this.Var123NumberOption; } }
+        public int? Var123Number { get { return this.Var123NumberOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -75,7 +75,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("array_and_items_nullable_prop")]
-        public List<Object> ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption; } set { this.ArrayAndItemsNullablePropOption = new Option<List<Object>>(value); } }
+        public List<Object> ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption.Value; } set { this.ArrayAndItemsNullablePropOption = new Option<List<Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayItemsNullable
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayItemsNullable
         /// </summary>
         [JsonPropertyName("array_items_nullable")]
-        public List<Object> ArrayItemsNullable { get { return this.ArrayItemsNullableOption; } set { this.ArrayItemsNullableOption = new Option<List<Object>>(value); } }
+        public List<Object> ArrayItemsNullable { get { return this.ArrayItemsNullableOption.Value; } set { this.ArrayItemsNullableOption = new Option<List<Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayNullableProp
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNullableProp
         /// </summary>
         [JsonPropertyName("array_nullable_prop")]
-        public List<Object> ArrayNullableProp { get { return this.ArrayNullablePropOption; } set { this.ArrayNullablePropOption = new Option<List<Object>>(value); } }
+        public List<Object> ArrayNullableProp { get { return this.ArrayNullablePropOption.Value; } set { this.ArrayNullablePropOption = new Option<List<Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of BooleanProp
@@ -114,7 +114,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BooleanProp
         /// </summary>
         [JsonPropertyName("boolean_prop")]
-        public bool? BooleanProp { get { return this.BooleanPropOption; } set { this.BooleanPropOption = new Option<bool?>(value); } }
+        public bool? BooleanProp { get { return this.BooleanPropOption.Value; } set { this.BooleanPropOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of DateProp
@@ -127,7 +127,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateProp
         /// </summary>
         [JsonPropertyName("date_prop")]
-        public DateTime? DateProp { get { return this.DatePropOption; } set { this.DatePropOption = new Option<DateTime?>(value); } }
+        public DateTime? DateProp { get { return this.DatePropOption.Value; } set { this.DatePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of DatetimeProp
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DatetimeProp
         /// </summary>
         [JsonPropertyName("datetime_prop")]
-        public DateTime? DatetimeProp { get { return this.DatetimePropOption; } set { this.DatetimePropOption = new Option<DateTime?>(value); } }
+        public DateTime? DatetimeProp { get { return this.DatetimePropOption.Value; } set { this.DatetimePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of IntegerProp
@@ -153,7 +153,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IntegerProp
         /// </summary>
         [JsonPropertyName("integer_prop")]
-        public int? IntegerProp { get { return this.IntegerPropOption; } set { this.IntegerPropOption = new Option<int?>(value); } }
+        public int? IntegerProp { get { return this.IntegerPropOption.Value; } set { this.IntegerPropOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of NumberProp
@@ -166,7 +166,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NumberProp
         /// </summary>
         [JsonPropertyName("number_prop")]
-        public decimal? NumberProp { get { return this.NumberPropOption; } set { this.NumberPropOption = new Option<decimal?>(value); } }
+        public decimal? NumberProp { get { return this.NumberPropOption.Value; } set { this.NumberPropOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectAndItemsNullableProp
@@ -179,7 +179,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("object_and_items_nullable_prop")]
-        public Dictionary<string, Object> ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption; } set { this.ObjectAndItemsNullablePropOption = new Option<Dictionary<string, Object>>(value); } }
+        public Dictionary<string, Object> ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption.Value; } set { this.ObjectAndItemsNullablePropOption = new Option<Dictionary<string, Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectItemsNullable
@@ -192,7 +192,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectItemsNullable
         /// </summary>
         [JsonPropertyName("object_items_nullable")]
-        public Dictionary<string, Object> ObjectItemsNullable { get { return this.ObjectItemsNullableOption; } set { this.ObjectItemsNullableOption = new Option<Dictionary<string, Object>>(value); } }
+        public Dictionary<string, Object> ObjectItemsNullable { get { return this.ObjectItemsNullableOption.Value; } set { this.ObjectItemsNullableOption = new Option<Dictionary<string, Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectNullableProp
@@ -205,7 +205,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectNullableProp
         /// </summary>
         [JsonPropertyName("object_nullable_prop")]
-        public Dictionary<string, Object> ObjectNullableProp { get { return this.ObjectNullablePropOption; } set { this.ObjectNullablePropOption = new Option<Dictionary<string, Object>>(value); } }
+        public Dictionary<string, Object> ObjectNullableProp { get { return this.ObjectNullablePropOption.Value; } set { this.ObjectNullablePropOption = new Option<Dictionary<string, Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of StringProp
@@ -218,7 +218,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringProp
         /// </summary>
         [JsonPropertyName("string_prop")]
-        public string StringProp { get { return this.StringPropOption; } set { this.StringPropOption = new Option<string>(value); } }
+        public string StringProp { get { return this.StringPropOption.Value; } set { this.StringPropOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<Guid?>(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [JsonPropertyName("JustNumber")]
-        public decimal? JustNumber { get { return this.JustNumberOption; } set { this.JustNumberOption = new Option<decimal?>(value); } }
+        public decimal? JustNumber { get { return this.JustNumberOption.Value; } set { this.JustNumberOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("bars")]
         [Obsolete]
-        public List<string> Bars { get { return this.BarsOption; } set { this.BarsOption = new Option<List<string>>(value); } }
+        public List<string> Bars { get { return this.BarsOption.Value; } set { this.BarsOption = new Option<List<string>>(value); } }
 
         /// <summary>
         /// Used to track the state of DeprecatedRef
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("deprecatedRef")]
         [Obsolete]
-        public DeprecatedObject DeprecatedRef { get { return this.DeprecatedRefOption; } set { this.DeprecatedRefOption = new Option<DeprecatedObject>(value); } }
+        public DeprecatedObject DeprecatedRef { get { return this.DeprecatedRefOption.Value; } set { this.DeprecatedRefOption = new Option<DeprecatedObject>(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("id")]
         [Obsolete]
-        public decimal? Id { get { return this.IdOption; } set { this.IdOption = new Option<decimal?>(value); } }
+        public decimal? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<string>(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Order.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Complete
         /// </summary>
         [JsonPropertyName("complete")]
-        public bool? Complete { get { return this.CompleteOption; } set { this.CompleteOption = new Option<bool?>(value); } }
+        public bool? Complete { get { return this.CompleteOption.Value; } set { this.CompleteOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -89,7 +89,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of PetId
@@ -102,7 +102,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets PetId
         /// </summary>
         [JsonPropertyName("petId")]
-        public long? PetId { get { return this.PetIdOption; } set { this.PetIdOption = new Option<long?>(value); } }
+        public long? PetId { get { return this.PetIdOption.Value; } set { this.PetIdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Quantity
@@ -115,7 +115,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Quantity
         /// </summary>
         [JsonPropertyName("quantity")]
-        public int? Quantity { get { return this.QuantityOption; } set { this.QuantityOption = new Option<int?>(value); } }
+        public int? Quantity { get { return this.QuantityOption.Value; } set { this.QuantityOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of ShipDate
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2020-02-02T20:20:20.000222Z</example> */
         [JsonPropertyName("shipDate")]
-        public DateTime? ShipDate { get { return this.ShipDateOption; } set { this.ShipDateOption = new Option<DateTime?>(value); } }
+        public DateTime? ShipDate { get { return this.ShipDateOption.Value; } set { this.ShipDateOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyBoolean
         /// </summary>
         [JsonPropertyName("my_boolean")]
-        public bool? MyBoolean { get { return this.MyBooleanOption; } set { this.MyBooleanOption = new Option<bool?>(value); } }
+        public bool? MyBoolean { get { return this.MyBooleanOption.Value; } set { this.MyBooleanOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of MyNumber
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [JsonPropertyName("my_number")]
-        public decimal? MyNumber { get { return this.MyNumberOption; } set { this.MyNumberOption = new Option<decimal?>(value); } }
+        public decimal? MyNumber { get { return this.MyNumberOption.Value; } set { this.MyNumberOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of MyString
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyString
         /// </summary>
         [JsonPropertyName("my_string")]
-        public string MyString { get { return this.MyStringOption; } set { this.MyStringOption = new Option<string>(value); } }
+        public string MyString { get { return this.MyStringOption.Value; } set { this.MyStringOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Pet.cs
@@ -89,7 +89,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Category
         /// </summary>
         [JsonPropertyName("category")]
-        public Category Category { get { return this.CategoryOption; } set { this.CategoryOption = new Option<Category>(value); } }
+        public Category Category { get { return this.CategoryOption.Value; } set { this.CategoryOption = new Option<Category>(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -102,7 +102,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Tags
@@ -115,7 +115,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Tags
         /// </summary>
         [JsonPropertyName("tags")]
-        public List<Tag> Tags { get { return this.TagsOption; } set { this.TagsOption = new Option<List<Tag>>(value); } }
+        public List<Tag> Tags { get { return this.TagsOption.Value; } set { this.TagsOption = new Option<List<Tag>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } }
+        public string Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Baz
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Baz
         /// </summary>
         [JsonPropertyName("baz")]
-        public string Baz { get { return this.BazOption; } set { this.BazOption = new Option<string>(value); } }
+        public string Baz { get { return this.BazOption.Value; } set { this.BazOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -334,7 +334,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_notnullable_date_prop")]
-        public DateTime? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption; } set { this.NotRequiredNotnullableDatePropOption = new Option<DateTime?>(value); } }
+        public DateTime? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption.Value; } set { this.NotRequiredNotnullableDatePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNotnullableintegerProp
@@ -347,7 +347,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [JsonPropertyName("not_required_notnullableinteger_prop")]
-        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption; } set { this.NotRequiredNotnullableintegerPropOption = new Option<int?>(value); } }
+        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption.Value; } set { this.NotRequiredNotnullableintegerPropOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableDateProp
@@ -360,7 +360,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_date_prop")]
-        public DateTime? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption; } set { this.NotRequiredNullableDatePropOption = new Option<DateTime?>(value); } }
+        public DateTime? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption.Value; } set { this.NotRequiredNullableDatePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableIntegerProp
@@ -373,7 +373,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableIntegerProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_integer_prop")]
-        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption; } set { this.NotRequiredNullableIntegerPropOption = new Option<int?>(value); } }
+        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption.Value; } set { this.NotRequiredNullableIntegerPropOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableArrayOfString
@@ -386,7 +386,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_array_of_string")]
-        public List<string> NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption; } set { this.NotrequiredNotnullableArrayOfStringOption = new Option<List<string>>(value); } }
+        public List<string> NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption.Value; } set { this.NotrequiredNotnullableArrayOfStringOption = new Option<List<string>>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableBooleanProp
@@ -399,7 +399,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_boolean_prop")]
-        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption; } set { this.NotrequiredNotnullableBooleanPropOption = new Option<bool?>(value); } }
+        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption.Value; } set { this.NotrequiredNotnullableBooleanPropOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableDatetimeProp
@@ -412,7 +412,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_datetime_prop")]
-        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption; } set { this.NotrequiredNotnullableDatetimePropOption = new Option<DateTime?>(value); } }
+        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption.Value; } set { this.NotrequiredNotnullableDatetimePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableStringProp
@@ -425,7 +425,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_string_prop")]
-        public string NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption; } set { this.NotrequiredNotnullableStringPropOption = new Option<string>(value); } }
+        public string NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption.Value; } set { this.NotrequiredNotnullableStringPropOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableUuid
@@ -439,7 +439,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_notnullable_uuid")]
-        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption; } set { this.NotrequiredNotnullableUuidOption = new Option<Guid?>(value); } }
+        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption.Value; } set { this.NotrequiredNotnullableUuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableArrayOfString
@@ -452,7 +452,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_nullable_array_of_string")]
-        public List<string> NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption; } set { this.NotrequiredNullableArrayOfStringOption = new Option<List<string>>(value); } }
+        public List<string> NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption.Value; } set { this.NotrequiredNullableArrayOfStringOption = new Option<List<string>>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableBooleanProp
@@ -465,7 +465,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_boolean_prop")]
-        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption; } set { this.NotrequiredNullableBooleanPropOption = new Option<bool?>(value); } }
+        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption.Value; } set { this.NotrequiredNullableBooleanPropOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableDatetimeProp
@@ -478,7 +478,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_datetime_prop")]
-        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption; } set { this.NotrequiredNullableDatetimePropOption = new Option<DateTime?>(value); } }
+        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption.Value; } set { this.NotrequiredNullableDatetimePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableStringProp
@@ -491,7 +491,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_string_prop")]
-        public string NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption; } set { this.NotrequiredNullableStringPropOption = new Option<string>(value); } }
+        public string NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption.Value; } set { this.NotrequiredNullableStringPropOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableUuid
@@ -505,7 +505,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_nullable_uuid")]
-        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption; } set { this.NotrequiredNullableUuidOption = new Option<Guid?>(value); } }
+        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption.Value; } set { this.NotrequiredNullableUuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets RequiredNullableArrayOfString

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Result.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result code</value>
         [JsonPropertyName("code")]
-        public string Code { get { return this.CodeOption; } set { this.CodeOption = new Option<string>(value); } }
+        public string Code { get { return this.CodeOption.Value; } set { this.CodeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Data
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string> Data { get { return this.DataOption; } set { this.DataOption = new Option<Dictionary<string, string>>(value); } }
+        public Dictionary<string, string> Data { get { return this.DataOption.Value; } set { this.DataOption = new Option<Dictionary<string, string>>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<string>(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Return.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [JsonPropertyName("return")]
-        public int? VarReturn { get { return this.VarReturnOption; } set { this.VarReturnOption = new Option<int?>(value); } }
+        public int? VarReturn { get { return this.VarReturnOption.Value; } set { this.VarReturnOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Unsafe
@@ -84,7 +84,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Unsafe
         /// </summary>
         [JsonPropertyName("unsafe")]
-        public string Unsafe { get { return this.UnsafeOption; } set { this.UnsafeOption = new Option<string>(value); } }
+        public string Unsafe { get { return this.UnsafeOption.Value; } set { this.UnsafeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Role
         /// </summary>
         [JsonPropertyName("role")]
-        public RolesReportsHashRole Role { get { return this.RoleOption; } set { this.RoleOption = new Option<RolesReportsHashRole>(value); } }
+        public RolesReportsHashRole Role { get { return this.RoleOption.Value; } set { this.RoleOption = new Option<RolesReportsHashRole>(value); } }
 
         /// <summary>
         /// Used to track the state of RoleUuid
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [JsonPropertyName("role_uuid")]
-        public Guid? RoleUuid { get { return this.RoleUuidOption; } set { this.RoleUuidOption = new Option<Guid?>(value); } }
+        public Guid? RoleUuid { get { return this.RoleUuidOption.Value; } set { this.RoleUuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new Option<string>(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarSpecialModelName
         /// </summary>
         [JsonPropertyName("_special_model.name_")]
-        public string VarSpecialModelName { get { return this.VarSpecialModelNameOption; } set { this.VarSpecialModelNameOption = new Option<string>(value); } }
+        public string VarSpecialModelName { get { return this.VarSpecialModelNameOption.Value; } set { this.VarSpecialModelNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SpecialPropertyName
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [JsonPropertyName("$special[property.name]")]
-        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption; } set { this.SpecialPropertyNameOption = new Option<long?>(value); } }
+        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption.Value; } set { this.SpecialPropertyNameOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Tag.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new Option<string>(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Value
         /// </summary>
         [JsonPropertyName("value")]
-        public string Value { get { return this.ValueOption; } set { this.ValueOption = new Option<string>(value); } }
+        public string Value { get { return this.ValueOption.Value; } set { this.ValueOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets TestCollectionEndingWithWordList
         /// </summary>
         [JsonPropertyName("TestCollectionEndingWithWordList")]
-        public List<TestCollectionEndingWithWordList> TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption; } set { this.TestCollectionEndingWithWordListOption = new Option<List<TestCollectionEndingWithWordList>>(value); } }
+        public List<TestCollectionEndingWithWordList> TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption.Value; } set { this.TestCollectionEndingWithWordListOption = new Option<List<TestCollectionEndingWithWordList>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SomeProperty
         /// </summary>
         [JsonPropertyName("someProperty")]
-        public string SomeProperty { get { return this.SomePropertyOption; } set { this.SomePropertyOption = new Option<string>(value); } }
+        public string SomeProperty { get { return this.SomePropertyOption.Value; } set { this.SomePropertyOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string> Data { get { return this.DataOption; } set { this.DataOption = new Option<Dictionary<string, string>>(value); } }
+        public Dictionary<string, string> Data { get { return this.DataOption.Value; } set { this.DataOption = new Option<Dictionary<string, string>>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<string>(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/User.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
         [JsonPropertyName("anyTypeProp")]
-        public Object AnyTypeProp { get { return this.AnyTypePropOption; } set { this.AnyTypePropOption = new Option<Object>(value); } }
+        public Object AnyTypeProp { get { return this.AnyTypePropOption.Value; } set { this.AnyTypePropOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of AnyTypePropNullable
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values.</value>
         [JsonPropertyName("anyTypePropNullable")]
-        public Object AnyTypePropNullable { get { return this.AnyTypePropNullableOption; } set { this.AnyTypePropNullableOption = new Option<Object>(value); } }
+        public Object AnyTypePropNullable { get { return this.AnyTypePropNullableOption.Value; } set { this.AnyTypePropNullableOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of Email
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Email
         /// </summary>
         [JsonPropertyName("email")]
-        public string Email { get { return this.EmailOption; } set { this.EmailOption = new Option<string>(value); } }
+        public string Email { get { return this.EmailOption.Value; } set { this.EmailOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of FirstName
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets FirstName
         /// </summary>
         [JsonPropertyName("firstName")]
-        public string FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new Option<string>(value); } }
+        public string FirstName { get { return this.FirstNameOption.Value; } set { this.FirstNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of LastName
@@ -142,7 +142,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LastName
         /// </summary>
         [JsonPropertyName("lastName")]
-        public string LastName { get { return this.LastNameOption; } set { this.LastNameOption = new Option<string>(value); } }
+        public string LastName { get { return this.LastNameOption.Value; } set { this.LastNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredProps
@@ -156,7 +156,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredProps")]
-        public Object ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption; } set { this.ObjectWithNoDeclaredPropsOption = new Option<Object>(value); } }
+        public Object ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption.Value; } set { this.ObjectWithNoDeclaredPropsOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredPropsNullable
@@ -170,7 +170,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredPropsNullable")]
-        public Object ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption; } set { this.ObjectWithNoDeclaredPropsNullableOption = new Option<Object>(value); } }
+        public Object ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption.Value; } set { this.ObjectWithNoDeclaredPropsNullableOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of Password
@@ -183,7 +183,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Password
         /// </summary>
         [JsonPropertyName("password")]
-        public string Password { get { return this.PasswordOption; } set { this.PasswordOption = new Option<string>(value); } }
+        public string Password { get { return this.PasswordOption.Value; } set { this.PasswordOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Phone
@@ -196,7 +196,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Phone
         /// </summary>
         [JsonPropertyName("phone")]
-        public string Phone { get { return this.PhoneOption; } set { this.PhoneOption = new Option<string>(value); } }
+        public string Phone { get { return this.PhoneOption.Value; } set { this.PhoneOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of UserStatus
@@ -210,7 +210,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [JsonPropertyName("userStatus")]
-        public int? UserStatus { get { return this.UserStatusOption; } set { this.UserStatusOption = new Option<int?>(value); } }
+        public int? UserStatus { get { return this.UserStatusOption.Value; } set { this.UserStatusOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Username
@@ -223,7 +223,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Username
         /// </summary>
         [JsonPropertyName("username")]
-        public string Username { get { return this.UsernameOption; } set { this.UsernameOption = new Option<string>(value); } }
+        public string Username { get { return this.UsernameOption.Value; } set { this.UsernameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Whale.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [JsonPropertyName("hasBaleen")]
-        public bool? HasBaleen { get { return this.HasBaleenOption; } set { this.HasBaleenOption = new Option<bool?>(value); } }
+        public bool? HasBaleen { get { return this.HasBaleenOption.Value; } set { this.HasBaleenOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of HasTeeth
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasTeeth
         /// </summary>
         [JsonPropertyName("hasTeeth")]
-        public bool? HasTeeth { get { return this.HasTeethOption; } set { this.HasTeethOption = new Option<bool?>(value); } }
+        public bool? HasTeeth { get { return this.HasTeethOption.Value; } set { this.HasTeethOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Kind
         /// </summary>
         [JsonPropertyName("kind")]
-        public string Kind { get { return this.KindOption; } set { this.KindOption = new Option<string>(value); } }
+        public string Kind { get { return this.KindOption.Value; } set { this.KindOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Count
         /// </summary>
         [JsonPropertyName("count")]
-        public decimal? Count { get { return this.CountOption; } set { this.CountOption = new Option<decimal?>(value); } }
+        public decimal? Count { get { return this.CountOption.Value; } set { this.CountOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -93,7 +93,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new Option<string>(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Orange.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Orange.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [JsonPropertyName("sweet")]
-        public bool? Sweet { get { return this.SweetOption; } set { this.SweetOption = new Option<bool?>(value); } }
+        public bool? Sweet { get { return this.SweetOption.Value; } set { this.SweetOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Activity.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ActivityOutputs
         /// </summary>
         [JsonPropertyName("activity_outputs")]
-        public Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs { get { return this.ActivityOutputsOption; } set { this.ActivityOutputsOption = new Option<Dictionary<string, List<ActivityOutputElementRepresentation>>>(value); } }
+        public Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs { get { return this.ActivityOutputsOption.Value; } set { this.ActivityOutputsOption = new Option<Dictionary<string, List<ActivityOutputElementRepresentation>>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop1
         /// </summary>
         [JsonPropertyName("prop1")]
-        public string Prop1 { get { return this.Prop1Option; } set { this.Prop1Option = new Option<string>(value); } }
+        public string Prop1 { get { return this.Prop1Option.Value; } set { this.Prop1Option = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Prop2
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop2
         /// </summary>
         [JsonPropertyName("prop2")]
-        public Object Prop2 { get { return this.Prop2Option; } set { this.Prop2Option = new Option<Object>(value); } }
+        public Object Prop2 { get { return this.Prop2Option.Value; } set { this.Prop2Option = new Option<Object>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Anytype1
         /// </summary>
         [JsonPropertyName("anytype_1")]
-        public Object Anytype1 { get { return this.Anytype1Option; } set { this.Anytype1Option = new Option<Object>(value); } }
+        public Object Anytype1 { get { return this.Anytype1Option.Value; } set { this.Anytype1Option = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of EmptyMap
@@ -81,7 +81,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>an object with no declared properties and no undeclared properties, hence it&#39;s an empty map.</value>
         [JsonPropertyName("empty_map")]
-        public Object EmptyMap { get { return this.EmptyMapOption; } set { this.EmptyMapOption = new Option<Object>(value); } }
+        public Object EmptyMap { get { return this.EmptyMapOption.Value; } set { this.EmptyMapOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfMapProperty
@@ -94,7 +94,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfMapProperty
         /// </summary>
         [JsonPropertyName("map_of_map_property")]
-        public Dictionary<string, Dictionary<string, string>> MapOfMapProperty { get { return this.MapOfMapPropertyOption; } set { this.MapOfMapPropertyOption = new Option<Dictionary<string, Dictionary<string, string>>>(value); } }
+        public Dictionary<string, Dictionary<string, string>> MapOfMapProperty { get { return this.MapOfMapPropertyOption.Value; } set { this.MapOfMapPropertyOption = new Option<Dictionary<string, Dictionary<string, string>>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapProperty
@@ -107,7 +107,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapProperty
         /// </summary>
         [JsonPropertyName("map_property")]
-        public Dictionary<string, string> MapProperty { get { return this.MapPropertyOption; } set { this.MapPropertyOption = new Option<Dictionary<string, string>>(value); } }
+        public Dictionary<string, string> MapProperty { get { return this.MapPropertyOption.Value; } set { this.MapPropertyOption = new Option<Dictionary<string, string>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype1
@@ -120,7 +120,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype1
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_1")]
-        public Object MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new Option<Object>(value); } }
+        public Object MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype2
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype2
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_2")]
-        public Object MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new Option<Object>(value); } }
+        public Object MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype3
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype3
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_3")]
-        public Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new Option<Dictionary<string, Object>>(value); } }
+        public Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new Option<Dictionary<string, Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesString
@@ -159,7 +159,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesString
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_string")]
-        public Dictionary<string, string> MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption; } set { this.MapWithUndeclaredPropertiesStringOption = new Option<Dictionary<string, string>>(value); } }
+        public Dictionary<string, string> MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption.Value; } set { this.MapWithUndeclaredPropertiesStringOption = new Option<Dictionary<string, string>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Animal.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new Option<string>(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [JsonPropertyName("code")]
-        public int? Code { get { return this.CodeOption; } set { this.CodeOption = new Option<int?>(value); } }
+        public int? Code { get { return this.CodeOption.Value; } set { this.CodeOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Message
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Message
         /// </summary>
         [JsonPropertyName("message")]
-        public string Message { get { return this.MessageOption; } set { this.MessageOption = new Option<string>(value); } }
+        public string Message { get { return this.MessageOption.Value; } set { this.MessageOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Type
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Type
         /// </summary>
         [JsonPropertyName("type")]
-        public string Type { get { return this.TypeOption; } set { this.TypeOption = new Option<string>(value); } }
+        public string Type { get { return this.TypeOption.Value; } set { this.TypeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Apple.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ColorCode
         /// </summary>
         [JsonPropertyName("color_code")]
-        public string ColorCode { get { return this.ColorCodeOption; } set { this.ColorCodeOption = new Option<string>(value); } }
+        public string ColorCode { get { return this.ColorCodeOption.Value; } set { this.ColorCodeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Cultivar
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Cultivar
         /// </summary>
         [JsonPropertyName("cultivar")]
-        public string Cultivar { get { return this.CultivarOption; } set { this.CultivarOption = new Option<string>(value); } }
+        public string Cultivar { get { return this.CultivarOption.Value; } set { this.CultivarOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Origin
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Origin
         /// </summary>
         [JsonPropertyName("origin")]
-        public string Origin { get { return this.OriginOption; } set { this.OriginOption = new Option<string>(value); } }
+        public string Origin { get { return this.OriginOption.Value; } set { this.OriginOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [JsonPropertyName("mealy")]
-        public bool? Mealy { get { return this.MealyOption; } set { this.MealyOption = new Option<bool?>(value); } }
+        public bool? Mealy { get { return this.MealyOption.Value; } set { this.MealyOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayArrayNumber")]
-        public List<List<decimal>> ArrayArrayNumber { get { return this.ArrayArrayNumberOption; } set { this.ArrayArrayNumberOption = new Option<List<List<decimal>>>(value); } }
+        public List<List<decimal>> ArrayArrayNumber { get { return this.ArrayArrayNumberOption.Value; } set { this.ArrayArrayNumberOption = new Option<List<List<decimal>>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayNumber")]
-        public List<decimal> ArrayNumber { get { return this.ArrayNumberOption; } set { this.ArrayNumberOption = new Option<List<decimal>>(value); } }
+        public List<decimal> ArrayNumber { get { return this.ArrayNumberOption.Value; } set { this.ArrayNumberOption = new Option<List<decimal>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfInteger
         /// </summary>
         [JsonPropertyName("array_array_of_integer")]
-        public List<List<long>> ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption; } set { this.ArrayArrayOfIntegerOption = new Option<List<List<long>>>(value); } }
+        public List<List<long>> ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption.Value; } set { this.ArrayArrayOfIntegerOption = new Option<List<List<long>>>(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayArrayOfModel
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfModel
         /// </summary>
         [JsonPropertyName("array_array_of_model")]
-        public List<List<ReadOnlyFirst>> ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption; } set { this.ArrayArrayOfModelOption = new Option<List<List<ReadOnlyFirst>>>(value); } }
+        public List<List<ReadOnlyFirst>> ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption.Value; } set { this.ArrayArrayOfModelOption = new Option<List<List<ReadOnlyFirst>>>(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayOfString
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayOfString
         /// </summary>
         [JsonPropertyName("array_of_string")]
-        public List<string> ArrayOfString { get { return this.ArrayOfStringOption; } set { this.ArrayOfStringOption = new Option<List<string>>(value); } }
+        public List<string> ArrayOfString { get { return this.ArrayOfStringOption.Value; } set { this.ArrayOfStringOption = new Option<List<string>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Banana.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [JsonPropertyName("lengthCm")]
-        public decimal? LengthCm { get { return this.LengthCmOption; } set { this.LengthCmOption = new Option<decimal?>(value); } }
+        public decimal? LengthCm { get { return this.LengthCmOption.Value; } set { this.LengthCmOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [JsonPropertyName("sweet")]
-        public bool? Sweet { get { return this.SweetOption; } set { this.SweetOption = new Option<bool?>(value); } }
+        public bool? Sweet { get { return this.SweetOption.Value; } set { this.SweetOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -64,7 +64,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Name of the pet </value>
         [JsonPropertyName("ATT_NAME")]
-        public string ATT_NAME { get { return this.ATT_NAMEOption; } set { this.ATT_NAMEOption = new Option<string>(value); } }
+        public string ATT_NAME { get { return this.ATT_NAMEOption.Value; } set { this.ATT_NAMEOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalCamel
@@ -77,7 +77,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalCamel
         /// </summary>
         [JsonPropertyName("CapitalCamel")]
-        public string CapitalCamel { get { return this.CapitalCamelOption; } set { this.CapitalCamelOption = new Option<string>(value); } }
+        public string CapitalCamel { get { return this.CapitalCamelOption.Value; } set { this.CapitalCamelOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalSnake
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalSnake
         /// </summary>
         [JsonPropertyName("Capital_Snake")]
-        public string CapitalSnake { get { return this.CapitalSnakeOption; } set { this.CapitalSnakeOption = new Option<string>(value); } }
+        public string CapitalSnake { get { return this.CapitalSnakeOption.Value; } set { this.CapitalSnakeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SCAETHFlowPoints
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SCAETHFlowPoints
         /// </summary>
         [JsonPropertyName("SCA_ETH_Flow_Points")]
-        public string SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption; } set { this.SCAETHFlowPointsOption = new Option<string>(value); } }
+        public string SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption.Value; } set { this.SCAETHFlowPointsOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SmallCamel
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallCamel
         /// </summary>
         [JsonPropertyName("smallCamel")]
-        public string SmallCamel { get { return this.SmallCamelOption; } set { this.SmallCamelOption = new Option<string>(value); } }
+        public string SmallCamel { get { return this.SmallCamelOption.Value; } set { this.SmallCamelOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SmallSnake
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallSnake
         /// </summary>
         [JsonPropertyName("small_Snake")]
-        public string SmallSnake { get { return this.SmallSnakeOption; } set { this.SmallSnakeOption = new Option<string>(value); } }
+        public string SmallSnake { get { return this.SmallSnakeOption.Value; } set { this.SmallSnakeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [JsonPropertyName("declawed")]
-        public bool? Declawed { get { return this.DeclawedOption; } set { this.DeclawedOption = new Option<bool?>(value); } }
+        public bool? Declawed { get { return this.DeclawedOption.Value; } set { this.DeclawedOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -106,7 +106,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new Option<string>(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<string>(value); } }
 
         /// <summary>
         /// The discriminator

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("_class")]
-        public string Class { get { return this.ClassOption; } set { this.ClassOption = new Option<string>(value); } }
+        public string Class { get { return this.ClassOption.Value; } set { this.ClassOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>Fri Jul 21 00:00:00 UTC 2017</example> */
         [JsonPropertyName("dateOnlyProperty")]
-        public DateTime? DateOnlyProperty { get { return this.DateOnlyPropertyOption; } set { this.DateOnlyPropertyOption = new Option<DateTime?>(value); } }
+        public DateTime? DateOnlyProperty { get { return this.DateOnlyPropertyOption.Value; } set { this.DateOnlyPropertyOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new Option<string>(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Breed
         /// </summary>
         [JsonPropertyName("breed")]
-        public string Breed { get { return this.BreedOption; } set { this.BreedOption = new Option<string>(value); } }
+        public string Breed { get { return this.BreedOption.Value; } set { this.BreedOption = new Option<string>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MainShape
         /// </summary>
         [JsonPropertyName("mainShape")]
-        public Shape MainShape { get { return this.MainShapeOption; } set { this.MainShapeOption = new Option<Shape>(value); } }
+        public Shape MainShape { get { return this.MainShapeOption.Value; } set { this.MainShapeOption = new Option<Shape>(value); } }
 
         /// <summary>
         /// Used to track the state of NullableShape
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableShape
         /// </summary>
         [JsonPropertyName("nullableShape")]
-        public NullableShape NullableShape { get { return this.NullableShapeOption; } set { this.NullableShapeOption = new Option<NullableShape>(value); } }
+        public NullableShape NullableShape { get { return this.NullableShapeOption.Value; } set { this.NullableShapeOption = new Option<NullableShape>(value); } }
 
         /// <summary>
         /// Used to track the state of ShapeOrNull
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ShapeOrNull
         /// </summary>
         [JsonPropertyName("shapeOrNull")]
-        public ShapeOrNull ShapeOrNull { get { return this.ShapeOrNullOption; } set { this.ShapeOrNullOption = new Option<ShapeOrNull>(value); } }
+        public ShapeOrNull ShapeOrNull { get { return this.ShapeOrNullOption.Value; } set { this.ShapeOrNullOption = new Option<ShapeOrNull>(value); } }
 
         /// <summary>
         /// Used to track the state of Shapes
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Shapes
         /// </summary>
         [JsonPropertyName("shapes")]
-        public List<Shape> Shapes { get { return this.ShapesOption; } set { this.ShapesOption = new Option<List<Shape>>(value); } }
+        public List<Shape> Shapes { get { return this.ShapesOption.Value; } set { this.ShapesOption = new Option<List<Shape>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayEnum
         /// </summary>
         [JsonPropertyName("array_enum")]
-        public List<EnumArrays.ArrayEnumEnum> ArrayEnum { get { return this.ArrayEnumOption; } set { this.ArrayEnumOption = new Option<List<EnumArrays.ArrayEnumEnum>>(value); } }
+        public List<EnumArrays.ArrayEnumEnum> ArrayEnum { get { return this.ArrayEnumOption.Value; } set { this.ArrayEnumOption = new Option<List<EnumArrays.ArrayEnumEnum>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/File.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Test capitalization</value>
         [JsonPropertyName("sourceURI")]
-        public string SourceURI { get { return this.SourceURIOption; } set { this.SourceURIOption = new Option<string>(value); } }
+        public string SourceURI { get { return this.SourceURIOption.Value; } set { this.SourceURIOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets File
         /// </summary>
         [JsonPropertyName("file")]
-        public File File { get { return this.FileOption; } set { this.FileOption = new Option<File>(value); } }
+        public File File { get { return this.FileOption.Value; } set { this.FileOption = new Option<File>(value); } }
 
         /// <summary>
         /// Used to track the state of Files
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Files
         /// </summary>
         [JsonPropertyName("files")]
-        public List<File> Files { get { return this.FilesOption; } set { this.FilesOption = new Option<List<File>>(value); } }
+        public List<File> Files { get { return this.FilesOption.Value; } set { this.FilesOption = new Option<List<File>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Foo.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } set { this.BarOption = new Option<string>(value); } }
+        public string Bar { get { return this.BarOption.Value; } set { this.BarOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public Foo String { get { return this.StringOption; } set { this.StringOption = new Option<Foo>(value); } }
+        public Foo String { get { return this.StringOption.Value; } set { this.StringOption = new Option<Foo>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -138,7 +138,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Binary
         /// </summary>
         [JsonPropertyName("binary")]
-        public System.IO.Stream Binary { get { return this.BinaryOption; } set { this.BinaryOption = new Option<System.IO.Stream>(value); } }
+        public System.IO.Stream Binary { get { return this.BinaryOption.Value; } set { this.BinaryOption = new Option<System.IO.Stream>(value); } }
 
         /// <summary>
         /// Used to track the state of DateTime
@@ -152,7 +152,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2007-12-03T10:15:30+01:00</example> */
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new Option<DateTime?>(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of Decimal
@@ -165,7 +165,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Decimal
         /// </summary>
         [JsonPropertyName("decimal")]
-        public decimal? Decimal { get { return this.DecimalOption; } set { this.DecimalOption = new Option<decimal?>(value); } }
+        public decimal? Decimal { get { return this.DecimalOption.Value; } set { this.DecimalOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of Double
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Double
         /// </summary>
         [JsonPropertyName("double")]
-        public double? Double { get { return this.DoubleOption; } set { this.DoubleOption = new Option<double?>(value); } }
+        public double? Double { get { return this.DoubleOption.Value; } set { this.DoubleOption = new Option<double?>(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName2
@@ -191,7 +191,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName2
         /// </summary>
         [JsonPropertyName("duplicate_property_name")]
-        public string DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option; } set { this.DuplicatePropertyName2Option = new Option<string>(value); } }
+        public string DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option.Value; } set { this.DuplicatePropertyName2Option = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName
@@ -204,7 +204,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName
         /// </summary>
         [JsonPropertyName("@duplicate_property_name")]
-        public string DuplicatePropertyName { get { return this.DuplicatePropertyNameOption; } set { this.DuplicatePropertyNameOption = new Option<string>(value); } }
+        public string DuplicatePropertyName { get { return this.DuplicatePropertyNameOption.Value; } set { this.DuplicatePropertyNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Float
@@ -217,7 +217,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Float
         /// </summary>
         [JsonPropertyName("float")]
-        public float? Float { get { return this.FloatOption; } set { this.FloatOption = new Option<float?>(value); } }
+        public float? Float { get { return this.FloatOption.Value; } set { this.FloatOption = new Option<float?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int32
@@ -230,7 +230,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32
         /// </summary>
         [JsonPropertyName("int32")]
-        public int? Int32 { get { return this.Int32Option; } set { this.Int32Option = new Option<int?>(value); } }
+        public int? Int32 { get { return this.Int32Option.Value; } set { this.Int32Option = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int32Range
@@ -243,7 +243,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32Range
         /// </summary>
         [JsonPropertyName("int32Range")]
-        public int? Int32Range { get { return this.Int32RangeOption; } set { this.Int32RangeOption = new Option<int?>(value); } }
+        public int? Int32Range { get { return this.Int32RangeOption.Value; } set { this.Int32RangeOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64
@@ -256,7 +256,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64
         /// </summary>
         [JsonPropertyName("int64")]
-        public long? Int64 { get { return this.Int64Option; } set { this.Int64Option = new Option<long?>(value); } }
+        public long? Int64 { get { return this.Int64Option.Value; } set { this.Int64Option = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Negative
@@ -269,7 +269,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Negative
         /// </summary>
         [JsonPropertyName("int64Negative")]
-        public long? Int64Negative { get { return this.Int64NegativeOption; } set { this.Int64NegativeOption = new Option<long?>(value); } }
+        public long? Int64Negative { get { return this.Int64NegativeOption.Value; } set { this.Int64NegativeOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64NegativeExclusive
@@ -282,7 +282,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64NegativeExclusive
         /// </summary>
         [JsonPropertyName("int64NegativeExclusive")]
-        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption; } set { this.Int64NegativeExclusiveOption = new Option<long?>(value); } }
+        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption.Value; } set { this.Int64NegativeExclusiveOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Positive
@@ -295,7 +295,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Positive
         /// </summary>
         [JsonPropertyName("int64Positive")]
-        public long? Int64Positive { get { return this.Int64PositiveOption; } set { this.Int64PositiveOption = new Option<long?>(value); } }
+        public long? Int64Positive { get { return this.Int64PositiveOption.Value; } set { this.Int64PositiveOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64PositiveExclusive
@@ -308,7 +308,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64PositiveExclusive
         /// </summary>
         [JsonPropertyName("int64PositiveExclusive")]
-        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption; } set { this.Int64PositiveExclusiveOption = new Option<long?>(value); } }
+        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption.Value; } set { this.Int64PositiveExclusiveOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Integer
@@ -321,7 +321,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [JsonPropertyName("integer")]
-        public int? Integer { get { return this.IntegerOption; } set { this.IntegerOption = new Option<int?>(value); } }
+        public int? Integer { get { return this.IntegerOption.Value; } set { this.IntegerOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithBackslash
@@ -335,7 +335,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>None</value>
         [JsonPropertyName("pattern_with_backslash")]
-        public string PatternWithBackslash { get { return this.PatternWithBackslashOption; } set { this.PatternWithBackslashOption = new Option<string>(value); } }
+        public string PatternWithBackslash { get { return this.PatternWithBackslashOption.Value; } set { this.PatternWithBackslashOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigits
@@ -349,7 +349,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string that is a 10 digit number. Can have leading zeros.</value>
         [JsonPropertyName("pattern_with_digits")]
-        public string PatternWithDigits { get { return this.PatternWithDigitsOption; } set { this.PatternWithDigitsOption = new Option<string>(value); } }
+        public string PatternWithDigits { get { return this.PatternWithDigitsOption.Value; } set { this.PatternWithDigitsOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigitsAndDelimiter
@@ -363,7 +363,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.</value>
         [JsonPropertyName("pattern_with_digits_and_delimiter")]
-        public string PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption; } set { this.PatternWithDigitsAndDelimiterOption = new Option<string>(value); } }
+        public string PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption.Value; } set { this.PatternWithDigitsAndDelimiterOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of String
@@ -376,7 +376,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public string String { get { return this.StringOption; } set { this.StringOption = new Option<string>(value); } }
+        public string String { get { return this.StringOption.Value; } set { this.StringOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of StringFormattedAsDecimal
@@ -389,7 +389,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringFormattedAsDecimal
         /// </summary>
         [JsonPropertyName("string_formatted_as_decimal")]
-        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption; } set { this.StringFormattedAsDecimalOption = new Option<decimal?>(value); } }
+        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption.Value; } set { this.StringFormattedAsDecimalOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedInteger
@@ -402,7 +402,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [JsonPropertyName("unsigned_integer")]
-        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption; } set { this.UnsignedIntegerOption = new Option<uint?>(value); } }
+        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption.Value; } set { this.UnsignedIntegerOption = new Option<uint?>(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedLong
@@ -415,7 +415,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedLong
         /// </summary>
         [JsonPropertyName("unsigned_long")]
-        public ulong? UnsignedLong { get { return this.UnsignedLongOption; } set { this.UnsignedLongOption = new Option<ulong?>(value); } }
+        public ulong? UnsignedLong { get { return this.UnsignedLongOption.Value; } set { this.UnsignedLongOption = new Option<ulong?>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -429,7 +429,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<Guid?>(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new Option<string>(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new Option<string>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -80,7 +80,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new Option<string>(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new Option<string>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } }
+        public string Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Foo
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Foo
         /// </summary>
         [JsonPropertyName("foo")]
-        public string Foo { get { return this.FooOption; } }
+        public string Foo { get { return this.FooOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableMessage
         /// </summary>
         [JsonPropertyName("NullableMessage")]
-        public string NullableMessage { get { return this.NullableMessageOption; } set { this.NullableMessageOption = new Option<string>(value); } }
+        public string NullableMessage { get { return this.NullableMessageOption.Value; } set { this.NullableMessageOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/List.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123List
         /// </summary>
         [JsonPropertyName("123-list")]
-        public string Var123List { get { return this.Var123ListOption; } set { this.Var123ListOption = new Option<string>(value); } }
+        public string Var123List { get { return this.Var123ListOption.Value; } set { this.Var123ListOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets EscapedLiteralString
         /// </summary>
         [JsonPropertyName("escapedLiteralString")]
-        public string EscapedLiteralString { get { return this.EscapedLiteralStringOption; } set { this.EscapedLiteralStringOption = new Option<string>(value); } }
+        public string EscapedLiteralString { get { return this.EscapedLiteralStringOption.Value; } set { this.EscapedLiteralStringOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of UnescapedLiteralString
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnescapedLiteralString
         /// </summary>
         [JsonPropertyName("unescapedLiteralString")]
-        public string UnescapedLiteralString { get { return this.UnescapedLiteralStringOption; } set { this.UnescapedLiteralStringOption = new Option<string>(value); } }
+        public string UnescapedLiteralString { get { return this.UnescapedLiteralStringOption.Value; } set { this.UnescapedLiteralStringOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -125,7 +125,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DirectMap
         /// </summary>
         [JsonPropertyName("direct_map")]
-        public Dictionary<string, bool> DirectMap { get { return this.DirectMapOption; } set { this.DirectMapOption = new Option<Dictionary<string, bool>>(value); } }
+        public Dictionary<string, bool> DirectMap { get { return this.DirectMapOption.Value; } set { this.DirectMapOption = new Option<Dictionary<string, bool>>(value); } }
 
         /// <summary>
         /// Used to track the state of IndirectMap
@@ -138,7 +138,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IndirectMap
         /// </summary>
         [JsonPropertyName("indirect_map")]
-        public Dictionary<string, bool> IndirectMap { get { return this.IndirectMapOption; } set { this.IndirectMapOption = new Option<Dictionary<string, bool>>(value); } }
+        public Dictionary<string, bool> IndirectMap { get { return this.IndirectMapOption.Value; } set { this.IndirectMapOption = new Option<Dictionary<string, bool>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapMapOfString
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapMapOfString
         /// </summary>
         [JsonPropertyName("map_map_of_string")]
-        public Dictionary<string, Dictionary<string, string>> MapMapOfString { get { return this.MapMapOfStringOption; } set { this.MapMapOfStringOption = new Option<Dictionary<string, Dictionary<string, string>>>(value); } }
+        public Dictionary<string, Dictionary<string, string>> MapMapOfString { get { return this.MapMapOfStringOption.Value; } set { this.MapMapOfStringOption = new Option<Dictionary<string, Dictionary<string, string>>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfEnumString
@@ -164,7 +164,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfEnumString
         /// </summary>
         [JsonPropertyName("map_of_enum_string")]
-        public Dictionary<string, MapTest.InnerEnum> MapOfEnumString { get { return this.MapOfEnumStringOption; } set { this.MapOfEnumStringOption = new Option<Dictionary<string, MapTest.InnerEnum>>(value); } }
+        public Dictionary<string, MapTest.InnerEnum> MapOfEnumString { get { return this.MapOfEnumStringOption.Value; } set { this.MapOfEnumStringOption = new Option<Dictionary<string, MapTest.InnerEnum>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedAnyOfContent Content { get { return this.ContentOption; } set { this.ContentOption = new Option<MixedAnyOfContent>(value); } }
+        public MixedAnyOfContent Content { get { return this.ContentOption.Value; } set { this.ContentOption = new Option<MixedAnyOfContent>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedOneOfContent Content { get { return this.ContentOption; } set { this.ContentOption = new Option<MixedOneOfContent>(value); } }
+        public MixedOneOfContent Content { get { return this.ContentOption.Value; } set { this.ContentOption = new Option<MixedOneOfContent>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateTime
         /// </summary>
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new Option<DateTime?>(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of Map
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Map
         /// </summary>
         [JsonPropertyName("map")]
-        public Dictionary<string, Animal> Map { get { return this.MapOption; } set { this.MapOption = new Option<Dictionary<string, Animal>>(value); } }
+        public Dictionary<string, Animal> Map { get { return this.MapOption.Value; } set { this.MapOption = new Option<Dictionary<string, Animal>>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<Guid?>(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Used to track the state of UuidWithPattern
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [JsonPropertyName("uuid_with_pattern")]
-        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption; } set { this.UuidWithPatternOption = new Option<Guid?>(value); } }
+        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption.Value; } set { this.UuidWithPatternOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public string Id { get { return this.IdOption; } set { this.IdOption = new Option<string>(value); } }
+        public string Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("class")]
-        public string Class { get { return this.ClassOption; } set { this.ClassOption = new Option<string>(value); } }
+        public string Class { get { return this.ClassOption.Value; } set { this.ClassOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public int? Name { get { return this.NameOption; } set { this.NameOption = new Option<int?>(value); } }
+        public int? Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarClient
         /// </summary>
         [JsonPropertyName("client")]
-        public string VarClient { get { return this.VarClientOption; } set { this.VarClientOption = new Option<string>(value); } }
+        public string VarClient { get { return this.VarClientOption.Value; } set { this.VarClientOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -65,7 +65,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Property
         /// </summary>
         [JsonPropertyName("property")]
-        public string Property { get { return this.PropertyOption; } set { this.PropertyOption = new Option<string>(value); } }
+        public string Property { get { return this.PropertyOption.Value; } set { this.PropertyOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SnakeCase
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [JsonPropertyName("snake_case")]
-        public int? SnakeCase { get { return this.SnakeCaseOption; } }
+        public int? SnakeCase { get { return this.SnakeCaseOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Var123Number
@@ -91,7 +91,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123Number
         /// </summary>
         [JsonPropertyName("123Number")]
-        public int? Var123Number { get { return this.Var123NumberOption; } }
+        public int? Var123Number { get { return this.Var123NumberOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -75,7 +75,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("array_and_items_nullable_prop")]
-        public List<Object> ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption; } set { this.ArrayAndItemsNullablePropOption = new Option<List<Object>>(value); } }
+        public List<Object> ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption.Value; } set { this.ArrayAndItemsNullablePropOption = new Option<List<Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayItemsNullable
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayItemsNullable
         /// </summary>
         [JsonPropertyName("array_items_nullable")]
-        public List<Object> ArrayItemsNullable { get { return this.ArrayItemsNullableOption; } set { this.ArrayItemsNullableOption = new Option<List<Object>>(value); } }
+        public List<Object> ArrayItemsNullable { get { return this.ArrayItemsNullableOption.Value; } set { this.ArrayItemsNullableOption = new Option<List<Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayNullableProp
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNullableProp
         /// </summary>
         [JsonPropertyName("array_nullable_prop")]
-        public List<Object> ArrayNullableProp { get { return this.ArrayNullablePropOption; } set { this.ArrayNullablePropOption = new Option<List<Object>>(value); } }
+        public List<Object> ArrayNullableProp { get { return this.ArrayNullablePropOption.Value; } set { this.ArrayNullablePropOption = new Option<List<Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of BooleanProp
@@ -114,7 +114,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BooleanProp
         /// </summary>
         [JsonPropertyName("boolean_prop")]
-        public bool? BooleanProp { get { return this.BooleanPropOption; } set { this.BooleanPropOption = new Option<bool?>(value); } }
+        public bool? BooleanProp { get { return this.BooleanPropOption.Value; } set { this.BooleanPropOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of DateProp
@@ -127,7 +127,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateProp
         /// </summary>
         [JsonPropertyName("date_prop")]
-        public DateTime? DateProp { get { return this.DatePropOption; } set { this.DatePropOption = new Option<DateTime?>(value); } }
+        public DateTime? DateProp { get { return this.DatePropOption.Value; } set { this.DatePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of DatetimeProp
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DatetimeProp
         /// </summary>
         [JsonPropertyName("datetime_prop")]
-        public DateTime? DatetimeProp { get { return this.DatetimePropOption; } set { this.DatetimePropOption = new Option<DateTime?>(value); } }
+        public DateTime? DatetimeProp { get { return this.DatetimePropOption.Value; } set { this.DatetimePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of IntegerProp
@@ -153,7 +153,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IntegerProp
         /// </summary>
         [JsonPropertyName("integer_prop")]
-        public int? IntegerProp { get { return this.IntegerPropOption; } set { this.IntegerPropOption = new Option<int?>(value); } }
+        public int? IntegerProp { get { return this.IntegerPropOption.Value; } set { this.IntegerPropOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of NumberProp
@@ -166,7 +166,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NumberProp
         /// </summary>
         [JsonPropertyName("number_prop")]
-        public decimal? NumberProp { get { return this.NumberPropOption; } set { this.NumberPropOption = new Option<decimal?>(value); } }
+        public decimal? NumberProp { get { return this.NumberPropOption.Value; } set { this.NumberPropOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectAndItemsNullableProp
@@ -179,7 +179,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("object_and_items_nullable_prop")]
-        public Dictionary<string, Object> ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption; } set { this.ObjectAndItemsNullablePropOption = new Option<Dictionary<string, Object>>(value); } }
+        public Dictionary<string, Object> ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption.Value; } set { this.ObjectAndItemsNullablePropOption = new Option<Dictionary<string, Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectItemsNullable
@@ -192,7 +192,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectItemsNullable
         /// </summary>
         [JsonPropertyName("object_items_nullable")]
-        public Dictionary<string, Object> ObjectItemsNullable { get { return this.ObjectItemsNullableOption; } set { this.ObjectItemsNullableOption = new Option<Dictionary<string, Object>>(value); } }
+        public Dictionary<string, Object> ObjectItemsNullable { get { return this.ObjectItemsNullableOption.Value; } set { this.ObjectItemsNullableOption = new Option<Dictionary<string, Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectNullableProp
@@ -205,7 +205,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectNullableProp
         /// </summary>
         [JsonPropertyName("object_nullable_prop")]
-        public Dictionary<string, Object> ObjectNullableProp { get { return this.ObjectNullablePropOption; } set { this.ObjectNullablePropOption = new Option<Dictionary<string, Object>>(value); } }
+        public Dictionary<string, Object> ObjectNullableProp { get { return this.ObjectNullablePropOption.Value; } set { this.ObjectNullablePropOption = new Option<Dictionary<string, Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of StringProp
@@ -218,7 +218,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringProp
         /// </summary>
         [JsonPropertyName("string_prop")]
-        public string StringProp { get { return this.StringPropOption; } set { this.StringPropOption = new Option<string>(value); } }
+        public string StringProp { get { return this.StringPropOption.Value; } set { this.StringPropOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<Guid?>(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [JsonPropertyName("JustNumber")]
-        public decimal? JustNumber { get { return this.JustNumberOption; } set { this.JustNumberOption = new Option<decimal?>(value); } }
+        public decimal? JustNumber { get { return this.JustNumberOption.Value; } set { this.JustNumberOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("bars")]
         [Obsolete]
-        public List<string> Bars { get { return this.BarsOption; } set { this.BarsOption = new Option<List<string>>(value); } }
+        public List<string> Bars { get { return this.BarsOption.Value; } set { this.BarsOption = new Option<List<string>>(value); } }
 
         /// <summary>
         /// Used to track the state of DeprecatedRef
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("deprecatedRef")]
         [Obsolete]
-        public DeprecatedObject DeprecatedRef { get { return this.DeprecatedRefOption; } set { this.DeprecatedRefOption = new Option<DeprecatedObject>(value); } }
+        public DeprecatedObject DeprecatedRef { get { return this.DeprecatedRefOption.Value; } set { this.DeprecatedRefOption = new Option<DeprecatedObject>(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("id")]
         [Obsolete]
-        public decimal? Id { get { return this.IdOption; } set { this.IdOption = new Option<decimal?>(value); } }
+        public decimal? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<string>(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Order.cs
@@ -158,7 +158,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Complete
         /// </summary>
         [JsonPropertyName("complete")]
-        public bool? Complete { get { return this.CompleteOption; } set { this.CompleteOption = new Option<bool?>(value); } }
+        public bool? Complete { get { return this.CompleteOption.Value; } set { this.CompleteOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -171,7 +171,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of PetId
@@ -184,7 +184,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets PetId
         /// </summary>
         [JsonPropertyName("petId")]
-        public long? PetId { get { return this.PetIdOption; } set { this.PetIdOption = new Option<long?>(value); } }
+        public long? PetId { get { return this.PetIdOption.Value; } set { this.PetIdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Quantity
@@ -197,7 +197,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Quantity
         /// </summary>
         [JsonPropertyName("quantity")]
-        public int? Quantity { get { return this.QuantityOption; } set { this.QuantityOption = new Option<int?>(value); } }
+        public int? Quantity { get { return this.QuantityOption.Value; } set { this.QuantityOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of ShipDate
@@ -211,7 +211,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2020-02-02T20:20:20.000222Z</example> */
         [JsonPropertyName("shipDate")]
-        public DateTime? ShipDate { get { return this.ShipDateOption; } set { this.ShipDateOption = new Option<DateTime?>(value); } }
+        public DateTime? ShipDate { get { return this.ShipDateOption.Value; } set { this.ShipDateOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyBoolean
         /// </summary>
         [JsonPropertyName("my_boolean")]
-        public bool? MyBoolean { get { return this.MyBooleanOption; } set { this.MyBooleanOption = new Option<bool?>(value); } }
+        public bool? MyBoolean { get { return this.MyBooleanOption.Value; } set { this.MyBooleanOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of MyNumber
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [JsonPropertyName("my_number")]
-        public decimal? MyNumber { get { return this.MyNumberOption; } set { this.MyNumberOption = new Option<decimal?>(value); } }
+        public decimal? MyNumber { get { return this.MyNumberOption.Value; } set { this.MyNumberOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of MyString
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyString
         /// </summary>
         [JsonPropertyName("my_string")]
-        public string MyString { get { return this.MyStringOption; } set { this.MyStringOption = new Option<string>(value); } }
+        public string MyString { get { return this.MyStringOption.Value; } set { this.MyStringOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -171,7 +171,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Category
         /// </summary>
         [JsonPropertyName("category")]
-        public Category Category { get { return this.CategoryOption; } set { this.CategoryOption = new Option<Category>(value); } }
+        public Category Category { get { return this.CategoryOption.Value; } set { this.CategoryOption = new Option<Category>(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -184,7 +184,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Tags
@@ -197,7 +197,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Tags
         /// </summary>
         [JsonPropertyName("tags")]
-        public List<Tag> Tags { get { return this.TagsOption; } set { this.TagsOption = new Option<List<Tag>>(value); } }
+        public List<Tag> Tags { get { return this.TagsOption.Value; } set { this.TagsOption = new Option<List<Tag>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } }
+        public string Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Baz
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Baz
         /// </summary>
         [JsonPropertyName("baz")]
-        public string Baz { get { return this.BazOption; } set { this.BazOption = new Option<string>(value); } }
+        public string Baz { get { return this.BazOption.Value; } set { this.BazOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -1412,7 +1412,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_notnullable_date_prop")]
-        public DateTime? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption; } set { this.NotRequiredNotnullableDatePropOption = new Option<DateTime?>(value); } }
+        public DateTime? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption.Value; } set { this.NotRequiredNotnullableDatePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNotnullableintegerProp
@@ -1425,7 +1425,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [JsonPropertyName("not_required_notnullableinteger_prop")]
-        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption; } set { this.NotRequiredNotnullableintegerPropOption = new Option<int?>(value); } }
+        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption.Value; } set { this.NotRequiredNotnullableintegerPropOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableDateProp
@@ -1438,7 +1438,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_date_prop")]
-        public DateTime? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption; } set { this.NotRequiredNullableDatePropOption = new Option<DateTime?>(value); } }
+        public DateTime? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption.Value; } set { this.NotRequiredNullableDatePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableIntegerProp
@@ -1451,7 +1451,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableIntegerProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_integer_prop")]
-        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption; } set { this.NotRequiredNullableIntegerPropOption = new Option<int?>(value); } }
+        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption.Value; } set { this.NotRequiredNullableIntegerPropOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableArrayOfString
@@ -1464,7 +1464,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_array_of_string")]
-        public List<string> NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption; } set { this.NotrequiredNotnullableArrayOfStringOption = new Option<List<string>>(value); } }
+        public List<string> NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption.Value; } set { this.NotrequiredNotnullableArrayOfStringOption = new Option<List<string>>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableBooleanProp
@@ -1477,7 +1477,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_boolean_prop")]
-        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption; } set { this.NotrequiredNotnullableBooleanPropOption = new Option<bool?>(value); } }
+        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption.Value; } set { this.NotrequiredNotnullableBooleanPropOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableDatetimeProp
@@ -1490,7 +1490,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_datetime_prop")]
-        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption; } set { this.NotrequiredNotnullableDatetimePropOption = new Option<DateTime?>(value); } }
+        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption.Value; } set { this.NotrequiredNotnullableDatetimePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableStringProp
@@ -1503,7 +1503,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_string_prop")]
-        public string NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption; } set { this.NotrequiredNotnullableStringPropOption = new Option<string>(value); } }
+        public string NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption.Value; } set { this.NotrequiredNotnullableStringPropOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableUuid
@@ -1517,7 +1517,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_notnullable_uuid")]
-        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption; } set { this.NotrequiredNotnullableUuidOption = new Option<Guid?>(value); } }
+        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption.Value; } set { this.NotrequiredNotnullableUuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableArrayOfString
@@ -1530,7 +1530,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_nullable_array_of_string")]
-        public List<string> NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption; } set { this.NotrequiredNullableArrayOfStringOption = new Option<List<string>>(value); } }
+        public List<string> NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption.Value; } set { this.NotrequiredNullableArrayOfStringOption = new Option<List<string>>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableBooleanProp
@@ -1543,7 +1543,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_boolean_prop")]
-        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption; } set { this.NotrequiredNullableBooleanPropOption = new Option<bool?>(value); } }
+        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption.Value; } set { this.NotrequiredNullableBooleanPropOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableDatetimeProp
@@ -1556,7 +1556,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_datetime_prop")]
-        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption; } set { this.NotrequiredNullableDatetimePropOption = new Option<DateTime?>(value); } }
+        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption.Value; } set { this.NotrequiredNullableDatetimePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableStringProp
@@ -1569,7 +1569,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_string_prop")]
-        public string NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption; } set { this.NotrequiredNullableStringPropOption = new Option<string>(value); } }
+        public string NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption.Value; } set { this.NotrequiredNullableStringPropOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableUuid
@@ -1583,7 +1583,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_nullable_uuid")]
-        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption; } set { this.NotrequiredNullableUuidOption = new Option<Guid?>(value); } }
+        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption.Value; } set { this.NotrequiredNullableUuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets RequiredNullableArrayOfString

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Result.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result code</value>
         [JsonPropertyName("code")]
-        public string Code { get { return this.CodeOption; } set { this.CodeOption = new Option<string>(value); } }
+        public string Code { get { return this.CodeOption.Value; } set { this.CodeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Data
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string> Data { get { return this.DataOption; } set { this.DataOption = new Option<Dictionary<string, string>>(value); } }
+        public Dictionary<string, string> Data { get { return this.DataOption.Value; } set { this.DataOption = new Option<Dictionary<string, string>>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<string>(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [JsonPropertyName("return")]
-        public int? VarReturn { get { return this.VarReturnOption; } set { this.VarReturnOption = new Option<int?>(value); } }
+        public int? VarReturn { get { return this.VarReturnOption.Value; } set { this.VarReturnOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Unsafe
@@ -84,7 +84,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Unsafe
         /// </summary>
         [JsonPropertyName("unsafe")]
-        public string Unsafe { get { return this.UnsafeOption; } set { this.UnsafeOption = new Option<string>(value); } }
+        public string Unsafe { get { return this.UnsafeOption.Value; } set { this.UnsafeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Role
         /// </summary>
         [JsonPropertyName("role")]
-        public RolesReportsHashRole Role { get { return this.RoleOption; } set { this.RoleOption = new Option<RolesReportsHashRole>(value); } }
+        public RolesReportsHashRole Role { get { return this.RoleOption.Value; } set { this.RoleOption = new Option<RolesReportsHashRole>(value); } }
 
         /// <summary>
         /// Used to track the state of RoleUuid
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [JsonPropertyName("role_uuid")]
-        public Guid? RoleUuid { get { return this.RoleUuidOption; } set { this.RoleUuidOption = new Option<Guid?>(value); } }
+        public Guid? RoleUuid { get { return this.RoleUuidOption.Value; } set { this.RoleUuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new Option<string>(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarSpecialModelName
         /// </summary>
         [JsonPropertyName("_special_model.name_")]
-        public string VarSpecialModelName { get { return this.VarSpecialModelNameOption; } set { this.VarSpecialModelNameOption = new Option<string>(value); } }
+        public string VarSpecialModelName { get { return this.VarSpecialModelNameOption.Value; } set { this.VarSpecialModelNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SpecialPropertyName
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [JsonPropertyName("$special[property.name]")]
-        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption; } set { this.SpecialPropertyNameOption = new Option<long?>(value); } }
+        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption.Value; } set { this.SpecialPropertyNameOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new Option<string>(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Value
         /// </summary>
         [JsonPropertyName("value")]
-        public string Value { get { return this.ValueOption; } set { this.ValueOption = new Option<string>(value); } }
+        public string Value { get { return this.ValueOption.Value; } set { this.ValueOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets TestCollectionEndingWithWordList
         /// </summary>
         [JsonPropertyName("TestCollectionEndingWithWordList")]
-        public List<TestCollectionEndingWithWordList> TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption; } set { this.TestCollectionEndingWithWordListOption = new Option<List<TestCollectionEndingWithWordList>>(value); } }
+        public List<TestCollectionEndingWithWordList> TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption.Value; } set { this.TestCollectionEndingWithWordListOption = new Option<List<TestCollectionEndingWithWordList>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SomeProperty
         /// </summary>
         [JsonPropertyName("someProperty")]
-        public string SomeProperty { get { return this.SomePropertyOption; } set { this.SomePropertyOption = new Option<string>(value); } }
+        public string SomeProperty { get { return this.SomePropertyOption.Value; } set { this.SomePropertyOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string> Data { get { return this.DataOption; } set { this.DataOption = new Option<Dictionary<string, string>>(value); } }
+        public Dictionary<string, string> Data { get { return this.DataOption.Value; } set { this.DataOption = new Option<Dictionary<string, string>>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<string>(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
         [JsonPropertyName("anyTypeProp")]
-        public Object AnyTypeProp { get { return this.AnyTypePropOption; } set { this.AnyTypePropOption = new Option<Object>(value); } }
+        public Object AnyTypeProp { get { return this.AnyTypePropOption.Value; } set { this.AnyTypePropOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of AnyTypePropNullable
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values.</value>
         [JsonPropertyName("anyTypePropNullable")]
-        public Object AnyTypePropNullable { get { return this.AnyTypePropNullableOption; } set { this.AnyTypePropNullableOption = new Option<Object>(value); } }
+        public Object AnyTypePropNullable { get { return this.AnyTypePropNullableOption.Value; } set { this.AnyTypePropNullableOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of Email
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Email
         /// </summary>
         [JsonPropertyName("email")]
-        public string Email { get { return this.EmailOption; } set { this.EmailOption = new Option<string>(value); } }
+        public string Email { get { return this.EmailOption.Value; } set { this.EmailOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of FirstName
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets FirstName
         /// </summary>
         [JsonPropertyName("firstName")]
-        public string FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new Option<string>(value); } }
+        public string FirstName { get { return this.FirstNameOption.Value; } set { this.FirstNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of LastName
@@ -142,7 +142,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LastName
         /// </summary>
         [JsonPropertyName("lastName")]
-        public string LastName { get { return this.LastNameOption; } set { this.LastNameOption = new Option<string>(value); } }
+        public string LastName { get { return this.LastNameOption.Value; } set { this.LastNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredProps
@@ -156,7 +156,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredProps")]
-        public Object ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption; } set { this.ObjectWithNoDeclaredPropsOption = new Option<Object>(value); } }
+        public Object ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption.Value; } set { this.ObjectWithNoDeclaredPropsOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredPropsNullable
@@ -170,7 +170,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredPropsNullable")]
-        public Object ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption; } set { this.ObjectWithNoDeclaredPropsNullableOption = new Option<Object>(value); } }
+        public Object ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption.Value; } set { this.ObjectWithNoDeclaredPropsNullableOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of Password
@@ -183,7 +183,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Password
         /// </summary>
         [JsonPropertyName("password")]
-        public string Password { get { return this.PasswordOption; } set { this.PasswordOption = new Option<string>(value); } }
+        public string Password { get { return this.PasswordOption.Value; } set { this.PasswordOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Phone
@@ -196,7 +196,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Phone
         /// </summary>
         [JsonPropertyName("phone")]
-        public string Phone { get { return this.PhoneOption; } set { this.PhoneOption = new Option<string>(value); } }
+        public string Phone { get { return this.PhoneOption.Value; } set { this.PhoneOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of UserStatus
@@ -210,7 +210,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [JsonPropertyName("userStatus")]
-        public int? UserStatus { get { return this.UserStatusOption; } set { this.UserStatusOption = new Option<int?>(value); } }
+        public int? UserStatus { get { return this.UserStatusOption.Value; } set { this.UserStatusOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Username
@@ -223,7 +223,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Username
         /// </summary>
         [JsonPropertyName("username")]
-        public string Username { get { return this.UsernameOption; } set { this.UsernameOption = new Option<string>(value); } }
+        public string Username { get { return this.UsernameOption.Value; } set { this.UsernameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [JsonPropertyName("hasBaleen")]
-        public bool? HasBaleen { get { return this.HasBaleenOption; } set { this.HasBaleenOption = new Option<bool?>(value); } }
+        public bool? HasBaleen { get { return this.HasBaleenOption.Value; } set { this.HasBaleenOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of HasTeeth
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasTeeth
         /// </summary>
         [JsonPropertyName("hasTeeth")]
-        public bool? HasTeeth { get { return this.HasTeethOption; } set { this.HasTeethOption = new Option<bool?>(value); } }
+        public bool? HasTeeth { get { return this.HasTeethOption.Value; } set { this.HasTeethOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Now
         /// </summary>
         [JsonPropertyName("now")]
-        public DateTime? Now { get { return this.NowOption; } set { this.NowOption = new Option<DateTime?>(value); } }
+        public DateTime? Now { get { return this.NowOption.Value; } set { this.NowOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of Today
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Today
         /// </summary>
         [JsonPropertyName("today")]
-        public DateTime? Today { get { return this.TodayOption; } set { this.TodayOption = new Option<DateTime?>(value); } }
+        public DateTime? Today { get { return this.TodayOption.Value; } set { this.TodayOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Adult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Adult.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Children
         /// </summary>
         [JsonPropertyName("children")]
-        public List<Child> Children { get { return this.ChildrenOption; } set { this.ChildrenOption = new Option<List<Child>>(value); } }
+        public List<Child> Children { get { return this.ChildrenOption.Value; } set { this.ChildrenOption = new Option<List<Child>>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Age
         /// </summary>
         [JsonPropertyName("age")]
-        public int? Age { get { return this.AgeOption; } set { this.AgeOption = new Option<int?>(value); } }
+        public int? Age { get { return this.AgeOption.Value; } set { this.AgeOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of BoosterSeat
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BoosterSeat
         /// </summary>
         [JsonPropertyName("boosterSeat")]
-        public bool? BoosterSeat { get { return this.BoosterSeatOption; } set { this.BoosterSeatOption = new Option<bool?>(value); } }
+        public bool? BoosterSeat { get { return this.BoosterSeatOption.Value; } set { this.BoosterSeatOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Person.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Person.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets FirstName
         /// </summary>
         [JsonPropertyName("firstName")]
-        public string FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new Option<string>(value); } }
+        public string FirstName { get { return this.FirstNameOption.Value; } set { this.FirstNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of LastName
@@ -69,7 +69,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LastName
         /// </summary>
         [JsonPropertyName("lastName")]
-        public string LastName { get { return this.LastNameOption; } set { this.LastNameOption = new Option<string>(value); } }
+        public string LastName { get { return this.LastNameOption.Value; } set { this.LastNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// The discriminator

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Kind
         /// </summary>
         [JsonPropertyName("kind")]
-        public string Kind { get { return this.KindOption; } set { this.KindOption = new Option<string>(value); } }
+        public string Kind { get { return this.KindOption.Value; } set { this.KindOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Count
         /// </summary>
         [JsonPropertyName("count")]
-        public decimal? Count { get { return this.CountOption; } set { this.CountOption = new Option<decimal?>(value); } }
+        public decimal? Count { get { return this.CountOption.Value; } set { this.CountOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -80,7 +80,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new Option<string>(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
@@ -52,7 +52,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Kind
         /// </summary>
         [JsonPropertyName("kind")]
-        public string Kind { get { return this.KindOption; } set { this.KindOption = new Option<string>(value); } }
+        public string Kind { get { return this.KindOption.Value; } set { this.KindOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
@@ -52,7 +52,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Count
         /// </summary>
         [JsonPropertyName("count")]
-        public decimal? Count { get { return this.CountOption; } set { this.CountOption = new Option<decimal?>(value); } }
+        public decimal? Count { get { return this.CountOption.Value; } set { this.CountOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
@@ -79,7 +79,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new Option<string>(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Activity.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ActivityOutputs
         /// </summary>
         [JsonPropertyName("activity_outputs")]
-        public Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs { get { return this.ActivityOutputsOption; } set { this.ActivityOutputsOption = new Option<Dictionary<string, List<ActivityOutputElementRepresentation>>>(value); } }
+        public Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs { get { return this.ActivityOutputsOption.Value; } set { this.ActivityOutputsOption = new Option<Dictionary<string, List<ActivityOutputElementRepresentation>>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop1
         /// </summary>
         [JsonPropertyName("prop1")]
-        public string Prop1 { get { return this.Prop1Option; } set { this.Prop1Option = new Option<string>(value); } }
+        public string Prop1 { get { return this.Prop1Option.Value; } set { this.Prop1Option = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Prop2
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop2
         /// </summary>
         [JsonPropertyName("prop2")]
-        public Object Prop2 { get { return this.Prop2Option; } set { this.Prop2Option = new Option<Object>(value); } }
+        public Object Prop2 { get { return this.Prop2Option.Value; } set { this.Prop2Option = new Option<Object>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Anytype1
         /// </summary>
         [JsonPropertyName("anytype_1")]
-        public Object Anytype1 { get { return this.Anytype1Option; } set { this.Anytype1Option = new Option<Object>(value); } }
+        public Object Anytype1 { get { return this.Anytype1Option.Value; } set { this.Anytype1Option = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of EmptyMap
@@ -81,7 +81,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>an object with no declared properties and no undeclared properties, hence it&#39;s an empty map.</value>
         [JsonPropertyName("empty_map")]
-        public Object EmptyMap { get { return this.EmptyMapOption; } set { this.EmptyMapOption = new Option<Object>(value); } }
+        public Object EmptyMap { get { return this.EmptyMapOption.Value; } set { this.EmptyMapOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfMapProperty
@@ -94,7 +94,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfMapProperty
         /// </summary>
         [JsonPropertyName("map_of_map_property")]
-        public Dictionary<string, Dictionary<string, string>> MapOfMapProperty { get { return this.MapOfMapPropertyOption; } set { this.MapOfMapPropertyOption = new Option<Dictionary<string, Dictionary<string, string>>>(value); } }
+        public Dictionary<string, Dictionary<string, string>> MapOfMapProperty { get { return this.MapOfMapPropertyOption.Value; } set { this.MapOfMapPropertyOption = new Option<Dictionary<string, Dictionary<string, string>>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapProperty
@@ -107,7 +107,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapProperty
         /// </summary>
         [JsonPropertyName("map_property")]
-        public Dictionary<string, string> MapProperty { get { return this.MapPropertyOption; } set { this.MapPropertyOption = new Option<Dictionary<string, string>>(value); } }
+        public Dictionary<string, string> MapProperty { get { return this.MapPropertyOption.Value; } set { this.MapPropertyOption = new Option<Dictionary<string, string>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype1
@@ -120,7 +120,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype1
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_1")]
-        public Object MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new Option<Object>(value); } }
+        public Object MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype2
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype2
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_2")]
-        public Object MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new Option<Object>(value); } }
+        public Object MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype3
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype3
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_3")]
-        public Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new Option<Dictionary<string, Object>>(value); } }
+        public Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new Option<Dictionary<string, Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesString
@@ -159,7 +159,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesString
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_string")]
-        public Dictionary<string, string> MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption; } set { this.MapWithUndeclaredPropertiesStringOption = new Option<Dictionary<string, string>>(value); } }
+        public Dictionary<string, string> MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption.Value; } set { this.MapWithUndeclaredPropertiesStringOption = new Option<Dictionary<string, string>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Animal.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new Option<string>(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [JsonPropertyName("code")]
-        public int? Code { get { return this.CodeOption; } set { this.CodeOption = new Option<int?>(value); } }
+        public int? Code { get { return this.CodeOption.Value; } set { this.CodeOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Message
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Message
         /// </summary>
         [JsonPropertyName("message")]
-        public string Message { get { return this.MessageOption; } set { this.MessageOption = new Option<string>(value); } }
+        public string Message { get { return this.MessageOption.Value; } set { this.MessageOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Type
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Type
         /// </summary>
         [JsonPropertyName("type")]
-        public string Type { get { return this.TypeOption; } set { this.TypeOption = new Option<string>(value); } }
+        public string Type { get { return this.TypeOption.Value; } set { this.TypeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Apple.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ColorCode
         /// </summary>
         [JsonPropertyName("color_code")]
-        public string ColorCode { get { return this.ColorCodeOption; } set { this.ColorCodeOption = new Option<string>(value); } }
+        public string ColorCode { get { return this.ColorCodeOption.Value; } set { this.ColorCodeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Cultivar
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Cultivar
         /// </summary>
         [JsonPropertyName("cultivar")]
-        public string Cultivar { get { return this.CultivarOption; } set { this.CultivarOption = new Option<string>(value); } }
+        public string Cultivar { get { return this.CultivarOption.Value; } set { this.CultivarOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Origin
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Origin
         /// </summary>
         [JsonPropertyName("origin")]
-        public string Origin { get { return this.OriginOption; } set { this.OriginOption = new Option<string>(value); } }
+        public string Origin { get { return this.OriginOption.Value; } set { this.OriginOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [JsonPropertyName("mealy")]
-        public bool? Mealy { get { return this.MealyOption; } set { this.MealyOption = new Option<bool?>(value); } }
+        public bool? Mealy { get { return this.MealyOption.Value; } set { this.MealyOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayArrayNumber")]
-        public List<List<decimal>> ArrayArrayNumber { get { return this.ArrayArrayNumberOption; } set { this.ArrayArrayNumberOption = new Option<List<List<decimal>>>(value); } }
+        public List<List<decimal>> ArrayArrayNumber { get { return this.ArrayArrayNumberOption.Value; } set { this.ArrayArrayNumberOption = new Option<List<List<decimal>>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayNumber")]
-        public List<decimal> ArrayNumber { get { return this.ArrayNumberOption; } set { this.ArrayNumberOption = new Option<List<decimal>>(value); } }
+        public List<decimal> ArrayNumber { get { return this.ArrayNumberOption.Value; } set { this.ArrayNumberOption = new Option<List<decimal>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfInteger
         /// </summary>
         [JsonPropertyName("array_array_of_integer")]
-        public List<List<long>> ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption; } set { this.ArrayArrayOfIntegerOption = new Option<List<List<long>>>(value); } }
+        public List<List<long>> ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption.Value; } set { this.ArrayArrayOfIntegerOption = new Option<List<List<long>>>(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayArrayOfModel
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfModel
         /// </summary>
         [JsonPropertyName("array_array_of_model")]
-        public List<List<ReadOnlyFirst>> ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption; } set { this.ArrayArrayOfModelOption = new Option<List<List<ReadOnlyFirst>>>(value); } }
+        public List<List<ReadOnlyFirst>> ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption.Value; } set { this.ArrayArrayOfModelOption = new Option<List<List<ReadOnlyFirst>>>(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayOfString
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayOfString
         /// </summary>
         [JsonPropertyName("array_of_string")]
-        public List<string> ArrayOfString { get { return this.ArrayOfStringOption; } set { this.ArrayOfStringOption = new Option<List<string>>(value); } }
+        public List<string> ArrayOfString { get { return this.ArrayOfStringOption.Value; } set { this.ArrayOfStringOption = new Option<List<string>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Banana.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [JsonPropertyName("lengthCm")]
-        public decimal? LengthCm { get { return this.LengthCmOption; } set { this.LengthCmOption = new Option<decimal?>(value); } }
+        public decimal? LengthCm { get { return this.LengthCmOption.Value; } set { this.LengthCmOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [JsonPropertyName("sweet")]
-        public bool? Sweet { get { return this.SweetOption; } set { this.SweetOption = new Option<bool?>(value); } }
+        public bool? Sweet { get { return this.SweetOption.Value; } set { this.SweetOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -64,7 +64,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Name of the pet </value>
         [JsonPropertyName("ATT_NAME")]
-        public string ATT_NAME { get { return this.ATT_NAMEOption; } set { this.ATT_NAMEOption = new Option<string>(value); } }
+        public string ATT_NAME { get { return this.ATT_NAMEOption.Value; } set { this.ATT_NAMEOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalCamel
@@ -77,7 +77,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalCamel
         /// </summary>
         [JsonPropertyName("CapitalCamel")]
-        public string CapitalCamel { get { return this.CapitalCamelOption; } set { this.CapitalCamelOption = new Option<string>(value); } }
+        public string CapitalCamel { get { return this.CapitalCamelOption.Value; } set { this.CapitalCamelOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalSnake
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalSnake
         /// </summary>
         [JsonPropertyName("Capital_Snake")]
-        public string CapitalSnake { get { return this.CapitalSnakeOption; } set { this.CapitalSnakeOption = new Option<string>(value); } }
+        public string CapitalSnake { get { return this.CapitalSnakeOption.Value; } set { this.CapitalSnakeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SCAETHFlowPoints
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SCAETHFlowPoints
         /// </summary>
         [JsonPropertyName("SCA_ETH_Flow_Points")]
-        public string SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption; } set { this.SCAETHFlowPointsOption = new Option<string>(value); } }
+        public string SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption.Value; } set { this.SCAETHFlowPointsOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SmallCamel
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallCamel
         /// </summary>
         [JsonPropertyName("smallCamel")]
-        public string SmallCamel { get { return this.SmallCamelOption; } set { this.SmallCamelOption = new Option<string>(value); } }
+        public string SmallCamel { get { return this.SmallCamelOption.Value; } set { this.SmallCamelOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SmallSnake
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallSnake
         /// </summary>
         [JsonPropertyName("small_Snake")]
-        public string SmallSnake { get { return this.SmallSnakeOption; } set { this.SmallSnakeOption = new Option<string>(value); } }
+        public string SmallSnake { get { return this.SmallSnakeOption.Value; } set { this.SmallSnakeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Cat.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [JsonPropertyName("declawed")]
-        public bool? Declawed { get { return this.DeclawedOption; } set { this.DeclawedOption = new Option<bool?>(value); } }
+        public bool? Declawed { get { return this.DeclawedOption.Value; } set { this.DeclawedOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Category.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new Option<string>(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("_class")]
-        public string Class { get { return this.ClassOption; } set { this.ClassOption = new Option<string>(value); } }
+        public string Class { get { return this.ClassOption.Value; } set { this.ClassOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>Fri Jul 21 00:00:00 UTC 2017</example> */
         [JsonPropertyName("dateOnlyProperty")]
-        public DateTime? DateOnlyProperty { get { return this.DateOnlyPropertyOption; } set { this.DateOnlyPropertyOption = new Option<DateTime?>(value); } }
+        public DateTime? DateOnlyProperty { get { return this.DateOnlyPropertyOption.Value; } set { this.DateOnlyPropertyOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new Option<string>(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Dog.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Breed
         /// </summary>
         [JsonPropertyName("breed")]
-        public string Breed { get { return this.BreedOption; } set { this.BreedOption = new Option<string>(value); } }
+        public string Breed { get { return this.BreedOption.Value; } set { this.BreedOption = new Option<string>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MainShape
         /// </summary>
         [JsonPropertyName("mainShape")]
-        public Shape MainShape { get { return this.MainShapeOption; } set { this.MainShapeOption = new Option<Shape>(value); } }
+        public Shape MainShape { get { return this.MainShapeOption.Value; } set { this.MainShapeOption = new Option<Shape>(value); } }
 
         /// <summary>
         /// Used to track the state of NullableShape
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableShape
         /// </summary>
         [JsonPropertyName("nullableShape")]
-        public NullableShape NullableShape { get { return this.NullableShapeOption; } set { this.NullableShapeOption = new Option<NullableShape>(value); } }
+        public NullableShape NullableShape { get { return this.NullableShapeOption.Value; } set { this.NullableShapeOption = new Option<NullableShape>(value); } }
 
         /// <summary>
         /// Used to track the state of ShapeOrNull
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ShapeOrNull
         /// </summary>
         [JsonPropertyName("shapeOrNull")]
-        public ShapeOrNull ShapeOrNull { get { return this.ShapeOrNullOption; } set { this.ShapeOrNullOption = new Option<ShapeOrNull>(value); } }
+        public ShapeOrNull ShapeOrNull { get { return this.ShapeOrNullOption.Value; } set { this.ShapeOrNullOption = new Option<ShapeOrNull>(value); } }
 
         /// <summary>
         /// Used to track the state of Shapes
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Shapes
         /// </summary>
         [JsonPropertyName("shapes")]
-        public List<Shape> Shapes { get { return this.ShapesOption; } set { this.ShapesOption = new Option<List<Shape>>(value); } }
+        public List<Shape> Shapes { get { return this.ShapesOption.Value; } set { this.ShapesOption = new Option<List<Shape>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayEnum
         /// </summary>
         [JsonPropertyName("array_enum")]
-        public List<EnumArraysArrayEnumInner> ArrayEnum { get { return this.ArrayEnumOption; } set { this.ArrayEnumOption = new Option<List<EnumArraysArrayEnumInner>>(value); } }
+        public List<EnumArraysArrayEnumInner> ArrayEnum { get { return this.ArrayEnumOption.Value; } set { this.ArrayEnumOption = new Option<List<EnumArraysArrayEnumInner>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/File.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Test capitalization</value>
         [JsonPropertyName("sourceURI")]
-        public string SourceURI { get { return this.SourceURIOption; } set { this.SourceURIOption = new Option<string>(value); } }
+        public string SourceURI { get { return this.SourceURIOption.Value; } set { this.SourceURIOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets File
         /// </summary>
         [JsonPropertyName("file")]
-        public File File { get { return this.FileOption; } set { this.FileOption = new Option<File>(value); } }
+        public File File { get { return this.FileOption.Value; } set { this.FileOption = new Option<File>(value); } }
 
         /// <summary>
         /// Used to track the state of Files
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Files
         /// </summary>
         [JsonPropertyName("files")]
-        public List<File> Files { get { return this.FilesOption; } set { this.FilesOption = new Option<List<File>>(value); } }
+        public List<File> Files { get { return this.FilesOption.Value; } set { this.FilesOption = new Option<List<File>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Foo.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } set { this.BarOption = new Option<string>(value); } }
+        public string Bar { get { return this.BarOption.Value; } set { this.BarOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public Foo String { get { return this.StringOption; } set { this.StringOption = new Option<Foo>(value); } }
+        public Foo String { get { return this.StringOption.Value; } set { this.StringOption = new Option<Foo>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -138,7 +138,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Binary
         /// </summary>
         [JsonPropertyName("binary")]
-        public System.IO.Stream Binary { get { return this.BinaryOption; } set { this.BinaryOption = new Option<System.IO.Stream>(value); } }
+        public System.IO.Stream Binary { get { return this.BinaryOption.Value; } set { this.BinaryOption = new Option<System.IO.Stream>(value); } }
 
         /// <summary>
         /// Used to track the state of DateTime
@@ -152,7 +152,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2007-12-03T10:15:30+01:00</example> */
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new Option<DateTime?>(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of Decimal
@@ -165,7 +165,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Decimal
         /// </summary>
         [JsonPropertyName("decimal")]
-        public decimal? Decimal { get { return this.DecimalOption; } set { this.DecimalOption = new Option<decimal?>(value); } }
+        public decimal? Decimal { get { return this.DecimalOption.Value; } set { this.DecimalOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of Double
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Double
         /// </summary>
         [JsonPropertyName("double")]
-        public double? Double { get { return this.DoubleOption; } set { this.DoubleOption = new Option<double?>(value); } }
+        public double? Double { get { return this.DoubleOption.Value; } set { this.DoubleOption = new Option<double?>(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName2
@@ -191,7 +191,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName2
         /// </summary>
         [JsonPropertyName("duplicate_property_name")]
-        public string DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option; } set { this.DuplicatePropertyName2Option = new Option<string>(value); } }
+        public string DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option.Value; } set { this.DuplicatePropertyName2Option = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName
@@ -204,7 +204,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName
         /// </summary>
         [JsonPropertyName("@duplicate_property_name")]
-        public string DuplicatePropertyName { get { return this.DuplicatePropertyNameOption; } set { this.DuplicatePropertyNameOption = new Option<string>(value); } }
+        public string DuplicatePropertyName { get { return this.DuplicatePropertyNameOption.Value; } set { this.DuplicatePropertyNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Float
@@ -217,7 +217,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Float
         /// </summary>
         [JsonPropertyName("float")]
-        public float? Float { get { return this.FloatOption; } set { this.FloatOption = new Option<float?>(value); } }
+        public float? Float { get { return this.FloatOption.Value; } set { this.FloatOption = new Option<float?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int32
@@ -230,7 +230,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32
         /// </summary>
         [JsonPropertyName("int32")]
-        public int? Int32 { get { return this.Int32Option; } set { this.Int32Option = new Option<int?>(value); } }
+        public int? Int32 { get { return this.Int32Option.Value; } set { this.Int32Option = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int32Range
@@ -243,7 +243,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32Range
         /// </summary>
         [JsonPropertyName("int32Range")]
-        public int? Int32Range { get { return this.Int32RangeOption; } set { this.Int32RangeOption = new Option<int?>(value); } }
+        public int? Int32Range { get { return this.Int32RangeOption.Value; } set { this.Int32RangeOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64
@@ -256,7 +256,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64
         /// </summary>
         [JsonPropertyName("int64")]
-        public long? Int64 { get { return this.Int64Option; } set { this.Int64Option = new Option<long?>(value); } }
+        public long? Int64 { get { return this.Int64Option.Value; } set { this.Int64Option = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Negative
@@ -269,7 +269,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Negative
         /// </summary>
         [JsonPropertyName("int64Negative")]
-        public long? Int64Negative { get { return this.Int64NegativeOption; } set { this.Int64NegativeOption = new Option<long?>(value); } }
+        public long? Int64Negative { get { return this.Int64NegativeOption.Value; } set { this.Int64NegativeOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64NegativeExclusive
@@ -282,7 +282,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64NegativeExclusive
         /// </summary>
         [JsonPropertyName("int64NegativeExclusive")]
-        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption; } set { this.Int64NegativeExclusiveOption = new Option<long?>(value); } }
+        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption.Value; } set { this.Int64NegativeExclusiveOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Positive
@@ -295,7 +295,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Positive
         /// </summary>
         [JsonPropertyName("int64Positive")]
-        public long? Int64Positive { get { return this.Int64PositiveOption; } set { this.Int64PositiveOption = new Option<long?>(value); } }
+        public long? Int64Positive { get { return this.Int64PositiveOption.Value; } set { this.Int64PositiveOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64PositiveExclusive
@@ -308,7 +308,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64PositiveExclusive
         /// </summary>
         [JsonPropertyName("int64PositiveExclusive")]
-        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption; } set { this.Int64PositiveExclusiveOption = new Option<long?>(value); } }
+        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption.Value; } set { this.Int64PositiveExclusiveOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Integer
@@ -321,7 +321,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [JsonPropertyName("integer")]
-        public int? Integer { get { return this.IntegerOption; } set { this.IntegerOption = new Option<int?>(value); } }
+        public int? Integer { get { return this.IntegerOption.Value; } set { this.IntegerOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithBackslash
@@ -335,7 +335,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>None</value>
         [JsonPropertyName("pattern_with_backslash")]
-        public string PatternWithBackslash { get { return this.PatternWithBackslashOption; } set { this.PatternWithBackslashOption = new Option<string>(value); } }
+        public string PatternWithBackslash { get { return this.PatternWithBackslashOption.Value; } set { this.PatternWithBackslashOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigits
@@ -349,7 +349,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string that is a 10 digit number. Can have leading zeros.</value>
         [JsonPropertyName("pattern_with_digits")]
-        public string PatternWithDigits { get { return this.PatternWithDigitsOption; } set { this.PatternWithDigitsOption = new Option<string>(value); } }
+        public string PatternWithDigits { get { return this.PatternWithDigitsOption.Value; } set { this.PatternWithDigitsOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigitsAndDelimiter
@@ -363,7 +363,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.</value>
         [JsonPropertyName("pattern_with_digits_and_delimiter")]
-        public string PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption; } set { this.PatternWithDigitsAndDelimiterOption = new Option<string>(value); } }
+        public string PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption.Value; } set { this.PatternWithDigitsAndDelimiterOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of String
@@ -376,7 +376,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public string String { get { return this.StringOption; } set { this.StringOption = new Option<string>(value); } }
+        public string String { get { return this.StringOption.Value; } set { this.StringOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of StringFormattedAsDecimal
@@ -389,7 +389,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringFormattedAsDecimal
         /// </summary>
         [JsonPropertyName("string_formatted_as_decimal")]
-        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption; } set { this.StringFormattedAsDecimalOption = new Option<decimal?>(value); } }
+        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption.Value; } set { this.StringFormattedAsDecimalOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedInteger
@@ -402,7 +402,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [JsonPropertyName("unsigned_integer")]
-        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption; } set { this.UnsignedIntegerOption = new Option<uint?>(value); } }
+        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption.Value; } set { this.UnsignedIntegerOption = new Option<uint?>(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedLong
@@ -415,7 +415,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedLong
         /// </summary>
         [JsonPropertyName("unsigned_long")]
-        public ulong? UnsignedLong { get { return this.UnsignedLongOption; } set { this.UnsignedLongOption = new Option<ulong?>(value); } }
+        public ulong? UnsignedLong { get { return this.UnsignedLongOption.Value; } set { this.UnsignedLongOption = new Option<ulong?>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -429,7 +429,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<Guid?>(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new Option<string>(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new Option<string>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -80,7 +80,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new Option<string>(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new Option<string>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } }
+        public string Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Foo
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Foo
         /// </summary>
         [JsonPropertyName("foo")]
-        public string Foo { get { return this.FooOption; } }
+        public string Foo { get { return this.FooOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableMessage
         /// </summary>
         [JsonPropertyName("NullableMessage")]
-        public string NullableMessage { get { return this.NullableMessageOption; } set { this.NullableMessageOption = new Option<string>(value); } }
+        public string NullableMessage { get { return this.NullableMessageOption.Value; } set { this.NullableMessageOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/List.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123List
         /// </summary>
         [JsonPropertyName("123-list")]
-        public string Var123List { get { return this.Var123ListOption; } set { this.Var123ListOption = new Option<string>(value); } }
+        public string Var123List { get { return this.Var123ListOption.Value; } set { this.Var123ListOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets EscapedLiteralString
         /// </summary>
         [JsonPropertyName("escapedLiteralString")]
-        public string EscapedLiteralString { get { return this.EscapedLiteralStringOption; } set { this.EscapedLiteralStringOption = new Option<string>(value); } }
+        public string EscapedLiteralString { get { return this.EscapedLiteralStringOption.Value; } set { this.EscapedLiteralStringOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of UnescapedLiteralString
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnescapedLiteralString
         /// </summary>
         [JsonPropertyName("unescapedLiteralString")]
-        public string UnescapedLiteralString { get { return this.UnescapedLiteralStringOption; } set { this.UnescapedLiteralStringOption = new Option<string>(value); } }
+        public string UnescapedLiteralString { get { return this.UnescapedLiteralStringOption.Value; } set { this.UnescapedLiteralStringOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DirectMap
         /// </summary>
         [JsonPropertyName("direct_map")]
-        public Dictionary<string, bool> DirectMap { get { return this.DirectMapOption; } set { this.DirectMapOption = new Option<Dictionary<string, bool>>(value); } }
+        public Dictionary<string, bool> DirectMap { get { return this.DirectMapOption.Value; } set { this.DirectMapOption = new Option<Dictionary<string, bool>>(value); } }
 
         /// <summary>
         /// Used to track the state of IndirectMap
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IndirectMap
         /// </summary>
         [JsonPropertyName("indirect_map")]
-        public Dictionary<string, bool> IndirectMap { get { return this.IndirectMapOption; } set { this.IndirectMapOption = new Option<Dictionary<string, bool>>(value); } }
+        public Dictionary<string, bool> IndirectMap { get { return this.IndirectMapOption.Value; } set { this.IndirectMapOption = new Option<Dictionary<string, bool>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapMapOfString
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapMapOfString
         /// </summary>
         [JsonPropertyName("map_map_of_string")]
-        public Dictionary<string, Dictionary<string, string>> MapMapOfString { get { return this.MapMapOfStringOption; } set { this.MapMapOfStringOption = new Option<Dictionary<string, Dictionary<string, string>>>(value); } }
+        public Dictionary<string, Dictionary<string, string>> MapMapOfString { get { return this.MapMapOfStringOption.Value; } set { this.MapMapOfStringOption = new Option<Dictionary<string, Dictionary<string, string>>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfEnumString
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfEnumString
         /// </summary>
         [JsonPropertyName("map_of_enum_string")]
-        public Dictionary<string, MapTestMapOfEnumStringValue> MapOfEnumString { get { return this.MapOfEnumStringOption; } set { this.MapOfEnumStringOption = new Option<Dictionary<string, MapTestMapOfEnumStringValue>>(value); } }
+        public Dictionary<string, MapTestMapOfEnumStringValue> MapOfEnumString { get { return this.MapOfEnumStringOption.Value; } set { this.MapOfEnumStringOption = new Option<Dictionary<string, MapTestMapOfEnumStringValue>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedAnyOfContent Content { get { return this.ContentOption; } set { this.ContentOption = new Option<MixedAnyOfContent>(value); } }
+        public MixedAnyOfContent Content { get { return this.ContentOption.Value; } set { this.ContentOption = new Option<MixedAnyOfContent>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedOneOfContent Content { get { return this.ContentOption; } set { this.ContentOption = new Option<MixedOneOfContent>(value); } }
+        public MixedOneOfContent Content { get { return this.ContentOption.Value; } set { this.ContentOption = new Option<MixedOneOfContent>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateTime
         /// </summary>
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new Option<DateTime?>(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of Map
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Map
         /// </summary>
         [JsonPropertyName("map")]
-        public Dictionary<string, Animal> Map { get { return this.MapOption; } set { this.MapOption = new Option<Dictionary<string, Animal>>(value); } }
+        public Dictionary<string, Animal> Map { get { return this.MapOption.Value; } set { this.MapOption = new Option<Dictionary<string, Animal>>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<Guid?>(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Used to track the state of UuidWithPattern
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [JsonPropertyName("uuid_with_pattern")]
-        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption; } set { this.UuidWithPatternOption = new Option<Guid?>(value); } }
+        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption.Value; } set { this.UuidWithPatternOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public string Id { get { return this.IdOption; } set { this.IdOption = new Option<string>(value); } }
+        public string Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("class")]
-        public string Class { get { return this.ClassOption; } set { this.ClassOption = new Option<string>(value); } }
+        public string Class { get { return this.ClassOption.Value; } set { this.ClassOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public int? Name { get { return this.NameOption; } set { this.NameOption = new Option<int?>(value); } }
+        public int? Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarClient
         /// </summary>
         [JsonPropertyName("client")]
-        public string VarClient { get { return this.VarClientOption; } set { this.VarClientOption = new Option<string>(value); } }
+        public string VarClient { get { return this.VarClientOption.Value; } set { this.VarClientOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Name.cs
@@ -65,7 +65,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Property
         /// </summary>
         [JsonPropertyName("property")]
-        public string Property { get { return this.PropertyOption; } set { this.PropertyOption = new Option<string>(value); } }
+        public string Property { get { return this.PropertyOption.Value; } set { this.PropertyOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SnakeCase
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [JsonPropertyName("snake_case")]
-        public int? SnakeCase { get { return this.SnakeCaseOption; } }
+        public int? SnakeCase { get { return this.SnakeCaseOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Var123Number
@@ -91,7 +91,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123Number
         /// </summary>
         [JsonPropertyName("123Number")]
-        public int? Var123Number { get { return this.Var123NumberOption; } }
+        public int? Var123Number { get { return this.Var123NumberOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -75,7 +75,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("array_and_items_nullable_prop")]
-        public List<Object> ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption; } set { this.ArrayAndItemsNullablePropOption = new Option<List<Object>>(value); } }
+        public List<Object> ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption.Value; } set { this.ArrayAndItemsNullablePropOption = new Option<List<Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayItemsNullable
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayItemsNullable
         /// </summary>
         [JsonPropertyName("array_items_nullable")]
-        public List<Object> ArrayItemsNullable { get { return this.ArrayItemsNullableOption; } set { this.ArrayItemsNullableOption = new Option<List<Object>>(value); } }
+        public List<Object> ArrayItemsNullable { get { return this.ArrayItemsNullableOption.Value; } set { this.ArrayItemsNullableOption = new Option<List<Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayNullableProp
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNullableProp
         /// </summary>
         [JsonPropertyName("array_nullable_prop")]
-        public List<Object> ArrayNullableProp { get { return this.ArrayNullablePropOption; } set { this.ArrayNullablePropOption = new Option<List<Object>>(value); } }
+        public List<Object> ArrayNullableProp { get { return this.ArrayNullablePropOption.Value; } set { this.ArrayNullablePropOption = new Option<List<Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of BooleanProp
@@ -114,7 +114,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BooleanProp
         /// </summary>
         [JsonPropertyName("boolean_prop")]
-        public bool? BooleanProp { get { return this.BooleanPropOption; } set { this.BooleanPropOption = new Option<bool?>(value); } }
+        public bool? BooleanProp { get { return this.BooleanPropOption.Value; } set { this.BooleanPropOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of DateProp
@@ -127,7 +127,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateProp
         /// </summary>
         [JsonPropertyName("date_prop")]
-        public DateTime? DateProp { get { return this.DatePropOption; } set { this.DatePropOption = new Option<DateTime?>(value); } }
+        public DateTime? DateProp { get { return this.DatePropOption.Value; } set { this.DatePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of DatetimeProp
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DatetimeProp
         /// </summary>
         [JsonPropertyName("datetime_prop")]
-        public DateTime? DatetimeProp { get { return this.DatetimePropOption; } set { this.DatetimePropOption = new Option<DateTime?>(value); } }
+        public DateTime? DatetimeProp { get { return this.DatetimePropOption.Value; } set { this.DatetimePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of IntegerProp
@@ -153,7 +153,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IntegerProp
         /// </summary>
         [JsonPropertyName("integer_prop")]
-        public int? IntegerProp { get { return this.IntegerPropOption; } set { this.IntegerPropOption = new Option<int?>(value); } }
+        public int? IntegerProp { get { return this.IntegerPropOption.Value; } set { this.IntegerPropOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of NumberProp
@@ -166,7 +166,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NumberProp
         /// </summary>
         [JsonPropertyName("number_prop")]
-        public decimal? NumberProp { get { return this.NumberPropOption; } set { this.NumberPropOption = new Option<decimal?>(value); } }
+        public decimal? NumberProp { get { return this.NumberPropOption.Value; } set { this.NumberPropOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectAndItemsNullableProp
@@ -179,7 +179,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("object_and_items_nullable_prop")]
-        public Dictionary<string, Object> ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption; } set { this.ObjectAndItemsNullablePropOption = new Option<Dictionary<string, Object>>(value); } }
+        public Dictionary<string, Object> ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption.Value; } set { this.ObjectAndItemsNullablePropOption = new Option<Dictionary<string, Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectItemsNullable
@@ -192,7 +192,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectItemsNullable
         /// </summary>
         [JsonPropertyName("object_items_nullable")]
-        public Dictionary<string, Object> ObjectItemsNullable { get { return this.ObjectItemsNullableOption; } set { this.ObjectItemsNullableOption = new Option<Dictionary<string, Object>>(value); } }
+        public Dictionary<string, Object> ObjectItemsNullable { get { return this.ObjectItemsNullableOption.Value; } set { this.ObjectItemsNullableOption = new Option<Dictionary<string, Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectNullableProp
@@ -205,7 +205,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectNullableProp
         /// </summary>
         [JsonPropertyName("object_nullable_prop")]
-        public Dictionary<string, Object> ObjectNullableProp { get { return this.ObjectNullablePropOption; } set { this.ObjectNullablePropOption = new Option<Dictionary<string, Object>>(value); } }
+        public Dictionary<string, Object> ObjectNullableProp { get { return this.ObjectNullablePropOption.Value; } set { this.ObjectNullablePropOption = new Option<Dictionary<string, Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of StringProp
@@ -218,7 +218,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringProp
         /// </summary>
         [JsonPropertyName("string_prop")]
-        public string StringProp { get { return this.StringPropOption; } set { this.StringPropOption = new Option<string>(value); } }
+        public string StringProp { get { return this.StringPropOption.Value; } set { this.StringPropOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<Guid?>(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [JsonPropertyName("JustNumber")]
-        public decimal? JustNumber { get { return this.JustNumberOption; } set { this.JustNumberOption = new Option<decimal?>(value); } }
+        public decimal? JustNumber { get { return this.JustNumberOption.Value; } set { this.JustNumberOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("bars")]
         [Obsolete]
-        public List<string> Bars { get { return this.BarsOption; } set { this.BarsOption = new Option<List<string>>(value); } }
+        public List<string> Bars { get { return this.BarsOption.Value; } set { this.BarsOption = new Option<List<string>>(value); } }
 
         /// <summary>
         /// Used to track the state of DeprecatedRef
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("deprecatedRef")]
         [Obsolete]
-        public DeprecatedObject DeprecatedRef { get { return this.DeprecatedRefOption; } set { this.DeprecatedRefOption = new Option<DeprecatedObject>(value); } }
+        public DeprecatedObject DeprecatedRef { get { return this.DeprecatedRefOption.Value; } set { this.DeprecatedRefOption = new Option<DeprecatedObject>(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("id")]
         [Obsolete]
-        public decimal? Id { get { return this.IdOption; } set { this.IdOption = new Option<decimal?>(value); } }
+        public decimal? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<string>(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Order.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Complete
         /// </summary>
         [JsonPropertyName("complete")]
-        public bool? Complete { get { return this.CompleteOption; } set { this.CompleteOption = new Option<bool?>(value); } }
+        public bool? Complete { get { return this.CompleteOption.Value; } set { this.CompleteOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -89,7 +89,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of PetId
@@ -102,7 +102,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets PetId
         /// </summary>
         [JsonPropertyName("petId")]
-        public long? PetId { get { return this.PetIdOption; } set { this.PetIdOption = new Option<long?>(value); } }
+        public long? PetId { get { return this.PetIdOption.Value; } set { this.PetIdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Quantity
@@ -115,7 +115,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Quantity
         /// </summary>
         [JsonPropertyName("quantity")]
-        public int? Quantity { get { return this.QuantityOption; } set { this.QuantityOption = new Option<int?>(value); } }
+        public int? Quantity { get { return this.QuantityOption.Value; } set { this.QuantityOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of ShipDate
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2020-02-02T20:20:20.000222Z</example> */
         [JsonPropertyName("shipDate")]
-        public DateTime? ShipDate { get { return this.ShipDateOption; } set { this.ShipDateOption = new Option<DateTime?>(value); } }
+        public DateTime? ShipDate { get { return this.ShipDateOption.Value; } set { this.ShipDateOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyBoolean
         /// </summary>
         [JsonPropertyName("my_boolean")]
-        public bool? MyBoolean { get { return this.MyBooleanOption; } set { this.MyBooleanOption = new Option<bool?>(value); } }
+        public bool? MyBoolean { get { return this.MyBooleanOption.Value; } set { this.MyBooleanOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of MyNumber
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [JsonPropertyName("my_number")]
-        public decimal? MyNumber { get { return this.MyNumberOption; } set { this.MyNumberOption = new Option<decimal?>(value); } }
+        public decimal? MyNumber { get { return this.MyNumberOption.Value; } set { this.MyNumberOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of MyString
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyString
         /// </summary>
         [JsonPropertyName("my_string")]
-        public string MyString { get { return this.MyStringOption; } set { this.MyStringOption = new Option<string>(value); } }
+        public string MyString { get { return this.MyStringOption.Value; } set { this.MyStringOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Pet.cs
@@ -89,7 +89,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Category
         /// </summary>
         [JsonPropertyName("category")]
-        public Category Category { get { return this.CategoryOption; } set { this.CategoryOption = new Option<Category>(value); } }
+        public Category Category { get { return this.CategoryOption.Value; } set { this.CategoryOption = new Option<Category>(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -102,7 +102,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Tags
@@ -115,7 +115,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Tags
         /// </summary>
         [JsonPropertyName("tags")]
-        public List<Tag> Tags { get { return this.TagsOption; } set { this.TagsOption = new Option<List<Tag>>(value); } }
+        public List<Tag> Tags { get { return this.TagsOption.Value; } set { this.TagsOption = new Option<List<Tag>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } }
+        public string Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Baz
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Baz
         /// </summary>
         [JsonPropertyName("baz")]
-        public string Baz { get { return this.BazOption; } set { this.BazOption = new Option<string>(value); } }
+        public string Baz { get { return this.BazOption.Value; } set { this.BazOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -334,7 +334,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_notnullable_date_prop")]
-        public DateTime? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption; } set { this.NotRequiredNotnullableDatePropOption = new Option<DateTime?>(value); } }
+        public DateTime? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption.Value; } set { this.NotRequiredNotnullableDatePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNotnullableintegerProp
@@ -347,7 +347,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [JsonPropertyName("not_required_notnullableinteger_prop")]
-        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption; } set { this.NotRequiredNotnullableintegerPropOption = new Option<int?>(value); } }
+        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption.Value; } set { this.NotRequiredNotnullableintegerPropOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableDateProp
@@ -360,7 +360,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_date_prop")]
-        public DateTime? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption; } set { this.NotRequiredNullableDatePropOption = new Option<DateTime?>(value); } }
+        public DateTime? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption.Value; } set { this.NotRequiredNullableDatePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableIntegerProp
@@ -373,7 +373,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableIntegerProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_integer_prop")]
-        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption; } set { this.NotRequiredNullableIntegerPropOption = new Option<int?>(value); } }
+        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption.Value; } set { this.NotRequiredNullableIntegerPropOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableArrayOfString
@@ -386,7 +386,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_array_of_string")]
-        public List<string> NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption; } set { this.NotrequiredNotnullableArrayOfStringOption = new Option<List<string>>(value); } }
+        public List<string> NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption.Value; } set { this.NotrequiredNotnullableArrayOfStringOption = new Option<List<string>>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableBooleanProp
@@ -399,7 +399,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_boolean_prop")]
-        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption; } set { this.NotrequiredNotnullableBooleanPropOption = new Option<bool?>(value); } }
+        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption.Value; } set { this.NotrequiredNotnullableBooleanPropOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableDatetimeProp
@@ -412,7 +412,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_datetime_prop")]
-        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption; } set { this.NotrequiredNotnullableDatetimePropOption = new Option<DateTime?>(value); } }
+        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption.Value; } set { this.NotrequiredNotnullableDatetimePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableStringProp
@@ -425,7 +425,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_string_prop")]
-        public string NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption; } set { this.NotrequiredNotnullableStringPropOption = new Option<string>(value); } }
+        public string NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption.Value; } set { this.NotrequiredNotnullableStringPropOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableUuid
@@ -439,7 +439,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_notnullable_uuid")]
-        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption; } set { this.NotrequiredNotnullableUuidOption = new Option<Guid?>(value); } }
+        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption.Value; } set { this.NotrequiredNotnullableUuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableArrayOfString
@@ -452,7 +452,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_nullable_array_of_string")]
-        public List<string> NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption; } set { this.NotrequiredNullableArrayOfStringOption = new Option<List<string>>(value); } }
+        public List<string> NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption.Value; } set { this.NotrequiredNullableArrayOfStringOption = new Option<List<string>>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableBooleanProp
@@ -465,7 +465,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_boolean_prop")]
-        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption; } set { this.NotrequiredNullableBooleanPropOption = new Option<bool?>(value); } }
+        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption.Value; } set { this.NotrequiredNullableBooleanPropOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableDatetimeProp
@@ -478,7 +478,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_datetime_prop")]
-        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption; } set { this.NotrequiredNullableDatetimePropOption = new Option<DateTime?>(value); } }
+        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption.Value; } set { this.NotrequiredNullableDatetimePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableStringProp
@@ -491,7 +491,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_string_prop")]
-        public string NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption; } set { this.NotrequiredNullableStringPropOption = new Option<string>(value); } }
+        public string NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption.Value; } set { this.NotrequiredNullableStringPropOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableUuid
@@ -505,7 +505,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_nullable_uuid")]
-        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption; } set { this.NotrequiredNullableUuidOption = new Option<Guid?>(value); } }
+        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption.Value; } set { this.NotrequiredNullableUuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets RequiredNullableArrayOfString

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Result.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result code</value>
         [JsonPropertyName("code")]
-        public string Code { get { return this.CodeOption; } set { this.CodeOption = new Option<string>(value); } }
+        public string Code { get { return this.CodeOption.Value; } set { this.CodeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Data
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string> Data { get { return this.DataOption; } set { this.DataOption = new Option<Dictionary<string, string>>(value); } }
+        public Dictionary<string, string> Data { get { return this.DataOption.Value; } set { this.DataOption = new Option<Dictionary<string, string>>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<string>(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Return.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [JsonPropertyName("return")]
-        public int? VarReturn { get { return this.VarReturnOption; } set { this.VarReturnOption = new Option<int?>(value); } }
+        public int? VarReturn { get { return this.VarReturnOption.Value; } set { this.VarReturnOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Unsafe
@@ -84,7 +84,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Unsafe
         /// </summary>
         [JsonPropertyName("unsafe")]
-        public string Unsafe { get { return this.UnsafeOption; } set { this.UnsafeOption = new Option<string>(value); } }
+        public string Unsafe { get { return this.UnsafeOption.Value; } set { this.UnsafeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Role
         /// </summary>
         [JsonPropertyName("role")]
-        public RolesReportsHashRole Role { get { return this.RoleOption; } set { this.RoleOption = new Option<RolesReportsHashRole>(value); } }
+        public RolesReportsHashRole Role { get { return this.RoleOption.Value; } set { this.RoleOption = new Option<RolesReportsHashRole>(value); } }
 
         /// <summary>
         /// Used to track the state of RoleUuid
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [JsonPropertyName("role_uuid")]
-        public Guid? RoleUuid { get { return this.RoleUuidOption; } set { this.RoleUuidOption = new Option<Guid?>(value); } }
+        public Guid? RoleUuid { get { return this.RoleUuidOption.Value; } set { this.RoleUuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new Option<string>(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarSpecialModelName
         /// </summary>
         [JsonPropertyName("_special_model.name_")]
-        public string VarSpecialModelName { get { return this.VarSpecialModelNameOption; } set { this.VarSpecialModelNameOption = new Option<string>(value); } }
+        public string VarSpecialModelName { get { return this.VarSpecialModelNameOption.Value; } set { this.VarSpecialModelNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SpecialPropertyName
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [JsonPropertyName("$special[property.name]")]
-        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption; } set { this.SpecialPropertyNameOption = new Option<long?>(value); } }
+        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption.Value; } set { this.SpecialPropertyNameOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Tag.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new Option<string>(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Value
         /// </summary>
         [JsonPropertyName("value")]
-        public string Value { get { return this.ValueOption; } set { this.ValueOption = new Option<string>(value); } }
+        public string Value { get { return this.ValueOption.Value; } set { this.ValueOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets TestCollectionEndingWithWordList
         /// </summary>
         [JsonPropertyName("TestCollectionEndingWithWordList")]
-        public List<TestCollectionEndingWithWordList> TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption; } set { this.TestCollectionEndingWithWordListOption = new Option<List<TestCollectionEndingWithWordList>>(value); } }
+        public List<TestCollectionEndingWithWordList> TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption.Value; } set { this.TestCollectionEndingWithWordListOption = new Option<List<TestCollectionEndingWithWordList>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SomeProperty
         /// </summary>
         [JsonPropertyName("someProperty")]
-        public string SomeProperty { get { return this.SomePropertyOption; } set { this.SomePropertyOption = new Option<string>(value); } }
+        public string SomeProperty { get { return this.SomePropertyOption.Value; } set { this.SomePropertyOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string> Data { get { return this.DataOption; } set { this.DataOption = new Option<Dictionary<string, string>>(value); } }
+        public Dictionary<string, string> Data { get { return this.DataOption.Value; } set { this.DataOption = new Option<Dictionary<string, string>>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<string>(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/User.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
         [JsonPropertyName("anyTypeProp")]
-        public Object AnyTypeProp { get { return this.AnyTypePropOption; } set { this.AnyTypePropOption = new Option<Object>(value); } }
+        public Object AnyTypeProp { get { return this.AnyTypePropOption.Value; } set { this.AnyTypePropOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of AnyTypePropNullable
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values.</value>
         [JsonPropertyName("anyTypePropNullable")]
-        public Object AnyTypePropNullable { get { return this.AnyTypePropNullableOption; } set { this.AnyTypePropNullableOption = new Option<Object>(value); } }
+        public Object AnyTypePropNullable { get { return this.AnyTypePropNullableOption.Value; } set { this.AnyTypePropNullableOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of Email
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Email
         /// </summary>
         [JsonPropertyName("email")]
-        public string Email { get { return this.EmailOption; } set { this.EmailOption = new Option<string>(value); } }
+        public string Email { get { return this.EmailOption.Value; } set { this.EmailOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of FirstName
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets FirstName
         /// </summary>
         [JsonPropertyName("firstName")]
-        public string FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new Option<string>(value); } }
+        public string FirstName { get { return this.FirstNameOption.Value; } set { this.FirstNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of LastName
@@ -142,7 +142,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LastName
         /// </summary>
         [JsonPropertyName("lastName")]
-        public string LastName { get { return this.LastNameOption; } set { this.LastNameOption = new Option<string>(value); } }
+        public string LastName { get { return this.LastNameOption.Value; } set { this.LastNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredProps
@@ -156,7 +156,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredProps")]
-        public Object ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption; } set { this.ObjectWithNoDeclaredPropsOption = new Option<Object>(value); } }
+        public Object ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption.Value; } set { this.ObjectWithNoDeclaredPropsOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredPropsNullable
@@ -170,7 +170,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredPropsNullable")]
-        public Object ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption; } set { this.ObjectWithNoDeclaredPropsNullableOption = new Option<Object>(value); } }
+        public Object ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption.Value; } set { this.ObjectWithNoDeclaredPropsNullableOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of Password
@@ -183,7 +183,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Password
         /// </summary>
         [JsonPropertyName("password")]
-        public string Password { get { return this.PasswordOption; } set { this.PasswordOption = new Option<string>(value); } }
+        public string Password { get { return this.PasswordOption.Value; } set { this.PasswordOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Phone
@@ -196,7 +196,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Phone
         /// </summary>
         [JsonPropertyName("phone")]
-        public string Phone { get { return this.PhoneOption; } set { this.PhoneOption = new Option<string>(value); } }
+        public string Phone { get { return this.PhoneOption.Value; } set { this.PhoneOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of UserStatus
@@ -210,7 +210,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [JsonPropertyName("userStatus")]
-        public int? UserStatus { get { return this.UserStatusOption; } set { this.UserStatusOption = new Option<int?>(value); } }
+        public int? UserStatus { get { return this.UserStatusOption.Value; } set { this.UserStatusOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Username
@@ -223,7 +223,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Username
         /// </summary>
         [JsonPropertyName("username")]
-        public string Username { get { return this.UsernameOption; } set { this.UsernameOption = new Option<string>(value); } }
+        public string Username { get { return this.UsernameOption.Value; } set { this.UsernameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Whale.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [JsonPropertyName("hasBaleen")]
-        public bool? HasBaleen { get { return this.HasBaleenOption; } set { this.HasBaleenOption = new Option<bool?>(value); } }
+        public bool? HasBaleen { get { return this.HasBaleenOption.Value; } set { this.HasBaleenOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of HasTeeth
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasTeeth
         /// </summary>
         [JsonPropertyName("hasTeeth")]
-        public bool? HasTeeth { get { return this.HasTeethOption; } set { this.HasTeethOption = new Option<bool?>(value); } }
+        public bool? HasTeeth { get { return this.HasTeethOption.Value; } set { this.HasTeethOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Kind
         /// </summary>
         [JsonPropertyName("kind")]
-        public string Kind { get { return this.KindOption; } set { this.KindOption = new Option<string>(value); } }
+        public string Kind { get { return this.KindOption.Value; } set { this.KindOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Count
         /// </summary>
         [JsonPropertyName("count")]
-        public decimal? Count { get { return this.CountOption; } set { this.CountOption = new Option<decimal?>(value); } }
+        public decimal? Count { get { return this.CountOption.Value; } set { this.CountOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -93,7 +93,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new Option<string>(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Orange.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Orange.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [JsonPropertyName("sweet")]
-        public bool? Sweet { get { return this.SweetOption; } set { this.SweetOption = new Option<bool?>(value); } }
+        public bool? Sweet { get { return this.SweetOption.Value; } set { this.SweetOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Activity.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ActivityOutputs
         /// </summary>
         [JsonPropertyName("activity_outputs")]
-        public Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs { get { return this.ActivityOutputsOption; } set { this.ActivityOutputsOption = new Option<Dictionary<string, List<ActivityOutputElementRepresentation>>>(value); } }
+        public Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs { get { return this.ActivityOutputsOption.Value; } set { this.ActivityOutputsOption = new Option<Dictionary<string, List<ActivityOutputElementRepresentation>>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop1
         /// </summary>
         [JsonPropertyName("prop1")]
-        public string Prop1 { get { return this.Prop1Option; } set { this.Prop1Option = new Option<string>(value); } }
+        public string Prop1 { get { return this.Prop1Option.Value; } set { this.Prop1Option = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Prop2
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop2
         /// </summary>
         [JsonPropertyName("prop2")]
-        public Object Prop2 { get { return this.Prop2Option; } set { this.Prop2Option = new Option<Object>(value); } }
+        public Object Prop2 { get { return this.Prop2Option.Value; } set { this.Prop2Option = new Option<Object>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Anytype1
         /// </summary>
         [JsonPropertyName("anytype_1")]
-        public Object Anytype1 { get { return this.Anytype1Option; } set { this.Anytype1Option = new Option<Object>(value); } }
+        public Object Anytype1 { get { return this.Anytype1Option.Value; } set { this.Anytype1Option = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of EmptyMap
@@ -81,7 +81,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>an object with no declared properties and no undeclared properties, hence it&#39;s an empty map.</value>
         [JsonPropertyName("empty_map")]
-        public Object EmptyMap { get { return this.EmptyMapOption; } set { this.EmptyMapOption = new Option<Object>(value); } }
+        public Object EmptyMap { get { return this.EmptyMapOption.Value; } set { this.EmptyMapOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfMapProperty
@@ -94,7 +94,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfMapProperty
         /// </summary>
         [JsonPropertyName("map_of_map_property")]
-        public Dictionary<string, Dictionary<string, string>> MapOfMapProperty { get { return this.MapOfMapPropertyOption; } set { this.MapOfMapPropertyOption = new Option<Dictionary<string, Dictionary<string, string>>>(value); } }
+        public Dictionary<string, Dictionary<string, string>> MapOfMapProperty { get { return this.MapOfMapPropertyOption.Value; } set { this.MapOfMapPropertyOption = new Option<Dictionary<string, Dictionary<string, string>>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapProperty
@@ -107,7 +107,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapProperty
         /// </summary>
         [JsonPropertyName("map_property")]
-        public Dictionary<string, string> MapProperty { get { return this.MapPropertyOption; } set { this.MapPropertyOption = new Option<Dictionary<string, string>>(value); } }
+        public Dictionary<string, string> MapProperty { get { return this.MapPropertyOption.Value; } set { this.MapPropertyOption = new Option<Dictionary<string, string>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype1
@@ -120,7 +120,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype1
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_1")]
-        public Object MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new Option<Object>(value); } }
+        public Object MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype2
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype2
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_2")]
-        public Object MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new Option<Object>(value); } }
+        public Object MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype3
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype3
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_3")]
-        public Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new Option<Dictionary<string, Object>>(value); } }
+        public Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new Option<Dictionary<string, Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesString
@@ -159,7 +159,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesString
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_string")]
-        public Dictionary<string, string> MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption; } set { this.MapWithUndeclaredPropertiesStringOption = new Option<Dictionary<string, string>>(value); } }
+        public Dictionary<string, string> MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption.Value; } set { this.MapWithUndeclaredPropertiesStringOption = new Option<Dictionary<string, string>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Animal.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new Option<string>(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [JsonPropertyName("code")]
-        public int? Code { get { return this.CodeOption; } set { this.CodeOption = new Option<int?>(value); } }
+        public int? Code { get { return this.CodeOption.Value; } set { this.CodeOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Message
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Message
         /// </summary>
         [JsonPropertyName("message")]
-        public string Message { get { return this.MessageOption; } set { this.MessageOption = new Option<string>(value); } }
+        public string Message { get { return this.MessageOption.Value; } set { this.MessageOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Type
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Type
         /// </summary>
         [JsonPropertyName("type")]
-        public string Type { get { return this.TypeOption; } set { this.TypeOption = new Option<string>(value); } }
+        public string Type { get { return this.TypeOption.Value; } set { this.TypeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Apple.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ColorCode
         /// </summary>
         [JsonPropertyName("color_code")]
-        public string ColorCode { get { return this.ColorCodeOption; } set { this.ColorCodeOption = new Option<string>(value); } }
+        public string ColorCode { get { return this.ColorCodeOption.Value; } set { this.ColorCodeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Cultivar
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Cultivar
         /// </summary>
         [JsonPropertyName("cultivar")]
-        public string Cultivar { get { return this.CultivarOption; } set { this.CultivarOption = new Option<string>(value); } }
+        public string Cultivar { get { return this.CultivarOption.Value; } set { this.CultivarOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Origin
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Origin
         /// </summary>
         [JsonPropertyName("origin")]
-        public string Origin { get { return this.OriginOption; } set { this.OriginOption = new Option<string>(value); } }
+        public string Origin { get { return this.OriginOption.Value; } set { this.OriginOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [JsonPropertyName("mealy")]
-        public bool? Mealy { get { return this.MealyOption; } set { this.MealyOption = new Option<bool?>(value); } }
+        public bool? Mealy { get { return this.MealyOption.Value; } set { this.MealyOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayArrayNumber")]
-        public List<List<decimal>> ArrayArrayNumber { get { return this.ArrayArrayNumberOption; } set { this.ArrayArrayNumberOption = new Option<List<List<decimal>>>(value); } }
+        public List<List<decimal>> ArrayArrayNumber { get { return this.ArrayArrayNumberOption.Value; } set { this.ArrayArrayNumberOption = new Option<List<List<decimal>>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayNumber")]
-        public List<decimal> ArrayNumber { get { return this.ArrayNumberOption; } set { this.ArrayNumberOption = new Option<List<decimal>>(value); } }
+        public List<decimal> ArrayNumber { get { return this.ArrayNumberOption.Value; } set { this.ArrayNumberOption = new Option<List<decimal>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfInteger
         /// </summary>
         [JsonPropertyName("array_array_of_integer")]
-        public List<List<long>> ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption; } set { this.ArrayArrayOfIntegerOption = new Option<List<List<long>>>(value); } }
+        public List<List<long>> ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption.Value; } set { this.ArrayArrayOfIntegerOption = new Option<List<List<long>>>(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayArrayOfModel
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfModel
         /// </summary>
         [JsonPropertyName("array_array_of_model")]
-        public List<List<ReadOnlyFirst>> ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption; } set { this.ArrayArrayOfModelOption = new Option<List<List<ReadOnlyFirst>>>(value); } }
+        public List<List<ReadOnlyFirst>> ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption.Value; } set { this.ArrayArrayOfModelOption = new Option<List<List<ReadOnlyFirst>>>(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayOfString
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayOfString
         /// </summary>
         [JsonPropertyName("array_of_string")]
-        public List<string> ArrayOfString { get { return this.ArrayOfStringOption; } set { this.ArrayOfStringOption = new Option<List<string>>(value); } }
+        public List<string> ArrayOfString { get { return this.ArrayOfStringOption.Value; } set { this.ArrayOfStringOption = new Option<List<string>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Banana.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [JsonPropertyName("lengthCm")]
-        public decimal? LengthCm { get { return this.LengthCmOption; } set { this.LengthCmOption = new Option<decimal?>(value); } }
+        public decimal? LengthCm { get { return this.LengthCmOption.Value; } set { this.LengthCmOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [JsonPropertyName("sweet")]
-        public bool? Sweet { get { return this.SweetOption; } set { this.SweetOption = new Option<bool?>(value); } }
+        public bool? Sweet { get { return this.SweetOption.Value; } set { this.SweetOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -64,7 +64,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Name of the pet </value>
         [JsonPropertyName("ATT_NAME")]
-        public string ATT_NAME { get { return this.ATT_NAMEOption; } set { this.ATT_NAMEOption = new Option<string>(value); } }
+        public string ATT_NAME { get { return this.ATT_NAMEOption.Value; } set { this.ATT_NAMEOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalCamel
@@ -77,7 +77,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalCamel
         /// </summary>
         [JsonPropertyName("CapitalCamel")]
-        public string CapitalCamel { get { return this.CapitalCamelOption; } set { this.CapitalCamelOption = new Option<string>(value); } }
+        public string CapitalCamel { get { return this.CapitalCamelOption.Value; } set { this.CapitalCamelOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalSnake
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalSnake
         /// </summary>
         [JsonPropertyName("Capital_Snake")]
-        public string CapitalSnake { get { return this.CapitalSnakeOption; } set { this.CapitalSnakeOption = new Option<string>(value); } }
+        public string CapitalSnake { get { return this.CapitalSnakeOption.Value; } set { this.CapitalSnakeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SCAETHFlowPoints
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SCAETHFlowPoints
         /// </summary>
         [JsonPropertyName("SCA_ETH_Flow_Points")]
-        public string SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption; } set { this.SCAETHFlowPointsOption = new Option<string>(value); } }
+        public string SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption.Value; } set { this.SCAETHFlowPointsOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SmallCamel
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallCamel
         /// </summary>
         [JsonPropertyName("smallCamel")]
-        public string SmallCamel { get { return this.SmallCamelOption; } set { this.SmallCamelOption = new Option<string>(value); } }
+        public string SmallCamel { get { return this.SmallCamelOption.Value; } set { this.SmallCamelOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SmallSnake
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallSnake
         /// </summary>
         [JsonPropertyName("small_Snake")]
-        public string SmallSnake { get { return this.SmallSnakeOption; } set { this.SmallSnakeOption = new Option<string>(value); } }
+        public string SmallSnake { get { return this.SmallSnakeOption.Value; } set { this.SmallSnakeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [JsonPropertyName("declawed")]
-        public bool? Declawed { get { return this.DeclawedOption; } set { this.DeclawedOption = new Option<bool?>(value); } }
+        public bool? Declawed { get { return this.DeclawedOption.Value; } set { this.DeclawedOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -106,7 +106,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new Option<string>(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<string>(value); } }
 
         /// <summary>
         /// The discriminator

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("_class")]
-        public string Class { get { return this.ClassOption; } set { this.ClassOption = new Option<string>(value); } }
+        public string Class { get { return this.ClassOption.Value; } set { this.ClassOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>Fri Jul 21 00:00:00 UTC 2017</example> */
         [JsonPropertyName("dateOnlyProperty")]
-        public DateTime? DateOnlyProperty { get { return this.DateOnlyPropertyOption; } set { this.DateOnlyPropertyOption = new Option<DateTime?>(value); } }
+        public DateTime? DateOnlyProperty { get { return this.DateOnlyPropertyOption.Value; } set { this.DateOnlyPropertyOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new Option<string>(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Breed
         /// </summary>
         [JsonPropertyName("breed")]
-        public string Breed { get { return this.BreedOption; } set { this.BreedOption = new Option<string>(value); } }
+        public string Breed { get { return this.BreedOption.Value; } set { this.BreedOption = new Option<string>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MainShape
         /// </summary>
         [JsonPropertyName("mainShape")]
-        public Shape MainShape { get { return this.MainShapeOption; } set { this.MainShapeOption = new Option<Shape>(value); } }
+        public Shape MainShape { get { return this.MainShapeOption.Value; } set { this.MainShapeOption = new Option<Shape>(value); } }
 
         /// <summary>
         /// Used to track the state of NullableShape
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableShape
         /// </summary>
         [JsonPropertyName("nullableShape")]
-        public NullableShape NullableShape { get { return this.NullableShapeOption; } set { this.NullableShapeOption = new Option<NullableShape>(value); } }
+        public NullableShape NullableShape { get { return this.NullableShapeOption.Value; } set { this.NullableShapeOption = new Option<NullableShape>(value); } }
 
         /// <summary>
         /// Used to track the state of ShapeOrNull
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ShapeOrNull
         /// </summary>
         [JsonPropertyName("shapeOrNull")]
-        public ShapeOrNull ShapeOrNull { get { return this.ShapeOrNullOption; } set { this.ShapeOrNullOption = new Option<ShapeOrNull>(value); } }
+        public ShapeOrNull ShapeOrNull { get { return this.ShapeOrNullOption.Value; } set { this.ShapeOrNullOption = new Option<ShapeOrNull>(value); } }
 
         /// <summary>
         /// Used to track the state of Shapes
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Shapes
         /// </summary>
         [JsonPropertyName("shapes")]
-        public List<Shape> Shapes { get { return this.ShapesOption; } set { this.ShapesOption = new Option<List<Shape>>(value); } }
+        public List<Shape> Shapes { get { return this.ShapesOption.Value; } set { this.ShapesOption = new Option<List<Shape>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayEnum
         /// </summary>
         [JsonPropertyName("array_enum")]
-        public List<EnumArrays.ArrayEnumEnum> ArrayEnum { get { return this.ArrayEnumOption; } set { this.ArrayEnumOption = new Option<List<EnumArrays.ArrayEnumEnum>>(value); } }
+        public List<EnumArrays.ArrayEnumEnum> ArrayEnum { get { return this.ArrayEnumOption.Value; } set { this.ArrayEnumOption = new Option<List<EnumArrays.ArrayEnumEnum>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/File.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Test capitalization</value>
         [JsonPropertyName("sourceURI")]
-        public string SourceURI { get { return this.SourceURIOption; } set { this.SourceURIOption = new Option<string>(value); } }
+        public string SourceURI { get { return this.SourceURIOption.Value; } set { this.SourceURIOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets File
         /// </summary>
         [JsonPropertyName("file")]
-        public File File { get { return this.FileOption; } set { this.FileOption = new Option<File>(value); } }
+        public File File { get { return this.FileOption.Value; } set { this.FileOption = new Option<File>(value); } }
 
         /// <summary>
         /// Used to track the state of Files
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Files
         /// </summary>
         [JsonPropertyName("files")]
-        public List<File> Files { get { return this.FilesOption; } set { this.FilesOption = new Option<List<File>>(value); } }
+        public List<File> Files { get { return this.FilesOption.Value; } set { this.FilesOption = new Option<List<File>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Foo.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } set { this.BarOption = new Option<string>(value); } }
+        public string Bar { get { return this.BarOption.Value; } set { this.BarOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public Foo String { get { return this.StringOption; } set { this.StringOption = new Option<Foo>(value); } }
+        public Foo String { get { return this.StringOption.Value; } set { this.StringOption = new Option<Foo>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -138,7 +138,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Binary
         /// </summary>
         [JsonPropertyName("binary")]
-        public System.IO.Stream Binary { get { return this.BinaryOption; } set { this.BinaryOption = new Option<System.IO.Stream>(value); } }
+        public System.IO.Stream Binary { get { return this.BinaryOption.Value; } set { this.BinaryOption = new Option<System.IO.Stream>(value); } }
 
         /// <summary>
         /// Used to track the state of DateTime
@@ -152,7 +152,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2007-12-03T10:15:30+01:00</example> */
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new Option<DateTime?>(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of Decimal
@@ -165,7 +165,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Decimal
         /// </summary>
         [JsonPropertyName("decimal")]
-        public decimal? Decimal { get { return this.DecimalOption; } set { this.DecimalOption = new Option<decimal?>(value); } }
+        public decimal? Decimal { get { return this.DecimalOption.Value; } set { this.DecimalOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of Double
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Double
         /// </summary>
         [JsonPropertyName("double")]
-        public double? Double { get { return this.DoubleOption; } set { this.DoubleOption = new Option<double?>(value); } }
+        public double? Double { get { return this.DoubleOption.Value; } set { this.DoubleOption = new Option<double?>(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName2
@@ -191,7 +191,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName2
         /// </summary>
         [JsonPropertyName("duplicate_property_name")]
-        public string DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option; } set { this.DuplicatePropertyName2Option = new Option<string>(value); } }
+        public string DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option.Value; } set { this.DuplicatePropertyName2Option = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName
@@ -204,7 +204,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName
         /// </summary>
         [JsonPropertyName("@duplicate_property_name")]
-        public string DuplicatePropertyName { get { return this.DuplicatePropertyNameOption; } set { this.DuplicatePropertyNameOption = new Option<string>(value); } }
+        public string DuplicatePropertyName { get { return this.DuplicatePropertyNameOption.Value; } set { this.DuplicatePropertyNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Float
@@ -217,7 +217,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Float
         /// </summary>
         [JsonPropertyName("float")]
-        public float? Float { get { return this.FloatOption; } set { this.FloatOption = new Option<float?>(value); } }
+        public float? Float { get { return this.FloatOption.Value; } set { this.FloatOption = new Option<float?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int32
@@ -230,7 +230,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32
         /// </summary>
         [JsonPropertyName("int32")]
-        public int? Int32 { get { return this.Int32Option; } set { this.Int32Option = new Option<int?>(value); } }
+        public int? Int32 { get { return this.Int32Option.Value; } set { this.Int32Option = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int32Range
@@ -243,7 +243,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32Range
         /// </summary>
         [JsonPropertyName("int32Range")]
-        public int? Int32Range { get { return this.Int32RangeOption; } set { this.Int32RangeOption = new Option<int?>(value); } }
+        public int? Int32Range { get { return this.Int32RangeOption.Value; } set { this.Int32RangeOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64
@@ -256,7 +256,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64
         /// </summary>
         [JsonPropertyName("int64")]
-        public long? Int64 { get { return this.Int64Option; } set { this.Int64Option = new Option<long?>(value); } }
+        public long? Int64 { get { return this.Int64Option.Value; } set { this.Int64Option = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Negative
@@ -269,7 +269,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Negative
         /// </summary>
         [JsonPropertyName("int64Negative")]
-        public long? Int64Negative { get { return this.Int64NegativeOption; } set { this.Int64NegativeOption = new Option<long?>(value); } }
+        public long? Int64Negative { get { return this.Int64NegativeOption.Value; } set { this.Int64NegativeOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64NegativeExclusive
@@ -282,7 +282,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64NegativeExclusive
         /// </summary>
         [JsonPropertyName("int64NegativeExclusive")]
-        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption; } set { this.Int64NegativeExclusiveOption = new Option<long?>(value); } }
+        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption.Value; } set { this.Int64NegativeExclusiveOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Positive
@@ -295,7 +295,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Positive
         /// </summary>
         [JsonPropertyName("int64Positive")]
-        public long? Int64Positive { get { return this.Int64PositiveOption; } set { this.Int64PositiveOption = new Option<long?>(value); } }
+        public long? Int64Positive { get { return this.Int64PositiveOption.Value; } set { this.Int64PositiveOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64PositiveExclusive
@@ -308,7 +308,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64PositiveExclusive
         /// </summary>
         [JsonPropertyName("int64PositiveExclusive")]
-        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption; } set { this.Int64PositiveExclusiveOption = new Option<long?>(value); } }
+        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption.Value; } set { this.Int64PositiveExclusiveOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Integer
@@ -321,7 +321,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [JsonPropertyName("integer")]
-        public int? Integer { get { return this.IntegerOption; } set { this.IntegerOption = new Option<int?>(value); } }
+        public int? Integer { get { return this.IntegerOption.Value; } set { this.IntegerOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithBackslash
@@ -335,7 +335,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>None</value>
         [JsonPropertyName("pattern_with_backslash")]
-        public string PatternWithBackslash { get { return this.PatternWithBackslashOption; } set { this.PatternWithBackslashOption = new Option<string>(value); } }
+        public string PatternWithBackslash { get { return this.PatternWithBackslashOption.Value; } set { this.PatternWithBackslashOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigits
@@ -349,7 +349,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string that is a 10 digit number. Can have leading zeros.</value>
         [JsonPropertyName("pattern_with_digits")]
-        public string PatternWithDigits { get { return this.PatternWithDigitsOption; } set { this.PatternWithDigitsOption = new Option<string>(value); } }
+        public string PatternWithDigits { get { return this.PatternWithDigitsOption.Value; } set { this.PatternWithDigitsOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigitsAndDelimiter
@@ -363,7 +363,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.</value>
         [JsonPropertyName("pattern_with_digits_and_delimiter")]
-        public string PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption; } set { this.PatternWithDigitsAndDelimiterOption = new Option<string>(value); } }
+        public string PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption.Value; } set { this.PatternWithDigitsAndDelimiterOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of String
@@ -376,7 +376,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public string String { get { return this.StringOption; } set { this.StringOption = new Option<string>(value); } }
+        public string String { get { return this.StringOption.Value; } set { this.StringOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of StringFormattedAsDecimal
@@ -389,7 +389,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringFormattedAsDecimal
         /// </summary>
         [JsonPropertyName("string_formatted_as_decimal")]
-        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption; } set { this.StringFormattedAsDecimalOption = new Option<decimal?>(value); } }
+        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption.Value; } set { this.StringFormattedAsDecimalOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedInteger
@@ -402,7 +402,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [JsonPropertyName("unsigned_integer")]
-        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption; } set { this.UnsignedIntegerOption = new Option<uint?>(value); } }
+        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption.Value; } set { this.UnsignedIntegerOption = new Option<uint?>(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedLong
@@ -415,7 +415,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedLong
         /// </summary>
         [JsonPropertyName("unsigned_long")]
-        public ulong? UnsignedLong { get { return this.UnsignedLongOption; } set { this.UnsignedLongOption = new Option<ulong?>(value); } }
+        public ulong? UnsignedLong { get { return this.UnsignedLongOption.Value; } set { this.UnsignedLongOption = new Option<ulong?>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -429,7 +429,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<Guid?>(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new Option<string>(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new Option<string>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -80,7 +80,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new Option<string>(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new Option<string>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } }
+        public string Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Foo
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Foo
         /// </summary>
         [JsonPropertyName("foo")]
-        public string Foo { get { return this.FooOption; } }
+        public string Foo { get { return this.FooOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableMessage
         /// </summary>
         [JsonPropertyName("NullableMessage")]
-        public string NullableMessage { get { return this.NullableMessageOption; } set { this.NullableMessageOption = new Option<string>(value); } }
+        public string NullableMessage { get { return this.NullableMessageOption.Value; } set { this.NullableMessageOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/List.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123List
         /// </summary>
         [JsonPropertyName("123-list")]
-        public string Var123List { get { return this.Var123ListOption; } set { this.Var123ListOption = new Option<string>(value); } }
+        public string Var123List { get { return this.Var123ListOption.Value; } set { this.Var123ListOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets EscapedLiteralString
         /// </summary>
         [JsonPropertyName("escapedLiteralString")]
-        public string EscapedLiteralString { get { return this.EscapedLiteralStringOption; } set { this.EscapedLiteralStringOption = new Option<string>(value); } }
+        public string EscapedLiteralString { get { return this.EscapedLiteralStringOption.Value; } set { this.EscapedLiteralStringOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of UnescapedLiteralString
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnescapedLiteralString
         /// </summary>
         [JsonPropertyName("unescapedLiteralString")]
-        public string UnescapedLiteralString { get { return this.UnescapedLiteralStringOption; } set { this.UnescapedLiteralStringOption = new Option<string>(value); } }
+        public string UnescapedLiteralString { get { return this.UnescapedLiteralStringOption.Value; } set { this.UnescapedLiteralStringOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -125,7 +125,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DirectMap
         /// </summary>
         [JsonPropertyName("direct_map")]
-        public Dictionary<string, bool> DirectMap { get { return this.DirectMapOption; } set { this.DirectMapOption = new Option<Dictionary<string, bool>>(value); } }
+        public Dictionary<string, bool> DirectMap { get { return this.DirectMapOption.Value; } set { this.DirectMapOption = new Option<Dictionary<string, bool>>(value); } }
 
         /// <summary>
         /// Used to track the state of IndirectMap
@@ -138,7 +138,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IndirectMap
         /// </summary>
         [JsonPropertyName("indirect_map")]
-        public Dictionary<string, bool> IndirectMap { get { return this.IndirectMapOption; } set { this.IndirectMapOption = new Option<Dictionary<string, bool>>(value); } }
+        public Dictionary<string, bool> IndirectMap { get { return this.IndirectMapOption.Value; } set { this.IndirectMapOption = new Option<Dictionary<string, bool>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapMapOfString
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapMapOfString
         /// </summary>
         [JsonPropertyName("map_map_of_string")]
-        public Dictionary<string, Dictionary<string, string>> MapMapOfString { get { return this.MapMapOfStringOption; } set { this.MapMapOfStringOption = new Option<Dictionary<string, Dictionary<string, string>>>(value); } }
+        public Dictionary<string, Dictionary<string, string>> MapMapOfString { get { return this.MapMapOfStringOption.Value; } set { this.MapMapOfStringOption = new Option<Dictionary<string, Dictionary<string, string>>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfEnumString
@@ -164,7 +164,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfEnumString
         /// </summary>
         [JsonPropertyName("map_of_enum_string")]
-        public Dictionary<string, MapTest.InnerEnum> MapOfEnumString { get { return this.MapOfEnumStringOption; } set { this.MapOfEnumStringOption = new Option<Dictionary<string, MapTest.InnerEnum>>(value); } }
+        public Dictionary<string, MapTest.InnerEnum> MapOfEnumString { get { return this.MapOfEnumStringOption.Value; } set { this.MapOfEnumStringOption = new Option<Dictionary<string, MapTest.InnerEnum>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedAnyOfContent Content { get { return this.ContentOption; } set { this.ContentOption = new Option<MixedAnyOfContent>(value); } }
+        public MixedAnyOfContent Content { get { return this.ContentOption.Value; } set { this.ContentOption = new Option<MixedAnyOfContent>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedOneOfContent Content { get { return this.ContentOption; } set { this.ContentOption = new Option<MixedOneOfContent>(value); } }
+        public MixedOneOfContent Content { get { return this.ContentOption.Value; } set { this.ContentOption = new Option<MixedOneOfContent>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateTime
         /// </summary>
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new Option<DateTime?>(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of Map
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Map
         /// </summary>
         [JsonPropertyName("map")]
-        public Dictionary<string, Animal> Map { get { return this.MapOption; } set { this.MapOption = new Option<Dictionary<string, Animal>>(value); } }
+        public Dictionary<string, Animal> Map { get { return this.MapOption.Value; } set { this.MapOption = new Option<Dictionary<string, Animal>>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<Guid?>(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Used to track the state of UuidWithPattern
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [JsonPropertyName("uuid_with_pattern")]
-        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption; } set { this.UuidWithPatternOption = new Option<Guid?>(value); } }
+        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption.Value; } set { this.UuidWithPatternOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public string Id { get { return this.IdOption; } set { this.IdOption = new Option<string>(value); } }
+        public string Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("class")]
-        public string Class { get { return this.ClassOption; } set { this.ClassOption = new Option<string>(value); } }
+        public string Class { get { return this.ClassOption.Value; } set { this.ClassOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public int? Name { get { return this.NameOption; } set { this.NameOption = new Option<int?>(value); } }
+        public int? Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarClient
         /// </summary>
         [JsonPropertyName("client")]
-        public string VarClient { get { return this.VarClientOption; } set { this.VarClientOption = new Option<string>(value); } }
+        public string VarClient { get { return this.VarClientOption.Value; } set { this.VarClientOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -65,7 +65,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Property
         /// </summary>
         [JsonPropertyName("property")]
-        public string Property { get { return this.PropertyOption; } set { this.PropertyOption = new Option<string>(value); } }
+        public string Property { get { return this.PropertyOption.Value; } set { this.PropertyOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SnakeCase
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [JsonPropertyName("snake_case")]
-        public int? SnakeCase { get { return this.SnakeCaseOption; } }
+        public int? SnakeCase { get { return this.SnakeCaseOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Var123Number
@@ -91,7 +91,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123Number
         /// </summary>
         [JsonPropertyName("123Number")]
-        public int? Var123Number { get { return this.Var123NumberOption; } }
+        public int? Var123Number { get { return this.Var123NumberOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -75,7 +75,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("array_and_items_nullable_prop")]
-        public List<Object> ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption; } set { this.ArrayAndItemsNullablePropOption = new Option<List<Object>>(value); } }
+        public List<Object> ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption.Value; } set { this.ArrayAndItemsNullablePropOption = new Option<List<Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayItemsNullable
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayItemsNullable
         /// </summary>
         [JsonPropertyName("array_items_nullable")]
-        public List<Object> ArrayItemsNullable { get { return this.ArrayItemsNullableOption; } set { this.ArrayItemsNullableOption = new Option<List<Object>>(value); } }
+        public List<Object> ArrayItemsNullable { get { return this.ArrayItemsNullableOption.Value; } set { this.ArrayItemsNullableOption = new Option<List<Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayNullableProp
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNullableProp
         /// </summary>
         [JsonPropertyName("array_nullable_prop")]
-        public List<Object> ArrayNullableProp { get { return this.ArrayNullablePropOption; } set { this.ArrayNullablePropOption = new Option<List<Object>>(value); } }
+        public List<Object> ArrayNullableProp { get { return this.ArrayNullablePropOption.Value; } set { this.ArrayNullablePropOption = new Option<List<Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of BooleanProp
@@ -114,7 +114,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BooleanProp
         /// </summary>
         [JsonPropertyName("boolean_prop")]
-        public bool? BooleanProp { get { return this.BooleanPropOption; } set { this.BooleanPropOption = new Option<bool?>(value); } }
+        public bool? BooleanProp { get { return this.BooleanPropOption.Value; } set { this.BooleanPropOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of DateProp
@@ -127,7 +127,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateProp
         /// </summary>
         [JsonPropertyName("date_prop")]
-        public DateTime? DateProp { get { return this.DatePropOption; } set { this.DatePropOption = new Option<DateTime?>(value); } }
+        public DateTime? DateProp { get { return this.DatePropOption.Value; } set { this.DatePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of DatetimeProp
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DatetimeProp
         /// </summary>
         [JsonPropertyName("datetime_prop")]
-        public DateTime? DatetimeProp { get { return this.DatetimePropOption; } set { this.DatetimePropOption = new Option<DateTime?>(value); } }
+        public DateTime? DatetimeProp { get { return this.DatetimePropOption.Value; } set { this.DatetimePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of IntegerProp
@@ -153,7 +153,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IntegerProp
         /// </summary>
         [JsonPropertyName("integer_prop")]
-        public int? IntegerProp { get { return this.IntegerPropOption; } set { this.IntegerPropOption = new Option<int?>(value); } }
+        public int? IntegerProp { get { return this.IntegerPropOption.Value; } set { this.IntegerPropOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of NumberProp
@@ -166,7 +166,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NumberProp
         /// </summary>
         [JsonPropertyName("number_prop")]
-        public decimal? NumberProp { get { return this.NumberPropOption; } set { this.NumberPropOption = new Option<decimal?>(value); } }
+        public decimal? NumberProp { get { return this.NumberPropOption.Value; } set { this.NumberPropOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectAndItemsNullableProp
@@ -179,7 +179,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("object_and_items_nullable_prop")]
-        public Dictionary<string, Object> ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption; } set { this.ObjectAndItemsNullablePropOption = new Option<Dictionary<string, Object>>(value); } }
+        public Dictionary<string, Object> ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption.Value; } set { this.ObjectAndItemsNullablePropOption = new Option<Dictionary<string, Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectItemsNullable
@@ -192,7 +192,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectItemsNullable
         /// </summary>
         [JsonPropertyName("object_items_nullable")]
-        public Dictionary<string, Object> ObjectItemsNullable { get { return this.ObjectItemsNullableOption; } set { this.ObjectItemsNullableOption = new Option<Dictionary<string, Object>>(value); } }
+        public Dictionary<string, Object> ObjectItemsNullable { get { return this.ObjectItemsNullableOption.Value; } set { this.ObjectItemsNullableOption = new Option<Dictionary<string, Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectNullableProp
@@ -205,7 +205,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectNullableProp
         /// </summary>
         [JsonPropertyName("object_nullable_prop")]
-        public Dictionary<string, Object> ObjectNullableProp { get { return this.ObjectNullablePropOption; } set { this.ObjectNullablePropOption = new Option<Dictionary<string, Object>>(value); } }
+        public Dictionary<string, Object> ObjectNullableProp { get { return this.ObjectNullablePropOption.Value; } set { this.ObjectNullablePropOption = new Option<Dictionary<string, Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of StringProp
@@ -218,7 +218,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringProp
         /// </summary>
         [JsonPropertyName("string_prop")]
-        public string StringProp { get { return this.StringPropOption; } set { this.StringPropOption = new Option<string>(value); } }
+        public string StringProp { get { return this.StringPropOption.Value; } set { this.StringPropOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<Guid?>(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [JsonPropertyName("JustNumber")]
-        public decimal? JustNumber { get { return this.JustNumberOption; } set { this.JustNumberOption = new Option<decimal?>(value); } }
+        public decimal? JustNumber { get { return this.JustNumberOption.Value; } set { this.JustNumberOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("bars")]
         [Obsolete]
-        public List<string> Bars { get { return this.BarsOption; } set { this.BarsOption = new Option<List<string>>(value); } }
+        public List<string> Bars { get { return this.BarsOption.Value; } set { this.BarsOption = new Option<List<string>>(value); } }
 
         /// <summary>
         /// Used to track the state of DeprecatedRef
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("deprecatedRef")]
         [Obsolete]
-        public DeprecatedObject DeprecatedRef { get { return this.DeprecatedRefOption; } set { this.DeprecatedRefOption = new Option<DeprecatedObject>(value); } }
+        public DeprecatedObject DeprecatedRef { get { return this.DeprecatedRefOption.Value; } set { this.DeprecatedRefOption = new Option<DeprecatedObject>(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("id")]
         [Obsolete]
-        public decimal? Id { get { return this.IdOption; } set { this.IdOption = new Option<decimal?>(value); } }
+        public decimal? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<string>(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Order.cs
@@ -158,7 +158,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Complete
         /// </summary>
         [JsonPropertyName("complete")]
-        public bool? Complete { get { return this.CompleteOption; } set { this.CompleteOption = new Option<bool?>(value); } }
+        public bool? Complete { get { return this.CompleteOption.Value; } set { this.CompleteOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -171,7 +171,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of PetId
@@ -184,7 +184,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets PetId
         /// </summary>
         [JsonPropertyName("petId")]
-        public long? PetId { get { return this.PetIdOption; } set { this.PetIdOption = new Option<long?>(value); } }
+        public long? PetId { get { return this.PetIdOption.Value; } set { this.PetIdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Quantity
@@ -197,7 +197,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Quantity
         /// </summary>
         [JsonPropertyName("quantity")]
-        public int? Quantity { get { return this.QuantityOption; } set { this.QuantityOption = new Option<int?>(value); } }
+        public int? Quantity { get { return this.QuantityOption.Value; } set { this.QuantityOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of ShipDate
@@ -211,7 +211,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2020-02-02T20:20:20.000222Z</example> */
         [JsonPropertyName("shipDate")]
-        public DateTime? ShipDate { get { return this.ShipDateOption; } set { this.ShipDateOption = new Option<DateTime?>(value); } }
+        public DateTime? ShipDate { get { return this.ShipDateOption.Value; } set { this.ShipDateOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyBoolean
         /// </summary>
         [JsonPropertyName("my_boolean")]
-        public bool? MyBoolean { get { return this.MyBooleanOption; } set { this.MyBooleanOption = new Option<bool?>(value); } }
+        public bool? MyBoolean { get { return this.MyBooleanOption.Value; } set { this.MyBooleanOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of MyNumber
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [JsonPropertyName("my_number")]
-        public decimal? MyNumber { get { return this.MyNumberOption; } set { this.MyNumberOption = new Option<decimal?>(value); } }
+        public decimal? MyNumber { get { return this.MyNumberOption.Value; } set { this.MyNumberOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of MyString
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyString
         /// </summary>
         [JsonPropertyName("my_string")]
-        public string MyString { get { return this.MyStringOption; } set { this.MyStringOption = new Option<string>(value); } }
+        public string MyString { get { return this.MyStringOption.Value; } set { this.MyStringOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -171,7 +171,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Category
         /// </summary>
         [JsonPropertyName("category")]
-        public Category Category { get { return this.CategoryOption; } set { this.CategoryOption = new Option<Category>(value); } }
+        public Category Category { get { return this.CategoryOption.Value; } set { this.CategoryOption = new Option<Category>(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -184,7 +184,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Tags
@@ -197,7 +197,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Tags
         /// </summary>
         [JsonPropertyName("tags")]
-        public List<Tag> Tags { get { return this.TagsOption; } set { this.TagsOption = new Option<List<Tag>>(value); } }
+        public List<Tag> Tags { get { return this.TagsOption.Value; } set { this.TagsOption = new Option<List<Tag>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } }
+        public string Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Baz
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Baz
         /// </summary>
         [JsonPropertyName("baz")]
-        public string Baz { get { return this.BazOption; } set { this.BazOption = new Option<string>(value); } }
+        public string Baz { get { return this.BazOption.Value; } set { this.BazOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -1412,7 +1412,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_notnullable_date_prop")]
-        public DateTime? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption; } set { this.NotRequiredNotnullableDatePropOption = new Option<DateTime?>(value); } }
+        public DateTime? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption.Value; } set { this.NotRequiredNotnullableDatePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNotnullableintegerProp
@@ -1425,7 +1425,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [JsonPropertyName("not_required_notnullableinteger_prop")]
-        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption; } set { this.NotRequiredNotnullableintegerPropOption = new Option<int?>(value); } }
+        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption.Value; } set { this.NotRequiredNotnullableintegerPropOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableDateProp
@@ -1438,7 +1438,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_date_prop")]
-        public DateTime? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption; } set { this.NotRequiredNullableDatePropOption = new Option<DateTime?>(value); } }
+        public DateTime? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption.Value; } set { this.NotRequiredNullableDatePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableIntegerProp
@@ -1451,7 +1451,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableIntegerProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_integer_prop")]
-        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption; } set { this.NotRequiredNullableIntegerPropOption = new Option<int?>(value); } }
+        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption.Value; } set { this.NotRequiredNullableIntegerPropOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableArrayOfString
@@ -1464,7 +1464,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_array_of_string")]
-        public List<string> NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption; } set { this.NotrequiredNotnullableArrayOfStringOption = new Option<List<string>>(value); } }
+        public List<string> NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption.Value; } set { this.NotrequiredNotnullableArrayOfStringOption = new Option<List<string>>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableBooleanProp
@@ -1477,7 +1477,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_boolean_prop")]
-        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption; } set { this.NotrequiredNotnullableBooleanPropOption = new Option<bool?>(value); } }
+        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption.Value; } set { this.NotrequiredNotnullableBooleanPropOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableDatetimeProp
@@ -1490,7 +1490,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_datetime_prop")]
-        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption; } set { this.NotrequiredNotnullableDatetimePropOption = new Option<DateTime?>(value); } }
+        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption.Value; } set { this.NotrequiredNotnullableDatetimePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableStringProp
@@ -1503,7 +1503,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_string_prop")]
-        public string NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption; } set { this.NotrequiredNotnullableStringPropOption = new Option<string>(value); } }
+        public string NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption.Value; } set { this.NotrequiredNotnullableStringPropOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableUuid
@@ -1517,7 +1517,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_notnullable_uuid")]
-        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption; } set { this.NotrequiredNotnullableUuidOption = new Option<Guid?>(value); } }
+        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption.Value; } set { this.NotrequiredNotnullableUuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableArrayOfString
@@ -1530,7 +1530,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_nullable_array_of_string")]
-        public List<string> NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption; } set { this.NotrequiredNullableArrayOfStringOption = new Option<List<string>>(value); } }
+        public List<string> NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption.Value; } set { this.NotrequiredNullableArrayOfStringOption = new Option<List<string>>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableBooleanProp
@@ -1543,7 +1543,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_boolean_prop")]
-        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption; } set { this.NotrequiredNullableBooleanPropOption = new Option<bool?>(value); } }
+        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption.Value; } set { this.NotrequiredNullableBooleanPropOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableDatetimeProp
@@ -1556,7 +1556,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_datetime_prop")]
-        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption; } set { this.NotrequiredNullableDatetimePropOption = new Option<DateTime?>(value); } }
+        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption.Value; } set { this.NotrequiredNullableDatetimePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableStringProp
@@ -1569,7 +1569,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_string_prop")]
-        public string NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption; } set { this.NotrequiredNullableStringPropOption = new Option<string>(value); } }
+        public string NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption.Value; } set { this.NotrequiredNullableStringPropOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableUuid
@@ -1583,7 +1583,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_nullable_uuid")]
-        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption; } set { this.NotrequiredNullableUuidOption = new Option<Guid?>(value); } }
+        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption.Value; } set { this.NotrequiredNullableUuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets RequiredNullableArrayOfString

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Result.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result code</value>
         [JsonPropertyName("code")]
-        public string Code { get { return this.CodeOption; } set { this.CodeOption = new Option<string>(value); } }
+        public string Code { get { return this.CodeOption.Value; } set { this.CodeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Data
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string> Data { get { return this.DataOption; } set { this.DataOption = new Option<Dictionary<string, string>>(value); } }
+        public Dictionary<string, string> Data { get { return this.DataOption.Value; } set { this.DataOption = new Option<Dictionary<string, string>>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<string>(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [JsonPropertyName("return")]
-        public int? VarReturn { get { return this.VarReturnOption; } set { this.VarReturnOption = new Option<int?>(value); } }
+        public int? VarReturn { get { return this.VarReturnOption.Value; } set { this.VarReturnOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Unsafe
@@ -84,7 +84,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Unsafe
         /// </summary>
         [JsonPropertyName("unsafe")]
-        public string Unsafe { get { return this.UnsafeOption; } set { this.UnsafeOption = new Option<string>(value); } }
+        public string Unsafe { get { return this.UnsafeOption.Value; } set { this.UnsafeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Role
         /// </summary>
         [JsonPropertyName("role")]
-        public RolesReportsHashRole Role { get { return this.RoleOption; } set { this.RoleOption = new Option<RolesReportsHashRole>(value); } }
+        public RolesReportsHashRole Role { get { return this.RoleOption.Value; } set { this.RoleOption = new Option<RolesReportsHashRole>(value); } }
 
         /// <summary>
         /// Used to track the state of RoleUuid
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [JsonPropertyName("role_uuid")]
-        public Guid? RoleUuid { get { return this.RoleUuidOption; } set { this.RoleUuidOption = new Option<Guid?>(value); } }
+        public Guid? RoleUuid { get { return this.RoleUuidOption.Value; } set { this.RoleUuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new Option<string>(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarSpecialModelName
         /// </summary>
         [JsonPropertyName("_special_model.name_")]
-        public string VarSpecialModelName { get { return this.VarSpecialModelNameOption; } set { this.VarSpecialModelNameOption = new Option<string>(value); } }
+        public string VarSpecialModelName { get { return this.VarSpecialModelNameOption.Value; } set { this.VarSpecialModelNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SpecialPropertyName
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [JsonPropertyName("$special[property.name]")]
-        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption; } set { this.SpecialPropertyNameOption = new Option<long?>(value); } }
+        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption.Value; } set { this.SpecialPropertyNameOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new Option<string>(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Value
         /// </summary>
         [JsonPropertyName("value")]
-        public string Value { get { return this.ValueOption; } set { this.ValueOption = new Option<string>(value); } }
+        public string Value { get { return this.ValueOption.Value; } set { this.ValueOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets TestCollectionEndingWithWordList
         /// </summary>
         [JsonPropertyName("TestCollectionEndingWithWordList")]
-        public List<TestCollectionEndingWithWordList> TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption; } set { this.TestCollectionEndingWithWordListOption = new Option<List<TestCollectionEndingWithWordList>>(value); } }
+        public List<TestCollectionEndingWithWordList> TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption.Value; } set { this.TestCollectionEndingWithWordListOption = new Option<List<TestCollectionEndingWithWordList>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SomeProperty
         /// </summary>
         [JsonPropertyName("someProperty")]
-        public string SomeProperty { get { return this.SomePropertyOption; } set { this.SomePropertyOption = new Option<string>(value); } }
+        public string SomeProperty { get { return this.SomePropertyOption.Value; } set { this.SomePropertyOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string> Data { get { return this.DataOption; } set { this.DataOption = new Option<Dictionary<string, string>>(value); } }
+        public Dictionary<string, string> Data { get { return this.DataOption.Value; } set { this.DataOption = new Option<Dictionary<string, string>>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<string>(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
         [JsonPropertyName("anyTypeProp")]
-        public Object AnyTypeProp { get { return this.AnyTypePropOption; } set { this.AnyTypePropOption = new Option<Object>(value); } }
+        public Object AnyTypeProp { get { return this.AnyTypePropOption.Value; } set { this.AnyTypePropOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of AnyTypePropNullable
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values.</value>
         [JsonPropertyName("anyTypePropNullable")]
-        public Object AnyTypePropNullable { get { return this.AnyTypePropNullableOption; } set { this.AnyTypePropNullableOption = new Option<Object>(value); } }
+        public Object AnyTypePropNullable { get { return this.AnyTypePropNullableOption.Value; } set { this.AnyTypePropNullableOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of Email
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Email
         /// </summary>
         [JsonPropertyName("email")]
-        public string Email { get { return this.EmailOption; } set { this.EmailOption = new Option<string>(value); } }
+        public string Email { get { return this.EmailOption.Value; } set { this.EmailOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of FirstName
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets FirstName
         /// </summary>
         [JsonPropertyName("firstName")]
-        public string FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new Option<string>(value); } }
+        public string FirstName { get { return this.FirstNameOption.Value; } set { this.FirstNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of LastName
@@ -142,7 +142,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LastName
         /// </summary>
         [JsonPropertyName("lastName")]
-        public string LastName { get { return this.LastNameOption; } set { this.LastNameOption = new Option<string>(value); } }
+        public string LastName { get { return this.LastNameOption.Value; } set { this.LastNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredProps
@@ -156,7 +156,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredProps")]
-        public Object ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption; } set { this.ObjectWithNoDeclaredPropsOption = new Option<Object>(value); } }
+        public Object ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption.Value; } set { this.ObjectWithNoDeclaredPropsOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredPropsNullable
@@ -170,7 +170,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredPropsNullable")]
-        public Object ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption; } set { this.ObjectWithNoDeclaredPropsNullableOption = new Option<Object>(value); } }
+        public Object ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption.Value; } set { this.ObjectWithNoDeclaredPropsNullableOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of Password
@@ -183,7 +183,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Password
         /// </summary>
         [JsonPropertyName("password")]
-        public string Password { get { return this.PasswordOption; } set { this.PasswordOption = new Option<string>(value); } }
+        public string Password { get { return this.PasswordOption.Value; } set { this.PasswordOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Phone
@@ -196,7 +196,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Phone
         /// </summary>
         [JsonPropertyName("phone")]
-        public string Phone { get { return this.PhoneOption; } set { this.PhoneOption = new Option<string>(value); } }
+        public string Phone { get { return this.PhoneOption.Value; } set { this.PhoneOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of UserStatus
@@ -210,7 +210,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [JsonPropertyName("userStatus")]
-        public int? UserStatus { get { return this.UserStatusOption; } set { this.UserStatusOption = new Option<int?>(value); } }
+        public int? UserStatus { get { return this.UserStatusOption.Value; } set { this.UserStatusOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Username
@@ -223,7 +223,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Username
         /// </summary>
         [JsonPropertyName("username")]
-        public string Username { get { return this.UsernameOption; } set { this.UsernameOption = new Option<string>(value); } }
+        public string Username { get { return this.UsernameOption.Value; } set { this.UsernameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [JsonPropertyName("hasBaleen")]
-        public bool? HasBaleen { get { return this.HasBaleenOption; } set { this.HasBaleenOption = new Option<bool?>(value); } }
+        public bool? HasBaleen { get { return this.HasBaleenOption.Value; } set { this.HasBaleenOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of HasTeeth
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasTeeth
         /// </summary>
         [JsonPropertyName("hasTeeth")]
-        public bool? HasTeeth { get { return this.HasTeethOption; } set { this.HasTeethOption = new Option<bool?>(value); } }
+        public bool? HasTeeth { get { return this.HasTeethOption.Value; } set { this.HasTeethOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Now
         /// </summary>
         [JsonPropertyName("now")]
-        public DateTime? Now { get { return this.NowOption; } set { this.NowOption = new Option<DateTime?>(value); } }
+        public DateTime? Now { get { return this.NowOption.Value; } set { this.NowOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of Today
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Today
         /// </summary>
         [JsonPropertyName("today")]
-        public DateTime? Today { get { return this.TodayOption; } set { this.TodayOption = new Option<DateTime?>(value); } }
+        public DateTime? Today { get { return this.TodayOption.Value; } set { this.TodayOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Adult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Adult.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Children
         /// </summary>
         [JsonPropertyName("children")]
-        public List<Child>? Children { get { return this.ChildrenOption; } set { this.ChildrenOption = new(value); } }
+        public List<Child>? Children { get { return this.ChildrenOption.Value; } set { this.ChildrenOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Age
         /// </summary>
         [JsonPropertyName("age")]
-        public int? Age { get { return this.AgeOption; } set { this.AgeOption = new(value); } }
+        public int? Age { get { return this.AgeOption.Value; } set { this.AgeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of BoosterSeat
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BoosterSeat
         /// </summary>
         [JsonPropertyName("boosterSeat")]
-        public bool? BoosterSeat { get { return this.BoosterSeatOption; } set { this.BoosterSeatOption = new(value); } }
+        public bool? BoosterSeat { get { return this.BoosterSeatOption.Value; } set { this.BoosterSeatOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Person.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Person.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets FirstName
         /// </summary>
         [JsonPropertyName("firstName")]
-        public string? FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new(value); } }
+        public string? FirstName { get { return this.FirstNameOption.Value; } set { this.FirstNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of LastName
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LastName
         /// </summary>
         [JsonPropertyName("lastName")]
-        public string? LastName { get { return this.LastNameOption; } set { this.LastNameOption = new(value); } }
+        public string? LastName { get { return this.LastNameOption.Value; } set { this.LastNameOption = new(value); } }
 
         /// <summary>
         /// The discriminator

--- a/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Kind
         /// </summary>
         [JsonPropertyName("kind")]
-        public string? Kind { get { return this.KindOption; } set { this.KindOption = new(value); } }
+        public string? Kind { get { return this.KindOption.Value; } set { this.KindOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Count
         /// </summary>
         [JsonPropertyName("count")]
-        public decimal? Count { get { return this.CountOption; } set { this.CountOption = new(value); } }
+        public decimal? Count { get { return this.CountOption.Value; } set { this.CountOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -82,7 +82,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Kind
         /// </summary>
         [JsonPropertyName("kind")]
-        public string? Kind { get { return this.KindOption; } set { this.KindOption = new(value); } }
+        public string? Kind { get { return this.KindOption.Value; } set { this.KindOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Count
         /// </summary>
         [JsonPropertyName("count")]
-        public decimal? Count { get { return this.CountOption; } set { this.CountOption = new(value); } }
+        public decimal? Count { get { return this.CountOption.Value; } set { this.CountOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
@@ -81,7 +81,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Activity.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ActivityOutputs
         /// </summary>
         [JsonPropertyName("activity_outputs")]
-        public Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs { get { return this.ActivityOutputsOption; } set { this.ActivityOutputsOption = new(value); } }
+        public Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs { get { return this.ActivityOutputsOption.Value; } set { this.ActivityOutputsOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop1
         /// </summary>
         [JsonPropertyName("prop1")]
-        public string Prop1 { get { return this.Prop1Option; } set { this.Prop1Option = new(value); } }
+        public string Prop1 { get { return this.Prop1Option.Value; } set { this.Prop1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Prop2
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop2
         /// </summary>
         [JsonPropertyName("prop2")]
-        public Object Prop2 { get { return this.Prop2Option; } set { this.Prop2Option = new(value); } }
+        public Object Prop2 { get { return this.Prop2Option.Value; } set { this.Prop2Option = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Anytype1
         /// </summary>
         [JsonPropertyName("anytype_1")]
-        public Object Anytype1 { get { return this.Anytype1Option; } set { this.Anytype1Option = new(value); } }
+        public Object Anytype1 { get { return this.Anytype1Option.Value; } set { this.Anytype1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of EmptyMap
@@ -81,7 +81,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>an object with no declared properties and no undeclared properties, hence it&#39;s an empty map.</value>
         [JsonPropertyName("empty_map")]
-        public Object EmptyMap { get { return this.EmptyMapOption; } set { this.EmptyMapOption = new(value); } }
+        public Object EmptyMap { get { return this.EmptyMapOption.Value; } set { this.EmptyMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfMapProperty
@@ -94,7 +94,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfMapProperty
         /// </summary>
         [JsonPropertyName("map_of_map_property")]
-        public Dictionary<string, Dictionary<string, string>> MapOfMapProperty { get { return this.MapOfMapPropertyOption; } set { this.MapOfMapPropertyOption = new(value); } }
+        public Dictionary<string, Dictionary<string, string>> MapOfMapProperty { get { return this.MapOfMapPropertyOption.Value; } set { this.MapOfMapPropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapProperty
@@ -107,7 +107,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapProperty
         /// </summary>
         [JsonPropertyName("map_property")]
-        public Dictionary<string, string> MapProperty { get { return this.MapPropertyOption; } set { this.MapPropertyOption = new(value); } }
+        public Dictionary<string, string> MapProperty { get { return this.MapPropertyOption.Value; } set { this.MapPropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype1
@@ -120,7 +120,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype1
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_1")]
-        public Object MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new(value); } }
+        public Object MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype2
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype2
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_2")]
-        public Object MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new(value); } }
+        public Object MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype3
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype3
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_3")]
-        public Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new(value); } }
+        public Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesString
@@ -159,7 +159,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesString
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_string")]
-        public Dictionary<string, string> MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption; } set { this.MapWithUndeclaredPropertiesStringOption = new(value); } }
+        public Dictionary<string, string> MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption.Value; } set { this.MapWithUndeclaredPropertiesStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Animal.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [JsonPropertyName("code")]
-        public int? Code { get { return this.CodeOption; } set { this.CodeOption = new(value); } }
+        public int? Code { get { return this.CodeOption.Value; } set { this.CodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Message
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Message
         /// </summary>
         [JsonPropertyName("message")]
-        public string Message { get { return this.MessageOption; } set { this.MessageOption = new(value); } }
+        public string Message { get { return this.MessageOption.Value; } set { this.MessageOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Type
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Type
         /// </summary>
         [JsonPropertyName("type")]
-        public string Type { get { return this.TypeOption; } set { this.TypeOption = new(value); } }
+        public string Type { get { return this.TypeOption.Value; } set { this.TypeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Apple.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ColorCode
         /// </summary>
         [JsonPropertyName("color_code")]
-        public string ColorCode { get { return this.ColorCodeOption; } set { this.ColorCodeOption = new(value); } }
+        public string ColorCode { get { return this.ColorCodeOption.Value; } set { this.ColorCodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Cultivar
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Cultivar
         /// </summary>
         [JsonPropertyName("cultivar")]
-        public string Cultivar { get { return this.CultivarOption; } set { this.CultivarOption = new(value); } }
+        public string Cultivar { get { return this.CultivarOption.Value; } set { this.CultivarOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Origin
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Origin
         /// </summary>
         [JsonPropertyName("origin")]
-        public string Origin { get { return this.OriginOption; } set { this.OriginOption = new(value); } }
+        public string Origin { get { return this.OriginOption.Value; } set { this.OriginOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [JsonPropertyName("mealy")]
-        public bool? Mealy { get { return this.MealyOption; } set { this.MealyOption = new(value); } }
+        public bool? Mealy { get { return this.MealyOption.Value; } set { this.MealyOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayArrayNumber")]
-        public List<List<decimal>> ArrayArrayNumber { get { return this.ArrayArrayNumberOption; } set { this.ArrayArrayNumberOption = new(value); } }
+        public List<List<decimal>> ArrayArrayNumber { get { return this.ArrayArrayNumberOption.Value; } set { this.ArrayArrayNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayNumber")]
-        public List<decimal> ArrayNumber { get { return this.ArrayNumberOption; } set { this.ArrayNumberOption = new(value); } }
+        public List<decimal> ArrayNumber { get { return this.ArrayNumberOption.Value; } set { this.ArrayNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfInteger
         /// </summary>
         [JsonPropertyName("array_array_of_integer")]
-        public List<List<long>> ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption; } set { this.ArrayArrayOfIntegerOption = new(value); } }
+        public List<List<long>> ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption.Value; } set { this.ArrayArrayOfIntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayArrayOfModel
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfModel
         /// </summary>
         [JsonPropertyName("array_array_of_model")]
-        public List<List<ReadOnlyFirst>> ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption; } set { this.ArrayArrayOfModelOption = new(value); } }
+        public List<List<ReadOnlyFirst>> ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption.Value; } set { this.ArrayArrayOfModelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayOfString
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayOfString
         /// </summary>
         [JsonPropertyName("array_of_string")]
-        public List<string> ArrayOfString { get { return this.ArrayOfStringOption; } set { this.ArrayOfStringOption = new(value); } }
+        public List<string> ArrayOfString { get { return this.ArrayOfStringOption.Value; } set { this.ArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Banana.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [JsonPropertyName("lengthCm")]
-        public decimal? LengthCm { get { return this.LengthCmOption; } set { this.LengthCmOption = new(value); } }
+        public decimal? LengthCm { get { return this.LengthCmOption.Value; } set { this.LengthCmOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [JsonPropertyName("sweet")]
-        public bool? Sweet { get { return this.SweetOption; } set { this.SweetOption = new(value); } }
+        public bool? Sweet { get { return this.SweetOption.Value; } set { this.SweetOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -64,7 +64,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Name of the pet </value>
         [JsonPropertyName("ATT_NAME")]
-        public string ATT_NAME { get { return this.ATT_NAMEOption; } set { this.ATT_NAMEOption = new(value); } }
+        public string ATT_NAME { get { return this.ATT_NAMEOption.Value; } set { this.ATT_NAMEOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalCamel
@@ -77,7 +77,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalCamel
         /// </summary>
         [JsonPropertyName("CapitalCamel")]
-        public string CapitalCamel { get { return this.CapitalCamelOption; } set { this.CapitalCamelOption = new(value); } }
+        public string CapitalCamel { get { return this.CapitalCamelOption.Value; } set { this.CapitalCamelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalSnake
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalSnake
         /// </summary>
         [JsonPropertyName("Capital_Snake")]
-        public string CapitalSnake { get { return this.CapitalSnakeOption; } set { this.CapitalSnakeOption = new(value); } }
+        public string CapitalSnake { get { return this.CapitalSnakeOption.Value; } set { this.CapitalSnakeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SCAETHFlowPoints
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SCAETHFlowPoints
         /// </summary>
         [JsonPropertyName("SCA_ETH_Flow_Points")]
-        public string SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption; } set { this.SCAETHFlowPointsOption = new(value); } }
+        public string SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption.Value; } set { this.SCAETHFlowPointsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SmallCamel
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallCamel
         /// </summary>
         [JsonPropertyName("smallCamel")]
-        public string SmallCamel { get { return this.SmallCamelOption; } set { this.SmallCamelOption = new(value); } }
+        public string SmallCamel { get { return this.SmallCamelOption.Value; } set { this.SmallCamelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SmallSnake
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallSnake
         /// </summary>
         [JsonPropertyName("small_Snake")]
-        public string SmallSnake { get { return this.SmallSnakeOption; } set { this.SmallSnakeOption = new(value); } }
+        public string SmallSnake { get { return this.SmallSnakeOption.Value; } set { this.SmallSnakeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Cat.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [JsonPropertyName("declawed")]
-        public bool? Declawed { get { return this.DeclawedOption; } set { this.DeclawedOption = new(value); } }
+        public bool? Declawed { get { return this.DeclawedOption.Value; } set { this.DeclawedOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Category.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("_class")]
-        public string Class { get { return this.ClassOption; } set { this.ClassOption = new(value); } }
+        public string Class { get { return this.ClassOption.Value; } set { this.ClassOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>Fri Jul 21 00:00:00 UTC 2017</example> */
         [JsonPropertyName("dateOnlyProperty")]
-        public DateOnly? DateOnlyProperty { get { return this.DateOnlyPropertyOption; } set { this.DateOnlyPropertyOption = new(value); } }
+        public DateOnly? DateOnlyProperty { get { return this.DateOnlyPropertyOption.Value; } set { this.DateOnlyPropertyOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Dog.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Breed
         /// </summary>
         [JsonPropertyName("breed")]
-        public string Breed { get { return this.BreedOption; } set { this.BreedOption = new(value); } }
+        public string Breed { get { return this.BreedOption.Value; } set { this.BreedOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MainShape
         /// </summary>
         [JsonPropertyName("mainShape")]
-        public Shape MainShape { get { return this.MainShapeOption; } set { this.MainShapeOption = new(value); } }
+        public Shape MainShape { get { return this.MainShapeOption.Value; } set { this.MainShapeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NullableShape
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableShape
         /// </summary>
         [JsonPropertyName("nullableShape")]
-        public NullableShape NullableShape { get { return this.NullableShapeOption; } set { this.NullableShapeOption = new(value); } }
+        public NullableShape NullableShape { get { return this.NullableShapeOption.Value; } set { this.NullableShapeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ShapeOrNull
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ShapeOrNull
         /// </summary>
         [JsonPropertyName("shapeOrNull")]
-        public ShapeOrNull ShapeOrNull { get { return this.ShapeOrNullOption; } set { this.ShapeOrNullOption = new(value); } }
+        public ShapeOrNull ShapeOrNull { get { return this.ShapeOrNullOption.Value; } set { this.ShapeOrNullOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Shapes
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Shapes
         /// </summary>
         [JsonPropertyName("shapes")]
-        public List<Shape> Shapes { get { return this.ShapesOption; } set { this.ShapesOption = new(value); } }
+        public List<Shape> Shapes { get { return this.ShapesOption.Value; } set { this.ShapesOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayEnum
         /// </summary>
         [JsonPropertyName("array_enum")]
-        public List<EnumArraysArrayEnumInner> ArrayEnum { get { return this.ArrayEnumOption; } set { this.ArrayEnumOption = new(value); } }
+        public List<EnumArraysArrayEnumInner> ArrayEnum { get { return this.ArrayEnumOption.Value; } set { this.ArrayEnumOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/File.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Test capitalization</value>
         [JsonPropertyName("sourceURI")]
-        public string SourceURI { get { return this.SourceURIOption; } set { this.SourceURIOption = new(value); } }
+        public string SourceURI { get { return this.SourceURIOption.Value; } set { this.SourceURIOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets File
         /// </summary>
         [JsonPropertyName("file")]
-        public File File { get { return this.FileOption; } set { this.FileOption = new(value); } }
+        public File File { get { return this.FileOption.Value; } set { this.FileOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Files
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Files
         /// </summary>
         [JsonPropertyName("files")]
-        public List<File> Files { get { return this.FilesOption; } set { this.FilesOption = new(value); } }
+        public List<File> Files { get { return this.FilesOption.Value; } set { this.FilesOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Foo.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } set { this.BarOption = new(value); } }
+        public string Bar { get { return this.BarOption.Value; } set { this.BarOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public Foo String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public Foo String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -138,7 +138,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Binary
         /// </summary>
         [JsonPropertyName("binary")]
-        public System.IO.Stream Binary { get { return this.BinaryOption; } set { this.BinaryOption = new(value); } }
+        public System.IO.Stream Binary { get { return this.BinaryOption.Value; } set { this.BinaryOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DateTime
@@ -152,7 +152,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2007-12-03T10:15:30+01:00</example> */
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Decimal
@@ -165,7 +165,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Decimal
         /// </summary>
         [JsonPropertyName("decimal")]
-        public decimal? Decimal { get { return this.DecimalOption; } set { this.DecimalOption = new(value); } }
+        public decimal? Decimal { get { return this.DecimalOption.Value; } set { this.DecimalOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Double
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Double
         /// </summary>
         [JsonPropertyName("double")]
-        public double? Double { get { return this.DoubleOption; } set { this.DoubleOption = new(value); } }
+        public double? Double { get { return this.DoubleOption.Value; } set { this.DoubleOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName2
@@ -191,7 +191,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName2
         /// </summary>
         [JsonPropertyName("duplicate_property_name")]
-        public string DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option; } set { this.DuplicatePropertyName2Option = new(value); } }
+        public string DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option.Value; } set { this.DuplicatePropertyName2Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName
@@ -204,7 +204,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName
         /// </summary>
         [JsonPropertyName("@duplicate_property_name")]
-        public string DuplicatePropertyName { get { return this.DuplicatePropertyNameOption; } set { this.DuplicatePropertyNameOption = new(value); } }
+        public string DuplicatePropertyName { get { return this.DuplicatePropertyNameOption.Value; } set { this.DuplicatePropertyNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Float
@@ -217,7 +217,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Float
         /// </summary>
         [JsonPropertyName("float")]
-        public float? Float { get { return this.FloatOption; } set { this.FloatOption = new(value); } }
+        public float? Float { get { return this.FloatOption.Value; } set { this.FloatOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int32
@@ -230,7 +230,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32
         /// </summary>
         [JsonPropertyName("int32")]
-        public int? Int32 { get { return this.Int32Option; } set { this.Int32Option = new(value); } }
+        public int? Int32 { get { return this.Int32Option.Value; } set { this.Int32Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int32Range
@@ -243,7 +243,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32Range
         /// </summary>
         [JsonPropertyName("int32Range")]
-        public int? Int32Range { get { return this.Int32RangeOption; } set { this.Int32RangeOption = new(value); } }
+        public int? Int32Range { get { return this.Int32RangeOption.Value; } set { this.Int32RangeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64
@@ -256,7 +256,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64
         /// </summary>
         [JsonPropertyName("int64")]
-        public long? Int64 { get { return this.Int64Option; } set { this.Int64Option = new(value); } }
+        public long? Int64 { get { return this.Int64Option.Value; } set { this.Int64Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Negative
@@ -269,7 +269,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Negative
         /// </summary>
         [JsonPropertyName("int64Negative")]
-        public long? Int64Negative { get { return this.Int64NegativeOption; } set { this.Int64NegativeOption = new(value); } }
+        public long? Int64Negative { get { return this.Int64NegativeOption.Value; } set { this.Int64NegativeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64NegativeExclusive
@@ -282,7 +282,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64NegativeExclusive
         /// </summary>
         [JsonPropertyName("int64NegativeExclusive")]
-        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption; } set { this.Int64NegativeExclusiveOption = new(value); } }
+        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption.Value; } set { this.Int64NegativeExclusiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Positive
@@ -295,7 +295,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Positive
         /// </summary>
         [JsonPropertyName("int64Positive")]
-        public long? Int64Positive { get { return this.Int64PositiveOption; } set { this.Int64PositiveOption = new(value); } }
+        public long? Int64Positive { get { return this.Int64PositiveOption.Value; } set { this.Int64PositiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64PositiveExclusive
@@ -308,7 +308,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64PositiveExclusive
         /// </summary>
         [JsonPropertyName("int64PositiveExclusive")]
-        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption; } set { this.Int64PositiveExclusiveOption = new(value); } }
+        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption.Value; } set { this.Int64PositiveExclusiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Integer
@@ -321,7 +321,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [JsonPropertyName("integer")]
-        public int? Integer { get { return this.IntegerOption; } set { this.IntegerOption = new(value); } }
+        public int? Integer { get { return this.IntegerOption.Value; } set { this.IntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithBackslash
@@ -335,7 +335,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>None</value>
         [JsonPropertyName("pattern_with_backslash")]
-        public string PatternWithBackslash { get { return this.PatternWithBackslashOption; } set { this.PatternWithBackslashOption = new(value); } }
+        public string PatternWithBackslash { get { return this.PatternWithBackslashOption.Value; } set { this.PatternWithBackslashOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigits
@@ -349,7 +349,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string that is a 10 digit number. Can have leading zeros.</value>
         [JsonPropertyName("pattern_with_digits")]
-        public string PatternWithDigits { get { return this.PatternWithDigitsOption; } set { this.PatternWithDigitsOption = new(value); } }
+        public string PatternWithDigits { get { return this.PatternWithDigitsOption.Value; } set { this.PatternWithDigitsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigitsAndDelimiter
@@ -363,7 +363,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.</value>
         [JsonPropertyName("pattern_with_digits_and_delimiter")]
-        public string PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption; } set { this.PatternWithDigitsAndDelimiterOption = new(value); } }
+        public string PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption.Value; } set { this.PatternWithDigitsAndDelimiterOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of String
@@ -376,7 +376,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public string String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public string String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of StringFormattedAsDecimal
@@ -389,7 +389,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringFormattedAsDecimal
         /// </summary>
         [JsonPropertyName("string_formatted_as_decimal")]
-        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption; } set { this.StringFormattedAsDecimalOption = new(value); } }
+        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption.Value; } set { this.StringFormattedAsDecimalOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedInteger
@@ -402,7 +402,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [JsonPropertyName("unsigned_integer")]
-        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption; } set { this.UnsignedIntegerOption = new(value); } }
+        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption.Value; } set { this.UnsignedIntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedLong
@@ -415,7 +415,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedLong
         /// </summary>
         [JsonPropertyName("unsigned_long")]
-        public ulong? UnsignedLong { get { return this.UnsignedLongOption; } set { this.UnsignedLongOption = new(value); } }
+        public ulong? UnsignedLong { get { return this.UnsignedLongOption.Value; } set { this.UnsignedLongOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -429,7 +429,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -80,7 +80,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } }
+        public string Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Foo
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Foo
         /// </summary>
         [JsonPropertyName("foo")]
-        public string Foo { get { return this.FooOption; } }
+        public string Foo { get { return this.FooOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableMessage
         /// </summary>
         [JsonPropertyName("NullableMessage")]
-        public string NullableMessage { get { return this.NullableMessageOption; } set { this.NullableMessageOption = new(value); } }
+        public string NullableMessage { get { return this.NullableMessageOption.Value; } set { this.NullableMessageOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/List.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123List
         /// </summary>
         [JsonPropertyName("123-list")]
-        public string Var123List { get { return this.Var123ListOption; } set { this.Var123ListOption = new(value); } }
+        public string Var123List { get { return this.Var123ListOption.Value; } set { this.Var123ListOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets EscapedLiteralString
         /// </summary>
         [JsonPropertyName("escapedLiteralString")]
-        public string EscapedLiteralString { get { return this.EscapedLiteralStringOption; } set { this.EscapedLiteralStringOption = new(value); } }
+        public string EscapedLiteralString { get { return this.EscapedLiteralStringOption.Value; } set { this.EscapedLiteralStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnescapedLiteralString
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnescapedLiteralString
         /// </summary>
         [JsonPropertyName("unescapedLiteralString")]
-        public string UnescapedLiteralString { get { return this.UnescapedLiteralStringOption; } set { this.UnescapedLiteralStringOption = new(value); } }
+        public string UnescapedLiteralString { get { return this.UnescapedLiteralStringOption.Value; } set { this.UnescapedLiteralStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DirectMap
         /// </summary>
         [JsonPropertyName("direct_map")]
-        public Dictionary<string, bool> DirectMap { get { return this.DirectMapOption; } set { this.DirectMapOption = new(value); } }
+        public Dictionary<string, bool> DirectMap { get { return this.DirectMapOption.Value; } set { this.DirectMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of IndirectMap
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IndirectMap
         /// </summary>
         [JsonPropertyName("indirect_map")]
-        public Dictionary<string, bool> IndirectMap { get { return this.IndirectMapOption; } set { this.IndirectMapOption = new(value); } }
+        public Dictionary<string, bool> IndirectMap { get { return this.IndirectMapOption.Value; } set { this.IndirectMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapMapOfString
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapMapOfString
         /// </summary>
         [JsonPropertyName("map_map_of_string")]
-        public Dictionary<string, Dictionary<string, string>> MapMapOfString { get { return this.MapMapOfStringOption; } set { this.MapMapOfStringOption = new(value); } }
+        public Dictionary<string, Dictionary<string, string>> MapMapOfString { get { return this.MapMapOfStringOption.Value; } set { this.MapMapOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfEnumString
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfEnumString
         /// </summary>
         [JsonPropertyName("map_of_enum_string")]
-        public Dictionary<string, MapTestMapOfEnumStringValue> MapOfEnumString { get { return this.MapOfEnumStringOption; } set { this.MapOfEnumStringOption = new(value); } }
+        public Dictionary<string, MapTestMapOfEnumStringValue> MapOfEnumString { get { return this.MapOfEnumStringOption.Value; } set { this.MapOfEnumStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedAnyOfContent Content { get { return this.ContentOption; } set { this.ContentOption = new(value); } }
+        public MixedAnyOfContent Content { get { return this.ContentOption.Value; } set { this.ContentOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedOneOfContent Content { get { return this.ContentOption; } set { this.ContentOption = new(value); } }
+        public MixedOneOfContent Content { get { return this.ContentOption.Value; } set { this.ContentOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateTime
         /// </summary>
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Map
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Map
         /// </summary>
         [JsonPropertyName("map")]
-        public Dictionary<string, Animal> Map { get { return this.MapOption; } set { this.MapOption = new(value); } }
+        public Dictionary<string, Animal> Map { get { return this.MapOption.Value; } set { this.MapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UuidWithPattern
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [JsonPropertyName("uuid_with_pattern")]
-        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption; } set { this.UuidWithPatternOption = new(value); } }
+        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption.Value; } set { this.UuidWithPatternOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public string Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public string Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("class")]
-        public string Class { get { return this.ClassOption; } set { this.ClassOption = new(value); } }
+        public string Class { get { return this.ClassOption.Value; } set { this.ClassOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public int? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public int? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarClient
         /// </summary>
         [JsonPropertyName("client")]
-        public string VarClient { get { return this.VarClientOption; } set { this.VarClientOption = new(value); } }
+        public string VarClient { get { return this.VarClientOption.Value; } set { this.VarClientOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Name.cs
@@ -65,7 +65,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Property
         /// </summary>
         [JsonPropertyName("property")]
-        public string Property { get { return this.PropertyOption; } set { this.PropertyOption = new(value); } }
+        public string Property { get { return this.PropertyOption.Value; } set { this.PropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SnakeCase
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [JsonPropertyName("snake_case")]
-        public int? SnakeCase { get { return this.SnakeCaseOption; } }
+        public int? SnakeCase { get { return this.SnakeCaseOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Var123Number
@@ -91,7 +91,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123Number
         /// </summary>
         [JsonPropertyName("123Number")]
-        public int? Var123Number { get { return this.Var123NumberOption; } }
+        public int? Var123Number { get { return this.Var123NumberOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -75,7 +75,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("array_and_items_nullable_prop")]
-        public List<Object> ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption; } set { this.ArrayAndItemsNullablePropOption = new(value); } }
+        public List<Object> ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption.Value; } set { this.ArrayAndItemsNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayItemsNullable
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayItemsNullable
         /// </summary>
         [JsonPropertyName("array_items_nullable")]
-        public List<Object> ArrayItemsNullable { get { return this.ArrayItemsNullableOption; } set { this.ArrayItemsNullableOption = new(value); } }
+        public List<Object> ArrayItemsNullable { get { return this.ArrayItemsNullableOption.Value; } set { this.ArrayItemsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayNullableProp
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNullableProp
         /// </summary>
         [JsonPropertyName("array_nullable_prop")]
-        public List<Object> ArrayNullableProp { get { return this.ArrayNullablePropOption; } set { this.ArrayNullablePropOption = new(value); } }
+        public List<Object> ArrayNullableProp { get { return this.ArrayNullablePropOption.Value; } set { this.ArrayNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of BooleanProp
@@ -114,7 +114,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BooleanProp
         /// </summary>
         [JsonPropertyName("boolean_prop")]
-        public bool? BooleanProp { get { return this.BooleanPropOption; } set { this.BooleanPropOption = new(value); } }
+        public bool? BooleanProp { get { return this.BooleanPropOption.Value; } set { this.BooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DateProp
@@ -127,7 +127,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateProp
         /// </summary>
         [JsonPropertyName("date_prop")]
-        public DateOnly? DateProp { get { return this.DatePropOption; } set { this.DatePropOption = new(value); } }
+        public DateOnly? DateProp { get { return this.DatePropOption.Value; } set { this.DatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DatetimeProp
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DatetimeProp
         /// </summary>
         [JsonPropertyName("datetime_prop")]
-        public DateTime? DatetimeProp { get { return this.DatetimePropOption; } set { this.DatetimePropOption = new(value); } }
+        public DateTime? DatetimeProp { get { return this.DatetimePropOption.Value; } set { this.DatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of IntegerProp
@@ -153,7 +153,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IntegerProp
         /// </summary>
         [JsonPropertyName("integer_prop")]
-        public int? IntegerProp { get { return this.IntegerPropOption; } set { this.IntegerPropOption = new(value); } }
+        public int? IntegerProp { get { return this.IntegerPropOption.Value; } set { this.IntegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NumberProp
@@ -166,7 +166,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NumberProp
         /// </summary>
         [JsonPropertyName("number_prop")]
-        public decimal? NumberProp { get { return this.NumberPropOption; } set { this.NumberPropOption = new(value); } }
+        public decimal? NumberProp { get { return this.NumberPropOption.Value; } set { this.NumberPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectAndItemsNullableProp
@@ -179,7 +179,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("object_and_items_nullable_prop")]
-        public Dictionary<string, Object> ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption; } set { this.ObjectAndItemsNullablePropOption = new(value); } }
+        public Dictionary<string, Object> ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption.Value; } set { this.ObjectAndItemsNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectItemsNullable
@@ -192,7 +192,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectItemsNullable
         /// </summary>
         [JsonPropertyName("object_items_nullable")]
-        public Dictionary<string, Object> ObjectItemsNullable { get { return this.ObjectItemsNullableOption; } set { this.ObjectItemsNullableOption = new(value); } }
+        public Dictionary<string, Object> ObjectItemsNullable { get { return this.ObjectItemsNullableOption.Value; } set { this.ObjectItemsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectNullableProp
@@ -205,7 +205,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectNullableProp
         /// </summary>
         [JsonPropertyName("object_nullable_prop")]
-        public Dictionary<string, Object> ObjectNullableProp { get { return this.ObjectNullablePropOption; } set { this.ObjectNullablePropOption = new(value); } }
+        public Dictionary<string, Object> ObjectNullableProp { get { return this.ObjectNullablePropOption.Value; } set { this.ObjectNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of StringProp
@@ -218,7 +218,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringProp
         /// </summary>
         [JsonPropertyName("string_prop")]
-        public string StringProp { get { return this.StringPropOption; } set { this.StringPropOption = new(value); } }
+        public string StringProp { get { return this.StringPropOption.Value; } set { this.StringPropOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [JsonPropertyName("JustNumber")]
-        public decimal? JustNumber { get { return this.JustNumberOption; } set { this.JustNumberOption = new(value); } }
+        public decimal? JustNumber { get { return this.JustNumberOption.Value; } set { this.JustNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("bars")]
         [Obsolete]
-        public List<string> Bars { get { return this.BarsOption; } set { this.BarsOption = new(value); } }
+        public List<string> Bars { get { return this.BarsOption.Value; } set { this.BarsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DeprecatedRef
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("deprecatedRef")]
         [Obsolete]
-        public DeprecatedObject DeprecatedRef { get { return this.DeprecatedRefOption; } set { this.DeprecatedRefOption = new(value); } }
+        public DeprecatedObject DeprecatedRef { get { return this.DeprecatedRefOption.Value; } set { this.DeprecatedRefOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("id")]
         [Obsolete]
-        public decimal? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public decimal? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Order.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Complete
         /// </summary>
         [JsonPropertyName("complete")]
-        public bool? Complete { get { return this.CompleteOption; } set { this.CompleteOption = new(value); } }
+        public bool? Complete { get { return this.CompleteOption.Value; } set { this.CompleteOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -89,7 +89,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PetId
@@ -102,7 +102,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets PetId
         /// </summary>
         [JsonPropertyName("petId")]
-        public long? PetId { get { return this.PetIdOption; } set { this.PetIdOption = new(value); } }
+        public long? PetId { get { return this.PetIdOption.Value; } set { this.PetIdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Quantity
@@ -115,7 +115,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Quantity
         /// </summary>
         [JsonPropertyName("quantity")]
-        public int? Quantity { get { return this.QuantityOption; } set { this.QuantityOption = new(value); } }
+        public int? Quantity { get { return this.QuantityOption.Value; } set { this.QuantityOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ShipDate
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2020-02-02T20:20:20.000222Z</example> */
         [JsonPropertyName("shipDate")]
-        public DateTime? ShipDate { get { return this.ShipDateOption; } set { this.ShipDateOption = new(value); } }
+        public DateTime? ShipDate { get { return this.ShipDateOption.Value; } set { this.ShipDateOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyBoolean
         /// </summary>
         [JsonPropertyName("my_boolean")]
-        public bool? MyBoolean { get { return this.MyBooleanOption; } set { this.MyBooleanOption = new(value); } }
+        public bool? MyBoolean { get { return this.MyBooleanOption.Value; } set { this.MyBooleanOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MyNumber
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [JsonPropertyName("my_number")]
-        public decimal? MyNumber { get { return this.MyNumberOption; } set { this.MyNumberOption = new(value); } }
+        public decimal? MyNumber { get { return this.MyNumberOption.Value; } set { this.MyNumberOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MyString
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyString
         /// </summary>
         [JsonPropertyName("my_string")]
-        public string MyString { get { return this.MyStringOption; } set { this.MyStringOption = new(value); } }
+        public string MyString { get { return this.MyStringOption.Value; } set { this.MyStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Pet.cs
@@ -89,7 +89,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Category
         /// </summary>
         [JsonPropertyName("category")]
-        public Category Category { get { return this.CategoryOption; } set { this.CategoryOption = new(value); } }
+        public Category Category { get { return this.CategoryOption.Value; } set { this.CategoryOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -102,7 +102,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Tags
@@ -115,7 +115,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Tags
         /// </summary>
         [JsonPropertyName("tags")]
-        public List<Tag> Tags { get { return this.TagsOption; } set { this.TagsOption = new(value); } }
+        public List<Tag> Tags { get { return this.TagsOption.Value; } set { this.TagsOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } }
+        public string Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Baz
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Baz
         /// </summary>
         [JsonPropertyName("baz")]
-        public string Baz { get { return this.BazOption; } set { this.BazOption = new(value); } }
+        public string Baz { get { return this.BazOption.Value; } set { this.BazOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -334,7 +334,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_notnullable_date_prop")]
-        public DateOnly? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption; } set { this.NotRequiredNotnullableDatePropOption = new(value); } }
+        public DateOnly? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption.Value; } set { this.NotRequiredNotnullableDatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNotnullableintegerProp
@@ -347,7 +347,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [JsonPropertyName("not_required_notnullableinteger_prop")]
-        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption; } set { this.NotRequiredNotnullableintegerPropOption = new(value); } }
+        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption.Value; } set { this.NotRequiredNotnullableintegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableDateProp
@@ -360,7 +360,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_date_prop")]
-        public DateOnly? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption; } set { this.NotRequiredNullableDatePropOption = new(value); } }
+        public DateOnly? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption.Value; } set { this.NotRequiredNullableDatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableIntegerProp
@@ -373,7 +373,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableIntegerProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_integer_prop")]
-        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption; } set { this.NotRequiredNullableIntegerPropOption = new(value); } }
+        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption.Value; } set { this.NotRequiredNullableIntegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableArrayOfString
@@ -386,7 +386,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_array_of_string")]
-        public List<string> NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption; } set { this.NotrequiredNotnullableArrayOfStringOption = new(value); } }
+        public List<string> NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption.Value; } set { this.NotrequiredNotnullableArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableBooleanProp
@@ -399,7 +399,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_boolean_prop")]
-        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption; } set { this.NotrequiredNotnullableBooleanPropOption = new(value); } }
+        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption.Value; } set { this.NotrequiredNotnullableBooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableDatetimeProp
@@ -412,7 +412,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_datetime_prop")]
-        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption; } set { this.NotrequiredNotnullableDatetimePropOption = new(value); } }
+        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption.Value; } set { this.NotrequiredNotnullableDatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableStringProp
@@ -425,7 +425,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_string_prop")]
-        public string NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption; } set { this.NotrequiredNotnullableStringPropOption = new(value); } }
+        public string NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption.Value; } set { this.NotrequiredNotnullableStringPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableUuid
@@ -439,7 +439,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_notnullable_uuid")]
-        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption; } set { this.NotrequiredNotnullableUuidOption = new(value); } }
+        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption.Value; } set { this.NotrequiredNotnullableUuidOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableArrayOfString
@@ -452,7 +452,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_nullable_array_of_string")]
-        public List<string> NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption; } set { this.NotrequiredNullableArrayOfStringOption = new(value); } }
+        public List<string> NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption.Value; } set { this.NotrequiredNullableArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableBooleanProp
@@ -465,7 +465,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_boolean_prop")]
-        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption; } set { this.NotrequiredNullableBooleanPropOption = new(value); } }
+        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption.Value; } set { this.NotrequiredNullableBooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableDatetimeProp
@@ -478,7 +478,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_datetime_prop")]
-        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption; } set { this.NotrequiredNullableDatetimePropOption = new(value); } }
+        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption.Value; } set { this.NotrequiredNullableDatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableStringProp
@@ -491,7 +491,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_string_prop")]
-        public string NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption; } set { this.NotrequiredNullableStringPropOption = new(value); } }
+        public string NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption.Value; } set { this.NotrequiredNullableStringPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableUuid
@@ -505,7 +505,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_nullable_uuid")]
-        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption; } set { this.NotrequiredNullableUuidOption = new(value); } }
+        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption.Value; } set { this.NotrequiredNullableUuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets RequiredNullableArrayOfString

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Result.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result code</value>
         [JsonPropertyName("code")]
-        public string Code { get { return this.CodeOption; } set { this.CodeOption = new(value); } }
+        public string Code { get { return this.CodeOption.Value; } set { this.CodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Data
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string> Data { get { return this.DataOption; } set { this.DataOption = new(value); } }
+        public Dictionary<string, string> Data { get { return this.DataOption.Value; } set { this.DataOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Return.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [JsonPropertyName("return")]
-        public int? VarReturn { get { return this.VarReturnOption; } set { this.VarReturnOption = new(value); } }
+        public int? VarReturn { get { return this.VarReturnOption.Value; } set { this.VarReturnOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Unsafe
@@ -84,7 +84,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Unsafe
         /// </summary>
         [JsonPropertyName("unsafe")]
-        public string Unsafe { get { return this.UnsafeOption; } set { this.UnsafeOption = new(value); } }
+        public string Unsafe { get { return this.UnsafeOption.Value; } set { this.UnsafeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Role
         /// </summary>
         [JsonPropertyName("role")]
-        public RolesReportsHashRole Role { get { return this.RoleOption; } set { this.RoleOption = new(value); } }
+        public RolesReportsHashRole Role { get { return this.RoleOption.Value; } set { this.RoleOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of RoleUuid
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [JsonPropertyName("role_uuid")]
-        public Guid? RoleUuid { get { return this.RoleUuidOption; } set { this.RoleUuidOption = new(value); } }
+        public Guid? RoleUuid { get { return this.RoleUuidOption.Value; } set { this.RoleUuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarSpecialModelName
         /// </summary>
         [JsonPropertyName("_special_model.name_")]
-        public string VarSpecialModelName { get { return this.VarSpecialModelNameOption; } set { this.VarSpecialModelNameOption = new(value); } }
+        public string VarSpecialModelName { get { return this.VarSpecialModelNameOption.Value; } set { this.VarSpecialModelNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SpecialPropertyName
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [JsonPropertyName("$special[property.name]")]
-        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption; } set { this.SpecialPropertyNameOption = new(value); } }
+        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption.Value; } set { this.SpecialPropertyNameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Tag.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Value
         /// </summary>
         [JsonPropertyName("value")]
-        public string Value { get { return this.ValueOption; } set { this.ValueOption = new(value); } }
+        public string Value { get { return this.ValueOption.Value; } set { this.ValueOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets TestCollectionEndingWithWordList
         /// </summary>
         [JsonPropertyName("TestCollectionEndingWithWordList")]
-        public List<TestCollectionEndingWithWordList> TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption; } set { this.TestCollectionEndingWithWordListOption = new(value); } }
+        public List<TestCollectionEndingWithWordList> TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption.Value; } set { this.TestCollectionEndingWithWordListOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SomeProperty
         /// </summary>
         [JsonPropertyName("someProperty")]
-        public string SomeProperty { get { return this.SomePropertyOption; } set { this.SomePropertyOption = new(value); } }
+        public string SomeProperty { get { return this.SomePropertyOption.Value; } set { this.SomePropertyOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string> Data { get { return this.DataOption; } set { this.DataOption = new(value); } }
+        public Dictionary<string, string> Data { get { return this.DataOption.Value; } set { this.DataOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/User.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
         [JsonPropertyName("anyTypeProp")]
-        public Object AnyTypeProp { get { return this.AnyTypePropOption; } set { this.AnyTypePropOption = new(value); } }
+        public Object AnyTypeProp { get { return this.AnyTypePropOption.Value; } set { this.AnyTypePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of AnyTypePropNullable
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values.</value>
         [JsonPropertyName("anyTypePropNullable")]
-        public Object AnyTypePropNullable { get { return this.AnyTypePropNullableOption; } set { this.AnyTypePropNullableOption = new(value); } }
+        public Object AnyTypePropNullable { get { return this.AnyTypePropNullableOption.Value; } set { this.AnyTypePropNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Email
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Email
         /// </summary>
         [JsonPropertyName("email")]
-        public string Email { get { return this.EmailOption; } set { this.EmailOption = new(value); } }
+        public string Email { get { return this.EmailOption.Value; } set { this.EmailOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of FirstName
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets FirstName
         /// </summary>
         [JsonPropertyName("firstName")]
-        public string FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new(value); } }
+        public string FirstName { get { return this.FirstNameOption.Value; } set { this.FirstNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of LastName
@@ -142,7 +142,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LastName
         /// </summary>
         [JsonPropertyName("lastName")]
-        public string LastName { get { return this.LastNameOption; } set { this.LastNameOption = new(value); } }
+        public string LastName { get { return this.LastNameOption.Value; } set { this.LastNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredProps
@@ -156,7 +156,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredProps")]
-        public Object ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption; } set { this.ObjectWithNoDeclaredPropsOption = new(value); } }
+        public Object ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption.Value; } set { this.ObjectWithNoDeclaredPropsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredPropsNullable
@@ -170,7 +170,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredPropsNullable")]
-        public Object ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption; } set { this.ObjectWithNoDeclaredPropsNullableOption = new(value); } }
+        public Object ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption.Value; } set { this.ObjectWithNoDeclaredPropsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Password
@@ -183,7 +183,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Password
         /// </summary>
         [JsonPropertyName("password")]
-        public string Password { get { return this.PasswordOption; } set { this.PasswordOption = new(value); } }
+        public string Password { get { return this.PasswordOption.Value; } set { this.PasswordOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Phone
@@ -196,7 +196,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Phone
         /// </summary>
         [JsonPropertyName("phone")]
-        public string Phone { get { return this.PhoneOption; } set { this.PhoneOption = new(value); } }
+        public string Phone { get { return this.PhoneOption.Value; } set { this.PhoneOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UserStatus
@@ -210,7 +210,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [JsonPropertyName("userStatus")]
-        public int? UserStatus { get { return this.UserStatusOption; } set { this.UserStatusOption = new(value); } }
+        public int? UserStatus { get { return this.UserStatusOption.Value; } set { this.UserStatusOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Username
@@ -223,7 +223,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Username
         /// </summary>
         [JsonPropertyName("username")]
-        public string Username { get { return this.UsernameOption; } set { this.UsernameOption = new(value); } }
+        public string Username { get { return this.UsernameOption.Value; } set { this.UsernameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Whale.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [JsonPropertyName("hasBaleen")]
-        public bool? HasBaleen { get { return this.HasBaleenOption; } set { this.HasBaleenOption = new(value); } }
+        public bool? HasBaleen { get { return this.HasBaleenOption.Value; } set { this.HasBaleenOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of HasTeeth
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasTeeth
         /// </summary>
         [JsonPropertyName("hasTeeth")]
-        public bool? HasTeeth { get { return this.HasTeethOption; } set { this.HasTeethOption = new(value); } }
+        public bool? HasTeeth { get { return this.HasTeethOption.Value; } set { this.HasTeethOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Activity.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ActivityOutputs
         /// </summary>
         [JsonPropertyName("activity_outputs")]
-        public Dictionary<string, List<ActivityOutputElementRepresentation>>? ActivityOutputs { get { return this.ActivityOutputsOption; } set { this.ActivityOutputsOption = new(value); } }
+        public Dictionary<string, List<ActivityOutputElementRepresentation>>? ActivityOutputs { get { return this.ActivityOutputsOption.Value; } set { this.ActivityOutputsOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop1
         /// </summary>
         [JsonPropertyName("prop1")]
-        public string? Prop1 { get { return this.Prop1Option; } set { this.Prop1Option = new(value); } }
+        public string? Prop1 { get { return this.Prop1Option.Value; } set { this.Prop1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Prop2
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop2
         /// </summary>
         [JsonPropertyName("prop2")]
-        public Object? Prop2 { get { return this.Prop2Option; } set { this.Prop2Option = new(value); } }
+        public Object? Prop2 { get { return this.Prop2Option.Value; } set { this.Prop2Option = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -69,7 +69,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Anytype1
         /// </summary>
         [JsonPropertyName("anytype_1")]
-        public Object? Anytype1 { get { return this.Anytype1Option; } set { this.Anytype1Option = new(value); } }
+        public Object? Anytype1 { get { return this.Anytype1Option.Value; } set { this.Anytype1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of EmptyMap
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>an object with no declared properties and no undeclared properties, hence it&#39;s an empty map.</value>
         [JsonPropertyName("empty_map")]
-        public Object? EmptyMap { get { return this.EmptyMapOption; } set { this.EmptyMapOption = new(value); } }
+        public Object? EmptyMap { get { return this.EmptyMapOption.Value; } set { this.EmptyMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfMapProperty
@@ -96,7 +96,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfMapProperty
         /// </summary>
         [JsonPropertyName("map_of_map_property")]
-        public Dictionary<string, Dictionary<string, string>>? MapOfMapProperty { get { return this.MapOfMapPropertyOption; } set { this.MapOfMapPropertyOption = new(value); } }
+        public Dictionary<string, Dictionary<string, string>>? MapOfMapProperty { get { return this.MapOfMapPropertyOption.Value; } set { this.MapOfMapPropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapProperty
@@ -109,7 +109,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapProperty
         /// </summary>
         [JsonPropertyName("map_property")]
-        public Dictionary<string, string>? MapProperty { get { return this.MapPropertyOption; } set { this.MapPropertyOption = new(value); } }
+        public Dictionary<string, string>? MapProperty { get { return this.MapPropertyOption.Value; } set { this.MapPropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype1
@@ -122,7 +122,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype1
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_1")]
-        public Object? MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new(value); } }
+        public Object? MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype2
@@ -135,7 +135,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype2
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_2")]
-        public Object? MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new(value); } }
+        public Object? MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype3
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype3
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_3")]
-        public Dictionary<string, Object>? MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new(value); } }
+        public Dictionary<string, Object>? MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesString
@@ -161,7 +161,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesString
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_string")]
-        public Dictionary<string, string>? MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption; } set { this.MapWithUndeclaredPropertiesStringOption = new(value); } }
+        public Dictionary<string, string>? MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption.Value; } set { this.MapWithUndeclaredPropertiesStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Animal.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [JsonPropertyName("code")]
-        public int? Code { get { return this.CodeOption; } set { this.CodeOption = new(value); } }
+        public int? Code { get { return this.CodeOption.Value; } set { this.CodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Message
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Message
         /// </summary>
         [JsonPropertyName("message")]
-        public string? Message { get { return this.MessageOption; } set { this.MessageOption = new(value); } }
+        public string? Message { get { return this.MessageOption.Value; } set { this.MessageOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Type
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Type
         /// </summary>
         [JsonPropertyName("type")]
-        public string? Type { get { return this.TypeOption; } set { this.TypeOption = new(value); } }
+        public string? Type { get { return this.TypeOption.Value; } set { this.TypeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Apple.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ColorCode
         /// </summary>
         [JsonPropertyName("color_code")]
-        public string? ColorCode { get { return this.ColorCodeOption; } set { this.ColorCodeOption = new(value); } }
+        public string? ColorCode { get { return this.ColorCodeOption.Value; } set { this.ColorCodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Cultivar
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Cultivar
         /// </summary>
         [JsonPropertyName("cultivar")]
-        public string? Cultivar { get { return this.CultivarOption; } set { this.CultivarOption = new(value); } }
+        public string? Cultivar { get { return this.CultivarOption.Value; } set { this.CultivarOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Origin
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Origin
         /// </summary>
         [JsonPropertyName("origin")]
-        public string? Origin { get { return this.OriginOption; } set { this.OriginOption = new(value); } }
+        public string? Origin { get { return this.OriginOption.Value; } set { this.OriginOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [JsonPropertyName("mealy")]
-        public bool? Mealy { get { return this.MealyOption; } set { this.MealyOption = new(value); } }
+        public bool? Mealy { get { return this.MealyOption.Value; } set { this.MealyOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayArrayNumber")]
-        public List<List<decimal>>? ArrayArrayNumber { get { return this.ArrayArrayNumberOption; } set { this.ArrayArrayNumberOption = new(value); } }
+        public List<List<decimal>>? ArrayArrayNumber { get { return this.ArrayArrayNumberOption.Value; } set { this.ArrayArrayNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayNumber")]
-        public List<decimal>? ArrayNumber { get { return this.ArrayNumberOption; } set { this.ArrayNumberOption = new(value); } }
+        public List<decimal>? ArrayNumber { get { return this.ArrayNumberOption.Value; } set { this.ArrayNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfInteger
         /// </summary>
         [JsonPropertyName("array_array_of_integer")]
-        public List<List<long>>? ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption; } set { this.ArrayArrayOfIntegerOption = new(value); } }
+        public List<List<long>>? ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption.Value; } set { this.ArrayArrayOfIntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayArrayOfModel
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfModel
         /// </summary>
         [JsonPropertyName("array_array_of_model")]
-        public List<List<ReadOnlyFirst>>? ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption; } set { this.ArrayArrayOfModelOption = new(value); } }
+        public List<List<ReadOnlyFirst>>? ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption.Value; } set { this.ArrayArrayOfModelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayOfString
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayOfString
         /// </summary>
         [JsonPropertyName("array_of_string")]
-        public List<string>? ArrayOfString { get { return this.ArrayOfStringOption; } set { this.ArrayOfStringOption = new(value); } }
+        public List<string>? ArrayOfString { get { return this.ArrayOfStringOption.Value; } set { this.ArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Banana.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [JsonPropertyName("lengthCm")]
-        public decimal? LengthCm { get { return this.LengthCmOption; } set { this.LengthCmOption = new(value); } }
+        public decimal? LengthCm { get { return this.LengthCmOption.Value; } set { this.LengthCmOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [JsonPropertyName("sweet")]
-        public bool? Sweet { get { return this.SweetOption; } set { this.SweetOption = new(value); } }
+        public bool? Sweet { get { return this.SweetOption.Value; } set { this.SweetOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -66,7 +66,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Name of the pet </value>
         [JsonPropertyName("ATT_NAME")]
-        public string? ATT_NAME { get { return this.ATT_NAMEOption; } set { this.ATT_NAMEOption = new(value); } }
+        public string? ATT_NAME { get { return this.ATT_NAMEOption.Value; } set { this.ATT_NAMEOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalCamel
@@ -79,7 +79,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalCamel
         /// </summary>
         [JsonPropertyName("CapitalCamel")]
-        public string? CapitalCamel { get { return this.CapitalCamelOption; } set { this.CapitalCamelOption = new(value); } }
+        public string? CapitalCamel { get { return this.CapitalCamelOption.Value; } set { this.CapitalCamelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalSnake
@@ -92,7 +92,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalSnake
         /// </summary>
         [JsonPropertyName("Capital_Snake")]
-        public string? CapitalSnake { get { return this.CapitalSnakeOption; } set { this.CapitalSnakeOption = new(value); } }
+        public string? CapitalSnake { get { return this.CapitalSnakeOption.Value; } set { this.CapitalSnakeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SCAETHFlowPoints
@@ -105,7 +105,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SCAETHFlowPoints
         /// </summary>
         [JsonPropertyName("SCA_ETH_Flow_Points")]
-        public string? SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption; } set { this.SCAETHFlowPointsOption = new(value); } }
+        public string? SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption.Value; } set { this.SCAETHFlowPointsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SmallCamel
@@ -118,7 +118,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallCamel
         /// </summary>
         [JsonPropertyName("smallCamel")]
-        public string? SmallCamel { get { return this.SmallCamelOption; } set { this.SmallCamelOption = new(value); } }
+        public string? SmallCamel { get { return this.SmallCamelOption.Value; } set { this.SmallCamelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SmallSnake
@@ -131,7 +131,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallSnake
         /// </summary>
         [JsonPropertyName("small_Snake")]
-        public string? SmallSnake { get { return this.SmallSnakeOption; } set { this.SmallSnakeOption = new(value); } }
+        public string? SmallSnake { get { return this.SmallSnakeOption.Value; } set { this.SmallSnakeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [JsonPropertyName("declawed")]
-        public bool? Declawed { get { return this.DeclawedOption; } set { this.DeclawedOption = new(value); } }
+        public bool? Declawed { get { return this.DeclawedOption.Value; } set { this.DeclawedOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -108,7 +108,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// The discriminator

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("_class")]
-        public string? Class { get { return this.ClassOption; } set { this.ClassOption = new(value); } }
+        public string? Class { get { return this.ClassOption.Value; } set { this.ClassOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>Fri Jul 21 00:00:00 UTC 2017</example> */
         [JsonPropertyName("dateOnlyProperty")]
-        public DateOnly? DateOnlyProperty { get { return this.DateOnlyPropertyOption; } set { this.DateOnlyPropertyOption = new(value); } }
+        public DateOnly? DateOnlyProperty { get { return this.DateOnlyPropertyOption.Value; } set { this.DateOnlyPropertyOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Dog.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Breed
         /// </summary>
         [JsonPropertyName("breed")]
-        public string? Breed { get { return this.BreedOption; } set { this.BreedOption = new(value); } }
+        public string? Breed { get { return this.BreedOption.Value; } set { this.BreedOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Drawing.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MainShape
         /// </summary>
         [JsonPropertyName("mainShape")]
-        public Shape? MainShape { get { return this.MainShapeOption; } set { this.MainShapeOption = new(value); } }
+        public Shape? MainShape { get { return this.MainShapeOption.Value; } set { this.MainShapeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NullableShape
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableShape
         /// </summary>
         [JsonPropertyName("nullableShape")]
-        public NullableShape? NullableShape { get { return this.NullableShapeOption; } set { this.NullableShapeOption = new(value); } }
+        public NullableShape? NullableShape { get { return this.NullableShapeOption.Value; } set { this.NullableShapeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ShapeOrNull
@@ -87,7 +87,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ShapeOrNull
         /// </summary>
         [JsonPropertyName("shapeOrNull")]
-        public ShapeOrNull? ShapeOrNull { get { return this.ShapeOrNullOption; } set { this.ShapeOrNullOption = new(value); } }
+        public ShapeOrNull? ShapeOrNull { get { return this.ShapeOrNullOption.Value; } set { this.ShapeOrNullOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Shapes
@@ -100,7 +100,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Shapes
         /// </summary>
         [JsonPropertyName("shapes")]
-        public List<Shape>? Shapes { get { return this.ShapesOption; } set { this.ShapesOption = new(value); } }
+        public List<Shape>? Shapes { get { return this.ShapesOption.Value; } set { this.ShapesOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -202,7 +202,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayEnum
         /// </summary>
         [JsonPropertyName("array_enum")]
-        public List<EnumArrays.ArrayEnumEnum>? ArrayEnum { get { return this.ArrayEnumOption; } set { this.ArrayEnumOption = new(value); } }
+        public List<EnumArrays.ArrayEnumEnum>? ArrayEnum { get { return this.ArrayEnumOption.Value; } set { this.ArrayEnumOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/File.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Test capitalization</value>
         [JsonPropertyName("sourceURI")]
-        public string? SourceURI { get { return this.SourceURIOption; } set { this.SourceURIOption = new(value); } }
+        public string? SourceURI { get { return this.SourceURIOption.Value; } set { this.SourceURIOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets File
         /// </summary>
         [JsonPropertyName("file")]
-        public File? File { get { return this.FileOption; } set { this.FileOption = new(value); } }
+        public File? File { get { return this.FileOption.Value; } set { this.FileOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Files
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Files
         /// </summary>
         [JsonPropertyName("files")]
-        public List<File>? Files { get { return this.FilesOption; } set { this.FilesOption = new(value); } }
+        public List<File>? Files { get { return this.FilesOption.Value; } set { this.FilesOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Foo.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string? Bar { get { return this.BarOption; } set { this.BarOption = new(value); } }
+        public string? Bar { get { return this.BarOption.Value; } set { this.BarOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public Foo? String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public Foo? String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Binary
         /// </summary>
         [JsonPropertyName("binary")]
-        public System.IO.Stream? Binary { get { return this.BinaryOption; } set { this.BinaryOption = new(value); } }
+        public System.IO.Stream? Binary { get { return this.BinaryOption.Value; } set { this.BinaryOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DateTime
@@ -154,7 +154,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2007-12-03T10:15:30+01:00</example> */
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Decimal
@@ -167,7 +167,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Decimal
         /// </summary>
         [JsonPropertyName("decimal")]
-        public decimal? Decimal { get { return this.DecimalOption; } set { this.DecimalOption = new(value); } }
+        public decimal? Decimal { get { return this.DecimalOption.Value; } set { this.DecimalOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Double
@@ -180,7 +180,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Double
         /// </summary>
         [JsonPropertyName("double")]
-        public double? Double { get { return this.DoubleOption; } set { this.DoubleOption = new(value); } }
+        public double? Double { get { return this.DoubleOption.Value; } set { this.DoubleOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName2
@@ -193,7 +193,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName2
         /// </summary>
         [JsonPropertyName("duplicate_property_name")]
-        public string? DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option; } set { this.DuplicatePropertyName2Option = new(value); } }
+        public string? DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option.Value; } set { this.DuplicatePropertyName2Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName
@@ -206,7 +206,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName
         /// </summary>
         [JsonPropertyName("@duplicate_property_name")]
-        public string? DuplicatePropertyName { get { return this.DuplicatePropertyNameOption; } set { this.DuplicatePropertyNameOption = new(value); } }
+        public string? DuplicatePropertyName { get { return this.DuplicatePropertyNameOption.Value; } set { this.DuplicatePropertyNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Float
@@ -219,7 +219,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Float
         /// </summary>
         [JsonPropertyName("float")]
-        public float? Float { get { return this.FloatOption; } set { this.FloatOption = new(value); } }
+        public float? Float { get { return this.FloatOption.Value; } set { this.FloatOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int32
@@ -232,7 +232,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32
         /// </summary>
         [JsonPropertyName("int32")]
-        public int? Int32 { get { return this.Int32Option; } set { this.Int32Option = new(value); } }
+        public int? Int32 { get { return this.Int32Option.Value; } set { this.Int32Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int32Range
@@ -245,7 +245,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32Range
         /// </summary>
         [JsonPropertyName("int32Range")]
-        public int? Int32Range { get { return this.Int32RangeOption; } set { this.Int32RangeOption = new(value); } }
+        public int? Int32Range { get { return this.Int32RangeOption.Value; } set { this.Int32RangeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64
@@ -258,7 +258,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64
         /// </summary>
         [JsonPropertyName("int64")]
-        public long? Int64 { get { return this.Int64Option; } set { this.Int64Option = new(value); } }
+        public long? Int64 { get { return this.Int64Option.Value; } set { this.Int64Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Negative
@@ -271,7 +271,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Negative
         /// </summary>
         [JsonPropertyName("int64Negative")]
-        public long? Int64Negative { get { return this.Int64NegativeOption; } set { this.Int64NegativeOption = new(value); } }
+        public long? Int64Negative { get { return this.Int64NegativeOption.Value; } set { this.Int64NegativeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64NegativeExclusive
@@ -284,7 +284,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64NegativeExclusive
         /// </summary>
         [JsonPropertyName("int64NegativeExclusive")]
-        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption; } set { this.Int64NegativeExclusiveOption = new(value); } }
+        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption.Value; } set { this.Int64NegativeExclusiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Positive
@@ -297,7 +297,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Positive
         /// </summary>
         [JsonPropertyName("int64Positive")]
-        public long? Int64Positive { get { return this.Int64PositiveOption; } set { this.Int64PositiveOption = new(value); } }
+        public long? Int64Positive { get { return this.Int64PositiveOption.Value; } set { this.Int64PositiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64PositiveExclusive
@@ -310,7 +310,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64PositiveExclusive
         /// </summary>
         [JsonPropertyName("int64PositiveExclusive")]
-        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption; } set { this.Int64PositiveExclusiveOption = new(value); } }
+        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption.Value; } set { this.Int64PositiveExclusiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Integer
@@ -323,7 +323,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [JsonPropertyName("integer")]
-        public int? Integer { get { return this.IntegerOption; } set { this.IntegerOption = new(value); } }
+        public int? Integer { get { return this.IntegerOption.Value; } set { this.IntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithBackslash
@@ -337,7 +337,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>None</value>
         [JsonPropertyName("pattern_with_backslash")]
-        public string? PatternWithBackslash { get { return this.PatternWithBackslashOption; } set { this.PatternWithBackslashOption = new(value); } }
+        public string? PatternWithBackslash { get { return this.PatternWithBackslashOption.Value; } set { this.PatternWithBackslashOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigits
@@ -351,7 +351,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string that is a 10 digit number. Can have leading zeros.</value>
         [JsonPropertyName("pattern_with_digits")]
-        public string? PatternWithDigits { get { return this.PatternWithDigitsOption; } set { this.PatternWithDigitsOption = new(value); } }
+        public string? PatternWithDigits { get { return this.PatternWithDigitsOption.Value; } set { this.PatternWithDigitsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigitsAndDelimiter
@@ -365,7 +365,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.</value>
         [JsonPropertyName("pattern_with_digits_and_delimiter")]
-        public string? PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption; } set { this.PatternWithDigitsAndDelimiterOption = new(value); } }
+        public string? PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption.Value; } set { this.PatternWithDigitsAndDelimiterOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of String
@@ -378,7 +378,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public string? String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public string? String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of StringFormattedAsDecimal
@@ -391,7 +391,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringFormattedAsDecimal
         /// </summary>
         [JsonPropertyName("string_formatted_as_decimal")]
-        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption; } set { this.StringFormattedAsDecimalOption = new(value); } }
+        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption.Value; } set { this.StringFormattedAsDecimalOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedInteger
@@ -404,7 +404,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [JsonPropertyName("unsigned_integer")]
-        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption; } set { this.UnsignedIntegerOption = new(value); } }
+        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption.Value; } set { this.UnsignedIntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedLong
@@ -417,7 +417,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedLong
         /// </summary>
         [JsonPropertyName("unsigned_long")]
-        public ulong? UnsignedLong { get { return this.UnsignedLongOption; } set { this.UnsignedLongOption = new(value); } }
+        public ulong? UnsignedLong { get { return this.UnsignedLongOption.Value; } set { this.UnsignedLongOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -431,7 +431,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -82,7 +82,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string? Bar { get { return this.BarOption; } }
+        public string? Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Foo
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Foo
         /// </summary>
         [JsonPropertyName("foo")]
-        public string? Foo { get { return this.FooOption; } }
+        public string? Foo { get { return this.FooOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableMessage
         /// </summary>
         [JsonPropertyName("NullableMessage")]
-        public string? NullableMessage { get { return this.NullableMessageOption; } set { this.NullableMessageOption = new(value); } }
+        public string? NullableMessage { get { return this.NullableMessageOption.Value; } set { this.NullableMessageOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/List.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123List
         /// </summary>
         [JsonPropertyName("123-list")]
-        public string? Var123List { get { return this.Var123ListOption; } set { this.Var123ListOption = new(value); } }
+        public string? Var123List { get { return this.Var123ListOption.Value; } set { this.Var123ListOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets EscapedLiteralString
         /// </summary>
         [JsonPropertyName("escapedLiteralString")]
-        public string? EscapedLiteralString { get { return this.EscapedLiteralStringOption; } set { this.EscapedLiteralStringOption = new(value); } }
+        public string? EscapedLiteralString { get { return this.EscapedLiteralStringOption.Value; } set { this.EscapedLiteralStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnescapedLiteralString
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnescapedLiteralString
         /// </summary>
         [JsonPropertyName("unescapedLiteralString")]
-        public string? UnescapedLiteralString { get { return this.UnescapedLiteralStringOption; } set { this.UnescapedLiteralStringOption = new(value); } }
+        public string? UnescapedLiteralString { get { return this.UnescapedLiteralStringOption.Value; } set { this.UnescapedLiteralStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MapTest.cs
@@ -127,7 +127,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DirectMap
         /// </summary>
         [JsonPropertyName("direct_map")]
-        public Dictionary<string, bool>? DirectMap { get { return this.DirectMapOption; } set { this.DirectMapOption = new(value); } }
+        public Dictionary<string, bool>? DirectMap { get { return this.DirectMapOption.Value; } set { this.DirectMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of IndirectMap
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IndirectMap
         /// </summary>
         [JsonPropertyName("indirect_map")]
-        public Dictionary<string, bool>? IndirectMap { get { return this.IndirectMapOption; } set { this.IndirectMapOption = new(value); } }
+        public Dictionary<string, bool>? IndirectMap { get { return this.IndirectMapOption.Value; } set { this.IndirectMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapMapOfString
@@ -153,7 +153,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapMapOfString
         /// </summary>
         [JsonPropertyName("map_map_of_string")]
-        public Dictionary<string, Dictionary<string, string>>? MapMapOfString { get { return this.MapMapOfStringOption; } set { this.MapMapOfStringOption = new(value); } }
+        public Dictionary<string, Dictionary<string, string>>? MapMapOfString { get { return this.MapMapOfStringOption.Value; } set { this.MapMapOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfEnumString
@@ -166,7 +166,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfEnumString
         /// </summary>
         [JsonPropertyName("map_of_enum_string")]
-        public Dictionary<string, MapTest.InnerEnum>? MapOfEnumString { get { return this.MapOfEnumStringOption; } set { this.MapOfEnumStringOption = new(value); } }
+        public Dictionary<string, MapTest.InnerEnum>? MapOfEnumString { get { return this.MapOfEnumStringOption.Value; } set { this.MapOfEnumStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedAnyOfContent? Content { get { return this.ContentOption; } set { this.ContentOption = new(value); } }
+        public MixedAnyOfContent? Content { get { return this.ContentOption.Value; } set { this.ContentOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedOneOfContent? Content { get { return this.ContentOption; } set { this.ContentOption = new(value); } }
+        public MixedOneOfContent? Content { get { return this.ContentOption.Value; } set { this.ContentOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateTime
         /// </summary>
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Map
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Map
         /// </summary>
         [JsonPropertyName("map")]
-        public Dictionary<string, Animal>? Map { get { return this.MapOption; } set { this.MapOption = new(value); } }
+        public Dictionary<string, Animal>? Map { get { return this.MapOption.Value; } set { this.MapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -87,7 +87,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UuidWithPattern
@@ -100,7 +100,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [JsonPropertyName("uuid_with_pattern")]
-        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption; } set { this.UuidWithPatternOption = new(value); } }
+        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption.Value; } set { this.UuidWithPatternOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public string? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public string? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("class")]
-        public string? Class { get { return this.ClassOption; } set { this.ClassOption = new(value); } }
+        public string? Class { get { return this.ClassOption.Value; } set { this.ClassOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public int? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public int? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarClient
         /// </summary>
         [JsonPropertyName("client")]
-        public string? VarClient { get { return this.VarClientOption; } set { this.VarClientOption = new(value); } }
+        public string? VarClient { get { return this.VarClientOption.Value; } set { this.VarClientOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Property
         /// </summary>
         [JsonPropertyName("property")]
-        public string? Property { get { return this.PropertyOption; } set { this.PropertyOption = new(value); } }
+        public string? Property { get { return this.PropertyOption.Value; } set { this.PropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SnakeCase
@@ -80,7 +80,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [JsonPropertyName("snake_case")]
-        public int? SnakeCase { get { return this.SnakeCaseOption; } }
+        public int? SnakeCase { get { return this.SnakeCaseOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Var123Number
@@ -93,7 +93,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123Number
         /// </summary>
         [JsonPropertyName("123Number")]
-        public int? Var123Number { get { return this.Var123NumberOption; } }
+        public int? Var123Number { get { return this.Var123NumberOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -77,7 +77,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("array_and_items_nullable_prop")]
-        public List<Object>? ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption; } set { this.ArrayAndItemsNullablePropOption = new(value); } }
+        public List<Object>? ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption.Value; } set { this.ArrayAndItemsNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayItemsNullable
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayItemsNullable
         /// </summary>
         [JsonPropertyName("array_items_nullable")]
-        public List<Object>? ArrayItemsNullable { get { return this.ArrayItemsNullableOption; } set { this.ArrayItemsNullableOption = new(value); } }
+        public List<Object>? ArrayItemsNullable { get { return this.ArrayItemsNullableOption.Value; } set { this.ArrayItemsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayNullableProp
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNullableProp
         /// </summary>
         [JsonPropertyName("array_nullable_prop")]
-        public List<Object>? ArrayNullableProp { get { return this.ArrayNullablePropOption; } set { this.ArrayNullablePropOption = new(value); } }
+        public List<Object>? ArrayNullableProp { get { return this.ArrayNullablePropOption.Value; } set { this.ArrayNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of BooleanProp
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BooleanProp
         /// </summary>
         [JsonPropertyName("boolean_prop")]
-        public bool? BooleanProp { get { return this.BooleanPropOption; } set { this.BooleanPropOption = new(value); } }
+        public bool? BooleanProp { get { return this.BooleanPropOption.Value; } set { this.BooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DateProp
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateProp
         /// </summary>
         [JsonPropertyName("date_prop")]
-        public DateOnly? DateProp { get { return this.DatePropOption; } set { this.DatePropOption = new(value); } }
+        public DateOnly? DateProp { get { return this.DatePropOption.Value; } set { this.DatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DatetimeProp
@@ -142,7 +142,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DatetimeProp
         /// </summary>
         [JsonPropertyName("datetime_prop")]
-        public DateTime? DatetimeProp { get { return this.DatetimePropOption; } set { this.DatetimePropOption = new(value); } }
+        public DateTime? DatetimeProp { get { return this.DatetimePropOption.Value; } set { this.DatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of IntegerProp
@@ -155,7 +155,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IntegerProp
         /// </summary>
         [JsonPropertyName("integer_prop")]
-        public int? IntegerProp { get { return this.IntegerPropOption; } set { this.IntegerPropOption = new(value); } }
+        public int? IntegerProp { get { return this.IntegerPropOption.Value; } set { this.IntegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NumberProp
@@ -168,7 +168,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NumberProp
         /// </summary>
         [JsonPropertyName("number_prop")]
-        public decimal? NumberProp { get { return this.NumberPropOption; } set { this.NumberPropOption = new(value); } }
+        public decimal? NumberProp { get { return this.NumberPropOption.Value; } set { this.NumberPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectAndItemsNullableProp
@@ -181,7 +181,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("object_and_items_nullable_prop")]
-        public Dictionary<string, Object>? ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption; } set { this.ObjectAndItemsNullablePropOption = new(value); } }
+        public Dictionary<string, Object>? ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption.Value; } set { this.ObjectAndItemsNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectItemsNullable
@@ -194,7 +194,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectItemsNullable
         /// </summary>
         [JsonPropertyName("object_items_nullable")]
-        public Dictionary<string, Object>? ObjectItemsNullable { get { return this.ObjectItemsNullableOption; } set { this.ObjectItemsNullableOption = new(value); } }
+        public Dictionary<string, Object>? ObjectItemsNullable { get { return this.ObjectItemsNullableOption.Value; } set { this.ObjectItemsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectNullableProp
@@ -207,7 +207,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectNullableProp
         /// </summary>
         [JsonPropertyName("object_nullable_prop")]
-        public Dictionary<string, Object>? ObjectNullableProp { get { return this.ObjectNullablePropOption; } set { this.ObjectNullablePropOption = new(value); } }
+        public Dictionary<string, Object>? ObjectNullableProp { get { return this.ObjectNullablePropOption.Value; } set { this.ObjectNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of StringProp
@@ -220,7 +220,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringProp
         /// </summary>
         [JsonPropertyName("string_prop")]
-        public string? StringProp { get { return this.StringPropOption; } set { this.StringPropOption = new(value); } }
+        public string? StringProp { get { return this.StringPropOption.Value; } set { this.StringPropOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [JsonPropertyName("JustNumber")]
-        public decimal? JustNumber { get { return this.JustNumberOption; } set { this.JustNumberOption = new(value); } }
+        public decimal? JustNumber { get { return this.JustNumberOption.Value; } set { this.JustNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("bars")]
         [Obsolete]
-        public List<string>? Bars { get { return this.BarsOption; } set { this.BarsOption = new(value); } }
+        public List<string>? Bars { get { return this.BarsOption.Value; } set { this.BarsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DeprecatedRef
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("deprecatedRef")]
         [Obsolete]
-        public DeprecatedObject? DeprecatedRef { get { return this.DeprecatedRefOption; } set { this.DeprecatedRefOption = new(value); } }
+        public DeprecatedObject? DeprecatedRef { get { return this.DeprecatedRefOption.Value; } set { this.DeprecatedRefOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("id")]
         [Obsolete]
-        public decimal? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public decimal? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public string? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Order.cs
@@ -160,7 +160,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Complete
         /// </summary>
         [JsonPropertyName("complete")]
-        public bool? Complete { get { return this.CompleteOption; } set { this.CompleteOption = new(value); } }
+        public bool? Complete { get { return this.CompleteOption.Value; } set { this.CompleteOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -173,7 +173,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PetId
@@ -186,7 +186,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets PetId
         /// </summary>
         [JsonPropertyName("petId")]
-        public long? PetId { get { return this.PetIdOption; } set { this.PetIdOption = new(value); } }
+        public long? PetId { get { return this.PetIdOption.Value; } set { this.PetIdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Quantity
@@ -199,7 +199,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Quantity
         /// </summary>
         [JsonPropertyName("quantity")]
-        public int? Quantity { get { return this.QuantityOption; } set { this.QuantityOption = new(value); } }
+        public int? Quantity { get { return this.QuantityOption.Value; } set { this.QuantityOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ShipDate
@@ -213,7 +213,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2020-02-02T20:20:20.000222Z</example> */
         [JsonPropertyName("shipDate")]
-        public DateTime? ShipDate { get { return this.ShipDateOption; } set { this.ShipDateOption = new(value); } }
+        public DateTime? ShipDate { get { return this.ShipDateOption.Value; } set { this.ShipDateOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyBoolean
         /// </summary>
         [JsonPropertyName("my_boolean")]
-        public bool? MyBoolean { get { return this.MyBooleanOption; } set { this.MyBooleanOption = new(value); } }
+        public bool? MyBoolean { get { return this.MyBooleanOption.Value; } set { this.MyBooleanOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MyNumber
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [JsonPropertyName("my_number")]
-        public decimal? MyNumber { get { return this.MyNumberOption; } set { this.MyNumberOption = new(value); } }
+        public decimal? MyNumber { get { return this.MyNumberOption.Value; } set { this.MyNumberOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MyString
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyString
         /// </summary>
         [JsonPropertyName("my_string")]
-        public string? MyString { get { return this.MyStringOption; } set { this.MyStringOption = new(value); } }
+        public string? MyString { get { return this.MyStringOption.Value; } set { this.MyStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
@@ -173,7 +173,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Category
         /// </summary>
         [JsonPropertyName("category")]
-        public Category? Category { get { return this.CategoryOption; } set { this.CategoryOption = new(value); } }
+        public Category? Category { get { return this.CategoryOption.Value; } set { this.CategoryOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -186,7 +186,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Tags
@@ -199,7 +199,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Tags
         /// </summary>
         [JsonPropertyName("tags")]
-        public List<Tag>? Tags { get { return this.TagsOption; } set { this.TagsOption = new(value); } }
+        public List<Tag>? Tags { get { return this.TagsOption.Value; } set { this.TagsOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string? Bar { get { return this.BarOption; } }
+        public string? Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Baz
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Baz
         /// </summary>
         [JsonPropertyName("baz")]
-        public string? Baz { get { return this.BazOption; } set { this.BazOption = new(value); } }
+        public string? Baz { get { return this.BazOption.Value; } set { this.BazOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -1414,7 +1414,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_notnullable_date_prop")]
-        public DateOnly? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption; } set { this.NotRequiredNotnullableDatePropOption = new(value); } }
+        public DateOnly? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption.Value; } set { this.NotRequiredNotnullableDatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNotnullableintegerProp
@@ -1427,7 +1427,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [JsonPropertyName("not_required_notnullableinteger_prop")]
-        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption; } set { this.NotRequiredNotnullableintegerPropOption = new(value); } }
+        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption.Value; } set { this.NotRequiredNotnullableintegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableDateProp
@@ -1440,7 +1440,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_date_prop")]
-        public DateOnly? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption; } set { this.NotRequiredNullableDatePropOption = new(value); } }
+        public DateOnly? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption.Value; } set { this.NotRequiredNullableDatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableIntegerProp
@@ -1453,7 +1453,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableIntegerProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_integer_prop")]
-        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption; } set { this.NotRequiredNullableIntegerPropOption = new(value); } }
+        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption.Value; } set { this.NotRequiredNullableIntegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableArrayOfString
@@ -1466,7 +1466,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_array_of_string")]
-        public List<string>? NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption; } set { this.NotrequiredNotnullableArrayOfStringOption = new(value); } }
+        public List<string>? NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption.Value; } set { this.NotrequiredNotnullableArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableBooleanProp
@@ -1479,7 +1479,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_boolean_prop")]
-        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption; } set { this.NotrequiredNotnullableBooleanPropOption = new(value); } }
+        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption.Value; } set { this.NotrequiredNotnullableBooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableDatetimeProp
@@ -1492,7 +1492,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_datetime_prop")]
-        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption; } set { this.NotrequiredNotnullableDatetimePropOption = new(value); } }
+        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption.Value; } set { this.NotrequiredNotnullableDatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableStringProp
@@ -1505,7 +1505,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_string_prop")]
-        public string? NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption; } set { this.NotrequiredNotnullableStringPropOption = new(value); } }
+        public string? NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption.Value; } set { this.NotrequiredNotnullableStringPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableUuid
@@ -1519,7 +1519,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_notnullable_uuid")]
-        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption; } set { this.NotrequiredNotnullableUuidOption = new(value); } }
+        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption.Value; } set { this.NotrequiredNotnullableUuidOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableArrayOfString
@@ -1532,7 +1532,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_nullable_array_of_string")]
-        public List<string>? NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption; } set { this.NotrequiredNullableArrayOfStringOption = new(value); } }
+        public List<string>? NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption.Value; } set { this.NotrequiredNullableArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableBooleanProp
@@ -1545,7 +1545,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_boolean_prop")]
-        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption; } set { this.NotrequiredNullableBooleanPropOption = new(value); } }
+        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption.Value; } set { this.NotrequiredNullableBooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableDatetimeProp
@@ -1558,7 +1558,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_datetime_prop")]
-        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption; } set { this.NotrequiredNullableDatetimePropOption = new(value); } }
+        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption.Value; } set { this.NotrequiredNullableDatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableStringProp
@@ -1571,7 +1571,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_string_prop")]
-        public string? NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption; } set { this.NotrequiredNullableStringPropOption = new(value); } }
+        public string? NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption.Value; } set { this.NotrequiredNullableStringPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableUuid
@@ -1585,7 +1585,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_nullable_uuid")]
-        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption; } set { this.NotrequiredNullableUuidOption = new(value); } }
+        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption.Value; } set { this.NotrequiredNullableUuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets RequiredNullableArrayOfString

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Result.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result code</value>
         [JsonPropertyName("code")]
-        public string? Code { get { return this.CodeOption; } set { this.CodeOption = new(value); } }
+        public string? Code { get { return this.CodeOption.Value; } set { this.CodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Data
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string>? Data { get { return this.DataOption; } set { this.DataOption = new(value); } }
+        public Dictionary<string, string>? Data { get { return this.DataOption.Value; } set { this.DataOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
@@ -73,7 +73,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [JsonPropertyName("return")]
-        public int? VarReturn { get { return this.VarReturnOption; } set { this.VarReturnOption = new(value); } }
+        public int? VarReturn { get { return this.VarReturnOption.Value; } set { this.VarReturnOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Unsafe
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Unsafe
         /// </summary>
         [JsonPropertyName("unsafe")]
-        public string? Unsafe { get { return this.UnsafeOption; } set { this.UnsafeOption = new(value); } }
+        public string? Unsafe { get { return this.UnsafeOption.Value; } set { this.UnsafeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Role
         /// </summary>
         [JsonPropertyName("role")]
-        public RolesReportsHashRole? Role { get { return this.RoleOption; } set { this.RoleOption = new(value); } }
+        public RolesReportsHashRole? Role { get { return this.RoleOption.Value; } set { this.RoleOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of RoleUuid
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [JsonPropertyName("role_uuid")]
-        public Guid? RoleUuid { get { return this.RoleUuidOption; } set { this.RoleUuidOption = new(value); } }
+        public Guid? RoleUuid { get { return this.RoleUuidOption.Value; } set { this.RoleUuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarSpecialModelName
         /// </summary>
         [JsonPropertyName("_special_model.name_")]
-        public string? VarSpecialModelName { get { return this.VarSpecialModelNameOption; } set { this.VarSpecialModelNameOption = new(value); } }
+        public string? VarSpecialModelName { get { return this.VarSpecialModelNameOption.Value; } set { this.VarSpecialModelNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SpecialPropertyName
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [JsonPropertyName("$special[property.name]")]
-        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption; } set { this.SpecialPropertyNameOption = new(value); } }
+        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption.Value; } set { this.SpecialPropertyNameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Value
         /// </summary>
         [JsonPropertyName("value")]
-        public string? Value { get { return this.ValueOption; } set { this.ValueOption = new(value); } }
+        public string? Value { get { return this.ValueOption.Value; } set { this.ValueOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets TestCollectionEndingWithWordList
         /// </summary>
         [JsonPropertyName("TestCollectionEndingWithWordList")]
-        public List<TestCollectionEndingWithWordList>? TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption; } set { this.TestCollectionEndingWithWordListOption = new(value); } }
+        public List<TestCollectionEndingWithWordList>? TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption.Value; } set { this.TestCollectionEndingWithWordListOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SomeProperty
         /// </summary>
         [JsonPropertyName("someProperty")]
-        public string? SomeProperty { get { return this.SomePropertyOption; } set { this.SomePropertyOption = new(value); } }
+        public string? SomeProperty { get { return this.SomePropertyOption.Value; } set { this.SomePropertyOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
@@ -73,7 +73,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string>? Data { get { return this.DataOption; } set { this.DataOption = new(value); } }
+        public Dictionary<string, string>? Data { get { return this.DataOption.Value; } set { this.DataOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -87,7 +87,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
         [JsonPropertyName("anyTypeProp")]
-        public Object? AnyTypeProp { get { return this.AnyTypePropOption; } set { this.AnyTypePropOption = new(value); } }
+        public Object? AnyTypeProp { get { return this.AnyTypePropOption.Value; } set { this.AnyTypePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of AnyTypePropNullable
@@ -92,7 +92,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values.</value>
         [JsonPropertyName("anyTypePropNullable")]
-        public Object? AnyTypePropNullable { get { return this.AnyTypePropNullableOption; } set { this.AnyTypePropNullableOption = new(value); } }
+        public Object? AnyTypePropNullable { get { return this.AnyTypePropNullableOption.Value; } set { this.AnyTypePropNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Email
@@ -105,7 +105,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Email
         /// </summary>
         [JsonPropertyName("email")]
-        public string? Email { get { return this.EmailOption; } set { this.EmailOption = new(value); } }
+        public string? Email { get { return this.EmailOption.Value; } set { this.EmailOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of FirstName
@@ -118,7 +118,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets FirstName
         /// </summary>
         [JsonPropertyName("firstName")]
-        public string? FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new(value); } }
+        public string? FirstName { get { return this.FirstNameOption.Value; } set { this.FirstNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -131,7 +131,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of LastName
@@ -144,7 +144,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LastName
         /// </summary>
         [JsonPropertyName("lastName")]
-        public string? LastName { get { return this.LastNameOption; } set { this.LastNameOption = new(value); } }
+        public string? LastName { get { return this.LastNameOption.Value; } set { this.LastNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredProps
@@ -158,7 +158,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredProps")]
-        public Object? ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption; } set { this.ObjectWithNoDeclaredPropsOption = new(value); } }
+        public Object? ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption.Value; } set { this.ObjectWithNoDeclaredPropsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredPropsNullable
@@ -172,7 +172,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredPropsNullable")]
-        public Object? ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption; } set { this.ObjectWithNoDeclaredPropsNullableOption = new(value); } }
+        public Object? ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption.Value; } set { this.ObjectWithNoDeclaredPropsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Password
@@ -185,7 +185,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Password
         /// </summary>
         [JsonPropertyName("password")]
-        public string? Password { get { return this.PasswordOption; } set { this.PasswordOption = new(value); } }
+        public string? Password { get { return this.PasswordOption.Value; } set { this.PasswordOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Phone
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Phone
         /// </summary>
         [JsonPropertyName("phone")]
-        public string? Phone { get { return this.PhoneOption; } set { this.PhoneOption = new(value); } }
+        public string? Phone { get { return this.PhoneOption.Value; } set { this.PhoneOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UserStatus
@@ -212,7 +212,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [JsonPropertyName("userStatus")]
-        public int? UserStatus { get { return this.UserStatusOption; } set { this.UserStatusOption = new(value); } }
+        public int? UserStatus { get { return this.UserStatusOption.Value; } set { this.UserStatusOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Username
@@ -225,7 +225,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Username
         /// </summary>
         [JsonPropertyName("username")]
-        public string? Username { get { return this.UsernameOption; } set { this.UsernameOption = new(value); } }
+        public string? Username { get { return this.UsernameOption.Value; } set { this.UsernameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
@@ -65,7 +65,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [JsonPropertyName("hasBaleen")]
-        public bool? HasBaleen { get { return this.HasBaleenOption; } set { this.HasBaleenOption = new(value); } }
+        public bool? HasBaleen { get { return this.HasBaleenOption.Value; } set { this.HasBaleenOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of HasTeeth
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasTeeth
         /// </summary>
         [JsonPropertyName("hasTeeth")]
-        public bool? HasTeeth { get { return this.HasTeethOption; } set { this.HasTeethOption = new(value); } }
+        public bool? HasTeeth { get { return this.HasTeethOption.Value; } set { this.HasTeethOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Kind
         /// </summary>
         [JsonPropertyName("kind")]
-        public string? Kind { get { return this.KindOption; } set { this.KindOption = new(value); } }
+        public string? Kind { get { return this.KindOption.Value; } set { this.KindOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Count
         /// </summary>
         [JsonPropertyName("count")]
-        public decimal? Count { get { return this.CountOption; } set { this.CountOption = new(value); } }
+        public decimal? Count { get { return this.CountOption.Value; } set { this.CountOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -95,7 +95,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Orange.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Orange.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [JsonPropertyName("sweet")]
-        public bool? Sweet { get { return this.SweetOption; } set { this.SweetOption = new(value); } }
+        public bool? Sweet { get { return this.SweetOption.Value; } set { this.SweetOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Activity.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ActivityOutputs
         /// </summary>
         [JsonPropertyName("activity_outputs")]
-        public Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs { get { return this.ActivityOutputsOption; } set { this.ActivityOutputsOption = new(value); } }
+        public Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs { get { return this.ActivityOutputsOption.Value; } set { this.ActivityOutputsOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop1
         /// </summary>
         [JsonPropertyName("prop1")]
-        public string Prop1 { get { return this.Prop1Option; } set { this.Prop1Option = new(value); } }
+        public string Prop1 { get { return this.Prop1Option.Value; } set { this.Prop1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Prop2
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop2
         /// </summary>
         [JsonPropertyName("prop2")]
-        public Object Prop2 { get { return this.Prop2Option; } set { this.Prop2Option = new(value); } }
+        public Object Prop2 { get { return this.Prop2Option.Value; } set { this.Prop2Option = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Anytype1
         /// </summary>
         [JsonPropertyName("anytype_1")]
-        public Object Anytype1 { get { return this.Anytype1Option; } set { this.Anytype1Option = new(value); } }
+        public Object Anytype1 { get { return this.Anytype1Option.Value; } set { this.Anytype1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of EmptyMap
@@ -81,7 +81,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>an object with no declared properties and no undeclared properties, hence it&#39;s an empty map.</value>
         [JsonPropertyName("empty_map")]
-        public Object EmptyMap { get { return this.EmptyMapOption; } set { this.EmptyMapOption = new(value); } }
+        public Object EmptyMap { get { return this.EmptyMapOption.Value; } set { this.EmptyMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfMapProperty
@@ -94,7 +94,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfMapProperty
         /// </summary>
         [JsonPropertyName("map_of_map_property")]
-        public Dictionary<string, Dictionary<string, string>> MapOfMapProperty { get { return this.MapOfMapPropertyOption; } set { this.MapOfMapPropertyOption = new(value); } }
+        public Dictionary<string, Dictionary<string, string>> MapOfMapProperty { get { return this.MapOfMapPropertyOption.Value; } set { this.MapOfMapPropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapProperty
@@ -107,7 +107,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapProperty
         /// </summary>
         [JsonPropertyName("map_property")]
-        public Dictionary<string, string> MapProperty { get { return this.MapPropertyOption; } set { this.MapPropertyOption = new(value); } }
+        public Dictionary<string, string> MapProperty { get { return this.MapPropertyOption.Value; } set { this.MapPropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype1
@@ -120,7 +120,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype1
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_1")]
-        public Object MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new(value); } }
+        public Object MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype2
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype2
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_2")]
-        public Object MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new(value); } }
+        public Object MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype3
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype3
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_3")]
-        public Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new(value); } }
+        public Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesString
@@ -159,7 +159,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesString
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_string")]
-        public Dictionary<string, string> MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption; } set { this.MapWithUndeclaredPropertiesStringOption = new(value); } }
+        public Dictionary<string, string> MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption.Value; } set { this.MapWithUndeclaredPropertiesStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Animal.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [JsonPropertyName("code")]
-        public int? Code { get { return this.CodeOption; } set { this.CodeOption = new(value); } }
+        public int? Code { get { return this.CodeOption.Value; } set { this.CodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Message
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Message
         /// </summary>
         [JsonPropertyName("message")]
-        public string Message { get { return this.MessageOption; } set { this.MessageOption = new(value); } }
+        public string Message { get { return this.MessageOption.Value; } set { this.MessageOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Type
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Type
         /// </summary>
         [JsonPropertyName("type")]
-        public string Type { get { return this.TypeOption; } set { this.TypeOption = new(value); } }
+        public string Type { get { return this.TypeOption.Value; } set { this.TypeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Apple.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ColorCode
         /// </summary>
         [JsonPropertyName("color_code")]
-        public string ColorCode { get { return this.ColorCodeOption; } set { this.ColorCodeOption = new(value); } }
+        public string ColorCode { get { return this.ColorCodeOption.Value; } set { this.ColorCodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Cultivar
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Cultivar
         /// </summary>
         [JsonPropertyName("cultivar")]
-        public string Cultivar { get { return this.CultivarOption; } set { this.CultivarOption = new(value); } }
+        public string Cultivar { get { return this.CultivarOption.Value; } set { this.CultivarOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Origin
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Origin
         /// </summary>
         [JsonPropertyName("origin")]
-        public string Origin { get { return this.OriginOption; } set { this.OriginOption = new(value); } }
+        public string Origin { get { return this.OriginOption.Value; } set { this.OriginOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [JsonPropertyName("mealy")]
-        public bool? Mealy { get { return this.MealyOption; } set { this.MealyOption = new(value); } }
+        public bool? Mealy { get { return this.MealyOption.Value; } set { this.MealyOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayArrayNumber")]
-        public List<List<decimal>> ArrayArrayNumber { get { return this.ArrayArrayNumberOption; } set { this.ArrayArrayNumberOption = new(value); } }
+        public List<List<decimal>> ArrayArrayNumber { get { return this.ArrayArrayNumberOption.Value; } set { this.ArrayArrayNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayNumber")]
-        public List<decimal> ArrayNumber { get { return this.ArrayNumberOption; } set { this.ArrayNumberOption = new(value); } }
+        public List<decimal> ArrayNumber { get { return this.ArrayNumberOption.Value; } set { this.ArrayNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfInteger
         /// </summary>
         [JsonPropertyName("array_array_of_integer")]
-        public List<List<long>> ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption; } set { this.ArrayArrayOfIntegerOption = new(value); } }
+        public List<List<long>> ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption.Value; } set { this.ArrayArrayOfIntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayArrayOfModel
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfModel
         /// </summary>
         [JsonPropertyName("array_array_of_model")]
-        public List<List<ReadOnlyFirst>> ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption; } set { this.ArrayArrayOfModelOption = new(value); } }
+        public List<List<ReadOnlyFirst>> ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption.Value; } set { this.ArrayArrayOfModelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayOfString
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayOfString
         /// </summary>
         [JsonPropertyName("array_of_string")]
-        public List<string> ArrayOfString { get { return this.ArrayOfStringOption; } set { this.ArrayOfStringOption = new(value); } }
+        public List<string> ArrayOfString { get { return this.ArrayOfStringOption.Value; } set { this.ArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Banana.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [JsonPropertyName("lengthCm")]
-        public decimal? LengthCm { get { return this.LengthCmOption; } set { this.LengthCmOption = new(value); } }
+        public decimal? LengthCm { get { return this.LengthCmOption.Value; } set { this.LengthCmOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [JsonPropertyName("sweet")]
-        public bool? Sweet { get { return this.SweetOption; } set { this.SweetOption = new(value); } }
+        public bool? Sweet { get { return this.SweetOption.Value; } set { this.SweetOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -64,7 +64,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Name of the pet </value>
         [JsonPropertyName("ATT_NAME")]
-        public string ATT_NAME { get { return this.ATT_NAMEOption; } set { this.ATT_NAMEOption = new(value); } }
+        public string ATT_NAME { get { return this.ATT_NAMEOption.Value; } set { this.ATT_NAMEOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalCamel
@@ -77,7 +77,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalCamel
         /// </summary>
         [JsonPropertyName("CapitalCamel")]
-        public string CapitalCamel { get { return this.CapitalCamelOption; } set { this.CapitalCamelOption = new(value); } }
+        public string CapitalCamel { get { return this.CapitalCamelOption.Value; } set { this.CapitalCamelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalSnake
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalSnake
         /// </summary>
         [JsonPropertyName("Capital_Snake")]
-        public string CapitalSnake { get { return this.CapitalSnakeOption; } set { this.CapitalSnakeOption = new(value); } }
+        public string CapitalSnake { get { return this.CapitalSnakeOption.Value; } set { this.CapitalSnakeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SCAETHFlowPoints
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SCAETHFlowPoints
         /// </summary>
         [JsonPropertyName("SCA_ETH_Flow_Points")]
-        public string SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption; } set { this.SCAETHFlowPointsOption = new(value); } }
+        public string SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption.Value; } set { this.SCAETHFlowPointsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SmallCamel
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallCamel
         /// </summary>
         [JsonPropertyName("smallCamel")]
-        public string SmallCamel { get { return this.SmallCamelOption; } set { this.SmallCamelOption = new(value); } }
+        public string SmallCamel { get { return this.SmallCamelOption.Value; } set { this.SmallCamelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SmallSnake
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallSnake
         /// </summary>
         [JsonPropertyName("small_Snake")]
-        public string SmallSnake { get { return this.SmallSnakeOption; } set { this.SmallSnakeOption = new(value); } }
+        public string SmallSnake { get { return this.SmallSnakeOption.Value; } set { this.SmallSnakeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [JsonPropertyName("declawed")]
-        public bool? Declawed { get { return this.DeclawedOption; } set { this.DeclawedOption = new(value); } }
+        public bool? Declawed { get { return this.DeclawedOption.Value; } set { this.DeclawedOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -106,7 +106,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// The discriminator

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("_class")]
-        public string Class { get { return this.ClassOption; } set { this.ClassOption = new(value); } }
+        public string Class { get { return this.ClassOption.Value; } set { this.ClassOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>Fri Jul 21 00:00:00 UTC 2017</example> */
         [JsonPropertyName("dateOnlyProperty")]
-        public DateOnly? DateOnlyProperty { get { return this.DateOnlyPropertyOption; } set { this.DateOnlyPropertyOption = new(value); } }
+        public DateOnly? DateOnlyProperty { get { return this.DateOnlyPropertyOption.Value; } set { this.DateOnlyPropertyOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Breed
         /// </summary>
         [JsonPropertyName("breed")]
-        public string Breed { get { return this.BreedOption; } set { this.BreedOption = new(value); } }
+        public string Breed { get { return this.BreedOption.Value; } set { this.BreedOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MainShape
         /// </summary>
         [JsonPropertyName("mainShape")]
-        public Shape MainShape { get { return this.MainShapeOption; } set { this.MainShapeOption = new(value); } }
+        public Shape MainShape { get { return this.MainShapeOption.Value; } set { this.MainShapeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NullableShape
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableShape
         /// </summary>
         [JsonPropertyName("nullableShape")]
-        public NullableShape NullableShape { get { return this.NullableShapeOption; } set { this.NullableShapeOption = new(value); } }
+        public NullableShape NullableShape { get { return this.NullableShapeOption.Value; } set { this.NullableShapeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ShapeOrNull
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ShapeOrNull
         /// </summary>
         [JsonPropertyName("shapeOrNull")]
-        public ShapeOrNull ShapeOrNull { get { return this.ShapeOrNullOption; } set { this.ShapeOrNullOption = new(value); } }
+        public ShapeOrNull ShapeOrNull { get { return this.ShapeOrNullOption.Value; } set { this.ShapeOrNullOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Shapes
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Shapes
         /// </summary>
         [JsonPropertyName("shapes")]
-        public List<Shape> Shapes { get { return this.ShapesOption; } set { this.ShapesOption = new(value); } }
+        public List<Shape> Shapes { get { return this.ShapesOption.Value; } set { this.ShapesOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayEnum
         /// </summary>
         [JsonPropertyName("array_enum")]
-        public List<EnumArrays.ArrayEnumEnum> ArrayEnum { get { return this.ArrayEnumOption; } set { this.ArrayEnumOption = new(value); } }
+        public List<EnumArrays.ArrayEnumEnum> ArrayEnum { get { return this.ArrayEnumOption.Value; } set { this.ArrayEnumOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/File.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Test capitalization</value>
         [JsonPropertyName("sourceURI")]
-        public string SourceURI { get { return this.SourceURIOption; } set { this.SourceURIOption = new(value); } }
+        public string SourceURI { get { return this.SourceURIOption.Value; } set { this.SourceURIOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets File
         /// </summary>
         [JsonPropertyName("file")]
-        public File File { get { return this.FileOption; } set { this.FileOption = new(value); } }
+        public File File { get { return this.FileOption.Value; } set { this.FileOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Files
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Files
         /// </summary>
         [JsonPropertyName("files")]
-        public List<File> Files { get { return this.FilesOption; } set { this.FilesOption = new(value); } }
+        public List<File> Files { get { return this.FilesOption.Value; } set { this.FilesOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Foo.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } set { this.BarOption = new(value); } }
+        public string Bar { get { return this.BarOption.Value; } set { this.BarOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public Foo String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public Foo String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -138,7 +138,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Binary
         /// </summary>
         [JsonPropertyName("binary")]
-        public System.IO.Stream Binary { get { return this.BinaryOption; } set { this.BinaryOption = new(value); } }
+        public System.IO.Stream Binary { get { return this.BinaryOption.Value; } set { this.BinaryOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DateTime
@@ -152,7 +152,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2007-12-03T10:15:30+01:00</example> */
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Decimal
@@ -165,7 +165,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Decimal
         /// </summary>
         [JsonPropertyName("decimal")]
-        public decimal? Decimal { get { return this.DecimalOption; } set { this.DecimalOption = new(value); } }
+        public decimal? Decimal { get { return this.DecimalOption.Value; } set { this.DecimalOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Double
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Double
         /// </summary>
         [JsonPropertyName("double")]
-        public double? Double { get { return this.DoubleOption; } set { this.DoubleOption = new(value); } }
+        public double? Double { get { return this.DoubleOption.Value; } set { this.DoubleOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName2
@@ -191,7 +191,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName2
         /// </summary>
         [JsonPropertyName("duplicate_property_name")]
-        public string DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option; } set { this.DuplicatePropertyName2Option = new(value); } }
+        public string DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option.Value; } set { this.DuplicatePropertyName2Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName
@@ -204,7 +204,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName
         /// </summary>
         [JsonPropertyName("@duplicate_property_name")]
-        public string DuplicatePropertyName { get { return this.DuplicatePropertyNameOption; } set { this.DuplicatePropertyNameOption = new(value); } }
+        public string DuplicatePropertyName { get { return this.DuplicatePropertyNameOption.Value; } set { this.DuplicatePropertyNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Float
@@ -217,7 +217,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Float
         /// </summary>
         [JsonPropertyName("float")]
-        public float? Float { get { return this.FloatOption; } set { this.FloatOption = new(value); } }
+        public float? Float { get { return this.FloatOption.Value; } set { this.FloatOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int32
@@ -230,7 +230,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32
         /// </summary>
         [JsonPropertyName("int32")]
-        public int? Int32 { get { return this.Int32Option; } set { this.Int32Option = new(value); } }
+        public int? Int32 { get { return this.Int32Option.Value; } set { this.Int32Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int32Range
@@ -243,7 +243,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32Range
         /// </summary>
         [JsonPropertyName("int32Range")]
-        public int? Int32Range { get { return this.Int32RangeOption; } set { this.Int32RangeOption = new(value); } }
+        public int? Int32Range { get { return this.Int32RangeOption.Value; } set { this.Int32RangeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64
@@ -256,7 +256,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64
         /// </summary>
         [JsonPropertyName("int64")]
-        public long? Int64 { get { return this.Int64Option; } set { this.Int64Option = new(value); } }
+        public long? Int64 { get { return this.Int64Option.Value; } set { this.Int64Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Negative
@@ -269,7 +269,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Negative
         /// </summary>
         [JsonPropertyName("int64Negative")]
-        public long? Int64Negative { get { return this.Int64NegativeOption; } set { this.Int64NegativeOption = new(value); } }
+        public long? Int64Negative { get { return this.Int64NegativeOption.Value; } set { this.Int64NegativeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64NegativeExclusive
@@ -282,7 +282,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64NegativeExclusive
         /// </summary>
         [JsonPropertyName("int64NegativeExclusive")]
-        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption; } set { this.Int64NegativeExclusiveOption = new(value); } }
+        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption.Value; } set { this.Int64NegativeExclusiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Positive
@@ -295,7 +295,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Positive
         /// </summary>
         [JsonPropertyName("int64Positive")]
-        public long? Int64Positive { get { return this.Int64PositiveOption; } set { this.Int64PositiveOption = new(value); } }
+        public long? Int64Positive { get { return this.Int64PositiveOption.Value; } set { this.Int64PositiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64PositiveExclusive
@@ -308,7 +308,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64PositiveExclusive
         /// </summary>
         [JsonPropertyName("int64PositiveExclusive")]
-        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption; } set { this.Int64PositiveExclusiveOption = new(value); } }
+        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption.Value; } set { this.Int64PositiveExclusiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Integer
@@ -321,7 +321,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [JsonPropertyName("integer")]
-        public int? Integer { get { return this.IntegerOption; } set { this.IntegerOption = new(value); } }
+        public int? Integer { get { return this.IntegerOption.Value; } set { this.IntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithBackslash
@@ -335,7 +335,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>None</value>
         [JsonPropertyName("pattern_with_backslash")]
-        public string PatternWithBackslash { get { return this.PatternWithBackslashOption; } set { this.PatternWithBackslashOption = new(value); } }
+        public string PatternWithBackslash { get { return this.PatternWithBackslashOption.Value; } set { this.PatternWithBackslashOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigits
@@ -349,7 +349,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string that is a 10 digit number. Can have leading zeros.</value>
         [JsonPropertyName("pattern_with_digits")]
-        public string PatternWithDigits { get { return this.PatternWithDigitsOption; } set { this.PatternWithDigitsOption = new(value); } }
+        public string PatternWithDigits { get { return this.PatternWithDigitsOption.Value; } set { this.PatternWithDigitsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigitsAndDelimiter
@@ -363,7 +363,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.</value>
         [JsonPropertyName("pattern_with_digits_and_delimiter")]
-        public string PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption; } set { this.PatternWithDigitsAndDelimiterOption = new(value); } }
+        public string PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption.Value; } set { this.PatternWithDigitsAndDelimiterOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of String
@@ -376,7 +376,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public string String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public string String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of StringFormattedAsDecimal
@@ -389,7 +389,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringFormattedAsDecimal
         /// </summary>
         [JsonPropertyName("string_formatted_as_decimal")]
-        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption; } set { this.StringFormattedAsDecimalOption = new(value); } }
+        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption.Value; } set { this.StringFormattedAsDecimalOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedInteger
@@ -402,7 +402,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [JsonPropertyName("unsigned_integer")]
-        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption; } set { this.UnsignedIntegerOption = new(value); } }
+        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption.Value; } set { this.UnsignedIntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedLong
@@ -415,7 +415,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedLong
         /// </summary>
         [JsonPropertyName("unsigned_long")]
-        public ulong? UnsignedLong { get { return this.UnsignedLongOption; } set { this.UnsignedLongOption = new(value); } }
+        public ulong? UnsignedLong { get { return this.UnsignedLongOption.Value; } set { this.UnsignedLongOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -429,7 +429,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -80,7 +80,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } }
+        public string Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Foo
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Foo
         /// </summary>
         [JsonPropertyName("foo")]
-        public string Foo { get { return this.FooOption; } }
+        public string Foo { get { return this.FooOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableMessage
         /// </summary>
         [JsonPropertyName("NullableMessage")]
-        public string NullableMessage { get { return this.NullableMessageOption; } set { this.NullableMessageOption = new(value); } }
+        public string NullableMessage { get { return this.NullableMessageOption.Value; } set { this.NullableMessageOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/List.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123List
         /// </summary>
         [JsonPropertyName("123-list")]
-        public string Var123List { get { return this.Var123ListOption; } set { this.Var123ListOption = new(value); } }
+        public string Var123List { get { return this.Var123ListOption.Value; } set { this.Var123ListOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets EscapedLiteralString
         /// </summary>
         [JsonPropertyName("escapedLiteralString")]
-        public string EscapedLiteralString { get { return this.EscapedLiteralStringOption; } set { this.EscapedLiteralStringOption = new(value); } }
+        public string EscapedLiteralString { get { return this.EscapedLiteralStringOption.Value; } set { this.EscapedLiteralStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnescapedLiteralString
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnescapedLiteralString
         /// </summary>
         [JsonPropertyName("unescapedLiteralString")]
-        public string UnescapedLiteralString { get { return this.UnescapedLiteralStringOption; } set { this.UnescapedLiteralStringOption = new(value); } }
+        public string UnescapedLiteralString { get { return this.UnescapedLiteralStringOption.Value; } set { this.UnescapedLiteralStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -125,7 +125,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DirectMap
         /// </summary>
         [JsonPropertyName("direct_map")]
-        public Dictionary<string, bool> DirectMap { get { return this.DirectMapOption; } set { this.DirectMapOption = new(value); } }
+        public Dictionary<string, bool> DirectMap { get { return this.DirectMapOption.Value; } set { this.DirectMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of IndirectMap
@@ -138,7 +138,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IndirectMap
         /// </summary>
         [JsonPropertyName("indirect_map")]
-        public Dictionary<string, bool> IndirectMap { get { return this.IndirectMapOption; } set { this.IndirectMapOption = new(value); } }
+        public Dictionary<string, bool> IndirectMap { get { return this.IndirectMapOption.Value; } set { this.IndirectMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapMapOfString
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapMapOfString
         /// </summary>
         [JsonPropertyName("map_map_of_string")]
-        public Dictionary<string, Dictionary<string, string>> MapMapOfString { get { return this.MapMapOfStringOption; } set { this.MapMapOfStringOption = new(value); } }
+        public Dictionary<string, Dictionary<string, string>> MapMapOfString { get { return this.MapMapOfStringOption.Value; } set { this.MapMapOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfEnumString
@@ -164,7 +164,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfEnumString
         /// </summary>
         [JsonPropertyName("map_of_enum_string")]
-        public Dictionary<string, MapTest.InnerEnum> MapOfEnumString { get { return this.MapOfEnumStringOption; } set { this.MapOfEnumStringOption = new(value); } }
+        public Dictionary<string, MapTest.InnerEnum> MapOfEnumString { get { return this.MapOfEnumStringOption.Value; } set { this.MapOfEnumStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedAnyOfContent Content { get { return this.ContentOption; } set { this.ContentOption = new(value); } }
+        public MixedAnyOfContent Content { get { return this.ContentOption.Value; } set { this.ContentOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedOneOfContent Content { get { return this.ContentOption; } set { this.ContentOption = new(value); } }
+        public MixedOneOfContent Content { get { return this.ContentOption.Value; } set { this.ContentOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateTime
         /// </summary>
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Map
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Map
         /// </summary>
         [JsonPropertyName("map")]
-        public Dictionary<string, Animal> Map { get { return this.MapOption; } set { this.MapOption = new(value); } }
+        public Dictionary<string, Animal> Map { get { return this.MapOption.Value; } set { this.MapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UuidWithPattern
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [JsonPropertyName("uuid_with_pattern")]
-        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption; } set { this.UuidWithPatternOption = new(value); } }
+        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption.Value; } set { this.UuidWithPatternOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public string Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public string Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("class")]
-        public string Class { get { return this.ClassOption; } set { this.ClassOption = new(value); } }
+        public string Class { get { return this.ClassOption.Value; } set { this.ClassOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public int? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public int? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarClient
         /// </summary>
         [JsonPropertyName("client")]
-        public string VarClient { get { return this.VarClientOption; } set { this.VarClientOption = new(value); } }
+        public string VarClient { get { return this.VarClientOption.Value; } set { this.VarClientOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -65,7 +65,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Property
         /// </summary>
         [JsonPropertyName("property")]
-        public string Property { get { return this.PropertyOption; } set { this.PropertyOption = new(value); } }
+        public string Property { get { return this.PropertyOption.Value; } set { this.PropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SnakeCase
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [JsonPropertyName("snake_case")]
-        public int? SnakeCase { get { return this.SnakeCaseOption; } }
+        public int? SnakeCase { get { return this.SnakeCaseOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Var123Number
@@ -91,7 +91,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123Number
         /// </summary>
         [JsonPropertyName("123Number")]
-        public int? Var123Number { get { return this.Var123NumberOption; } }
+        public int? Var123Number { get { return this.Var123NumberOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -75,7 +75,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("array_and_items_nullable_prop")]
-        public List<Object> ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption; } set { this.ArrayAndItemsNullablePropOption = new(value); } }
+        public List<Object> ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption.Value; } set { this.ArrayAndItemsNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayItemsNullable
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayItemsNullable
         /// </summary>
         [JsonPropertyName("array_items_nullable")]
-        public List<Object> ArrayItemsNullable { get { return this.ArrayItemsNullableOption; } set { this.ArrayItemsNullableOption = new(value); } }
+        public List<Object> ArrayItemsNullable { get { return this.ArrayItemsNullableOption.Value; } set { this.ArrayItemsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayNullableProp
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNullableProp
         /// </summary>
         [JsonPropertyName("array_nullable_prop")]
-        public List<Object> ArrayNullableProp { get { return this.ArrayNullablePropOption; } set { this.ArrayNullablePropOption = new(value); } }
+        public List<Object> ArrayNullableProp { get { return this.ArrayNullablePropOption.Value; } set { this.ArrayNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of BooleanProp
@@ -114,7 +114,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BooleanProp
         /// </summary>
         [JsonPropertyName("boolean_prop")]
-        public bool? BooleanProp { get { return this.BooleanPropOption; } set { this.BooleanPropOption = new(value); } }
+        public bool? BooleanProp { get { return this.BooleanPropOption.Value; } set { this.BooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DateProp
@@ -127,7 +127,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateProp
         /// </summary>
         [JsonPropertyName("date_prop")]
-        public DateOnly? DateProp { get { return this.DatePropOption; } set { this.DatePropOption = new(value); } }
+        public DateOnly? DateProp { get { return this.DatePropOption.Value; } set { this.DatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DatetimeProp
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DatetimeProp
         /// </summary>
         [JsonPropertyName("datetime_prop")]
-        public DateTime? DatetimeProp { get { return this.DatetimePropOption; } set { this.DatetimePropOption = new(value); } }
+        public DateTime? DatetimeProp { get { return this.DatetimePropOption.Value; } set { this.DatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of IntegerProp
@@ -153,7 +153,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IntegerProp
         /// </summary>
         [JsonPropertyName("integer_prop")]
-        public int? IntegerProp { get { return this.IntegerPropOption; } set { this.IntegerPropOption = new(value); } }
+        public int? IntegerProp { get { return this.IntegerPropOption.Value; } set { this.IntegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NumberProp
@@ -166,7 +166,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NumberProp
         /// </summary>
         [JsonPropertyName("number_prop")]
-        public decimal? NumberProp { get { return this.NumberPropOption; } set { this.NumberPropOption = new(value); } }
+        public decimal? NumberProp { get { return this.NumberPropOption.Value; } set { this.NumberPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectAndItemsNullableProp
@@ -179,7 +179,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("object_and_items_nullable_prop")]
-        public Dictionary<string, Object> ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption; } set { this.ObjectAndItemsNullablePropOption = new(value); } }
+        public Dictionary<string, Object> ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption.Value; } set { this.ObjectAndItemsNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectItemsNullable
@@ -192,7 +192,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectItemsNullable
         /// </summary>
         [JsonPropertyName("object_items_nullable")]
-        public Dictionary<string, Object> ObjectItemsNullable { get { return this.ObjectItemsNullableOption; } set { this.ObjectItemsNullableOption = new(value); } }
+        public Dictionary<string, Object> ObjectItemsNullable { get { return this.ObjectItemsNullableOption.Value; } set { this.ObjectItemsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectNullableProp
@@ -205,7 +205,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectNullableProp
         /// </summary>
         [JsonPropertyName("object_nullable_prop")]
-        public Dictionary<string, Object> ObjectNullableProp { get { return this.ObjectNullablePropOption; } set { this.ObjectNullablePropOption = new(value); } }
+        public Dictionary<string, Object> ObjectNullableProp { get { return this.ObjectNullablePropOption.Value; } set { this.ObjectNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of StringProp
@@ -218,7 +218,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringProp
         /// </summary>
         [JsonPropertyName("string_prop")]
-        public string StringProp { get { return this.StringPropOption; } set { this.StringPropOption = new(value); } }
+        public string StringProp { get { return this.StringPropOption.Value; } set { this.StringPropOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [JsonPropertyName("JustNumber")]
-        public decimal? JustNumber { get { return this.JustNumberOption; } set { this.JustNumberOption = new(value); } }
+        public decimal? JustNumber { get { return this.JustNumberOption.Value; } set { this.JustNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("bars")]
         [Obsolete]
-        public List<string> Bars { get { return this.BarsOption; } set { this.BarsOption = new(value); } }
+        public List<string> Bars { get { return this.BarsOption.Value; } set { this.BarsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DeprecatedRef
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("deprecatedRef")]
         [Obsolete]
-        public DeprecatedObject DeprecatedRef { get { return this.DeprecatedRefOption; } set { this.DeprecatedRefOption = new(value); } }
+        public DeprecatedObject DeprecatedRef { get { return this.DeprecatedRefOption.Value; } set { this.DeprecatedRefOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("id")]
         [Obsolete]
-        public decimal? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public decimal? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Order.cs
@@ -158,7 +158,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Complete
         /// </summary>
         [JsonPropertyName("complete")]
-        public bool? Complete { get { return this.CompleteOption; } set { this.CompleteOption = new(value); } }
+        public bool? Complete { get { return this.CompleteOption.Value; } set { this.CompleteOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -171,7 +171,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PetId
@@ -184,7 +184,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets PetId
         /// </summary>
         [JsonPropertyName("petId")]
-        public long? PetId { get { return this.PetIdOption; } set { this.PetIdOption = new(value); } }
+        public long? PetId { get { return this.PetIdOption.Value; } set { this.PetIdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Quantity
@@ -197,7 +197,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Quantity
         /// </summary>
         [JsonPropertyName("quantity")]
-        public int? Quantity { get { return this.QuantityOption; } set { this.QuantityOption = new(value); } }
+        public int? Quantity { get { return this.QuantityOption.Value; } set { this.QuantityOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ShipDate
@@ -211,7 +211,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2020-02-02T20:20:20.000222Z</example> */
         [JsonPropertyName("shipDate")]
-        public DateTime? ShipDate { get { return this.ShipDateOption; } set { this.ShipDateOption = new(value); } }
+        public DateTime? ShipDate { get { return this.ShipDateOption.Value; } set { this.ShipDateOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyBoolean
         /// </summary>
         [JsonPropertyName("my_boolean")]
-        public bool? MyBoolean { get { return this.MyBooleanOption; } set { this.MyBooleanOption = new(value); } }
+        public bool? MyBoolean { get { return this.MyBooleanOption.Value; } set { this.MyBooleanOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MyNumber
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [JsonPropertyName("my_number")]
-        public decimal? MyNumber { get { return this.MyNumberOption; } set { this.MyNumberOption = new(value); } }
+        public decimal? MyNumber { get { return this.MyNumberOption.Value; } set { this.MyNumberOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MyString
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyString
         /// </summary>
         [JsonPropertyName("my_string")]
-        public string MyString { get { return this.MyStringOption; } set { this.MyStringOption = new(value); } }
+        public string MyString { get { return this.MyStringOption.Value; } set { this.MyStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -171,7 +171,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Category
         /// </summary>
         [JsonPropertyName("category")]
-        public Category Category { get { return this.CategoryOption; } set { this.CategoryOption = new(value); } }
+        public Category Category { get { return this.CategoryOption.Value; } set { this.CategoryOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -184,7 +184,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Tags
@@ -197,7 +197,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Tags
         /// </summary>
         [JsonPropertyName("tags")]
-        public List<Tag> Tags { get { return this.TagsOption; } set { this.TagsOption = new(value); } }
+        public List<Tag> Tags { get { return this.TagsOption.Value; } set { this.TagsOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } }
+        public string Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Baz
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Baz
         /// </summary>
         [JsonPropertyName("baz")]
-        public string Baz { get { return this.BazOption; } set { this.BazOption = new(value); } }
+        public string Baz { get { return this.BazOption.Value; } set { this.BazOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -1412,7 +1412,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_notnullable_date_prop")]
-        public DateOnly? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption; } set { this.NotRequiredNotnullableDatePropOption = new(value); } }
+        public DateOnly? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption.Value; } set { this.NotRequiredNotnullableDatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNotnullableintegerProp
@@ -1425,7 +1425,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [JsonPropertyName("not_required_notnullableinteger_prop")]
-        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption; } set { this.NotRequiredNotnullableintegerPropOption = new(value); } }
+        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption.Value; } set { this.NotRequiredNotnullableintegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableDateProp
@@ -1438,7 +1438,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_date_prop")]
-        public DateOnly? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption; } set { this.NotRequiredNullableDatePropOption = new(value); } }
+        public DateOnly? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption.Value; } set { this.NotRequiredNullableDatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableIntegerProp
@@ -1451,7 +1451,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableIntegerProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_integer_prop")]
-        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption; } set { this.NotRequiredNullableIntegerPropOption = new(value); } }
+        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption.Value; } set { this.NotRequiredNullableIntegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableArrayOfString
@@ -1464,7 +1464,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_array_of_string")]
-        public List<string> NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption; } set { this.NotrequiredNotnullableArrayOfStringOption = new(value); } }
+        public List<string> NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption.Value; } set { this.NotrequiredNotnullableArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableBooleanProp
@@ -1477,7 +1477,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_boolean_prop")]
-        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption; } set { this.NotrequiredNotnullableBooleanPropOption = new(value); } }
+        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption.Value; } set { this.NotrequiredNotnullableBooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableDatetimeProp
@@ -1490,7 +1490,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_datetime_prop")]
-        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption; } set { this.NotrequiredNotnullableDatetimePropOption = new(value); } }
+        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption.Value; } set { this.NotrequiredNotnullableDatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableStringProp
@@ -1503,7 +1503,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_string_prop")]
-        public string NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption; } set { this.NotrequiredNotnullableStringPropOption = new(value); } }
+        public string NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption.Value; } set { this.NotrequiredNotnullableStringPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableUuid
@@ -1517,7 +1517,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_notnullable_uuid")]
-        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption; } set { this.NotrequiredNotnullableUuidOption = new(value); } }
+        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption.Value; } set { this.NotrequiredNotnullableUuidOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableArrayOfString
@@ -1530,7 +1530,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_nullable_array_of_string")]
-        public List<string> NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption; } set { this.NotrequiredNullableArrayOfStringOption = new(value); } }
+        public List<string> NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption.Value; } set { this.NotrequiredNullableArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableBooleanProp
@@ -1543,7 +1543,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_boolean_prop")]
-        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption; } set { this.NotrequiredNullableBooleanPropOption = new(value); } }
+        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption.Value; } set { this.NotrequiredNullableBooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableDatetimeProp
@@ -1556,7 +1556,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_datetime_prop")]
-        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption; } set { this.NotrequiredNullableDatetimePropOption = new(value); } }
+        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption.Value; } set { this.NotrequiredNullableDatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableStringProp
@@ -1569,7 +1569,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_string_prop")]
-        public string NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption; } set { this.NotrequiredNullableStringPropOption = new(value); } }
+        public string NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption.Value; } set { this.NotrequiredNullableStringPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableUuid
@@ -1583,7 +1583,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_nullable_uuid")]
-        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption; } set { this.NotrequiredNullableUuidOption = new(value); } }
+        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption.Value; } set { this.NotrequiredNullableUuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets RequiredNullableArrayOfString

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Result.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result code</value>
         [JsonPropertyName("code")]
-        public string Code { get { return this.CodeOption; } set { this.CodeOption = new(value); } }
+        public string Code { get { return this.CodeOption.Value; } set { this.CodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Data
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string> Data { get { return this.DataOption; } set { this.DataOption = new(value); } }
+        public Dictionary<string, string> Data { get { return this.DataOption.Value; } set { this.DataOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [JsonPropertyName("return")]
-        public int? VarReturn { get { return this.VarReturnOption; } set { this.VarReturnOption = new(value); } }
+        public int? VarReturn { get { return this.VarReturnOption.Value; } set { this.VarReturnOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Unsafe
@@ -84,7 +84,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Unsafe
         /// </summary>
         [JsonPropertyName("unsafe")]
-        public string Unsafe { get { return this.UnsafeOption; } set { this.UnsafeOption = new(value); } }
+        public string Unsafe { get { return this.UnsafeOption.Value; } set { this.UnsafeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Role
         /// </summary>
         [JsonPropertyName("role")]
-        public RolesReportsHashRole Role { get { return this.RoleOption; } set { this.RoleOption = new(value); } }
+        public RolesReportsHashRole Role { get { return this.RoleOption.Value; } set { this.RoleOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of RoleUuid
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [JsonPropertyName("role_uuid")]
-        public Guid? RoleUuid { get { return this.RoleUuidOption; } set { this.RoleUuidOption = new(value); } }
+        public Guid? RoleUuid { get { return this.RoleUuidOption.Value; } set { this.RoleUuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarSpecialModelName
         /// </summary>
         [JsonPropertyName("_special_model.name_")]
-        public string VarSpecialModelName { get { return this.VarSpecialModelNameOption; } set { this.VarSpecialModelNameOption = new(value); } }
+        public string VarSpecialModelName { get { return this.VarSpecialModelNameOption.Value; } set { this.VarSpecialModelNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SpecialPropertyName
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [JsonPropertyName("$special[property.name]")]
-        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption; } set { this.SpecialPropertyNameOption = new(value); } }
+        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption.Value; } set { this.SpecialPropertyNameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Value
         /// </summary>
         [JsonPropertyName("value")]
-        public string Value { get { return this.ValueOption; } set { this.ValueOption = new(value); } }
+        public string Value { get { return this.ValueOption.Value; } set { this.ValueOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets TestCollectionEndingWithWordList
         /// </summary>
         [JsonPropertyName("TestCollectionEndingWithWordList")]
-        public List<TestCollectionEndingWithWordList> TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption; } set { this.TestCollectionEndingWithWordListOption = new(value); } }
+        public List<TestCollectionEndingWithWordList> TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption.Value; } set { this.TestCollectionEndingWithWordListOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SomeProperty
         /// </summary>
         [JsonPropertyName("someProperty")]
-        public string SomeProperty { get { return this.SomePropertyOption; } set { this.SomePropertyOption = new(value); } }
+        public string SomeProperty { get { return this.SomePropertyOption.Value; } set { this.SomePropertyOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string> Data { get { return this.DataOption; } set { this.DataOption = new(value); } }
+        public Dictionary<string, string> Data { get { return this.DataOption.Value; } set { this.DataOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
         [JsonPropertyName("anyTypeProp")]
-        public Object AnyTypeProp { get { return this.AnyTypePropOption; } set { this.AnyTypePropOption = new(value); } }
+        public Object AnyTypeProp { get { return this.AnyTypePropOption.Value; } set { this.AnyTypePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of AnyTypePropNullable
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values.</value>
         [JsonPropertyName("anyTypePropNullable")]
-        public Object AnyTypePropNullable { get { return this.AnyTypePropNullableOption; } set { this.AnyTypePropNullableOption = new(value); } }
+        public Object AnyTypePropNullable { get { return this.AnyTypePropNullableOption.Value; } set { this.AnyTypePropNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Email
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Email
         /// </summary>
         [JsonPropertyName("email")]
-        public string Email { get { return this.EmailOption; } set { this.EmailOption = new(value); } }
+        public string Email { get { return this.EmailOption.Value; } set { this.EmailOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of FirstName
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets FirstName
         /// </summary>
         [JsonPropertyName("firstName")]
-        public string FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new(value); } }
+        public string FirstName { get { return this.FirstNameOption.Value; } set { this.FirstNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of LastName
@@ -142,7 +142,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LastName
         /// </summary>
         [JsonPropertyName("lastName")]
-        public string LastName { get { return this.LastNameOption; } set { this.LastNameOption = new(value); } }
+        public string LastName { get { return this.LastNameOption.Value; } set { this.LastNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredProps
@@ -156,7 +156,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredProps")]
-        public Object ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption; } set { this.ObjectWithNoDeclaredPropsOption = new(value); } }
+        public Object ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption.Value; } set { this.ObjectWithNoDeclaredPropsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredPropsNullable
@@ -170,7 +170,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredPropsNullable")]
-        public Object ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption; } set { this.ObjectWithNoDeclaredPropsNullableOption = new(value); } }
+        public Object ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption.Value; } set { this.ObjectWithNoDeclaredPropsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Password
@@ -183,7 +183,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Password
         /// </summary>
         [JsonPropertyName("password")]
-        public string Password { get { return this.PasswordOption; } set { this.PasswordOption = new(value); } }
+        public string Password { get { return this.PasswordOption.Value; } set { this.PasswordOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Phone
@@ -196,7 +196,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Phone
         /// </summary>
         [JsonPropertyName("phone")]
-        public string Phone { get { return this.PhoneOption; } set { this.PhoneOption = new(value); } }
+        public string Phone { get { return this.PhoneOption.Value; } set { this.PhoneOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UserStatus
@@ -210,7 +210,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [JsonPropertyName("userStatus")]
-        public int? UserStatus { get { return this.UserStatusOption; } set { this.UserStatusOption = new(value); } }
+        public int? UserStatus { get { return this.UserStatusOption.Value; } set { this.UserStatusOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Username
@@ -223,7 +223,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Username
         /// </summary>
         [JsonPropertyName("username")]
-        public string Username { get { return this.UsernameOption; } set { this.UsernameOption = new(value); } }
+        public string Username { get { return this.UsernameOption.Value; } set { this.UsernameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [JsonPropertyName("hasBaleen")]
-        public bool? HasBaleen { get { return this.HasBaleenOption; } set { this.HasBaleenOption = new(value); } }
+        public bool? HasBaleen { get { return this.HasBaleenOption.Value; } set { this.HasBaleenOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of HasTeeth
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasTeeth
         /// </summary>
         [JsonPropertyName("hasTeeth")]
-        public bool? HasTeeth { get { return this.HasTeethOption; } set { this.HasTeethOption = new(value); } }
+        public bool? HasTeeth { get { return this.HasTeethOption.Value; } set { this.HasTeethOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Activity.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ActivityOutputs
         /// </summary>
         [JsonPropertyName("activity_outputs")]
-        public Dictionary<string, List<ActivityOutputElementRepresentation>>? ActivityOutputs { get { return this.ActivityOutputsOption; } set { this.ActivityOutputsOption = new(value); } }
+        public Dictionary<string, List<ActivityOutputElementRepresentation>>? ActivityOutputs { get { return this.ActivityOutputsOption.Value; } set { this.ActivityOutputsOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop1
         /// </summary>
         [JsonPropertyName("prop1")]
-        public string? Prop1 { get { return this.Prop1Option; } set { this.Prop1Option = new(value); } }
+        public string? Prop1 { get { return this.Prop1Option.Value; } set { this.Prop1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Prop2
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop2
         /// </summary>
         [JsonPropertyName("prop2")]
-        public Object? Prop2 { get { return this.Prop2Option; } set { this.Prop2Option = new(value); } }
+        public Object? Prop2 { get { return this.Prop2Option.Value; } set { this.Prop2Option = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Anytype1
         /// </summary>
         [JsonPropertyName("anytype_1")]
-        public Object? Anytype1 { get { return this.Anytype1Option; } set { this.Anytype1Option = new(value); } }
+        public Object? Anytype1 { get { return this.Anytype1Option.Value; } set { this.Anytype1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of EmptyMap
@@ -84,7 +84,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>an object with no declared properties and no undeclared properties, hence it&#39;s an empty map.</value>
         [JsonPropertyName("empty_map")]
-        public Object? EmptyMap { get { return this.EmptyMapOption; } set { this.EmptyMapOption = new(value); } }
+        public Object? EmptyMap { get { return this.EmptyMapOption.Value; } set { this.EmptyMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfMapProperty
@@ -97,7 +97,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfMapProperty
         /// </summary>
         [JsonPropertyName("map_of_map_property")]
-        public Dictionary<string, Dictionary<string, string>>? MapOfMapProperty { get { return this.MapOfMapPropertyOption; } set { this.MapOfMapPropertyOption = new(value); } }
+        public Dictionary<string, Dictionary<string, string>>? MapOfMapProperty { get { return this.MapOfMapPropertyOption.Value; } set { this.MapOfMapPropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapProperty
@@ -110,7 +110,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapProperty
         /// </summary>
         [JsonPropertyName("map_property")]
-        public Dictionary<string, string>? MapProperty { get { return this.MapPropertyOption; } set { this.MapPropertyOption = new(value); } }
+        public Dictionary<string, string>? MapProperty { get { return this.MapPropertyOption.Value; } set { this.MapPropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype1
@@ -123,7 +123,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype1
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_1")]
-        public Object? MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new(value); } }
+        public Object? MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype2
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype2
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_2")]
-        public Object? MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new(value); } }
+        public Object? MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype3
@@ -149,7 +149,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype3
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_3")]
-        public Dictionary<string, Object>? MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new(value); } }
+        public Dictionary<string, Object>? MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesString
@@ -162,7 +162,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesString
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_string")]
-        public Dictionary<string, string>? MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption; } set { this.MapWithUndeclaredPropertiesStringOption = new(value); } }
+        public Dictionary<string, string>? MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption.Value; } set { this.MapWithUndeclaredPropertiesStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Animal.cs
@@ -64,7 +64,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [JsonPropertyName("code")]
-        public int? Code { get { return this.CodeOption; } set { this.CodeOption = new(value); } }
+        public int? Code { get { return this.CodeOption.Value; } set { this.CodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Message
@@ -73,7 +73,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Message
         /// </summary>
         [JsonPropertyName("message")]
-        public string? Message { get { return this.MessageOption; } set { this.MessageOption = new(value); } }
+        public string? Message { get { return this.MessageOption.Value; } set { this.MessageOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Type
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Type
         /// </summary>
         [JsonPropertyName("type")]
-        public string? Type { get { return this.TypeOption; } set { this.TypeOption = new(value); } }
+        public string? Type { get { return this.TypeOption.Value; } set { this.TypeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Apple.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ColorCode
         /// </summary>
         [JsonPropertyName("color_code")]
-        public string? ColorCode { get { return this.ColorCodeOption; } set { this.ColorCodeOption = new(value); } }
+        public string? ColorCode { get { return this.ColorCodeOption.Value; } set { this.ColorCodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Cultivar
@@ -73,7 +73,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Cultivar
         /// </summary>
         [JsonPropertyName("cultivar")]
-        public string? Cultivar { get { return this.CultivarOption; } set { this.CultivarOption = new(value); } }
+        public string? Cultivar { get { return this.CultivarOption.Value; } set { this.CultivarOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Origin
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Origin
         /// </summary>
         [JsonPropertyName("origin")]
-        public string? Origin { get { return this.OriginOption; } set { this.OriginOption = new(value); } }
+        public string? Origin { get { return this.OriginOption.Value; } set { this.OriginOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -64,7 +64,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [JsonPropertyName("mealy")]
-        public bool? Mealy { get { return this.MealyOption; } set { this.MealyOption = new(value); } }
+        public bool? Mealy { get { return this.MealyOption.Value; } set { this.MealyOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayArrayNumber")]
-        public List<List<decimal>>? ArrayArrayNumber { get { return this.ArrayArrayNumberOption; } set { this.ArrayArrayNumberOption = new(value); } }
+        public List<List<decimal>>? ArrayArrayNumber { get { return this.ArrayArrayNumberOption.Value; } set { this.ArrayArrayNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayNumber")]
-        public List<decimal>? ArrayNumber { get { return this.ArrayNumberOption; } set { this.ArrayNumberOption = new(value); } }
+        public List<decimal>? ArrayNumber { get { return this.ArrayNumberOption.Value; } set { this.ArrayNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfInteger
         /// </summary>
         [JsonPropertyName("array_array_of_integer")]
-        public List<List<long>>? ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption; } set { this.ArrayArrayOfIntegerOption = new(value); } }
+        public List<List<long>>? ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption.Value; } set { this.ArrayArrayOfIntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayArrayOfModel
@@ -73,7 +73,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfModel
         /// </summary>
         [JsonPropertyName("array_array_of_model")]
-        public List<List<ReadOnlyFirst>>? ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption; } set { this.ArrayArrayOfModelOption = new(value); } }
+        public List<List<ReadOnlyFirst>>? ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption.Value; } set { this.ArrayArrayOfModelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayOfString
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayOfString
         /// </summary>
         [JsonPropertyName("array_of_string")]
-        public List<string>? ArrayOfString { get { return this.ArrayOfStringOption; } set { this.ArrayOfStringOption = new(value); } }
+        public List<string>? ArrayOfString { get { return this.ArrayOfStringOption.Value; } set { this.ArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Banana.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [JsonPropertyName("lengthCm")]
-        public decimal? LengthCm { get { return this.LengthCmOption; } set { this.LengthCmOption = new(value); } }
+        public decimal? LengthCm { get { return this.LengthCmOption.Value; } set { this.LengthCmOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -64,7 +64,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [JsonPropertyName("sweet")]
-        public bool? Sweet { get { return this.SweetOption; } set { this.SweetOption = new(value); } }
+        public bool? Sweet { get { return this.SweetOption.Value; } set { this.SweetOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Name of the pet </value>
         [JsonPropertyName("ATT_NAME")]
-        public string? ATT_NAME { get { return this.ATT_NAMEOption; } set { this.ATT_NAMEOption = new(value); } }
+        public string? ATT_NAME { get { return this.ATT_NAMEOption.Value; } set { this.ATT_NAMEOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalCamel
@@ -80,7 +80,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalCamel
         /// </summary>
         [JsonPropertyName("CapitalCamel")]
-        public string? CapitalCamel { get { return this.CapitalCamelOption; } set { this.CapitalCamelOption = new(value); } }
+        public string? CapitalCamel { get { return this.CapitalCamelOption.Value; } set { this.CapitalCamelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalSnake
@@ -93,7 +93,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalSnake
         /// </summary>
         [JsonPropertyName("Capital_Snake")]
-        public string? CapitalSnake { get { return this.CapitalSnakeOption; } set { this.CapitalSnakeOption = new(value); } }
+        public string? CapitalSnake { get { return this.CapitalSnakeOption.Value; } set { this.CapitalSnakeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SCAETHFlowPoints
@@ -106,7 +106,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SCAETHFlowPoints
         /// </summary>
         [JsonPropertyName("SCA_ETH_Flow_Points")]
-        public string? SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption; } set { this.SCAETHFlowPointsOption = new(value); } }
+        public string? SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption.Value; } set { this.SCAETHFlowPointsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SmallCamel
@@ -119,7 +119,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallCamel
         /// </summary>
         [JsonPropertyName("smallCamel")]
-        public string? SmallCamel { get { return this.SmallCamelOption; } set { this.SmallCamelOption = new(value); } }
+        public string? SmallCamel { get { return this.SmallCamelOption.Value; } set { this.SmallCamelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SmallSnake
@@ -132,7 +132,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallSnake
         /// </summary>
         [JsonPropertyName("small_Snake")]
-        public string? SmallSnake { get { return this.SmallSnakeOption; } set { this.SmallSnakeOption = new(value); } }
+        public string? SmallSnake { get { return this.SmallSnakeOption.Value; } set { this.SmallSnakeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [JsonPropertyName("declawed")]
-        public bool? Declawed { get { return this.DeclawedOption; } set { this.DeclawedOption = new(value); } }
+        public bool? Declawed { get { return this.DeclawedOption.Value; } set { this.DeclawedOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -109,7 +109,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// The discriminator

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("_class")]
-        public string? Class { get { return this.ClassOption; } set { this.ClassOption = new(value); } }
+        public string? Class { get { return this.ClassOption.Value; } set { this.ClassOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>Fri Jul 21 00:00:00 UTC 2017</example> */
         [JsonPropertyName("dateOnlyProperty")]
-        public DateOnly? DateOnlyProperty { get { return this.DateOnlyPropertyOption; } set { this.DateOnlyPropertyOption = new(value); } }
+        public DateOnly? DateOnlyProperty { get { return this.DateOnlyPropertyOption.Value; } set { this.DateOnlyPropertyOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Dog.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Breed
         /// </summary>
         [JsonPropertyName("breed")]
-        public string? Breed { get { return this.BreedOption; } set { this.BreedOption = new(value); } }
+        public string? Breed { get { return this.BreedOption.Value; } set { this.BreedOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Drawing.cs
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MainShape
         /// </summary>
         [JsonPropertyName("mainShape")]
-        public Shape? MainShape { get { return this.MainShapeOption; } set { this.MainShapeOption = new(value); } }
+        public Shape? MainShape { get { return this.MainShapeOption.Value; } set { this.MainShapeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NullableShape
@@ -75,7 +75,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableShape
         /// </summary>
         [JsonPropertyName("nullableShape")]
-        public NullableShape? NullableShape { get { return this.NullableShapeOption; } set { this.NullableShapeOption = new(value); } }
+        public NullableShape? NullableShape { get { return this.NullableShapeOption.Value; } set { this.NullableShapeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ShapeOrNull
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ShapeOrNull
         /// </summary>
         [JsonPropertyName("shapeOrNull")]
-        public ShapeOrNull? ShapeOrNull { get { return this.ShapeOrNullOption; } set { this.ShapeOrNullOption = new(value); } }
+        public ShapeOrNull? ShapeOrNull { get { return this.ShapeOrNullOption.Value; } set { this.ShapeOrNullOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Shapes
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Shapes
         /// </summary>
         [JsonPropertyName("shapes")]
-        public List<Shape>? Shapes { get { return this.ShapesOption; } set { this.ShapesOption = new(value); } }
+        public List<Shape>? Shapes { get { return this.ShapesOption.Value; } set { this.ShapesOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -203,7 +203,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayEnum
         /// </summary>
         [JsonPropertyName("array_enum")]
-        public List<EnumArrays.ArrayEnumEnum>? ArrayEnum { get { return this.ArrayEnumOption; } set { this.ArrayEnumOption = new(value); } }
+        public List<EnumArrays.ArrayEnumEnum>? ArrayEnum { get { return this.ArrayEnumOption.Value; } set { this.ArrayEnumOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/File.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Test capitalization</value>
         [JsonPropertyName("sourceURI")]
-        public string? SourceURI { get { return this.SourceURIOption; } set { this.SourceURIOption = new(value); } }
+        public string? SourceURI { get { return this.SourceURIOption.Value; } set { this.SourceURIOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets File
         /// </summary>
         [JsonPropertyName("file")]
-        public File? File { get { return this.FileOption; } set { this.FileOption = new(value); } }
+        public File? File { get { return this.FileOption.Value; } set { this.FileOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Files
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Files
         /// </summary>
         [JsonPropertyName("files")]
-        public List<File>? Files { get { return this.FilesOption; } set { this.FilesOption = new(value); } }
+        public List<File>? Files { get { return this.FilesOption.Value; } set { this.FilesOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Foo.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string? Bar { get { return this.BarOption; } set { this.BarOption = new(value); } }
+        public string? Bar { get { return this.BarOption.Value; } set { this.BarOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public Foo? String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public Foo? String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -141,7 +141,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Binary
         /// </summary>
         [JsonPropertyName("binary")]
-        public System.IO.Stream? Binary { get { return this.BinaryOption; } set { this.BinaryOption = new(value); } }
+        public System.IO.Stream? Binary { get { return this.BinaryOption.Value; } set { this.BinaryOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DateTime
@@ -155,7 +155,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2007-12-03T10:15:30+01:00</example> */
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Decimal
@@ -168,7 +168,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Decimal
         /// </summary>
         [JsonPropertyName("decimal")]
-        public decimal? Decimal { get { return this.DecimalOption; } set { this.DecimalOption = new(value); } }
+        public decimal? Decimal { get { return this.DecimalOption.Value; } set { this.DecimalOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Double
@@ -181,7 +181,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Double
         /// </summary>
         [JsonPropertyName("double")]
-        public double? Double { get { return this.DoubleOption; } set { this.DoubleOption = new(value); } }
+        public double? Double { get { return this.DoubleOption.Value; } set { this.DoubleOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName2
@@ -194,7 +194,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName2
         /// </summary>
         [JsonPropertyName("duplicate_property_name")]
-        public string? DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option; } set { this.DuplicatePropertyName2Option = new(value); } }
+        public string? DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option.Value; } set { this.DuplicatePropertyName2Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName
@@ -207,7 +207,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName
         /// </summary>
         [JsonPropertyName("@duplicate_property_name")]
-        public string? DuplicatePropertyName { get { return this.DuplicatePropertyNameOption; } set { this.DuplicatePropertyNameOption = new(value); } }
+        public string? DuplicatePropertyName { get { return this.DuplicatePropertyNameOption.Value; } set { this.DuplicatePropertyNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Float
@@ -220,7 +220,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Float
         /// </summary>
         [JsonPropertyName("float")]
-        public float? Float { get { return this.FloatOption; } set { this.FloatOption = new(value); } }
+        public float? Float { get { return this.FloatOption.Value; } set { this.FloatOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int32
@@ -233,7 +233,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32
         /// </summary>
         [JsonPropertyName("int32")]
-        public int? Int32 { get { return this.Int32Option; } set { this.Int32Option = new(value); } }
+        public int? Int32 { get { return this.Int32Option.Value; } set { this.Int32Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int32Range
@@ -246,7 +246,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32Range
         /// </summary>
         [JsonPropertyName("int32Range")]
-        public int? Int32Range { get { return this.Int32RangeOption; } set { this.Int32RangeOption = new(value); } }
+        public int? Int32Range { get { return this.Int32RangeOption.Value; } set { this.Int32RangeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64
@@ -259,7 +259,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64
         /// </summary>
         [JsonPropertyName("int64")]
-        public long? Int64 { get { return this.Int64Option; } set { this.Int64Option = new(value); } }
+        public long? Int64 { get { return this.Int64Option.Value; } set { this.Int64Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Negative
@@ -272,7 +272,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Negative
         /// </summary>
         [JsonPropertyName("int64Negative")]
-        public long? Int64Negative { get { return this.Int64NegativeOption; } set { this.Int64NegativeOption = new(value); } }
+        public long? Int64Negative { get { return this.Int64NegativeOption.Value; } set { this.Int64NegativeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64NegativeExclusive
@@ -285,7 +285,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64NegativeExclusive
         /// </summary>
         [JsonPropertyName("int64NegativeExclusive")]
-        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption; } set { this.Int64NegativeExclusiveOption = new(value); } }
+        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption.Value; } set { this.Int64NegativeExclusiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Positive
@@ -298,7 +298,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Positive
         /// </summary>
         [JsonPropertyName("int64Positive")]
-        public long? Int64Positive { get { return this.Int64PositiveOption; } set { this.Int64PositiveOption = new(value); } }
+        public long? Int64Positive { get { return this.Int64PositiveOption.Value; } set { this.Int64PositiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64PositiveExclusive
@@ -311,7 +311,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64PositiveExclusive
         /// </summary>
         [JsonPropertyName("int64PositiveExclusive")]
-        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption; } set { this.Int64PositiveExclusiveOption = new(value); } }
+        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption.Value; } set { this.Int64PositiveExclusiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Integer
@@ -324,7 +324,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [JsonPropertyName("integer")]
-        public int? Integer { get { return this.IntegerOption; } set { this.IntegerOption = new(value); } }
+        public int? Integer { get { return this.IntegerOption.Value; } set { this.IntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithBackslash
@@ -338,7 +338,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>None</value>
         [JsonPropertyName("pattern_with_backslash")]
-        public string? PatternWithBackslash { get { return this.PatternWithBackslashOption; } set { this.PatternWithBackslashOption = new(value); } }
+        public string? PatternWithBackslash { get { return this.PatternWithBackslashOption.Value; } set { this.PatternWithBackslashOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigits
@@ -352,7 +352,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string that is a 10 digit number. Can have leading zeros.</value>
         [JsonPropertyName("pattern_with_digits")]
-        public string? PatternWithDigits { get { return this.PatternWithDigitsOption; } set { this.PatternWithDigitsOption = new(value); } }
+        public string? PatternWithDigits { get { return this.PatternWithDigitsOption.Value; } set { this.PatternWithDigitsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigitsAndDelimiter
@@ -366,7 +366,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.</value>
         [JsonPropertyName("pattern_with_digits_and_delimiter")]
-        public string? PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption; } set { this.PatternWithDigitsAndDelimiterOption = new(value); } }
+        public string? PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption.Value; } set { this.PatternWithDigitsAndDelimiterOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of String
@@ -379,7 +379,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public string? String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public string? String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of StringFormattedAsDecimal
@@ -392,7 +392,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringFormattedAsDecimal
         /// </summary>
         [JsonPropertyName("string_formatted_as_decimal")]
-        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption; } set { this.StringFormattedAsDecimalOption = new(value); } }
+        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption.Value; } set { this.StringFormattedAsDecimalOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedInteger
@@ -405,7 +405,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [JsonPropertyName("unsigned_integer")]
-        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption; } set { this.UnsignedIntegerOption = new(value); } }
+        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption.Value; } set { this.UnsignedIntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedLong
@@ -418,7 +418,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedLong
         /// </summary>
         [JsonPropertyName("unsigned_long")]
-        public ulong? UnsignedLong { get { return this.UnsignedLongOption; } set { this.UnsignedLongOption = new(value); } }
+        public ulong? UnsignedLong { get { return this.UnsignedLongOption.Value; } set { this.UnsignedLongOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -432,7 +432,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
@@ -79,7 +79,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string? Bar { get { return this.BarOption; } }
+        public string? Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Foo
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Foo
         /// </summary>
         [JsonPropertyName("foo")]
-        public string? Foo { get { return this.FooOption; } }
+        public string? Foo { get { return this.FooOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableMessage
         /// </summary>
         [JsonPropertyName("NullableMessage")]
-        public string? NullableMessage { get { return this.NullableMessageOption; } set { this.NullableMessageOption = new(value); } }
+        public string? NullableMessage { get { return this.NullableMessageOption.Value; } set { this.NullableMessageOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/List.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123List
         /// </summary>
         [JsonPropertyName("123-list")]
-        public string? Var123List { get { return this.Var123ListOption; } set { this.Var123ListOption = new(value); } }
+        public string? Var123List { get { return this.Var123ListOption.Value; } set { this.Var123ListOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets EscapedLiteralString
         /// </summary>
         [JsonPropertyName("escapedLiteralString")]
-        public string? EscapedLiteralString { get { return this.EscapedLiteralStringOption; } set { this.EscapedLiteralStringOption = new(value); } }
+        public string? EscapedLiteralString { get { return this.EscapedLiteralStringOption.Value; } set { this.EscapedLiteralStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnescapedLiteralString
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnescapedLiteralString
         /// </summary>
         [JsonPropertyName("unescapedLiteralString")]
-        public string? UnescapedLiteralString { get { return this.UnescapedLiteralStringOption; } set { this.UnescapedLiteralStringOption = new(value); } }
+        public string? UnescapedLiteralString { get { return this.UnescapedLiteralStringOption.Value; } set { this.UnescapedLiteralStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MapTest.cs
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DirectMap
         /// </summary>
         [JsonPropertyName("direct_map")]
-        public Dictionary<string, bool>? DirectMap { get { return this.DirectMapOption; } set { this.DirectMapOption = new(value); } }
+        public Dictionary<string, bool>? DirectMap { get { return this.DirectMapOption.Value; } set { this.DirectMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of IndirectMap
@@ -141,7 +141,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IndirectMap
         /// </summary>
         [JsonPropertyName("indirect_map")]
-        public Dictionary<string, bool>? IndirectMap { get { return this.IndirectMapOption; } set { this.IndirectMapOption = new(value); } }
+        public Dictionary<string, bool>? IndirectMap { get { return this.IndirectMapOption.Value; } set { this.IndirectMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapMapOfString
@@ -154,7 +154,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapMapOfString
         /// </summary>
         [JsonPropertyName("map_map_of_string")]
-        public Dictionary<string, Dictionary<string, string>>? MapMapOfString { get { return this.MapMapOfStringOption; } set { this.MapMapOfStringOption = new(value); } }
+        public Dictionary<string, Dictionary<string, string>>? MapMapOfString { get { return this.MapMapOfStringOption.Value; } set { this.MapMapOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfEnumString
@@ -167,7 +167,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfEnumString
         /// </summary>
         [JsonPropertyName("map_of_enum_string")]
-        public Dictionary<string, MapTest.InnerEnum>? MapOfEnumString { get { return this.MapOfEnumStringOption; } set { this.MapOfEnumStringOption = new(value); } }
+        public Dictionary<string, MapTest.InnerEnum>? MapOfEnumString { get { return this.MapOfEnumStringOption.Value; } set { this.MapOfEnumStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedAnyOfContent? Content { get { return this.ContentOption; } set { this.ContentOption = new(value); } }
+        public MixedAnyOfContent? Content { get { return this.ContentOption.Value; } set { this.ContentOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedOneOfContent? Content { get { return this.ContentOption; } set { this.ContentOption = new(value); } }
+        public MixedOneOfContent? Content { get { return this.ContentOption.Value; } set { this.ContentOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateTime
         /// </summary>
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Map
@@ -75,7 +75,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Map
         /// </summary>
         [JsonPropertyName("map")]
-        public Dictionary<string, Animal>? Map { get { return this.MapOption; } set { this.MapOption = new(value); } }
+        public Dictionary<string, Animal>? Map { get { return this.MapOption.Value; } set { this.MapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UuidWithPattern
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [JsonPropertyName("uuid_with_pattern")]
-        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption; } set { this.UuidWithPatternOption = new(value); } }
+        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption.Value; } set { this.UuidWithPatternOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public string? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public string? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("class")]
-        public string? Class { get { return this.ClassOption; } set { this.ClassOption = new(value); } }
+        public string? Class { get { return this.ClassOption.Value; } set { this.ClassOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public int? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public int? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarClient
         /// </summary>
         [JsonPropertyName("client")]
-        public string? VarClient { get { return this.VarClientOption; } set { this.VarClientOption = new(value); } }
+        public string? VarClient { get { return this.VarClientOption.Value; } set { this.VarClientOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Property
         /// </summary>
         [JsonPropertyName("property")]
-        public string? Property { get { return this.PropertyOption; } set { this.PropertyOption = new(value); } }
+        public string? Property { get { return this.PropertyOption.Value; } set { this.PropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SnakeCase
@@ -81,7 +81,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [JsonPropertyName("snake_case")]
-        public int? SnakeCase { get { return this.SnakeCaseOption; } }
+        public int? SnakeCase { get { return this.SnakeCaseOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Var123Number
@@ -94,7 +94,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123Number
         /// </summary>
         [JsonPropertyName("123Number")]
-        public int? Var123Number { get { return this.Var123NumberOption; } }
+        public int? Var123Number { get { return this.Var123NumberOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("array_and_items_nullable_prop")]
-        public List<Object>? ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption; } set { this.ArrayAndItemsNullablePropOption = new(value); } }
+        public List<Object>? ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption.Value; } set { this.ArrayAndItemsNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayItemsNullable
@@ -91,7 +91,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayItemsNullable
         /// </summary>
         [JsonPropertyName("array_items_nullable")]
-        public List<Object>? ArrayItemsNullable { get { return this.ArrayItemsNullableOption; } set { this.ArrayItemsNullableOption = new(value); } }
+        public List<Object>? ArrayItemsNullable { get { return this.ArrayItemsNullableOption.Value; } set { this.ArrayItemsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayNullableProp
@@ -104,7 +104,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNullableProp
         /// </summary>
         [JsonPropertyName("array_nullable_prop")]
-        public List<Object>? ArrayNullableProp { get { return this.ArrayNullablePropOption; } set { this.ArrayNullablePropOption = new(value); } }
+        public List<Object>? ArrayNullableProp { get { return this.ArrayNullablePropOption.Value; } set { this.ArrayNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of BooleanProp
@@ -117,7 +117,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BooleanProp
         /// </summary>
         [JsonPropertyName("boolean_prop")]
-        public bool? BooleanProp { get { return this.BooleanPropOption; } set { this.BooleanPropOption = new(value); } }
+        public bool? BooleanProp { get { return this.BooleanPropOption.Value; } set { this.BooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DateProp
@@ -130,7 +130,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateProp
         /// </summary>
         [JsonPropertyName("date_prop")]
-        public DateOnly? DateProp { get { return this.DatePropOption; } set { this.DatePropOption = new(value); } }
+        public DateOnly? DateProp { get { return this.DatePropOption.Value; } set { this.DatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DatetimeProp
@@ -143,7 +143,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DatetimeProp
         /// </summary>
         [JsonPropertyName("datetime_prop")]
-        public DateTime? DatetimeProp { get { return this.DatetimePropOption; } set { this.DatetimePropOption = new(value); } }
+        public DateTime? DatetimeProp { get { return this.DatetimePropOption.Value; } set { this.DatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of IntegerProp
@@ -156,7 +156,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IntegerProp
         /// </summary>
         [JsonPropertyName("integer_prop")]
-        public int? IntegerProp { get { return this.IntegerPropOption; } set { this.IntegerPropOption = new(value); } }
+        public int? IntegerProp { get { return this.IntegerPropOption.Value; } set { this.IntegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NumberProp
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NumberProp
         /// </summary>
         [JsonPropertyName("number_prop")]
-        public decimal? NumberProp { get { return this.NumberPropOption; } set { this.NumberPropOption = new(value); } }
+        public decimal? NumberProp { get { return this.NumberPropOption.Value; } set { this.NumberPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectAndItemsNullableProp
@@ -182,7 +182,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("object_and_items_nullable_prop")]
-        public Dictionary<string, Object>? ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption; } set { this.ObjectAndItemsNullablePropOption = new(value); } }
+        public Dictionary<string, Object>? ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption.Value; } set { this.ObjectAndItemsNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectItemsNullable
@@ -195,7 +195,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectItemsNullable
         /// </summary>
         [JsonPropertyName("object_items_nullable")]
-        public Dictionary<string, Object>? ObjectItemsNullable { get { return this.ObjectItemsNullableOption; } set { this.ObjectItemsNullableOption = new(value); } }
+        public Dictionary<string, Object>? ObjectItemsNullable { get { return this.ObjectItemsNullableOption.Value; } set { this.ObjectItemsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectNullableProp
@@ -208,7 +208,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectNullableProp
         /// </summary>
         [JsonPropertyName("object_nullable_prop")]
-        public Dictionary<string, Object>? ObjectNullableProp { get { return this.ObjectNullablePropOption; } set { this.ObjectNullablePropOption = new(value); } }
+        public Dictionary<string, Object>? ObjectNullableProp { get { return this.ObjectNullablePropOption.Value; } set { this.ObjectNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of StringProp
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringProp
         /// </summary>
         [JsonPropertyName("string_prop")]
-        public string? StringProp { get { return this.StringPropOption; } set { this.StringPropOption = new(value); } }
+        public string? StringProp { get { return this.StringPropOption.Value; } set { this.StringPropOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [JsonPropertyName("JustNumber")]
-        public decimal? JustNumber { get { return this.JustNumberOption; } set { this.JustNumberOption = new(value); } }
+        public decimal? JustNumber { get { return this.JustNumberOption.Value; } set { this.JustNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("bars")]
         [Obsolete]
-        public List<string>? Bars { get { return this.BarsOption; } set { this.BarsOption = new(value); } }
+        public List<string>? Bars { get { return this.BarsOption.Value; } set { this.BarsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DeprecatedRef
@@ -77,7 +77,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("deprecatedRef")]
         [Obsolete]
-        public DeprecatedObject? DeprecatedRef { get { return this.DeprecatedRefOption; } set { this.DeprecatedRefOption = new(value); } }
+        public DeprecatedObject? DeprecatedRef { get { return this.DeprecatedRefOption.Value; } set { this.DeprecatedRefOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -91,7 +91,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("id")]
         [Obsolete]
-        public decimal? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public decimal? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -104,7 +104,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public string? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Order.cs
@@ -161,7 +161,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Complete
         /// </summary>
         [JsonPropertyName("complete")]
-        public bool? Complete { get { return this.CompleteOption; } set { this.CompleteOption = new(value); } }
+        public bool? Complete { get { return this.CompleteOption.Value; } set { this.CompleteOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -174,7 +174,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PetId
@@ -187,7 +187,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets PetId
         /// </summary>
         [JsonPropertyName("petId")]
-        public long? PetId { get { return this.PetIdOption; } set { this.PetIdOption = new(value); } }
+        public long? PetId { get { return this.PetIdOption.Value; } set { this.PetIdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Quantity
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Quantity
         /// </summary>
         [JsonPropertyName("quantity")]
-        public int? Quantity { get { return this.QuantityOption; } set { this.QuantityOption = new(value); } }
+        public int? Quantity { get { return this.QuantityOption.Value; } set { this.QuantityOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ShipDate
@@ -214,7 +214,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2020-02-02T20:20:20.000222Z</example> */
         [JsonPropertyName("shipDate")]
-        public DateTime? ShipDate { get { return this.ShipDateOption; } set { this.ShipDateOption = new(value); } }
+        public DateTime? ShipDate { get { return this.ShipDateOption.Value; } set { this.ShipDateOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyBoolean
         /// </summary>
         [JsonPropertyName("my_boolean")]
-        public bool? MyBoolean { get { return this.MyBooleanOption; } set { this.MyBooleanOption = new(value); } }
+        public bool? MyBoolean { get { return this.MyBooleanOption.Value; } set { this.MyBooleanOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MyNumber
@@ -73,7 +73,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [JsonPropertyName("my_number")]
-        public decimal? MyNumber { get { return this.MyNumberOption; } set { this.MyNumberOption = new(value); } }
+        public decimal? MyNumber { get { return this.MyNumberOption.Value; } set { this.MyNumberOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MyString
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyString
         /// </summary>
         [JsonPropertyName("my_string")]
-        public string? MyString { get { return this.MyStringOption; } set { this.MyStringOption = new(value); } }
+        public string? MyString { get { return this.MyStringOption.Value; } set { this.MyStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
@@ -174,7 +174,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Category
         /// </summary>
         [JsonPropertyName("category")]
-        public Category? Category { get { return this.CategoryOption; } set { this.CategoryOption = new(value); } }
+        public Category? Category { get { return this.CategoryOption.Value; } set { this.CategoryOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -187,7 +187,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Tags
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Tags
         /// </summary>
         [JsonPropertyName("tags")]
-        public List<Tag>? Tags { get { return this.TagsOption; } set { this.TagsOption = new(value); } }
+        public List<Tag>? Tags { get { return this.TagsOption.Value; } set { this.TagsOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string? Bar { get { return this.BarOption; } }
+        public string? Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Baz
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Baz
         /// </summary>
         [JsonPropertyName("baz")]
-        public string? Baz { get { return this.BazOption; } set { this.BazOption = new(value); } }
+        public string? Baz { get { return this.BazOption.Value; } set { this.BazOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -1415,7 +1415,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_notnullable_date_prop")]
-        public DateOnly? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption; } set { this.NotRequiredNotnullableDatePropOption = new(value); } }
+        public DateOnly? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption.Value; } set { this.NotRequiredNotnullableDatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNotnullableintegerProp
@@ -1428,7 +1428,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [JsonPropertyName("not_required_notnullableinteger_prop")]
-        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption; } set { this.NotRequiredNotnullableintegerPropOption = new(value); } }
+        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption.Value; } set { this.NotRequiredNotnullableintegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableDateProp
@@ -1441,7 +1441,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_date_prop")]
-        public DateOnly? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption; } set { this.NotRequiredNullableDatePropOption = new(value); } }
+        public DateOnly? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption.Value; } set { this.NotRequiredNullableDatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableIntegerProp
@@ -1454,7 +1454,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableIntegerProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_integer_prop")]
-        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption; } set { this.NotRequiredNullableIntegerPropOption = new(value); } }
+        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption.Value; } set { this.NotRequiredNullableIntegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableArrayOfString
@@ -1467,7 +1467,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_array_of_string")]
-        public List<string>? NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption; } set { this.NotrequiredNotnullableArrayOfStringOption = new(value); } }
+        public List<string>? NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption.Value; } set { this.NotrequiredNotnullableArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableBooleanProp
@@ -1480,7 +1480,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_boolean_prop")]
-        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption; } set { this.NotrequiredNotnullableBooleanPropOption = new(value); } }
+        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption.Value; } set { this.NotrequiredNotnullableBooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableDatetimeProp
@@ -1493,7 +1493,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_datetime_prop")]
-        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption; } set { this.NotrequiredNotnullableDatetimePropOption = new(value); } }
+        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption.Value; } set { this.NotrequiredNotnullableDatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableStringProp
@@ -1506,7 +1506,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_string_prop")]
-        public string? NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption; } set { this.NotrequiredNotnullableStringPropOption = new(value); } }
+        public string? NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption.Value; } set { this.NotrequiredNotnullableStringPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableUuid
@@ -1520,7 +1520,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_notnullable_uuid")]
-        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption; } set { this.NotrequiredNotnullableUuidOption = new(value); } }
+        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption.Value; } set { this.NotrequiredNotnullableUuidOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableArrayOfString
@@ -1533,7 +1533,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_nullable_array_of_string")]
-        public List<string>? NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption; } set { this.NotrequiredNullableArrayOfStringOption = new(value); } }
+        public List<string>? NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption.Value; } set { this.NotrequiredNullableArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableBooleanProp
@@ -1546,7 +1546,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_boolean_prop")]
-        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption; } set { this.NotrequiredNullableBooleanPropOption = new(value); } }
+        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption.Value; } set { this.NotrequiredNullableBooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableDatetimeProp
@@ -1559,7 +1559,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_datetime_prop")]
-        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption; } set { this.NotrequiredNullableDatetimePropOption = new(value); } }
+        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption.Value; } set { this.NotrequiredNullableDatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableStringProp
@@ -1572,7 +1572,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_string_prop")]
-        public string? NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption; } set { this.NotrequiredNullableStringPropOption = new(value); } }
+        public string? NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption.Value; } set { this.NotrequiredNullableStringPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableUuid
@@ -1586,7 +1586,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_nullable_uuid")]
-        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption; } set { this.NotrequiredNullableUuidOption = new(value); } }
+        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption.Value; } set { this.NotrequiredNullableUuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets RequiredNullableArrayOfString

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Result.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result code</value>
         [JsonPropertyName("code")]
-        public string? Code { get { return this.CodeOption; } set { this.CodeOption = new(value); } }
+        public string? Code { get { return this.CodeOption.Value; } set { this.CodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Data
@@ -75,7 +75,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string>? Data { get { return this.DataOption; } set { this.DataOption = new(value); } }
+        public Dictionary<string, string>? Data { get { return this.DataOption.Value; } set { this.DataOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -89,7 +89,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [JsonPropertyName("return")]
-        public int? VarReturn { get { return this.VarReturnOption; } set { this.VarReturnOption = new(value); } }
+        public int? VarReturn { get { return this.VarReturnOption.Value; } set { this.VarReturnOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Unsafe
@@ -87,7 +87,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Unsafe
         /// </summary>
         [JsonPropertyName("unsafe")]
-        public string? Unsafe { get { return this.UnsafeOption; } set { this.UnsafeOption = new(value); } }
+        public string? Unsafe { get { return this.UnsafeOption.Value; } set { this.UnsafeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Role
         /// </summary>
         [JsonPropertyName("role")]
-        public RolesReportsHashRole? Role { get { return this.RoleOption; } set { this.RoleOption = new(value); } }
+        public RolesReportsHashRole? Role { get { return this.RoleOption.Value; } set { this.RoleOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of RoleUuid
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [JsonPropertyName("role_uuid")]
-        public Guid? RoleUuid { get { return this.RoleUuidOption; } set { this.RoleUuidOption = new(value); } }
+        public Guid? RoleUuid { get { return this.RoleUuidOption.Value; } set { this.RoleUuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarSpecialModelName
         /// </summary>
         [JsonPropertyName("_special_model.name_")]
-        public string? VarSpecialModelName { get { return this.VarSpecialModelNameOption; } set { this.VarSpecialModelNameOption = new(value); } }
+        public string? VarSpecialModelName { get { return this.VarSpecialModelNameOption.Value; } set { this.VarSpecialModelNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SpecialPropertyName
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [JsonPropertyName("$special[property.name]")]
-        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption; } set { this.SpecialPropertyNameOption = new(value); } }
+        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption.Value; } set { this.SpecialPropertyNameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Value
         /// </summary>
         [JsonPropertyName("value")]
-        public string? Value { get { return this.ValueOption; } set { this.ValueOption = new(value); } }
+        public string? Value { get { return this.ValueOption.Value; } set { this.ValueOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets TestCollectionEndingWithWordList
         /// </summary>
         [JsonPropertyName("TestCollectionEndingWithWordList")]
-        public List<TestCollectionEndingWithWordList>? TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption; } set { this.TestCollectionEndingWithWordListOption = new(value); } }
+        public List<TestCollectionEndingWithWordList>? TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption.Value; } set { this.TestCollectionEndingWithWordListOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SomeProperty
         /// </summary>
         [JsonPropertyName("someProperty")]
-        public string? SomeProperty { get { return this.SomePropertyOption; } set { this.SomePropertyOption = new(value); } }
+        public string? SomeProperty { get { return this.SomePropertyOption.Value; } set { this.SomePropertyOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string>? Data { get { return this.DataOption; } set { this.DataOption = new(value); } }
+        public Dictionary<string, string>? Data { get { return this.DataOption.Value; } set { this.DataOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
@@ -79,7 +79,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
         [JsonPropertyName("anyTypeProp")]
-        public Object? AnyTypeProp { get { return this.AnyTypePropOption; } set { this.AnyTypePropOption = new(value); } }
+        public Object? AnyTypeProp { get { return this.AnyTypePropOption.Value; } set { this.AnyTypePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of AnyTypePropNullable
@@ -93,7 +93,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values.</value>
         [JsonPropertyName("anyTypePropNullable")]
-        public Object? AnyTypePropNullable { get { return this.AnyTypePropNullableOption; } set { this.AnyTypePropNullableOption = new(value); } }
+        public Object? AnyTypePropNullable { get { return this.AnyTypePropNullableOption.Value; } set { this.AnyTypePropNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Email
@@ -106,7 +106,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Email
         /// </summary>
         [JsonPropertyName("email")]
-        public string? Email { get { return this.EmailOption; } set { this.EmailOption = new(value); } }
+        public string? Email { get { return this.EmailOption.Value; } set { this.EmailOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of FirstName
@@ -119,7 +119,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets FirstName
         /// </summary>
         [JsonPropertyName("firstName")]
-        public string? FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new(value); } }
+        public string? FirstName { get { return this.FirstNameOption.Value; } set { this.FirstNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -132,7 +132,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of LastName
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LastName
         /// </summary>
         [JsonPropertyName("lastName")]
-        public string? LastName { get { return this.LastNameOption; } set { this.LastNameOption = new(value); } }
+        public string? LastName { get { return this.LastNameOption.Value; } set { this.LastNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredProps
@@ -159,7 +159,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredProps")]
-        public Object? ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption; } set { this.ObjectWithNoDeclaredPropsOption = new(value); } }
+        public Object? ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption.Value; } set { this.ObjectWithNoDeclaredPropsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredPropsNullable
@@ -173,7 +173,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredPropsNullable")]
-        public Object? ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption; } set { this.ObjectWithNoDeclaredPropsNullableOption = new(value); } }
+        public Object? ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption.Value; } set { this.ObjectWithNoDeclaredPropsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Password
@@ -186,7 +186,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Password
         /// </summary>
         [JsonPropertyName("password")]
-        public string? Password { get { return this.PasswordOption; } set { this.PasswordOption = new(value); } }
+        public string? Password { get { return this.PasswordOption.Value; } set { this.PasswordOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Phone
@@ -199,7 +199,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Phone
         /// </summary>
         [JsonPropertyName("phone")]
-        public string? Phone { get { return this.PhoneOption; } set { this.PhoneOption = new(value); } }
+        public string? Phone { get { return this.PhoneOption.Value; } set { this.PhoneOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UserStatus
@@ -213,7 +213,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [JsonPropertyName("userStatus")]
-        public int? UserStatus { get { return this.UserStatusOption; } set { this.UserStatusOption = new(value); } }
+        public int? UserStatus { get { return this.UserStatusOption.Value; } set { this.UserStatusOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Username
@@ -226,7 +226,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Username
         /// </summary>
         [JsonPropertyName("username")]
-        public string? Username { get { return this.UsernameOption; } set { this.UsernameOption = new(value); } }
+        public string? Username { get { return this.UsernameOption.Value; } set { this.UsernameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
@@ -66,7 +66,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [JsonPropertyName("hasBaleen")]
-        public bool? HasBaleen { get { return this.HasBaleenOption; } set { this.HasBaleenOption = new(value); } }
+        public bool? HasBaleen { get { return this.HasBaleenOption.Value; } set { this.HasBaleenOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of HasTeeth
@@ -79,7 +79,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasTeeth
         /// </summary>
         [JsonPropertyName("hasTeeth")]
-        public bool? HasTeeth { get { return this.HasTeethOption; } set { this.HasTeethOption = new(value); } }
+        public bool? HasTeeth { get { return this.HasTeethOption.Value; } set { this.HasTeethOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Now
         /// </summary>
         [JsonPropertyName("now")]
-        public DateTime? Now { get { return this.NowOption; } set { this.NowOption = new(value); } }
+        public DateTime? Now { get { return this.NowOption.Value; } set { this.NowOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Today
@@ -69,7 +69,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Today
         /// </summary>
         [JsonPropertyName("today")]
-        public DateTime? Today { get { return this.TodayOption; } set { this.TodayOption = new(value); } }
+        public DateTime? Today { get { return this.TodayOption.Value; } set { this.TodayOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Adult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Adult.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Children
         /// </summary>
         [JsonPropertyName("children")]
-        public List<Child>? Children { get { return this.ChildrenOption; } set { this.ChildrenOption = new(value); } }
+        public List<Child>? Children { get { return this.ChildrenOption.Value; } set { this.ChildrenOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Age
         /// </summary>
         [JsonPropertyName("age")]
-        public int? Age { get { return this.AgeOption; } set { this.AgeOption = new(value); } }
+        public int? Age { get { return this.AgeOption.Value; } set { this.AgeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of BoosterSeat
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BoosterSeat
         /// </summary>
         [JsonPropertyName("boosterSeat")]
-        public bool? BoosterSeat { get { return this.BoosterSeatOption; } set { this.BoosterSeatOption = new(value); } }
+        public bool? BoosterSeat { get { return this.BoosterSeatOption.Value; } set { this.BoosterSeatOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Person.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Person.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets FirstName
         /// </summary>
         [JsonPropertyName("firstName")]
-        public string? FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new(value); } }
+        public string? FirstName { get { return this.FirstNameOption.Value; } set { this.FirstNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of LastName
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LastName
         /// </summary>
         [JsonPropertyName("lastName")]
-        public string? LastName { get { return this.LastNameOption; } set { this.LastNameOption = new(value); } }
+        public string? LastName { get { return this.LastNameOption.Value; } set { this.LastNameOption = new(value); } }
 
         /// <summary>
         /// The discriminator

--- a/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Kind
         /// </summary>
         [JsonPropertyName("kind")]
-        public string? Kind { get { return this.KindOption; } set { this.KindOption = new(value); } }
+        public string? Kind { get { return this.KindOption.Value; } set { this.KindOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Count
         /// </summary>
         [JsonPropertyName("count")]
-        public decimal? Count { get { return this.CountOption; } set { this.CountOption = new(value); } }
+        public decimal? Count { get { return this.CountOption.Value; } set { this.CountOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -82,7 +82,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Kind
         /// </summary>
         [JsonPropertyName("kind")]
-        public string? Kind { get { return this.KindOption; } set { this.KindOption = new(value); } }
+        public string? Kind { get { return this.KindOption.Value; } set { this.KindOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Count
         /// </summary>
         [JsonPropertyName("count")]
-        public decimal? Count { get { return this.CountOption; } set { this.CountOption = new(value); } }
+        public decimal? Count { get { return this.CountOption.Value; } set { this.CountOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
@@ -81,7 +81,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Activity.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ActivityOutputs
         /// </summary>
         [JsonPropertyName("activity_outputs")]
-        public Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs { get { return this.ActivityOutputsOption; } set { this.ActivityOutputsOption = new(value); } }
+        public Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs { get { return this.ActivityOutputsOption.Value; } set { this.ActivityOutputsOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop1
         /// </summary>
         [JsonPropertyName("prop1")]
-        public string Prop1 { get { return this.Prop1Option; } set { this.Prop1Option = new(value); } }
+        public string Prop1 { get { return this.Prop1Option.Value; } set { this.Prop1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Prop2
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop2
         /// </summary>
         [JsonPropertyName("prop2")]
-        public Object Prop2 { get { return this.Prop2Option; } set { this.Prop2Option = new(value); } }
+        public Object Prop2 { get { return this.Prop2Option.Value; } set { this.Prop2Option = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Anytype1
         /// </summary>
         [JsonPropertyName("anytype_1")]
-        public Object Anytype1 { get { return this.Anytype1Option; } set { this.Anytype1Option = new(value); } }
+        public Object Anytype1 { get { return this.Anytype1Option.Value; } set { this.Anytype1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of EmptyMap
@@ -81,7 +81,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>an object with no declared properties and no undeclared properties, hence it&#39;s an empty map.</value>
         [JsonPropertyName("empty_map")]
-        public Object EmptyMap { get { return this.EmptyMapOption; } set { this.EmptyMapOption = new(value); } }
+        public Object EmptyMap { get { return this.EmptyMapOption.Value; } set { this.EmptyMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfMapProperty
@@ -94,7 +94,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfMapProperty
         /// </summary>
         [JsonPropertyName("map_of_map_property")]
-        public Dictionary<string, Dictionary<string, string>> MapOfMapProperty { get { return this.MapOfMapPropertyOption; } set { this.MapOfMapPropertyOption = new(value); } }
+        public Dictionary<string, Dictionary<string, string>> MapOfMapProperty { get { return this.MapOfMapPropertyOption.Value; } set { this.MapOfMapPropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapProperty
@@ -107,7 +107,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapProperty
         /// </summary>
         [JsonPropertyName("map_property")]
-        public Dictionary<string, string> MapProperty { get { return this.MapPropertyOption; } set { this.MapPropertyOption = new(value); } }
+        public Dictionary<string, string> MapProperty { get { return this.MapPropertyOption.Value; } set { this.MapPropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype1
@@ -120,7 +120,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype1
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_1")]
-        public Object MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new(value); } }
+        public Object MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype2
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype2
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_2")]
-        public Object MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new(value); } }
+        public Object MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype3
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype3
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_3")]
-        public Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new(value); } }
+        public Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesString
@@ -159,7 +159,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesString
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_string")]
-        public Dictionary<string, string> MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption; } set { this.MapWithUndeclaredPropertiesStringOption = new(value); } }
+        public Dictionary<string, string> MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption.Value; } set { this.MapWithUndeclaredPropertiesStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Animal.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [JsonPropertyName("code")]
-        public int? Code { get { return this.CodeOption; } set { this.CodeOption = new(value); } }
+        public int? Code { get { return this.CodeOption.Value; } set { this.CodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Message
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Message
         /// </summary>
         [JsonPropertyName("message")]
-        public string Message { get { return this.MessageOption; } set { this.MessageOption = new(value); } }
+        public string Message { get { return this.MessageOption.Value; } set { this.MessageOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Type
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Type
         /// </summary>
         [JsonPropertyName("type")]
-        public string Type { get { return this.TypeOption; } set { this.TypeOption = new(value); } }
+        public string Type { get { return this.TypeOption.Value; } set { this.TypeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Apple.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ColorCode
         /// </summary>
         [JsonPropertyName("color_code")]
-        public string ColorCode { get { return this.ColorCodeOption; } set { this.ColorCodeOption = new(value); } }
+        public string ColorCode { get { return this.ColorCodeOption.Value; } set { this.ColorCodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Cultivar
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Cultivar
         /// </summary>
         [JsonPropertyName("cultivar")]
-        public string Cultivar { get { return this.CultivarOption; } set { this.CultivarOption = new(value); } }
+        public string Cultivar { get { return this.CultivarOption.Value; } set { this.CultivarOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Origin
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Origin
         /// </summary>
         [JsonPropertyName("origin")]
-        public string Origin { get { return this.OriginOption; } set { this.OriginOption = new(value); } }
+        public string Origin { get { return this.OriginOption.Value; } set { this.OriginOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [JsonPropertyName("mealy")]
-        public bool? Mealy { get { return this.MealyOption; } set { this.MealyOption = new(value); } }
+        public bool? Mealy { get { return this.MealyOption.Value; } set { this.MealyOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayArrayNumber")]
-        public List<List<decimal>> ArrayArrayNumber { get { return this.ArrayArrayNumberOption; } set { this.ArrayArrayNumberOption = new(value); } }
+        public List<List<decimal>> ArrayArrayNumber { get { return this.ArrayArrayNumberOption.Value; } set { this.ArrayArrayNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayNumber")]
-        public List<decimal> ArrayNumber { get { return this.ArrayNumberOption; } set { this.ArrayNumberOption = new(value); } }
+        public List<decimal> ArrayNumber { get { return this.ArrayNumberOption.Value; } set { this.ArrayNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfInteger
         /// </summary>
         [JsonPropertyName("array_array_of_integer")]
-        public List<List<long>> ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption; } set { this.ArrayArrayOfIntegerOption = new(value); } }
+        public List<List<long>> ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption.Value; } set { this.ArrayArrayOfIntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayArrayOfModel
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfModel
         /// </summary>
         [JsonPropertyName("array_array_of_model")]
-        public List<List<ReadOnlyFirst>> ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption; } set { this.ArrayArrayOfModelOption = new(value); } }
+        public List<List<ReadOnlyFirst>> ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption.Value; } set { this.ArrayArrayOfModelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayOfString
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayOfString
         /// </summary>
         [JsonPropertyName("array_of_string")]
-        public List<string> ArrayOfString { get { return this.ArrayOfStringOption; } set { this.ArrayOfStringOption = new(value); } }
+        public List<string> ArrayOfString { get { return this.ArrayOfStringOption.Value; } set { this.ArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Banana.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [JsonPropertyName("lengthCm")]
-        public decimal? LengthCm { get { return this.LengthCmOption; } set { this.LengthCmOption = new(value); } }
+        public decimal? LengthCm { get { return this.LengthCmOption.Value; } set { this.LengthCmOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [JsonPropertyName("sweet")]
-        public bool? Sweet { get { return this.SweetOption; } set { this.SweetOption = new(value); } }
+        public bool? Sweet { get { return this.SweetOption.Value; } set { this.SweetOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -64,7 +64,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Name of the pet </value>
         [JsonPropertyName("ATT_NAME")]
-        public string ATT_NAME { get { return this.ATT_NAMEOption; } set { this.ATT_NAMEOption = new(value); } }
+        public string ATT_NAME { get { return this.ATT_NAMEOption.Value; } set { this.ATT_NAMEOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalCamel
@@ -77,7 +77,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalCamel
         /// </summary>
         [JsonPropertyName("CapitalCamel")]
-        public string CapitalCamel { get { return this.CapitalCamelOption; } set { this.CapitalCamelOption = new(value); } }
+        public string CapitalCamel { get { return this.CapitalCamelOption.Value; } set { this.CapitalCamelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalSnake
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalSnake
         /// </summary>
         [JsonPropertyName("Capital_Snake")]
-        public string CapitalSnake { get { return this.CapitalSnakeOption; } set { this.CapitalSnakeOption = new(value); } }
+        public string CapitalSnake { get { return this.CapitalSnakeOption.Value; } set { this.CapitalSnakeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SCAETHFlowPoints
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SCAETHFlowPoints
         /// </summary>
         [JsonPropertyName("SCA_ETH_Flow_Points")]
-        public string SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption; } set { this.SCAETHFlowPointsOption = new(value); } }
+        public string SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption.Value; } set { this.SCAETHFlowPointsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SmallCamel
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallCamel
         /// </summary>
         [JsonPropertyName("smallCamel")]
-        public string SmallCamel { get { return this.SmallCamelOption; } set { this.SmallCamelOption = new(value); } }
+        public string SmallCamel { get { return this.SmallCamelOption.Value; } set { this.SmallCamelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SmallSnake
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallSnake
         /// </summary>
         [JsonPropertyName("small_Snake")]
-        public string SmallSnake { get { return this.SmallSnakeOption; } set { this.SmallSnakeOption = new(value); } }
+        public string SmallSnake { get { return this.SmallSnakeOption.Value; } set { this.SmallSnakeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Cat.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [JsonPropertyName("declawed")]
-        public bool? Declawed { get { return this.DeclawedOption; } set { this.DeclawedOption = new(value); } }
+        public bool? Declawed { get { return this.DeclawedOption.Value; } set { this.DeclawedOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Category.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("_class")]
-        public string Class { get { return this.ClassOption; } set { this.ClassOption = new(value); } }
+        public string Class { get { return this.ClassOption.Value; } set { this.ClassOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>Fri Jul 21 00:00:00 UTC 2017</example> */
         [JsonPropertyName("dateOnlyProperty")]
-        public DateOnly? DateOnlyProperty { get { return this.DateOnlyPropertyOption; } set { this.DateOnlyPropertyOption = new(value); } }
+        public DateOnly? DateOnlyProperty { get { return this.DateOnlyPropertyOption.Value; } set { this.DateOnlyPropertyOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Dog.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Breed
         /// </summary>
         [JsonPropertyName("breed")]
-        public string Breed { get { return this.BreedOption; } set { this.BreedOption = new(value); } }
+        public string Breed { get { return this.BreedOption.Value; } set { this.BreedOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MainShape
         /// </summary>
         [JsonPropertyName("mainShape")]
-        public Shape MainShape { get { return this.MainShapeOption; } set { this.MainShapeOption = new(value); } }
+        public Shape MainShape { get { return this.MainShapeOption.Value; } set { this.MainShapeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NullableShape
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableShape
         /// </summary>
         [JsonPropertyName("nullableShape")]
-        public NullableShape NullableShape { get { return this.NullableShapeOption; } set { this.NullableShapeOption = new(value); } }
+        public NullableShape NullableShape { get { return this.NullableShapeOption.Value; } set { this.NullableShapeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ShapeOrNull
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ShapeOrNull
         /// </summary>
         [JsonPropertyName("shapeOrNull")]
-        public ShapeOrNull ShapeOrNull { get { return this.ShapeOrNullOption; } set { this.ShapeOrNullOption = new(value); } }
+        public ShapeOrNull ShapeOrNull { get { return this.ShapeOrNullOption.Value; } set { this.ShapeOrNullOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Shapes
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Shapes
         /// </summary>
         [JsonPropertyName("shapes")]
-        public List<Shape> Shapes { get { return this.ShapesOption; } set { this.ShapesOption = new(value); } }
+        public List<Shape> Shapes { get { return this.ShapesOption.Value; } set { this.ShapesOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayEnum
         /// </summary>
         [JsonPropertyName("array_enum")]
-        public List<EnumArraysArrayEnumInner> ArrayEnum { get { return this.ArrayEnumOption; } set { this.ArrayEnumOption = new(value); } }
+        public List<EnumArraysArrayEnumInner> ArrayEnum { get { return this.ArrayEnumOption.Value; } set { this.ArrayEnumOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/File.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Test capitalization</value>
         [JsonPropertyName("sourceURI")]
-        public string SourceURI { get { return this.SourceURIOption; } set { this.SourceURIOption = new(value); } }
+        public string SourceURI { get { return this.SourceURIOption.Value; } set { this.SourceURIOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets File
         /// </summary>
         [JsonPropertyName("file")]
-        public File File { get { return this.FileOption; } set { this.FileOption = new(value); } }
+        public File File { get { return this.FileOption.Value; } set { this.FileOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Files
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Files
         /// </summary>
         [JsonPropertyName("files")]
-        public List<File> Files { get { return this.FilesOption; } set { this.FilesOption = new(value); } }
+        public List<File> Files { get { return this.FilesOption.Value; } set { this.FilesOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Foo.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } set { this.BarOption = new(value); } }
+        public string Bar { get { return this.BarOption.Value; } set { this.BarOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public Foo String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public Foo String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -138,7 +138,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Binary
         /// </summary>
         [JsonPropertyName("binary")]
-        public System.IO.Stream Binary { get { return this.BinaryOption; } set { this.BinaryOption = new(value); } }
+        public System.IO.Stream Binary { get { return this.BinaryOption.Value; } set { this.BinaryOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DateTime
@@ -152,7 +152,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2007-12-03T10:15:30+01:00</example> */
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Decimal
@@ -165,7 +165,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Decimal
         /// </summary>
         [JsonPropertyName("decimal")]
-        public decimal? Decimal { get { return this.DecimalOption; } set { this.DecimalOption = new(value); } }
+        public decimal? Decimal { get { return this.DecimalOption.Value; } set { this.DecimalOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Double
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Double
         /// </summary>
         [JsonPropertyName("double")]
-        public double? Double { get { return this.DoubleOption; } set { this.DoubleOption = new(value); } }
+        public double? Double { get { return this.DoubleOption.Value; } set { this.DoubleOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName2
@@ -191,7 +191,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName2
         /// </summary>
         [JsonPropertyName("duplicate_property_name")]
-        public string DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option; } set { this.DuplicatePropertyName2Option = new(value); } }
+        public string DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option.Value; } set { this.DuplicatePropertyName2Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName
@@ -204,7 +204,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName
         /// </summary>
         [JsonPropertyName("@duplicate_property_name")]
-        public string DuplicatePropertyName { get { return this.DuplicatePropertyNameOption; } set { this.DuplicatePropertyNameOption = new(value); } }
+        public string DuplicatePropertyName { get { return this.DuplicatePropertyNameOption.Value; } set { this.DuplicatePropertyNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Float
@@ -217,7 +217,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Float
         /// </summary>
         [JsonPropertyName("float")]
-        public float? Float { get { return this.FloatOption; } set { this.FloatOption = new(value); } }
+        public float? Float { get { return this.FloatOption.Value; } set { this.FloatOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int32
@@ -230,7 +230,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32
         /// </summary>
         [JsonPropertyName("int32")]
-        public int? Int32 { get { return this.Int32Option; } set { this.Int32Option = new(value); } }
+        public int? Int32 { get { return this.Int32Option.Value; } set { this.Int32Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int32Range
@@ -243,7 +243,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32Range
         /// </summary>
         [JsonPropertyName("int32Range")]
-        public int? Int32Range { get { return this.Int32RangeOption; } set { this.Int32RangeOption = new(value); } }
+        public int? Int32Range { get { return this.Int32RangeOption.Value; } set { this.Int32RangeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64
@@ -256,7 +256,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64
         /// </summary>
         [JsonPropertyName("int64")]
-        public long? Int64 { get { return this.Int64Option; } set { this.Int64Option = new(value); } }
+        public long? Int64 { get { return this.Int64Option.Value; } set { this.Int64Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Negative
@@ -269,7 +269,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Negative
         /// </summary>
         [JsonPropertyName("int64Negative")]
-        public long? Int64Negative { get { return this.Int64NegativeOption; } set { this.Int64NegativeOption = new(value); } }
+        public long? Int64Negative { get { return this.Int64NegativeOption.Value; } set { this.Int64NegativeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64NegativeExclusive
@@ -282,7 +282,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64NegativeExclusive
         /// </summary>
         [JsonPropertyName("int64NegativeExclusive")]
-        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption; } set { this.Int64NegativeExclusiveOption = new(value); } }
+        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption.Value; } set { this.Int64NegativeExclusiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Positive
@@ -295,7 +295,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Positive
         /// </summary>
         [JsonPropertyName("int64Positive")]
-        public long? Int64Positive { get { return this.Int64PositiveOption; } set { this.Int64PositiveOption = new(value); } }
+        public long? Int64Positive { get { return this.Int64PositiveOption.Value; } set { this.Int64PositiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64PositiveExclusive
@@ -308,7 +308,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64PositiveExclusive
         /// </summary>
         [JsonPropertyName("int64PositiveExclusive")]
-        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption; } set { this.Int64PositiveExclusiveOption = new(value); } }
+        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption.Value; } set { this.Int64PositiveExclusiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Integer
@@ -321,7 +321,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [JsonPropertyName("integer")]
-        public int? Integer { get { return this.IntegerOption; } set { this.IntegerOption = new(value); } }
+        public int? Integer { get { return this.IntegerOption.Value; } set { this.IntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithBackslash
@@ -335,7 +335,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>None</value>
         [JsonPropertyName("pattern_with_backslash")]
-        public string PatternWithBackslash { get { return this.PatternWithBackslashOption; } set { this.PatternWithBackslashOption = new(value); } }
+        public string PatternWithBackslash { get { return this.PatternWithBackslashOption.Value; } set { this.PatternWithBackslashOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigits
@@ -349,7 +349,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string that is a 10 digit number. Can have leading zeros.</value>
         [JsonPropertyName("pattern_with_digits")]
-        public string PatternWithDigits { get { return this.PatternWithDigitsOption; } set { this.PatternWithDigitsOption = new(value); } }
+        public string PatternWithDigits { get { return this.PatternWithDigitsOption.Value; } set { this.PatternWithDigitsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigitsAndDelimiter
@@ -363,7 +363,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.</value>
         [JsonPropertyName("pattern_with_digits_and_delimiter")]
-        public string PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption; } set { this.PatternWithDigitsAndDelimiterOption = new(value); } }
+        public string PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption.Value; } set { this.PatternWithDigitsAndDelimiterOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of String
@@ -376,7 +376,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public string String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public string String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of StringFormattedAsDecimal
@@ -389,7 +389,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringFormattedAsDecimal
         /// </summary>
         [JsonPropertyName("string_formatted_as_decimal")]
-        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption; } set { this.StringFormattedAsDecimalOption = new(value); } }
+        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption.Value; } set { this.StringFormattedAsDecimalOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedInteger
@@ -402,7 +402,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [JsonPropertyName("unsigned_integer")]
-        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption; } set { this.UnsignedIntegerOption = new(value); } }
+        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption.Value; } set { this.UnsignedIntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedLong
@@ -415,7 +415,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedLong
         /// </summary>
         [JsonPropertyName("unsigned_long")]
-        public ulong? UnsignedLong { get { return this.UnsignedLongOption; } set { this.UnsignedLongOption = new(value); } }
+        public ulong? UnsignedLong { get { return this.UnsignedLongOption.Value; } set { this.UnsignedLongOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -429,7 +429,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -80,7 +80,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } }
+        public string Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Foo
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Foo
         /// </summary>
         [JsonPropertyName("foo")]
-        public string Foo { get { return this.FooOption; } }
+        public string Foo { get { return this.FooOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableMessage
         /// </summary>
         [JsonPropertyName("NullableMessage")]
-        public string NullableMessage { get { return this.NullableMessageOption; } set { this.NullableMessageOption = new(value); } }
+        public string NullableMessage { get { return this.NullableMessageOption.Value; } set { this.NullableMessageOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/List.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123List
         /// </summary>
         [JsonPropertyName("123-list")]
-        public string Var123List { get { return this.Var123ListOption; } set { this.Var123ListOption = new(value); } }
+        public string Var123List { get { return this.Var123ListOption.Value; } set { this.Var123ListOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets EscapedLiteralString
         /// </summary>
         [JsonPropertyName("escapedLiteralString")]
-        public string EscapedLiteralString { get { return this.EscapedLiteralStringOption; } set { this.EscapedLiteralStringOption = new(value); } }
+        public string EscapedLiteralString { get { return this.EscapedLiteralStringOption.Value; } set { this.EscapedLiteralStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnescapedLiteralString
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnescapedLiteralString
         /// </summary>
         [JsonPropertyName("unescapedLiteralString")]
-        public string UnescapedLiteralString { get { return this.UnescapedLiteralStringOption; } set { this.UnescapedLiteralStringOption = new(value); } }
+        public string UnescapedLiteralString { get { return this.UnescapedLiteralStringOption.Value; } set { this.UnescapedLiteralStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DirectMap
         /// </summary>
         [JsonPropertyName("direct_map")]
-        public Dictionary<string, bool> DirectMap { get { return this.DirectMapOption; } set { this.DirectMapOption = new(value); } }
+        public Dictionary<string, bool> DirectMap { get { return this.DirectMapOption.Value; } set { this.DirectMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of IndirectMap
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IndirectMap
         /// </summary>
         [JsonPropertyName("indirect_map")]
-        public Dictionary<string, bool> IndirectMap { get { return this.IndirectMapOption; } set { this.IndirectMapOption = new(value); } }
+        public Dictionary<string, bool> IndirectMap { get { return this.IndirectMapOption.Value; } set { this.IndirectMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapMapOfString
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapMapOfString
         /// </summary>
         [JsonPropertyName("map_map_of_string")]
-        public Dictionary<string, Dictionary<string, string>> MapMapOfString { get { return this.MapMapOfStringOption; } set { this.MapMapOfStringOption = new(value); } }
+        public Dictionary<string, Dictionary<string, string>> MapMapOfString { get { return this.MapMapOfStringOption.Value; } set { this.MapMapOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfEnumString
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfEnumString
         /// </summary>
         [JsonPropertyName("map_of_enum_string")]
-        public Dictionary<string, MapTestMapOfEnumStringValue> MapOfEnumString { get { return this.MapOfEnumStringOption; } set { this.MapOfEnumStringOption = new(value); } }
+        public Dictionary<string, MapTestMapOfEnumStringValue> MapOfEnumString { get { return this.MapOfEnumStringOption.Value; } set { this.MapOfEnumStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedAnyOfContent Content { get { return this.ContentOption; } set { this.ContentOption = new(value); } }
+        public MixedAnyOfContent Content { get { return this.ContentOption.Value; } set { this.ContentOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedOneOfContent Content { get { return this.ContentOption; } set { this.ContentOption = new(value); } }
+        public MixedOneOfContent Content { get { return this.ContentOption.Value; } set { this.ContentOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateTime
         /// </summary>
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Map
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Map
         /// </summary>
         [JsonPropertyName("map")]
-        public Dictionary<string, Animal> Map { get { return this.MapOption; } set { this.MapOption = new(value); } }
+        public Dictionary<string, Animal> Map { get { return this.MapOption.Value; } set { this.MapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UuidWithPattern
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [JsonPropertyName("uuid_with_pattern")]
-        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption; } set { this.UuidWithPatternOption = new(value); } }
+        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption.Value; } set { this.UuidWithPatternOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public string Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public string Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("class")]
-        public string Class { get { return this.ClassOption; } set { this.ClassOption = new(value); } }
+        public string Class { get { return this.ClassOption.Value; } set { this.ClassOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public int? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public int? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarClient
         /// </summary>
         [JsonPropertyName("client")]
-        public string VarClient { get { return this.VarClientOption; } set { this.VarClientOption = new(value); } }
+        public string VarClient { get { return this.VarClientOption.Value; } set { this.VarClientOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Name.cs
@@ -65,7 +65,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Property
         /// </summary>
         [JsonPropertyName("property")]
-        public string Property { get { return this.PropertyOption; } set { this.PropertyOption = new(value); } }
+        public string Property { get { return this.PropertyOption.Value; } set { this.PropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SnakeCase
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [JsonPropertyName("snake_case")]
-        public int? SnakeCase { get { return this.SnakeCaseOption; } }
+        public int? SnakeCase { get { return this.SnakeCaseOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Var123Number
@@ -91,7 +91,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123Number
         /// </summary>
         [JsonPropertyName("123Number")]
-        public int? Var123Number { get { return this.Var123NumberOption; } }
+        public int? Var123Number { get { return this.Var123NumberOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -75,7 +75,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("array_and_items_nullable_prop")]
-        public List<Object> ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption; } set { this.ArrayAndItemsNullablePropOption = new(value); } }
+        public List<Object> ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption.Value; } set { this.ArrayAndItemsNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayItemsNullable
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayItemsNullable
         /// </summary>
         [JsonPropertyName("array_items_nullable")]
-        public List<Object> ArrayItemsNullable { get { return this.ArrayItemsNullableOption; } set { this.ArrayItemsNullableOption = new(value); } }
+        public List<Object> ArrayItemsNullable { get { return this.ArrayItemsNullableOption.Value; } set { this.ArrayItemsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayNullableProp
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNullableProp
         /// </summary>
         [JsonPropertyName("array_nullable_prop")]
-        public List<Object> ArrayNullableProp { get { return this.ArrayNullablePropOption; } set { this.ArrayNullablePropOption = new(value); } }
+        public List<Object> ArrayNullableProp { get { return this.ArrayNullablePropOption.Value; } set { this.ArrayNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of BooleanProp
@@ -114,7 +114,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BooleanProp
         /// </summary>
         [JsonPropertyName("boolean_prop")]
-        public bool? BooleanProp { get { return this.BooleanPropOption; } set { this.BooleanPropOption = new(value); } }
+        public bool? BooleanProp { get { return this.BooleanPropOption.Value; } set { this.BooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DateProp
@@ -127,7 +127,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateProp
         /// </summary>
         [JsonPropertyName("date_prop")]
-        public DateOnly? DateProp { get { return this.DatePropOption; } set { this.DatePropOption = new(value); } }
+        public DateOnly? DateProp { get { return this.DatePropOption.Value; } set { this.DatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DatetimeProp
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DatetimeProp
         /// </summary>
         [JsonPropertyName("datetime_prop")]
-        public DateTime? DatetimeProp { get { return this.DatetimePropOption; } set { this.DatetimePropOption = new(value); } }
+        public DateTime? DatetimeProp { get { return this.DatetimePropOption.Value; } set { this.DatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of IntegerProp
@@ -153,7 +153,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IntegerProp
         /// </summary>
         [JsonPropertyName("integer_prop")]
-        public int? IntegerProp { get { return this.IntegerPropOption; } set { this.IntegerPropOption = new(value); } }
+        public int? IntegerProp { get { return this.IntegerPropOption.Value; } set { this.IntegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NumberProp
@@ -166,7 +166,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NumberProp
         /// </summary>
         [JsonPropertyName("number_prop")]
-        public decimal? NumberProp { get { return this.NumberPropOption; } set { this.NumberPropOption = new(value); } }
+        public decimal? NumberProp { get { return this.NumberPropOption.Value; } set { this.NumberPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectAndItemsNullableProp
@@ -179,7 +179,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("object_and_items_nullable_prop")]
-        public Dictionary<string, Object> ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption; } set { this.ObjectAndItemsNullablePropOption = new(value); } }
+        public Dictionary<string, Object> ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption.Value; } set { this.ObjectAndItemsNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectItemsNullable
@@ -192,7 +192,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectItemsNullable
         /// </summary>
         [JsonPropertyName("object_items_nullable")]
-        public Dictionary<string, Object> ObjectItemsNullable { get { return this.ObjectItemsNullableOption; } set { this.ObjectItemsNullableOption = new(value); } }
+        public Dictionary<string, Object> ObjectItemsNullable { get { return this.ObjectItemsNullableOption.Value; } set { this.ObjectItemsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectNullableProp
@@ -205,7 +205,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectNullableProp
         /// </summary>
         [JsonPropertyName("object_nullable_prop")]
-        public Dictionary<string, Object> ObjectNullableProp { get { return this.ObjectNullablePropOption; } set { this.ObjectNullablePropOption = new(value); } }
+        public Dictionary<string, Object> ObjectNullableProp { get { return this.ObjectNullablePropOption.Value; } set { this.ObjectNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of StringProp
@@ -218,7 +218,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringProp
         /// </summary>
         [JsonPropertyName("string_prop")]
-        public string StringProp { get { return this.StringPropOption; } set { this.StringPropOption = new(value); } }
+        public string StringProp { get { return this.StringPropOption.Value; } set { this.StringPropOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [JsonPropertyName("JustNumber")]
-        public decimal? JustNumber { get { return this.JustNumberOption; } set { this.JustNumberOption = new(value); } }
+        public decimal? JustNumber { get { return this.JustNumberOption.Value; } set { this.JustNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("bars")]
         [Obsolete]
-        public List<string> Bars { get { return this.BarsOption; } set { this.BarsOption = new(value); } }
+        public List<string> Bars { get { return this.BarsOption.Value; } set { this.BarsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DeprecatedRef
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("deprecatedRef")]
         [Obsolete]
-        public DeprecatedObject DeprecatedRef { get { return this.DeprecatedRefOption; } set { this.DeprecatedRefOption = new(value); } }
+        public DeprecatedObject DeprecatedRef { get { return this.DeprecatedRefOption.Value; } set { this.DeprecatedRefOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("id")]
         [Obsolete]
-        public decimal? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public decimal? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Order.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Complete
         /// </summary>
         [JsonPropertyName("complete")]
-        public bool? Complete { get { return this.CompleteOption; } set { this.CompleteOption = new(value); } }
+        public bool? Complete { get { return this.CompleteOption.Value; } set { this.CompleteOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -89,7 +89,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PetId
@@ -102,7 +102,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets PetId
         /// </summary>
         [JsonPropertyName("petId")]
-        public long? PetId { get { return this.PetIdOption; } set { this.PetIdOption = new(value); } }
+        public long? PetId { get { return this.PetIdOption.Value; } set { this.PetIdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Quantity
@@ -115,7 +115,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Quantity
         /// </summary>
         [JsonPropertyName("quantity")]
-        public int? Quantity { get { return this.QuantityOption; } set { this.QuantityOption = new(value); } }
+        public int? Quantity { get { return this.QuantityOption.Value; } set { this.QuantityOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ShipDate
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2020-02-02T20:20:20.000222Z</example> */
         [JsonPropertyName("shipDate")]
-        public DateTime? ShipDate { get { return this.ShipDateOption; } set { this.ShipDateOption = new(value); } }
+        public DateTime? ShipDate { get { return this.ShipDateOption.Value; } set { this.ShipDateOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyBoolean
         /// </summary>
         [JsonPropertyName("my_boolean")]
-        public bool? MyBoolean { get { return this.MyBooleanOption; } set { this.MyBooleanOption = new(value); } }
+        public bool? MyBoolean { get { return this.MyBooleanOption.Value; } set { this.MyBooleanOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MyNumber
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [JsonPropertyName("my_number")]
-        public decimal? MyNumber { get { return this.MyNumberOption; } set { this.MyNumberOption = new(value); } }
+        public decimal? MyNumber { get { return this.MyNumberOption.Value; } set { this.MyNumberOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MyString
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyString
         /// </summary>
         [JsonPropertyName("my_string")]
-        public string MyString { get { return this.MyStringOption; } set { this.MyStringOption = new(value); } }
+        public string MyString { get { return this.MyStringOption.Value; } set { this.MyStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Pet.cs
@@ -89,7 +89,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Category
         /// </summary>
         [JsonPropertyName("category")]
-        public Category Category { get { return this.CategoryOption; } set { this.CategoryOption = new(value); } }
+        public Category Category { get { return this.CategoryOption.Value; } set { this.CategoryOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -102,7 +102,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Tags
@@ -115,7 +115,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Tags
         /// </summary>
         [JsonPropertyName("tags")]
-        public List<Tag> Tags { get { return this.TagsOption; } set { this.TagsOption = new(value); } }
+        public List<Tag> Tags { get { return this.TagsOption.Value; } set { this.TagsOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } }
+        public string Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Baz
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Baz
         /// </summary>
         [JsonPropertyName("baz")]
-        public string Baz { get { return this.BazOption; } set { this.BazOption = new(value); } }
+        public string Baz { get { return this.BazOption.Value; } set { this.BazOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -334,7 +334,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_notnullable_date_prop")]
-        public DateOnly? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption; } set { this.NotRequiredNotnullableDatePropOption = new(value); } }
+        public DateOnly? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption.Value; } set { this.NotRequiredNotnullableDatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNotnullableintegerProp
@@ -347,7 +347,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [JsonPropertyName("not_required_notnullableinteger_prop")]
-        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption; } set { this.NotRequiredNotnullableintegerPropOption = new(value); } }
+        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption.Value; } set { this.NotRequiredNotnullableintegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableDateProp
@@ -360,7 +360,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_date_prop")]
-        public DateOnly? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption; } set { this.NotRequiredNullableDatePropOption = new(value); } }
+        public DateOnly? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption.Value; } set { this.NotRequiredNullableDatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableIntegerProp
@@ -373,7 +373,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableIntegerProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_integer_prop")]
-        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption; } set { this.NotRequiredNullableIntegerPropOption = new(value); } }
+        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption.Value; } set { this.NotRequiredNullableIntegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableArrayOfString
@@ -386,7 +386,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_array_of_string")]
-        public List<string> NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption; } set { this.NotrequiredNotnullableArrayOfStringOption = new(value); } }
+        public List<string> NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption.Value; } set { this.NotrequiredNotnullableArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableBooleanProp
@@ -399,7 +399,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_boolean_prop")]
-        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption; } set { this.NotrequiredNotnullableBooleanPropOption = new(value); } }
+        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption.Value; } set { this.NotrequiredNotnullableBooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableDatetimeProp
@@ -412,7 +412,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_datetime_prop")]
-        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption; } set { this.NotrequiredNotnullableDatetimePropOption = new(value); } }
+        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption.Value; } set { this.NotrequiredNotnullableDatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableStringProp
@@ -425,7 +425,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_string_prop")]
-        public string NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption; } set { this.NotrequiredNotnullableStringPropOption = new(value); } }
+        public string NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption.Value; } set { this.NotrequiredNotnullableStringPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableUuid
@@ -439,7 +439,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_notnullable_uuid")]
-        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption; } set { this.NotrequiredNotnullableUuidOption = new(value); } }
+        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption.Value; } set { this.NotrequiredNotnullableUuidOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableArrayOfString
@@ -452,7 +452,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_nullable_array_of_string")]
-        public List<string> NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption; } set { this.NotrequiredNullableArrayOfStringOption = new(value); } }
+        public List<string> NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption.Value; } set { this.NotrequiredNullableArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableBooleanProp
@@ -465,7 +465,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_boolean_prop")]
-        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption; } set { this.NotrequiredNullableBooleanPropOption = new(value); } }
+        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption.Value; } set { this.NotrequiredNullableBooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableDatetimeProp
@@ -478,7 +478,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_datetime_prop")]
-        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption; } set { this.NotrequiredNullableDatetimePropOption = new(value); } }
+        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption.Value; } set { this.NotrequiredNullableDatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableStringProp
@@ -491,7 +491,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_string_prop")]
-        public string NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption; } set { this.NotrequiredNullableStringPropOption = new(value); } }
+        public string NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption.Value; } set { this.NotrequiredNullableStringPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableUuid
@@ -505,7 +505,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_nullable_uuid")]
-        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption; } set { this.NotrequiredNullableUuidOption = new(value); } }
+        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption.Value; } set { this.NotrequiredNullableUuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets RequiredNullableArrayOfString

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Result.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result code</value>
         [JsonPropertyName("code")]
-        public string Code { get { return this.CodeOption; } set { this.CodeOption = new(value); } }
+        public string Code { get { return this.CodeOption.Value; } set { this.CodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Data
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string> Data { get { return this.DataOption; } set { this.DataOption = new(value); } }
+        public Dictionary<string, string> Data { get { return this.DataOption.Value; } set { this.DataOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Return.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [JsonPropertyName("return")]
-        public int? VarReturn { get { return this.VarReturnOption; } set { this.VarReturnOption = new(value); } }
+        public int? VarReturn { get { return this.VarReturnOption.Value; } set { this.VarReturnOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Unsafe
@@ -84,7 +84,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Unsafe
         /// </summary>
         [JsonPropertyName("unsafe")]
-        public string Unsafe { get { return this.UnsafeOption; } set { this.UnsafeOption = new(value); } }
+        public string Unsafe { get { return this.UnsafeOption.Value; } set { this.UnsafeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Role
         /// </summary>
         [JsonPropertyName("role")]
-        public RolesReportsHashRole Role { get { return this.RoleOption; } set { this.RoleOption = new(value); } }
+        public RolesReportsHashRole Role { get { return this.RoleOption.Value; } set { this.RoleOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of RoleUuid
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [JsonPropertyName("role_uuid")]
-        public Guid? RoleUuid { get { return this.RoleUuidOption; } set { this.RoleUuidOption = new(value); } }
+        public Guid? RoleUuid { get { return this.RoleUuidOption.Value; } set { this.RoleUuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarSpecialModelName
         /// </summary>
         [JsonPropertyName("_special_model.name_")]
-        public string VarSpecialModelName { get { return this.VarSpecialModelNameOption; } set { this.VarSpecialModelNameOption = new(value); } }
+        public string VarSpecialModelName { get { return this.VarSpecialModelNameOption.Value; } set { this.VarSpecialModelNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SpecialPropertyName
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [JsonPropertyName("$special[property.name]")]
-        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption; } set { this.SpecialPropertyNameOption = new(value); } }
+        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption.Value; } set { this.SpecialPropertyNameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Tag.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Value
         /// </summary>
         [JsonPropertyName("value")]
-        public string Value { get { return this.ValueOption; } set { this.ValueOption = new(value); } }
+        public string Value { get { return this.ValueOption.Value; } set { this.ValueOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets TestCollectionEndingWithWordList
         /// </summary>
         [JsonPropertyName("TestCollectionEndingWithWordList")]
-        public List<TestCollectionEndingWithWordList> TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption; } set { this.TestCollectionEndingWithWordListOption = new(value); } }
+        public List<TestCollectionEndingWithWordList> TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption.Value; } set { this.TestCollectionEndingWithWordListOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SomeProperty
         /// </summary>
         [JsonPropertyName("someProperty")]
-        public string SomeProperty { get { return this.SomePropertyOption; } set { this.SomePropertyOption = new(value); } }
+        public string SomeProperty { get { return this.SomePropertyOption.Value; } set { this.SomePropertyOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string> Data { get { return this.DataOption; } set { this.DataOption = new(value); } }
+        public Dictionary<string, string> Data { get { return this.DataOption.Value; } set { this.DataOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/User.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
         [JsonPropertyName("anyTypeProp")]
-        public Object AnyTypeProp { get { return this.AnyTypePropOption; } set { this.AnyTypePropOption = new(value); } }
+        public Object AnyTypeProp { get { return this.AnyTypePropOption.Value; } set { this.AnyTypePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of AnyTypePropNullable
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values.</value>
         [JsonPropertyName("anyTypePropNullable")]
-        public Object AnyTypePropNullable { get { return this.AnyTypePropNullableOption; } set { this.AnyTypePropNullableOption = new(value); } }
+        public Object AnyTypePropNullable { get { return this.AnyTypePropNullableOption.Value; } set { this.AnyTypePropNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Email
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Email
         /// </summary>
         [JsonPropertyName("email")]
-        public string Email { get { return this.EmailOption; } set { this.EmailOption = new(value); } }
+        public string Email { get { return this.EmailOption.Value; } set { this.EmailOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of FirstName
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets FirstName
         /// </summary>
         [JsonPropertyName("firstName")]
-        public string FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new(value); } }
+        public string FirstName { get { return this.FirstNameOption.Value; } set { this.FirstNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of LastName
@@ -142,7 +142,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LastName
         /// </summary>
         [JsonPropertyName("lastName")]
-        public string LastName { get { return this.LastNameOption; } set { this.LastNameOption = new(value); } }
+        public string LastName { get { return this.LastNameOption.Value; } set { this.LastNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredProps
@@ -156,7 +156,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredProps")]
-        public Object ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption; } set { this.ObjectWithNoDeclaredPropsOption = new(value); } }
+        public Object ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption.Value; } set { this.ObjectWithNoDeclaredPropsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredPropsNullable
@@ -170,7 +170,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredPropsNullable")]
-        public Object ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption; } set { this.ObjectWithNoDeclaredPropsNullableOption = new(value); } }
+        public Object ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption.Value; } set { this.ObjectWithNoDeclaredPropsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Password
@@ -183,7 +183,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Password
         /// </summary>
         [JsonPropertyName("password")]
-        public string Password { get { return this.PasswordOption; } set { this.PasswordOption = new(value); } }
+        public string Password { get { return this.PasswordOption.Value; } set { this.PasswordOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Phone
@@ -196,7 +196,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Phone
         /// </summary>
         [JsonPropertyName("phone")]
-        public string Phone { get { return this.PhoneOption; } set { this.PhoneOption = new(value); } }
+        public string Phone { get { return this.PhoneOption.Value; } set { this.PhoneOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UserStatus
@@ -210,7 +210,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [JsonPropertyName("userStatus")]
-        public int? UserStatus { get { return this.UserStatusOption; } set { this.UserStatusOption = new(value); } }
+        public int? UserStatus { get { return this.UserStatusOption.Value; } set { this.UserStatusOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Username
@@ -223,7 +223,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Username
         /// </summary>
         [JsonPropertyName("username")]
-        public string Username { get { return this.UsernameOption; } set { this.UsernameOption = new(value); } }
+        public string Username { get { return this.UsernameOption.Value; } set { this.UsernameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Whale.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [JsonPropertyName("hasBaleen")]
-        public bool? HasBaleen { get { return this.HasBaleenOption; } set { this.HasBaleenOption = new(value); } }
+        public bool? HasBaleen { get { return this.HasBaleenOption.Value; } set { this.HasBaleenOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of HasTeeth
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasTeeth
         /// </summary>
         [JsonPropertyName("hasTeeth")]
-        public bool? HasTeeth { get { return this.HasTeethOption; } set { this.HasTeethOption = new(value); } }
+        public bool? HasTeeth { get { return this.HasTeethOption.Value; } set { this.HasTeethOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Activity.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ActivityOutputs
         /// </summary>
         [JsonPropertyName("activity_outputs")]
-        public Dictionary<string, List<ActivityOutputElementRepresentation>>? ActivityOutputs { get { return this.ActivityOutputsOption; } set { this.ActivityOutputsOption = new(value); } }
+        public Dictionary<string, List<ActivityOutputElementRepresentation>>? ActivityOutputs { get { return this.ActivityOutputsOption.Value; } set { this.ActivityOutputsOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop1
         /// </summary>
         [JsonPropertyName("prop1")]
-        public string? Prop1 { get { return this.Prop1Option; } set { this.Prop1Option = new(value); } }
+        public string? Prop1 { get { return this.Prop1Option.Value; } set { this.Prop1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Prop2
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop2
         /// </summary>
         [JsonPropertyName("prop2")]
-        public Object? Prop2 { get { return this.Prop2Option; } set { this.Prop2Option = new(value); } }
+        public Object? Prop2 { get { return this.Prop2Option.Value; } set { this.Prop2Option = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -69,7 +69,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Anytype1
         /// </summary>
         [JsonPropertyName("anytype_1")]
-        public Object? Anytype1 { get { return this.Anytype1Option; } set { this.Anytype1Option = new(value); } }
+        public Object? Anytype1 { get { return this.Anytype1Option.Value; } set { this.Anytype1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of EmptyMap
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>an object with no declared properties and no undeclared properties, hence it&#39;s an empty map.</value>
         [JsonPropertyName("empty_map")]
-        public Object? EmptyMap { get { return this.EmptyMapOption; } set { this.EmptyMapOption = new(value); } }
+        public Object? EmptyMap { get { return this.EmptyMapOption.Value; } set { this.EmptyMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfMapProperty
@@ -96,7 +96,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfMapProperty
         /// </summary>
         [JsonPropertyName("map_of_map_property")]
-        public Dictionary<string, Dictionary<string, string>>? MapOfMapProperty { get { return this.MapOfMapPropertyOption; } set { this.MapOfMapPropertyOption = new(value); } }
+        public Dictionary<string, Dictionary<string, string>>? MapOfMapProperty { get { return this.MapOfMapPropertyOption.Value; } set { this.MapOfMapPropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapProperty
@@ -109,7 +109,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapProperty
         /// </summary>
         [JsonPropertyName("map_property")]
-        public Dictionary<string, string>? MapProperty { get { return this.MapPropertyOption; } set { this.MapPropertyOption = new(value); } }
+        public Dictionary<string, string>? MapProperty { get { return this.MapPropertyOption.Value; } set { this.MapPropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype1
@@ -122,7 +122,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype1
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_1")]
-        public Object? MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new(value); } }
+        public Object? MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype2
@@ -135,7 +135,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype2
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_2")]
-        public Object? MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new(value); } }
+        public Object? MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype3
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype3
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_3")]
-        public Dictionary<string, Object>? MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new(value); } }
+        public Dictionary<string, Object>? MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesString
@@ -161,7 +161,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesString
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_string")]
-        public Dictionary<string, string>? MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption; } set { this.MapWithUndeclaredPropertiesStringOption = new(value); } }
+        public Dictionary<string, string>? MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption.Value; } set { this.MapWithUndeclaredPropertiesStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Animal.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [JsonPropertyName("code")]
-        public int? Code { get { return this.CodeOption; } set { this.CodeOption = new(value); } }
+        public int? Code { get { return this.CodeOption.Value; } set { this.CodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Message
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Message
         /// </summary>
         [JsonPropertyName("message")]
-        public string? Message { get { return this.MessageOption; } set { this.MessageOption = new(value); } }
+        public string? Message { get { return this.MessageOption.Value; } set { this.MessageOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Type
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Type
         /// </summary>
         [JsonPropertyName("type")]
-        public string? Type { get { return this.TypeOption; } set { this.TypeOption = new(value); } }
+        public string? Type { get { return this.TypeOption.Value; } set { this.TypeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Apple.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ColorCode
         /// </summary>
         [JsonPropertyName("color_code")]
-        public string? ColorCode { get { return this.ColorCodeOption; } set { this.ColorCodeOption = new(value); } }
+        public string? ColorCode { get { return this.ColorCodeOption.Value; } set { this.ColorCodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Cultivar
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Cultivar
         /// </summary>
         [JsonPropertyName("cultivar")]
-        public string? Cultivar { get { return this.CultivarOption; } set { this.CultivarOption = new(value); } }
+        public string? Cultivar { get { return this.CultivarOption.Value; } set { this.CultivarOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Origin
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Origin
         /// </summary>
         [JsonPropertyName("origin")]
-        public string? Origin { get { return this.OriginOption; } set { this.OriginOption = new(value); } }
+        public string? Origin { get { return this.OriginOption.Value; } set { this.OriginOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [JsonPropertyName("mealy")]
-        public bool? Mealy { get { return this.MealyOption; } set { this.MealyOption = new(value); } }
+        public bool? Mealy { get { return this.MealyOption.Value; } set { this.MealyOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayArrayNumber")]
-        public List<List<decimal>>? ArrayArrayNumber { get { return this.ArrayArrayNumberOption; } set { this.ArrayArrayNumberOption = new(value); } }
+        public List<List<decimal>>? ArrayArrayNumber { get { return this.ArrayArrayNumberOption.Value; } set { this.ArrayArrayNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayNumber")]
-        public List<decimal>? ArrayNumber { get { return this.ArrayNumberOption; } set { this.ArrayNumberOption = new(value); } }
+        public List<decimal>? ArrayNumber { get { return this.ArrayNumberOption.Value; } set { this.ArrayNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfInteger
         /// </summary>
         [JsonPropertyName("array_array_of_integer")]
-        public List<List<long>>? ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption; } set { this.ArrayArrayOfIntegerOption = new(value); } }
+        public List<List<long>>? ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption.Value; } set { this.ArrayArrayOfIntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayArrayOfModel
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfModel
         /// </summary>
         [JsonPropertyName("array_array_of_model")]
-        public List<List<ReadOnlyFirst>>? ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption; } set { this.ArrayArrayOfModelOption = new(value); } }
+        public List<List<ReadOnlyFirst>>? ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption.Value; } set { this.ArrayArrayOfModelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayOfString
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayOfString
         /// </summary>
         [JsonPropertyName("array_of_string")]
-        public List<string>? ArrayOfString { get { return this.ArrayOfStringOption; } set { this.ArrayOfStringOption = new(value); } }
+        public List<string>? ArrayOfString { get { return this.ArrayOfStringOption.Value; } set { this.ArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Banana.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [JsonPropertyName("lengthCm")]
-        public decimal? LengthCm { get { return this.LengthCmOption; } set { this.LengthCmOption = new(value); } }
+        public decimal? LengthCm { get { return this.LengthCmOption.Value; } set { this.LengthCmOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [JsonPropertyName("sweet")]
-        public bool? Sweet { get { return this.SweetOption; } set { this.SweetOption = new(value); } }
+        public bool? Sweet { get { return this.SweetOption.Value; } set { this.SweetOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -66,7 +66,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Name of the pet </value>
         [JsonPropertyName("ATT_NAME")]
-        public string? ATT_NAME { get { return this.ATT_NAMEOption; } set { this.ATT_NAMEOption = new(value); } }
+        public string? ATT_NAME { get { return this.ATT_NAMEOption.Value; } set { this.ATT_NAMEOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalCamel
@@ -79,7 +79,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalCamel
         /// </summary>
         [JsonPropertyName("CapitalCamel")]
-        public string? CapitalCamel { get { return this.CapitalCamelOption; } set { this.CapitalCamelOption = new(value); } }
+        public string? CapitalCamel { get { return this.CapitalCamelOption.Value; } set { this.CapitalCamelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalSnake
@@ -92,7 +92,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalSnake
         /// </summary>
         [JsonPropertyName("Capital_Snake")]
-        public string? CapitalSnake { get { return this.CapitalSnakeOption; } set { this.CapitalSnakeOption = new(value); } }
+        public string? CapitalSnake { get { return this.CapitalSnakeOption.Value; } set { this.CapitalSnakeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SCAETHFlowPoints
@@ -105,7 +105,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SCAETHFlowPoints
         /// </summary>
         [JsonPropertyName("SCA_ETH_Flow_Points")]
-        public string? SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption; } set { this.SCAETHFlowPointsOption = new(value); } }
+        public string? SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption.Value; } set { this.SCAETHFlowPointsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SmallCamel
@@ -118,7 +118,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallCamel
         /// </summary>
         [JsonPropertyName("smallCamel")]
-        public string? SmallCamel { get { return this.SmallCamelOption; } set { this.SmallCamelOption = new(value); } }
+        public string? SmallCamel { get { return this.SmallCamelOption.Value; } set { this.SmallCamelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SmallSnake
@@ -131,7 +131,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallSnake
         /// </summary>
         [JsonPropertyName("small_Snake")]
-        public string? SmallSnake { get { return this.SmallSnakeOption; } set { this.SmallSnakeOption = new(value); } }
+        public string? SmallSnake { get { return this.SmallSnakeOption.Value; } set { this.SmallSnakeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [JsonPropertyName("declawed")]
-        public bool? Declawed { get { return this.DeclawedOption; } set { this.DeclawedOption = new(value); } }
+        public bool? Declawed { get { return this.DeclawedOption.Value; } set { this.DeclawedOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -108,7 +108,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// The discriminator

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("_class")]
-        public string? Class { get { return this.ClassOption; } set { this.ClassOption = new(value); } }
+        public string? Class { get { return this.ClassOption.Value; } set { this.ClassOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>Fri Jul 21 00:00:00 UTC 2017</example> */
         [JsonPropertyName("dateOnlyProperty")]
-        public DateOnly? DateOnlyProperty { get { return this.DateOnlyPropertyOption; } set { this.DateOnlyPropertyOption = new(value); } }
+        public DateOnly? DateOnlyProperty { get { return this.DateOnlyPropertyOption.Value; } set { this.DateOnlyPropertyOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Dog.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Breed
         /// </summary>
         [JsonPropertyName("breed")]
-        public string? Breed { get { return this.BreedOption; } set { this.BreedOption = new(value); } }
+        public string? Breed { get { return this.BreedOption.Value; } set { this.BreedOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Drawing.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MainShape
         /// </summary>
         [JsonPropertyName("mainShape")]
-        public Shape? MainShape { get { return this.MainShapeOption; } set { this.MainShapeOption = new(value); } }
+        public Shape? MainShape { get { return this.MainShapeOption.Value; } set { this.MainShapeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NullableShape
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableShape
         /// </summary>
         [JsonPropertyName("nullableShape")]
-        public NullableShape? NullableShape { get { return this.NullableShapeOption; } set { this.NullableShapeOption = new(value); } }
+        public NullableShape? NullableShape { get { return this.NullableShapeOption.Value; } set { this.NullableShapeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ShapeOrNull
@@ -87,7 +87,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ShapeOrNull
         /// </summary>
         [JsonPropertyName("shapeOrNull")]
-        public ShapeOrNull? ShapeOrNull { get { return this.ShapeOrNullOption; } set { this.ShapeOrNullOption = new(value); } }
+        public ShapeOrNull? ShapeOrNull { get { return this.ShapeOrNullOption.Value; } set { this.ShapeOrNullOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Shapes
@@ -100,7 +100,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Shapes
         /// </summary>
         [JsonPropertyName("shapes")]
-        public List<Shape>? Shapes { get { return this.ShapesOption; } set { this.ShapesOption = new(value); } }
+        public List<Shape>? Shapes { get { return this.ShapesOption.Value; } set { this.ShapesOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -202,7 +202,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayEnum
         /// </summary>
         [JsonPropertyName("array_enum")]
-        public List<EnumArrays.ArrayEnumEnum>? ArrayEnum { get { return this.ArrayEnumOption; } set { this.ArrayEnumOption = new(value); } }
+        public List<EnumArrays.ArrayEnumEnum>? ArrayEnum { get { return this.ArrayEnumOption.Value; } set { this.ArrayEnumOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/File.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Test capitalization</value>
         [JsonPropertyName("sourceURI")]
-        public string? SourceURI { get { return this.SourceURIOption; } set { this.SourceURIOption = new(value); } }
+        public string? SourceURI { get { return this.SourceURIOption.Value; } set { this.SourceURIOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets File
         /// </summary>
         [JsonPropertyName("file")]
-        public File? File { get { return this.FileOption; } set { this.FileOption = new(value); } }
+        public File? File { get { return this.FileOption.Value; } set { this.FileOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Files
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Files
         /// </summary>
         [JsonPropertyName("files")]
-        public List<File>? Files { get { return this.FilesOption; } set { this.FilesOption = new(value); } }
+        public List<File>? Files { get { return this.FilesOption.Value; } set { this.FilesOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Foo.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string? Bar { get { return this.BarOption; } set { this.BarOption = new(value); } }
+        public string? Bar { get { return this.BarOption.Value; } set { this.BarOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public Foo? String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public Foo? String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Binary
         /// </summary>
         [JsonPropertyName("binary")]
-        public System.IO.Stream? Binary { get { return this.BinaryOption; } set { this.BinaryOption = new(value); } }
+        public System.IO.Stream? Binary { get { return this.BinaryOption.Value; } set { this.BinaryOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DateTime
@@ -154,7 +154,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2007-12-03T10:15:30+01:00</example> */
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Decimal
@@ -167,7 +167,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Decimal
         /// </summary>
         [JsonPropertyName("decimal")]
-        public decimal? Decimal { get { return this.DecimalOption; } set { this.DecimalOption = new(value); } }
+        public decimal? Decimal { get { return this.DecimalOption.Value; } set { this.DecimalOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Double
@@ -180,7 +180,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Double
         /// </summary>
         [JsonPropertyName("double")]
-        public double? Double { get { return this.DoubleOption; } set { this.DoubleOption = new(value); } }
+        public double? Double { get { return this.DoubleOption.Value; } set { this.DoubleOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName2
@@ -193,7 +193,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName2
         /// </summary>
         [JsonPropertyName("duplicate_property_name")]
-        public string? DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option; } set { this.DuplicatePropertyName2Option = new(value); } }
+        public string? DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option.Value; } set { this.DuplicatePropertyName2Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName
@@ -206,7 +206,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName
         /// </summary>
         [JsonPropertyName("@duplicate_property_name")]
-        public string? DuplicatePropertyName { get { return this.DuplicatePropertyNameOption; } set { this.DuplicatePropertyNameOption = new(value); } }
+        public string? DuplicatePropertyName { get { return this.DuplicatePropertyNameOption.Value; } set { this.DuplicatePropertyNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Float
@@ -219,7 +219,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Float
         /// </summary>
         [JsonPropertyName("float")]
-        public float? Float { get { return this.FloatOption; } set { this.FloatOption = new(value); } }
+        public float? Float { get { return this.FloatOption.Value; } set { this.FloatOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int32
@@ -232,7 +232,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32
         /// </summary>
         [JsonPropertyName("int32")]
-        public int? Int32 { get { return this.Int32Option; } set { this.Int32Option = new(value); } }
+        public int? Int32 { get { return this.Int32Option.Value; } set { this.Int32Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int32Range
@@ -245,7 +245,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32Range
         /// </summary>
         [JsonPropertyName("int32Range")]
-        public int? Int32Range { get { return this.Int32RangeOption; } set { this.Int32RangeOption = new(value); } }
+        public int? Int32Range { get { return this.Int32RangeOption.Value; } set { this.Int32RangeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64
@@ -258,7 +258,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64
         /// </summary>
         [JsonPropertyName("int64")]
-        public long? Int64 { get { return this.Int64Option; } set { this.Int64Option = new(value); } }
+        public long? Int64 { get { return this.Int64Option.Value; } set { this.Int64Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Negative
@@ -271,7 +271,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Negative
         /// </summary>
         [JsonPropertyName("int64Negative")]
-        public long? Int64Negative { get { return this.Int64NegativeOption; } set { this.Int64NegativeOption = new(value); } }
+        public long? Int64Negative { get { return this.Int64NegativeOption.Value; } set { this.Int64NegativeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64NegativeExclusive
@@ -284,7 +284,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64NegativeExclusive
         /// </summary>
         [JsonPropertyName("int64NegativeExclusive")]
-        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption; } set { this.Int64NegativeExclusiveOption = new(value); } }
+        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption.Value; } set { this.Int64NegativeExclusiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Positive
@@ -297,7 +297,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Positive
         /// </summary>
         [JsonPropertyName("int64Positive")]
-        public long? Int64Positive { get { return this.Int64PositiveOption; } set { this.Int64PositiveOption = new(value); } }
+        public long? Int64Positive { get { return this.Int64PositiveOption.Value; } set { this.Int64PositiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64PositiveExclusive
@@ -310,7 +310,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64PositiveExclusive
         /// </summary>
         [JsonPropertyName("int64PositiveExclusive")]
-        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption; } set { this.Int64PositiveExclusiveOption = new(value); } }
+        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption.Value; } set { this.Int64PositiveExclusiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Integer
@@ -323,7 +323,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [JsonPropertyName("integer")]
-        public int? Integer { get { return this.IntegerOption; } set { this.IntegerOption = new(value); } }
+        public int? Integer { get { return this.IntegerOption.Value; } set { this.IntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithBackslash
@@ -337,7 +337,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>None</value>
         [JsonPropertyName("pattern_with_backslash")]
-        public string? PatternWithBackslash { get { return this.PatternWithBackslashOption; } set { this.PatternWithBackslashOption = new(value); } }
+        public string? PatternWithBackslash { get { return this.PatternWithBackslashOption.Value; } set { this.PatternWithBackslashOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigits
@@ -351,7 +351,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string that is a 10 digit number. Can have leading zeros.</value>
         [JsonPropertyName("pattern_with_digits")]
-        public string? PatternWithDigits { get { return this.PatternWithDigitsOption; } set { this.PatternWithDigitsOption = new(value); } }
+        public string? PatternWithDigits { get { return this.PatternWithDigitsOption.Value; } set { this.PatternWithDigitsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigitsAndDelimiter
@@ -365,7 +365,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.</value>
         [JsonPropertyName("pattern_with_digits_and_delimiter")]
-        public string? PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption; } set { this.PatternWithDigitsAndDelimiterOption = new(value); } }
+        public string? PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption.Value; } set { this.PatternWithDigitsAndDelimiterOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of String
@@ -378,7 +378,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public string? String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public string? String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of StringFormattedAsDecimal
@@ -391,7 +391,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringFormattedAsDecimal
         /// </summary>
         [JsonPropertyName("string_formatted_as_decimal")]
-        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption; } set { this.StringFormattedAsDecimalOption = new(value); } }
+        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption.Value; } set { this.StringFormattedAsDecimalOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedInteger
@@ -404,7 +404,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [JsonPropertyName("unsigned_integer")]
-        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption; } set { this.UnsignedIntegerOption = new(value); } }
+        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption.Value; } set { this.UnsignedIntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedLong
@@ -417,7 +417,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedLong
         /// </summary>
         [JsonPropertyName("unsigned_long")]
-        public ulong? UnsignedLong { get { return this.UnsignedLongOption; } set { this.UnsignedLongOption = new(value); } }
+        public ulong? UnsignedLong { get { return this.UnsignedLongOption.Value; } set { this.UnsignedLongOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -431,7 +431,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -82,7 +82,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string? Bar { get { return this.BarOption; } }
+        public string? Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Foo
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Foo
         /// </summary>
         [JsonPropertyName("foo")]
-        public string? Foo { get { return this.FooOption; } }
+        public string? Foo { get { return this.FooOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableMessage
         /// </summary>
         [JsonPropertyName("NullableMessage")]
-        public string? NullableMessage { get { return this.NullableMessageOption; } set { this.NullableMessageOption = new(value); } }
+        public string? NullableMessage { get { return this.NullableMessageOption.Value; } set { this.NullableMessageOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/List.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123List
         /// </summary>
         [JsonPropertyName("123-list")]
-        public string? Var123List { get { return this.Var123ListOption; } set { this.Var123ListOption = new(value); } }
+        public string? Var123List { get { return this.Var123ListOption.Value; } set { this.Var123ListOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets EscapedLiteralString
         /// </summary>
         [JsonPropertyName("escapedLiteralString")]
-        public string? EscapedLiteralString { get { return this.EscapedLiteralStringOption; } set { this.EscapedLiteralStringOption = new(value); } }
+        public string? EscapedLiteralString { get { return this.EscapedLiteralStringOption.Value; } set { this.EscapedLiteralStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnescapedLiteralString
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnescapedLiteralString
         /// </summary>
         [JsonPropertyName("unescapedLiteralString")]
-        public string? UnescapedLiteralString { get { return this.UnescapedLiteralStringOption; } set { this.UnescapedLiteralStringOption = new(value); } }
+        public string? UnescapedLiteralString { get { return this.UnescapedLiteralStringOption.Value; } set { this.UnescapedLiteralStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MapTest.cs
@@ -127,7 +127,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DirectMap
         /// </summary>
         [JsonPropertyName("direct_map")]
-        public Dictionary<string, bool>? DirectMap { get { return this.DirectMapOption; } set { this.DirectMapOption = new(value); } }
+        public Dictionary<string, bool>? DirectMap { get { return this.DirectMapOption.Value; } set { this.DirectMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of IndirectMap
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IndirectMap
         /// </summary>
         [JsonPropertyName("indirect_map")]
-        public Dictionary<string, bool>? IndirectMap { get { return this.IndirectMapOption; } set { this.IndirectMapOption = new(value); } }
+        public Dictionary<string, bool>? IndirectMap { get { return this.IndirectMapOption.Value; } set { this.IndirectMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapMapOfString
@@ -153,7 +153,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapMapOfString
         /// </summary>
         [JsonPropertyName("map_map_of_string")]
-        public Dictionary<string, Dictionary<string, string>>? MapMapOfString { get { return this.MapMapOfStringOption; } set { this.MapMapOfStringOption = new(value); } }
+        public Dictionary<string, Dictionary<string, string>>? MapMapOfString { get { return this.MapMapOfStringOption.Value; } set { this.MapMapOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfEnumString
@@ -166,7 +166,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfEnumString
         /// </summary>
         [JsonPropertyName("map_of_enum_string")]
-        public Dictionary<string, MapTest.InnerEnum>? MapOfEnumString { get { return this.MapOfEnumStringOption; } set { this.MapOfEnumStringOption = new(value); } }
+        public Dictionary<string, MapTest.InnerEnum>? MapOfEnumString { get { return this.MapOfEnumStringOption.Value; } set { this.MapOfEnumStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedAnyOfContent? Content { get { return this.ContentOption; } set { this.ContentOption = new(value); } }
+        public MixedAnyOfContent? Content { get { return this.ContentOption.Value; } set { this.ContentOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedOneOfContent? Content { get { return this.ContentOption; } set { this.ContentOption = new(value); } }
+        public MixedOneOfContent? Content { get { return this.ContentOption.Value; } set { this.ContentOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateTime
         /// </summary>
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Map
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Map
         /// </summary>
         [JsonPropertyName("map")]
-        public Dictionary<string, Animal>? Map { get { return this.MapOption; } set { this.MapOption = new(value); } }
+        public Dictionary<string, Animal>? Map { get { return this.MapOption.Value; } set { this.MapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -87,7 +87,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UuidWithPattern
@@ -100,7 +100,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [JsonPropertyName("uuid_with_pattern")]
-        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption; } set { this.UuidWithPatternOption = new(value); } }
+        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption.Value; } set { this.UuidWithPatternOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public string? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public string? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("class")]
-        public string? Class { get { return this.ClassOption; } set { this.ClassOption = new(value); } }
+        public string? Class { get { return this.ClassOption.Value; } set { this.ClassOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public int? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public int? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarClient
         /// </summary>
         [JsonPropertyName("client")]
-        public string? VarClient { get { return this.VarClientOption; } set { this.VarClientOption = new(value); } }
+        public string? VarClient { get { return this.VarClientOption.Value; } set { this.VarClientOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Property
         /// </summary>
         [JsonPropertyName("property")]
-        public string? Property { get { return this.PropertyOption; } set { this.PropertyOption = new(value); } }
+        public string? Property { get { return this.PropertyOption.Value; } set { this.PropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SnakeCase
@@ -80,7 +80,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [JsonPropertyName("snake_case")]
-        public int? SnakeCase { get { return this.SnakeCaseOption; } }
+        public int? SnakeCase { get { return this.SnakeCaseOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Var123Number
@@ -93,7 +93,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123Number
         /// </summary>
         [JsonPropertyName("123Number")]
-        public int? Var123Number { get { return this.Var123NumberOption; } }
+        public int? Var123Number { get { return this.Var123NumberOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -77,7 +77,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("array_and_items_nullable_prop")]
-        public List<Object>? ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption; } set { this.ArrayAndItemsNullablePropOption = new(value); } }
+        public List<Object>? ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption.Value; } set { this.ArrayAndItemsNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayItemsNullable
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayItemsNullable
         /// </summary>
         [JsonPropertyName("array_items_nullable")]
-        public List<Object>? ArrayItemsNullable { get { return this.ArrayItemsNullableOption; } set { this.ArrayItemsNullableOption = new(value); } }
+        public List<Object>? ArrayItemsNullable { get { return this.ArrayItemsNullableOption.Value; } set { this.ArrayItemsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayNullableProp
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNullableProp
         /// </summary>
         [JsonPropertyName("array_nullable_prop")]
-        public List<Object>? ArrayNullableProp { get { return this.ArrayNullablePropOption; } set { this.ArrayNullablePropOption = new(value); } }
+        public List<Object>? ArrayNullableProp { get { return this.ArrayNullablePropOption.Value; } set { this.ArrayNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of BooleanProp
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BooleanProp
         /// </summary>
         [JsonPropertyName("boolean_prop")]
-        public bool? BooleanProp { get { return this.BooleanPropOption; } set { this.BooleanPropOption = new(value); } }
+        public bool? BooleanProp { get { return this.BooleanPropOption.Value; } set { this.BooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DateProp
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateProp
         /// </summary>
         [JsonPropertyName("date_prop")]
-        public DateOnly? DateProp { get { return this.DatePropOption; } set { this.DatePropOption = new(value); } }
+        public DateOnly? DateProp { get { return this.DatePropOption.Value; } set { this.DatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DatetimeProp
@@ -142,7 +142,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DatetimeProp
         /// </summary>
         [JsonPropertyName("datetime_prop")]
-        public DateTime? DatetimeProp { get { return this.DatetimePropOption; } set { this.DatetimePropOption = new(value); } }
+        public DateTime? DatetimeProp { get { return this.DatetimePropOption.Value; } set { this.DatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of IntegerProp
@@ -155,7 +155,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IntegerProp
         /// </summary>
         [JsonPropertyName("integer_prop")]
-        public int? IntegerProp { get { return this.IntegerPropOption; } set { this.IntegerPropOption = new(value); } }
+        public int? IntegerProp { get { return this.IntegerPropOption.Value; } set { this.IntegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NumberProp
@@ -168,7 +168,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NumberProp
         /// </summary>
         [JsonPropertyName("number_prop")]
-        public decimal? NumberProp { get { return this.NumberPropOption; } set { this.NumberPropOption = new(value); } }
+        public decimal? NumberProp { get { return this.NumberPropOption.Value; } set { this.NumberPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectAndItemsNullableProp
@@ -181,7 +181,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("object_and_items_nullable_prop")]
-        public Dictionary<string, Object>? ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption; } set { this.ObjectAndItemsNullablePropOption = new(value); } }
+        public Dictionary<string, Object>? ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption.Value; } set { this.ObjectAndItemsNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectItemsNullable
@@ -194,7 +194,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectItemsNullable
         /// </summary>
         [JsonPropertyName("object_items_nullable")]
-        public Dictionary<string, Object>? ObjectItemsNullable { get { return this.ObjectItemsNullableOption; } set { this.ObjectItemsNullableOption = new(value); } }
+        public Dictionary<string, Object>? ObjectItemsNullable { get { return this.ObjectItemsNullableOption.Value; } set { this.ObjectItemsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectNullableProp
@@ -207,7 +207,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectNullableProp
         /// </summary>
         [JsonPropertyName("object_nullable_prop")]
-        public Dictionary<string, Object>? ObjectNullableProp { get { return this.ObjectNullablePropOption; } set { this.ObjectNullablePropOption = new(value); } }
+        public Dictionary<string, Object>? ObjectNullableProp { get { return this.ObjectNullablePropOption.Value; } set { this.ObjectNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of StringProp
@@ -220,7 +220,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringProp
         /// </summary>
         [JsonPropertyName("string_prop")]
-        public string? StringProp { get { return this.StringPropOption; } set { this.StringPropOption = new(value); } }
+        public string? StringProp { get { return this.StringPropOption.Value; } set { this.StringPropOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [JsonPropertyName("JustNumber")]
-        public decimal? JustNumber { get { return this.JustNumberOption; } set { this.JustNumberOption = new(value); } }
+        public decimal? JustNumber { get { return this.JustNumberOption.Value; } set { this.JustNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("bars")]
         [Obsolete]
-        public List<string>? Bars { get { return this.BarsOption; } set { this.BarsOption = new(value); } }
+        public List<string>? Bars { get { return this.BarsOption.Value; } set { this.BarsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DeprecatedRef
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("deprecatedRef")]
         [Obsolete]
-        public DeprecatedObject? DeprecatedRef { get { return this.DeprecatedRefOption; } set { this.DeprecatedRefOption = new(value); } }
+        public DeprecatedObject? DeprecatedRef { get { return this.DeprecatedRefOption.Value; } set { this.DeprecatedRefOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("id")]
         [Obsolete]
-        public decimal? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public decimal? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public string? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Order.cs
@@ -160,7 +160,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Complete
         /// </summary>
         [JsonPropertyName("complete")]
-        public bool? Complete { get { return this.CompleteOption; } set { this.CompleteOption = new(value); } }
+        public bool? Complete { get { return this.CompleteOption.Value; } set { this.CompleteOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -173,7 +173,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PetId
@@ -186,7 +186,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets PetId
         /// </summary>
         [JsonPropertyName("petId")]
-        public long? PetId { get { return this.PetIdOption; } set { this.PetIdOption = new(value); } }
+        public long? PetId { get { return this.PetIdOption.Value; } set { this.PetIdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Quantity
@@ -199,7 +199,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Quantity
         /// </summary>
         [JsonPropertyName("quantity")]
-        public int? Quantity { get { return this.QuantityOption; } set { this.QuantityOption = new(value); } }
+        public int? Quantity { get { return this.QuantityOption.Value; } set { this.QuantityOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ShipDate
@@ -213,7 +213,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2020-02-02T20:20:20.000222Z</example> */
         [JsonPropertyName("shipDate")]
-        public DateTime? ShipDate { get { return this.ShipDateOption; } set { this.ShipDateOption = new(value); } }
+        public DateTime? ShipDate { get { return this.ShipDateOption.Value; } set { this.ShipDateOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyBoolean
         /// </summary>
         [JsonPropertyName("my_boolean")]
-        public bool? MyBoolean { get { return this.MyBooleanOption; } set { this.MyBooleanOption = new(value); } }
+        public bool? MyBoolean { get { return this.MyBooleanOption.Value; } set { this.MyBooleanOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MyNumber
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [JsonPropertyName("my_number")]
-        public decimal? MyNumber { get { return this.MyNumberOption; } set { this.MyNumberOption = new(value); } }
+        public decimal? MyNumber { get { return this.MyNumberOption.Value; } set { this.MyNumberOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MyString
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyString
         /// </summary>
         [JsonPropertyName("my_string")]
-        public string? MyString { get { return this.MyStringOption; } set { this.MyStringOption = new(value); } }
+        public string? MyString { get { return this.MyStringOption.Value; } set { this.MyStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
@@ -173,7 +173,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Category
         /// </summary>
         [JsonPropertyName("category")]
-        public Category? Category { get { return this.CategoryOption; } set { this.CategoryOption = new(value); } }
+        public Category? Category { get { return this.CategoryOption.Value; } set { this.CategoryOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -186,7 +186,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Tags
@@ -199,7 +199,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Tags
         /// </summary>
         [JsonPropertyName("tags")]
-        public List<Tag>? Tags { get { return this.TagsOption; } set { this.TagsOption = new(value); } }
+        public List<Tag>? Tags { get { return this.TagsOption.Value; } set { this.TagsOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string? Bar { get { return this.BarOption; } }
+        public string? Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Baz
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Baz
         /// </summary>
         [JsonPropertyName("baz")]
-        public string? Baz { get { return this.BazOption; } set { this.BazOption = new(value); } }
+        public string? Baz { get { return this.BazOption.Value; } set { this.BazOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -1414,7 +1414,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_notnullable_date_prop")]
-        public DateOnly? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption; } set { this.NotRequiredNotnullableDatePropOption = new(value); } }
+        public DateOnly? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption.Value; } set { this.NotRequiredNotnullableDatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNotnullableintegerProp
@@ -1427,7 +1427,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [JsonPropertyName("not_required_notnullableinteger_prop")]
-        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption; } set { this.NotRequiredNotnullableintegerPropOption = new(value); } }
+        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption.Value; } set { this.NotRequiredNotnullableintegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableDateProp
@@ -1440,7 +1440,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_date_prop")]
-        public DateOnly? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption; } set { this.NotRequiredNullableDatePropOption = new(value); } }
+        public DateOnly? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption.Value; } set { this.NotRequiredNullableDatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableIntegerProp
@@ -1453,7 +1453,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableIntegerProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_integer_prop")]
-        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption; } set { this.NotRequiredNullableIntegerPropOption = new(value); } }
+        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption.Value; } set { this.NotRequiredNullableIntegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableArrayOfString
@@ -1466,7 +1466,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_array_of_string")]
-        public List<string>? NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption; } set { this.NotrequiredNotnullableArrayOfStringOption = new(value); } }
+        public List<string>? NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption.Value; } set { this.NotrequiredNotnullableArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableBooleanProp
@@ -1479,7 +1479,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_boolean_prop")]
-        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption; } set { this.NotrequiredNotnullableBooleanPropOption = new(value); } }
+        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption.Value; } set { this.NotrequiredNotnullableBooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableDatetimeProp
@@ -1492,7 +1492,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_datetime_prop")]
-        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption; } set { this.NotrequiredNotnullableDatetimePropOption = new(value); } }
+        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption.Value; } set { this.NotrequiredNotnullableDatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableStringProp
@@ -1505,7 +1505,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_string_prop")]
-        public string? NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption; } set { this.NotrequiredNotnullableStringPropOption = new(value); } }
+        public string? NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption.Value; } set { this.NotrequiredNotnullableStringPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableUuid
@@ -1519,7 +1519,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_notnullable_uuid")]
-        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption; } set { this.NotrequiredNotnullableUuidOption = new(value); } }
+        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption.Value; } set { this.NotrequiredNotnullableUuidOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableArrayOfString
@@ -1532,7 +1532,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_nullable_array_of_string")]
-        public List<string>? NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption; } set { this.NotrequiredNullableArrayOfStringOption = new(value); } }
+        public List<string>? NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption.Value; } set { this.NotrequiredNullableArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableBooleanProp
@@ -1545,7 +1545,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_boolean_prop")]
-        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption; } set { this.NotrequiredNullableBooleanPropOption = new(value); } }
+        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption.Value; } set { this.NotrequiredNullableBooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableDatetimeProp
@@ -1558,7 +1558,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_datetime_prop")]
-        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption; } set { this.NotrequiredNullableDatetimePropOption = new(value); } }
+        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption.Value; } set { this.NotrequiredNullableDatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableStringProp
@@ -1571,7 +1571,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_string_prop")]
-        public string? NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption; } set { this.NotrequiredNullableStringPropOption = new(value); } }
+        public string? NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption.Value; } set { this.NotrequiredNullableStringPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableUuid
@@ -1585,7 +1585,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_nullable_uuid")]
-        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption; } set { this.NotrequiredNullableUuidOption = new(value); } }
+        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption.Value; } set { this.NotrequiredNullableUuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets RequiredNullableArrayOfString

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Result.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result code</value>
         [JsonPropertyName("code")]
-        public string? Code { get { return this.CodeOption; } set { this.CodeOption = new(value); } }
+        public string? Code { get { return this.CodeOption.Value; } set { this.CodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Data
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string>? Data { get { return this.DataOption; } set { this.DataOption = new(value); } }
+        public Dictionary<string, string>? Data { get { return this.DataOption.Value; } set { this.DataOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
@@ -73,7 +73,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [JsonPropertyName("return")]
-        public int? VarReturn { get { return this.VarReturnOption; } set { this.VarReturnOption = new(value); } }
+        public int? VarReturn { get { return this.VarReturnOption.Value; } set { this.VarReturnOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Unsafe
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Unsafe
         /// </summary>
         [JsonPropertyName("unsafe")]
-        public string? Unsafe { get { return this.UnsafeOption; } set { this.UnsafeOption = new(value); } }
+        public string? Unsafe { get { return this.UnsafeOption.Value; } set { this.UnsafeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Role
         /// </summary>
         [JsonPropertyName("role")]
-        public RolesReportsHashRole? Role { get { return this.RoleOption; } set { this.RoleOption = new(value); } }
+        public RolesReportsHashRole? Role { get { return this.RoleOption.Value; } set { this.RoleOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of RoleUuid
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [JsonPropertyName("role_uuid")]
-        public Guid? RoleUuid { get { return this.RoleUuidOption; } set { this.RoleUuidOption = new(value); } }
+        public Guid? RoleUuid { get { return this.RoleUuidOption.Value; } set { this.RoleUuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarSpecialModelName
         /// </summary>
         [JsonPropertyName("_special_model.name_")]
-        public string? VarSpecialModelName { get { return this.VarSpecialModelNameOption; } set { this.VarSpecialModelNameOption = new(value); } }
+        public string? VarSpecialModelName { get { return this.VarSpecialModelNameOption.Value; } set { this.VarSpecialModelNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SpecialPropertyName
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [JsonPropertyName("$special[property.name]")]
-        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption; } set { this.SpecialPropertyNameOption = new(value); } }
+        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption.Value; } set { this.SpecialPropertyNameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Value
         /// </summary>
         [JsonPropertyName("value")]
-        public string? Value { get { return this.ValueOption; } set { this.ValueOption = new(value); } }
+        public string? Value { get { return this.ValueOption.Value; } set { this.ValueOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets TestCollectionEndingWithWordList
         /// </summary>
         [JsonPropertyName("TestCollectionEndingWithWordList")]
-        public List<TestCollectionEndingWithWordList>? TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption; } set { this.TestCollectionEndingWithWordListOption = new(value); } }
+        public List<TestCollectionEndingWithWordList>? TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption.Value; } set { this.TestCollectionEndingWithWordListOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SomeProperty
         /// </summary>
         [JsonPropertyName("someProperty")]
-        public string? SomeProperty { get { return this.SomePropertyOption; } set { this.SomePropertyOption = new(value); } }
+        public string? SomeProperty { get { return this.SomePropertyOption.Value; } set { this.SomePropertyOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
@@ -73,7 +73,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string>? Data { get { return this.DataOption; } set { this.DataOption = new(value); } }
+        public Dictionary<string, string>? Data { get { return this.DataOption.Value; } set { this.DataOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -87,7 +87,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
         [JsonPropertyName("anyTypeProp")]
-        public Object? AnyTypeProp { get { return this.AnyTypePropOption; } set { this.AnyTypePropOption = new(value); } }
+        public Object? AnyTypeProp { get { return this.AnyTypePropOption.Value; } set { this.AnyTypePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of AnyTypePropNullable
@@ -92,7 +92,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values.</value>
         [JsonPropertyName("anyTypePropNullable")]
-        public Object? AnyTypePropNullable { get { return this.AnyTypePropNullableOption; } set { this.AnyTypePropNullableOption = new(value); } }
+        public Object? AnyTypePropNullable { get { return this.AnyTypePropNullableOption.Value; } set { this.AnyTypePropNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Email
@@ -105,7 +105,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Email
         /// </summary>
         [JsonPropertyName("email")]
-        public string? Email { get { return this.EmailOption; } set { this.EmailOption = new(value); } }
+        public string? Email { get { return this.EmailOption.Value; } set { this.EmailOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of FirstName
@@ -118,7 +118,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets FirstName
         /// </summary>
         [JsonPropertyName("firstName")]
-        public string? FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new(value); } }
+        public string? FirstName { get { return this.FirstNameOption.Value; } set { this.FirstNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -131,7 +131,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of LastName
@@ -144,7 +144,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LastName
         /// </summary>
         [JsonPropertyName("lastName")]
-        public string? LastName { get { return this.LastNameOption; } set { this.LastNameOption = new(value); } }
+        public string? LastName { get { return this.LastNameOption.Value; } set { this.LastNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredProps
@@ -158,7 +158,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredProps")]
-        public Object? ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption; } set { this.ObjectWithNoDeclaredPropsOption = new(value); } }
+        public Object? ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption.Value; } set { this.ObjectWithNoDeclaredPropsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredPropsNullable
@@ -172,7 +172,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredPropsNullable")]
-        public Object? ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption; } set { this.ObjectWithNoDeclaredPropsNullableOption = new(value); } }
+        public Object? ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption.Value; } set { this.ObjectWithNoDeclaredPropsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Password
@@ -185,7 +185,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Password
         /// </summary>
         [JsonPropertyName("password")]
-        public string? Password { get { return this.PasswordOption; } set { this.PasswordOption = new(value); } }
+        public string? Password { get { return this.PasswordOption.Value; } set { this.PasswordOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Phone
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Phone
         /// </summary>
         [JsonPropertyName("phone")]
-        public string? Phone { get { return this.PhoneOption; } set { this.PhoneOption = new(value); } }
+        public string? Phone { get { return this.PhoneOption.Value; } set { this.PhoneOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UserStatus
@@ -212,7 +212,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [JsonPropertyName("userStatus")]
-        public int? UserStatus { get { return this.UserStatusOption; } set { this.UserStatusOption = new(value); } }
+        public int? UserStatus { get { return this.UserStatusOption.Value; } set { this.UserStatusOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Username
@@ -225,7 +225,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Username
         /// </summary>
         [JsonPropertyName("username")]
-        public string? Username { get { return this.UsernameOption; } set { this.UsernameOption = new(value); } }
+        public string? Username { get { return this.UsernameOption.Value; } set { this.UsernameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
@@ -65,7 +65,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [JsonPropertyName("hasBaleen")]
-        public bool? HasBaleen { get { return this.HasBaleenOption; } set { this.HasBaleenOption = new(value); } }
+        public bool? HasBaleen { get { return this.HasBaleenOption.Value; } set { this.HasBaleenOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of HasTeeth
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasTeeth
         /// </summary>
         [JsonPropertyName("hasTeeth")]
-        public bool? HasTeeth { get { return this.HasTeethOption; } set { this.HasTeethOption = new(value); } }
+        public bool? HasTeeth { get { return this.HasTeethOption.Value; } set { this.HasTeethOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Kind
         /// </summary>
         [JsonPropertyName("kind")]
-        public string? Kind { get { return this.KindOption; } set { this.KindOption = new(value); } }
+        public string? Kind { get { return this.KindOption.Value; } set { this.KindOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Count
         /// </summary>
         [JsonPropertyName("count")]
-        public decimal? Count { get { return this.CountOption; } set { this.CountOption = new(value); } }
+        public decimal? Count { get { return this.CountOption.Value; } set { this.CountOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -95,7 +95,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Orange.cs
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Orange.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [JsonPropertyName("sweet")]
-        public bool? Sweet { get { return this.SweetOption; } set { this.SweetOption = new(value); } }
+        public bool? Sweet { get { return this.SweetOption.Value; } set { this.SweetOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Activity.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ActivityOutputs
         /// </summary>
         [JsonPropertyName("activity_outputs")]
-        public Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs { get { return this.ActivityOutputsOption; } set { this.ActivityOutputsOption = new(value); } }
+        public Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs { get { return this.ActivityOutputsOption.Value; } set { this.ActivityOutputsOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop1
         /// </summary>
         [JsonPropertyName("prop1")]
-        public string Prop1 { get { return this.Prop1Option; } set { this.Prop1Option = new(value); } }
+        public string Prop1 { get { return this.Prop1Option.Value; } set { this.Prop1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Prop2
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop2
         /// </summary>
         [JsonPropertyName("prop2")]
-        public Object Prop2 { get { return this.Prop2Option; } set { this.Prop2Option = new(value); } }
+        public Object Prop2 { get { return this.Prop2Option.Value; } set { this.Prop2Option = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Anytype1
         /// </summary>
         [JsonPropertyName("anytype_1")]
-        public Object Anytype1 { get { return this.Anytype1Option; } set { this.Anytype1Option = new(value); } }
+        public Object Anytype1 { get { return this.Anytype1Option.Value; } set { this.Anytype1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of EmptyMap
@@ -81,7 +81,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>an object with no declared properties and no undeclared properties, hence it&#39;s an empty map.</value>
         [JsonPropertyName("empty_map")]
-        public Object EmptyMap { get { return this.EmptyMapOption; } set { this.EmptyMapOption = new(value); } }
+        public Object EmptyMap { get { return this.EmptyMapOption.Value; } set { this.EmptyMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfMapProperty
@@ -94,7 +94,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfMapProperty
         /// </summary>
         [JsonPropertyName("map_of_map_property")]
-        public Dictionary<string, Dictionary<string, string>> MapOfMapProperty { get { return this.MapOfMapPropertyOption; } set { this.MapOfMapPropertyOption = new(value); } }
+        public Dictionary<string, Dictionary<string, string>> MapOfMapProperty { get { return this.MapOfMapPropertyOption.Value; } set { this.MapOfMapPropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapProperty
@@ -107,7 +107,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapProperty
         /// </summary>
         [JsonPropertyName("map_property")]
-        public Dictionary<string, string> MapProperty { get { return this.MapPropertyOption; } set { this.MapPropertyOption = new(value); } }
+        public Dictionary<string, string> MapProperty { get { return this.MapPropertyOption.Value; } set { this.MapPropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype1
@@ -120,7 +120,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype1
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_1")]
-        public Object MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new(value); } }
+        public Object MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype2
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype2
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_2")]
-        public Object MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new(value); } }
+        public Object MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype3
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype3
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_3")]
-        public Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new(value); } }
+        public Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesString
@@ -159,7 +159,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesString
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_string")]
-        public Dictionary<string, string> MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption; } set { this.MapWithUndeclaredPropertiesStringOption = new(value); } }
+        public Dictionary<string, string> MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption.Value; } set { this.MapWithUndeclaredPropertiesStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Animal.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [JsonPropertyName("code")]
-        public int? Code { get { return this.CodeOption; } set { this.CodeOption = new(value); } }
+        public int? Code { get { return this.CodeOption.Value; } set { this.CodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Message
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Message
         /// </summary>
         [JsonPropertyName("message")]
-        public string Message { get { return this.MessageOption; } set { this.MessageOption = new(value); } }
+        public string Message { get { return this.MessageOption.Value; } set { this.MessageOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Type
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Type
         /// </summary>
         [JsonPropertyName("type")]
-        public string Type { get { return this.TypeOption; } set { this.TypeOption = new(value); } }
+        public string Type { get { return this.TypeOption.Value; } set { this.TypeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Apple.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ColorCode
         /// </summary>
         [JsonPropertyName("color_code")]
-        public string ColorCode { get { return this.ColorCodeOption; } set { this.ColorCodeOption = new(value); } }
+        public string ColorCode { get { return this.ColorCodeOption.Value; } set { this.ColorCodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Cultivar
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Cultivar
         /// </summary>
         [JsonPropertyName("cultivar")]
-        public string Cultivar { get { return this.CultivarOption; } set { this.CultivarOption = new(value); } }
+        public string Cultivar { get { return this.CultivarOption.Value; } set { this.CultivarOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Origin
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Origin
         /// </summary>
         [JsonPropertyName("origin")]
-        public string Origin { get { return this.OriginOption; } set { this.OriginOption = new(value); } }
+        public string Origin { get { return this.OriginOption.Value; } set { this.OriginOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [JsonPropertyName("mealy")]
-        public bool? Mealy { get { return this.MealyOption; } set { this.MealyOption = new(value); } }
+        public bool? Mealy { get { return this.MealyOption.Value; } set { this.MealyOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayArrayNumber")]
-        public List<List<decimal>> ArrayArrayNumber { get { return this.ArrayArrayNumberOption; } set { this.ArrayArrayNumberOption = new(value); } }
+        public List<List<decimal>> ArrayArrayNumber { get { return this.ArrayArrayNumberOption.Value; } set { this.ArrayArrayNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayNumber")]
-        public List<decimal> ArrayNumber { get { return this.ArrayNumberOption; } set { this.ArrayNumberOption = new(value); } }
+        public List<decimal> ArrayNumber { get { return this.ArrayNumberOption.Value; } set { this.ArrayNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfInteger
         /// </summary>
         [JsonPropertyName("array_array_of_integer")]
-        public List<List<long>> ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption; } set { this.ArrayArrayOfIntegerOption = new(value); } }
+        public List<List<long>> ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption.Value; } set { this.ArrayArrayOfIntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayArrayOfModel
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfModel
         /// </summary>
         [JsonPropertyName("array_array_of_model")]
-        public List<List<ReadOnlyFirst>> ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption; } set { this.ArrayArrayOfModelOption = new(value); } }
+        public List<List<ReadOnlyFirst>> ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption.Value; } set { this.ArrayArrayOfModelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayOfString
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayOfString
         /// </summary>
         [JsonPropertyName("array_of_string")]
-        public List<string> ArrayOfString { get { return this.ArrayOfStringOption; } set { this.ArrayOfStringOption = new(value); } }
+        public List<string> ArrayOfString { get { return this.ArrayOfStringOption.Value; } set { this.ArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Banana.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [JsonPropertyName("lengthCm")]
-        public decimal? LengthCm { get { return this.LengthCmOption; } set { this.LengthCmOption = new(value); } }
+        public decimal? LengthCm { get { return this.LengthCmOption.Value; } set { this.LengthCmOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [JsonPropertyName("sweet")]
-        public bool? Sweet { get { return this.SweetOption; } set { this.SweetOption = new(value); } }
+        public bool? Sweet { get { return this.SweetOption.Value; } set { this.SweetOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -64,7 +64,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Name of the pet </value>
         [JsonPropertyName("ATT_NAME")]
-        public string ATT_NAME { get { return this.ATT_NAMEOption; } set { this.ATT_NAMEOption = new(value); } }
+        public string ATT_NAME { get { return this.ATT_NAMEOption.Value; } set { this.ATT_NAMEOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalCamel
@@ -77,7 +77,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalCamel
         /// </summary>
         [JsonPropertyName("CapitalCamel")]
-        public string CapitalCamel { get { return this.CapitalCamelOption; } set { this.CapitalCamelOption = new(value); } }
+        public string CapitalCamel { get { return this.CapitalCamelOption.Value; } set { this.CapitalCamelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalSnake
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalSnake
         /// </summary>
         [JsonPropertyName("Capital_Snake")]
-        public string CapitalSnake { get { return this.CapitalSnakeOption; } set { this.CapitalSnakeOption = new(value); } }
+        public string CapitalSnake { get { return this.CapitalSnakeOption.Value; } set { this.CapitalSnakeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SCAETHFlowPoints
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SCAETHFlowPoints
         /// </summary>
         [JsonPropertyName("SCA_ETH_Flow_Points")]
-        public string SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption; } set { this.SCAETHFlowPointsOption = new(value); } }
+        public string SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption.Value; } set { this.SCAETHFlowPointsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SmallCamel
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallCamel
         /// </summary>
         [JsonPropertyName("smallCamel")]
-        public string SmallCamel { get { return this.SmallCamelOption; } set { this.SmallCamelOption = new(value); } }
+        public string SmallCamel { get { return this.SmallCamelOption.Value; } set { this.SmallCamelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SmallSnake
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallSnake
         /// </summary>
         [JsonPropertyName("small_Snake")]
-        public string SmallSnake { get { return this.SmallSnakeOption; } set { this.SmallSnakeOption = new(value); } }
+        public string SmallSnake { get { return this.SmallSnakeOption.Value; } set { this.SmallSnakeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [JsonPropertyName("declawed")]
-        public bool? Declawed { get { return this.DeclawedOption; } set { this.DeclawedOption = new(value); } }
+        public bool? Declawed { get { return this.DeclawedOption.Value; } set { this.DeclawedOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -106,7 +106,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// The discriminator

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("_class")]
-        public string Class { get { return this.ClassOption; } set { this.ClassOption = new(value); } }
+        public string Class { get { return this.ClassOption.Value; } set { this.ClassOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>Fri Jul 21 00:00:00 UTC 2017</example> */
         [JsonPropertyName("dateOnlyProperty")]
-        public DateOnly? DateOnlyProperty { get { return this.DateOnlyPropertyOption; } set { this.DateOnlyPropertyOption = new(value); } }
+        public DateOnly? DateOnlyProperty { get { return this.DateOnlyPropertyOption.Value; } set { this.DateOnlyPropertyOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Breed
         /// </summary>
         [JsonPropertyName("breed")]
-        public string Breed { get { return this.BreedOption; } set { this.BreedOption = new(value); } }
+        public string Breed { get { return this.BreedOption.Value; } set { this.BreedOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MainShape
         /// </summary>
         [JsonPropertyName("mainShape")]
-        public Shape MainShape { get { return this.MainShapeOption; } set { this.MainShapeOption = new(value); } }
+        public Shape MainShape { get { return this.MainShapeOption.Value; } set { this.MainShapeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NullableShape
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableShape
         /// </summary>
         [JsonPropertyName("nullableShape")]
-        public NullableShape NullableShape { get { return this.NullableShapeOption; } set { this.NullableShapeOption = new(value); } }
+        public NullableShape NullableShape { get { return this.NullableShapeOption.Value; } set { this.NullableShapeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ShapeOrNull
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ShapeOrNull
         /// </summary>
         [JsonPropertyName("shapeOrNull")]
-        public ShapeOrNull ShapeOrNull { get { return this.ShapeOrNullOption; } set { this.ShapeOrNullOption = new(value); } }
+        public ShapeOrNull ShapeOrNull { get { return this.ShapeOrNullOption.Value; } set { this.ShapeOrNullOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Shapes
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Shapes
         /// </summary>
         [JsonPropertyName("shapes")]
-        public List<Shape> Shapes { get { return this.ShapesOption; } set { this.ShapesOption = new(value); } }
+        public List<Shape> Shapes { get { return this.ShapesOption.Value; } set { this.ShapesOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayEnum
         /// </summary>
         [JsonPropertyName("array_enum")]
-        public List<EnumArrays.ArrayEnumEnum> ArrayEnum { get { return this.ArrayEnumOption; } set { this.ArrayEnumOption = new(value); } }
+        public List<EnumArrays.ArrayEnumEnum> ArrayEnum { get { return this.ArrayEnumOption.Value; } set { this.ArrayEnumOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/File.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Test capitalization</value>
         [JsonPropertyName("sourceURI")]
-        public string SourceURI { get { return this.SourceURIOption; } set { this.SourceURIOption = new(value); } }
+        public string SourceURI { get { return this.SourceURIOption.Value; } set { this.SourceURIOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets File
         /// </summary>
         [JsonPropertyName("file")]
-        public File File { get { return this.FileOption; } set { this.FileOption = new(value); } }
+        public File File { get { return this.FileOption.Value; } set { this.FileOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Files
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Files
         /// </summary>
         [JsonPropertyName("files")]
-        public List<File> Files { get { return this.FilesOption; } set { this.FilesOption = new(value); } }
+        public List<File> Files { get { return this.FilesOption.Value; } set { this.FilesOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Foo.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } set { this.BarOption = new(value); } }
+        public string Bar { get { return this.BarOption.Value; } set { this.BarOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public Foo String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public Foo String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -138,7 +138,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Binary
         /// </summary>
         [JsonPropertyName("binary")]
-        public System.IO.Stream Binary { get { return this.BinaryOption; } set { this.BinaryOption = new(value); } }
+        public System.IO.Stream Binary { get { return this.BinaryOption.Value; } set { this.BinaryOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DateTime
@@ -152,7 +152,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2007-12-03T10:15:30+01:00</example> */
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Decimal
@@ -165,7 +165,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Decimal
         /// </summary>
         [JsonPropertyName("decimal")]
-        public decimal? Decimal { get { return this.DecimalOption; } set { this.DecimalOption = new(value); } }
+        public decimal? Decimal { get { return this.DecimalOption.Value; } set { this.DecimalOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Double
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Double
         /// </summary>
         [JsonPropertyName("double")]
-        public double? Double { get { return this.DoubleOption; } set { this.DoubleOption = new(value); } }
+        public double? Double { get { return this.DoubleOption.Value; } set { this.DoubleOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName2
@@ -191,7 +191,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName2
         /// </summary>
         [JsonPropertyName("duplicate_property_name")]
-        public string DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option; } set { this.DuplicatePropertyName2Option = new(value); } }
+        public string DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option.Value; } set { this.DuplicatePropertyName2Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName
@@ -204,7 +204,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName
         /// </summary>
         [JsonPropertyName("@duplicate_property_name")]
-        public string DuplicatePropertyName { get { return this.DuplicatePropertyNameOption; } set { this.DuplicatePropertyNameOption = new(value); } }
+        public string DuplicatePropertyName { get { return this.DuplicatePropertyNameOption.Value; } set { this.DuplicatePropertyNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Float
@@ -217,7 +217,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Float
         /// </summary>
         [JsonPropertyName("float")]
-        public float? Float { get { return this.FloatOption; } set { this.FloatOption = new(value); } }
+        public float? Float { get { return this.FloatOption.Value; } set { this.FloatOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int32
@@ -230,7 +230,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32
         /// </summary>
         [JsonPropertyName("int32")]
-        public int? Int32 { get { return this.Int32Option; } set { this.Int32Option = new(value); } }
+        public int? Int32 { get { return this.Int32Option.Value; } set { this.Int32Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int32Range
@@ -243,7 +243,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32Range
         /// </summary>
         [JsonPropertyName("int32Range")]
-        public int? Int32Range { get { return this.Int32RangeOption; } set { this.Int32RangeOption = new(value); } }
+        public int? Int32Range { get { return this.Int32RangeOption.Value; } set { this.Int32RangeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64
@@ -256,7 +256,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64
         /// </summary>
         [JsonPropertyName("int64")]
-        public long? Int64 { get { return this.Int64Option; } set { this.Int64Option = new(value); } }
+        public long? Int64 { get { return this.Int64Option.Value; } set { this.Int64Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Negative
@@ -269,7 +269,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Negative
         /// </summary>
         [JsonPropertyName("int64Negative")]
-        public long? Int64Negative { get { return this.Int64NegativeOption; } set { this.Int64NegativeOption = new(value); } }
+        public long? Int64Negative { get { return this.Int64NegativeOption.Value; } set { this.Int64NegativeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64NegativeExclusive
@@ -282,7 +282,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64NegativeExclusive
         /// </summary>
         [JsonPropertyName("int64NegativeExclusive")]
-        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption; } set { this.Int64NegativeExclusiveOption = new(value); } }
+        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption.Value; } set { this.Int64NegativeExclusiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Positive
@@ -295,7 +295,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Positive
         /// </summary>
         [JsonPropertyName("int64Positive")]
-        public long? Int64Positive { get { return this.Int64PositiveOption; } set { this.Int64PositiveOption = new(value); } }
+        public long? Int64Positive { get { return this.Int64PositiveOption.Value; } set { this.Int64PositiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64PositiveExclusive
@@ -308,7 +308,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64PositiveExclusive
         /// </summary>
         [JsonPropertyName("int64PositiveExclusive")]
-        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption; } set { this.Int64PositiveExclusiveOption = new(value); } }
+        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption.Value; } set { this.Int64PositiveExclusiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Integer
@@ -321,7 +321,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [JsonPropertyName("integer")]
-        public int? Integer { get { return this.IntegerOption; } set { this.IntegerOption = new(value); } }
+        public int? Integer { get { return this.IntegerOption.Value; } set { this.IntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithBackslash
@@ -335,7 +335,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>None</value>
         [JsonPropertyName("pattern_with_backslash")]
-        public string PatternWithBackslash { get { return this.PatternWithBackslashOption; } set { this.PatternWithBackslashOption = new(value); } }
+        public string PatternWithBackslash { get { return this.PatternWithBackslashOption.Value; } set { this.PatternWithBackslashOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigits
@@ -349,7 +349,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string that is a 10 digit number. Can have leading zeros.</value>
         [JsonPropertyName("pattern_with_digits")]
-        public string PatternWithDigits { get { return this.PatternWithDigitsOption; } set { this.PatternWithDigitsOption = new(value); } }
+        public string PatternWithDigits { get { return this.PatternWithDigitsOption.Value; } set { this.PatternWithDigitsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigitsAndDelimiter
@@ -363,7 +363,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.</value>
         [JsonPropertyName("pattern_with_digits_and_delimiter")]
-        public string PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption; } set { this.PatternWithDigitsAndDelimiterOption = new(value); } }
+        public string PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption.Value; } set { this.PatternWithDigitsAndDelimiterOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of String
@@ -376,7 +376,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public string String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public string String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of StringFormattedAsDecimal
@@ -389,7 +389,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringFormattedAsDecimal
         /// </summary>
         [JsonPropertyName("string_formatted_as_decimal")]
-        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption; } set { this.StringFormattedAsDecimalOption = new(value); } }
+        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption.Value; } set { this.StringFormattedAsDecimalOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedInteger
@@ -402,7 +402,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [JsonPropertyName("unsigned_integer")]
-        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption; } set { this.UnsignedIntegerOption = new(value); } }
+        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption.Value; } set { this.UnsignedIntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedLong
@@ -415,7 +415,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedLong
         /// </summary>
         [JsonPropertyName("unsigned_long")]
-        public ulong? UnsignedLong { get { return this.UnsignedLongOption; } set { this.UnsignedLongOption = new(value); } }
+        public ulong? UnsignedLong { get { return this.UnsignedLongOption.Value; } set { this.UnsignedLongOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -429,7 +429,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -80,7 +80,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } }
+        public string Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Foo
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Foo
         /// </summary>
         [JsonPropertyName("foo")]
-        public string Foo { get { return this.FooOption; } }
+        public string Foo { get { return this.FooOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableMessage
         /// </summary>
         [JsonPropertyName("NullableMessage")]
-        public string NullableMessage { get { return this.NullableMessageOption; } set { this.NullableMessageOption = new(value); } }
+        public string NullableMessage { get { return this.NullableMessageOption.Value; } set { this.NullableMessageOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/List.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123List
         /// </summary>
         [JsonPropertyName("123-list")]
-        public string Var123List { get { return this.Var123ListOption; } set { this.Var123ListOption = new(value); } }
+        public string Var123List { get { return this.Var123ListOption.Value; } set { this.Var123ListOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets EscapedLiteralString
         /// </summary>
         [JsonPropertyName("escapedLiteralString")]
-        public string EscapedLiteralString { get { return this.EscapedLiteralStringOption; } set { this.EscapedLiteralStringOption = new(value); } }
+        public string EscapedLiteralString { get { return this.EscapedLiteralStringOption.Value; } set { this.EscapedLiteralStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnescapedLiteralString
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnescapedLiteralString
         /// </summary>
         [JsonPropertyName("unescapedLiteralString")]
-        public string UnescapedLiteralString { get { return this.UnescapedLiteralStringOption; } set { this.UnescapedLiteralStringOption = new(value); } }
+        public string UnescapedLiteralString { get { return this.UnescapedLiteralStringOption.Value; } set { this.UnescapedLiteralStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -125,7 +125,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DirectMap
         /// </summary>
         [JsonPropertyName("direct_map")]
-        public Dictionary<string, bool> DirectMap { get { return this.DirectMapOption; } set { this.DirectMapOption = new(value); } }
+        public Dictionary<string, bool> DirectMap { get { return this.DirectMapOption.Value; } set { this.DirectMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of IndirectMap
@@ -138,7 +138,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IndirectMap
         /// </summary>
         [JsonPropertyName("indirect_map")]
-        public Dictionary<string, bool> IndirectMap { get { return this.IndirectMapOption; } set { this.IndirectMapOption = new(value); } }
+        public Dictionary<string, bool> IndirectMap { get { return this.IndirectMapOption.Value; } set { this.IndirectMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapMapOfString
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapMapOfString
         /// </summary>
         [JsonPropertyName("map_map_of_string")]
-        public Dictionary<string, Dictionary<string, string>> MapMapOfString { get { return this.MapMapOfStringOption; } set { this.MapMapOfStringOption = new(value); } }
+        public Dictionary<string, Dictionary<string, string>> MapMapOfString { get { return this.MapMapOfStringOption.Value; } set { this.MapMapOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfEnumString
@@ -164,7 +164,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfEnumString
         /// </summary>
         [JsonPropertyName("map_of_enum_string")]
-        public Dictionary<string, MapTest.InnerEnum> MapOfEnumString { get { return this.MapOfEnumStringOption; } set { this.MapOfEnumStringOption = new(value); } }
+        public Dictionary<string, MapTest.InnerEnum> MapOfEnumString { get { return this.MapOfEnumStringOption.Value; } set { this.MapOfEnumStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedAnyOfContent Content { get { return this.ContentOption; } set { this.ContentOption = new(value); } }
+        public MixedAnyOfContent Content { get { return this.ContentOption.Value; } set { this.ContentOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedOneOfContent Content { get { return this.ContentOption; } set { this.ContentOption = new(value); } }
+        public MixedOneOfContent Content { get { return this.ContentOption.Value; } set { this.ContentOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateTime
         /// </summary>
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Map
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Map
         /// </summary>
         [JsonPropertyName("map")]
-        public Dictionary<string, Animal> Map { get { return this.MapOption; } set { this.MapOption = new(value); } }
+        public Dictionary<string, Animal> Map { get { return this.MapOption.Value; } set { this.MapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UuidWithPattern
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [JsonPropertyName("uuid_with_pattern")]
-        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption; } set { this.UuidWithPatternOption = new(value); } }
+        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption.Value; } set { this.UuidWithPatternOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public string Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public string Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("class")]
-        public string Class { get { return this.ClassOption; } set { this.ClassOption = new(value); } }
+        public string Class { get { return this.ClassOption.Value; } set { this.ClassOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public int? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public int? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarClient
         /// </summary>
         [JsonPropertyName("client")]
-        public string VarClient { get { return this.VarClientOption; } set { this.VarClientOption = new(value); } }
+        public string VarClient { get { return this.VarClientOption.Value; } set { this.VarClientOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -65,7 +65,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Property
         /// </summary>
         [JsonPropertyName("property")]
-        public string Property { get { return this.PropertyOption; } set { this.PropertyOption = new(value); } }
+        public string Property { get { return this.PropertyOption.Value; } set { this.PropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SnakeCase
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [JsonPropertyName("snake_case")]
-        public int? SnakeCase { get { return this.SnakeCaseOption; } }
+        public int? SnakeCase { get { return this.SnakeCaseOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Var123Number
@@ -91,7 +91,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123Number
         /// </summary>
         [JsonPropertyName("123Number")]
-        public int? Var123Number { get { return this.Var123NumberOption; } }
+        public int? Var123Number { get { return this.Var123NumberOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -75,7 +75,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("array_and_items_nullable_prop")]
-        public List<Object> ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption; } set { this.ArrayAndItemsNullablePropOption = new(value); } }
+        public List<Object> ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption.Value; } set { this.ArrayAndItemsNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayItemsNullable
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayItemsNullable
         /// </summary>
         [JsonPropertyName("array_items_nullable")]
-        public List<Object> ArrayItemsNullable { get { return this.ArrayItemsNullableOption; } set { this.ArrayItemsNullableOption = new(value); } }
+        public List<Object> ArrayItemsNullable { get { return this.ArrayItemsNullableOption.Value; } set { this.ArrayItemsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayNullableProp
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNullableProp
         /// </summary>
         [JsonPropertyName("array_nullable_prop")]
-        public List<Object> ArrayNullableProp { get { return this.ArrayNullablePropOption; } set { this.ArrayNullablePropOption = new(value); } }
+        public List<Object> ArrayNullableProp { get { return this.ArrayNullablePropOption.Value; } set { this.ArrayNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of BooleanProp
@@ -114,7 +114,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BooleanProp
         /// </summary>
         [JsonPropertyName("boolean_prop")]
-        public bool? BooleanProp { get { return this.BooleanPropOption; } set { this.BooleanPropOption = new(value); } }
+        public bool? BooleanProp { get { return this.BooleanPropOption.Value; } set { this.BooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DateProp
@@ -127,7 +127,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateProp
         /// </summary>
         [JsonPropertyName("date_prop")]
-        public DateOnly? DateProp { get { return this.DatePropOption; } set { this.DatePropOption = new(value); } }
+        public DateOnly? DateProp { get { return this.DatePropOption.Value; } set { this.DatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DatetimeProp
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DatetimeProp
         /// </summary>
         [JsonPropertyName("datetime_prop")]
-        public DateTime? DatetimeProp { get { return this.DatetimePropOption; } set { this.DatetimePropOption = new(value); } }
+        public DateTime? DatetimeProp { get { return this.DatetimePropOption.Value; } set { this.DatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of IntegerProp
@@ -153,7 +153,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IntegerProp
         /// </summary>
         [JsonPropertyName("integer_prop")]
-        public int? IntegerProp { get { return this.IntegerPropOption; } set { this.IntegerPropOption = new(value); } }
+        public int? IntegerProp { get { return this.IntegerPropOption.Value; } set { this.IntegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NumberProp
@@ -166,7 +166,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NumberProp
         /// </summary>
         [JsonPropertyName("number_prop")]
-        public decimal? NumberProp { get { return this.NumberPropOption; } set { this.NumberPropOption = new(value); } }
+        public decimal? NumberProp { get { return this.NumberPropOption.Value; } set { this.NumberPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectAndItemsNullableProp
@@ -179,7 +179,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("object_and_items_nullable_prop")]
-        public Dictionary<string, Object> ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption; } set { this.ObjectAndItemsNullablePropOption = new(value); } }
+        public Dictionary<string, Object> ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption.Value; } set { this.ObjectAndItemsNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectItemsNullable
@@ -192,7 +192,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectItemsNullable
         /// </summary>
         [JsonPropertyName("object_items_nullable")]
-        public Dictionary<string, Object> ObjectItemsNullable { get { return this.ObjectItemsNullableOption; } set { this.ObjectItemsNullableOption = new(value); } }
+        public Dictionary<string, Object> ObjectItemsNullable { get { return this.ObjectItemsNullableOption.Value; } set { this.ObjectItemsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectNullableProp
@@ -205,7 +205,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectNullableProp
         /// </summary>
         [JsonPropertyName("object_nullable_prop")]
-        public Dictionary<string, Object> ObjectNullableProp { get { return this.ObjectNullablePropOption; } set { this.ObjectNullablePropOption = new(value); } }
+        public Dictionary<string, Object> ObjectNullableProp { get { return this.ObjectNullablePropOption.Value; } set { this.ObjectNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of StringProp
@@ -218,7 +218,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringProp
         /// </summary>
         [JsonPropertyName("string_prop")]
-        public string StringProp { get { return this.StringPropOption; } set { this.StringPropOption = new(value); } }
+        public string StringProp { get { return this.StringPropOption.Value; } set { this.StringPropOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [JsonPropertyName("JustNumber")]
-        public decimal? JustNumber { get { return this.JustNumberOption; } set { this.JustNumberOption = new(value); } }
+        public decimal? JustNumber { get { return this.JustNumberOption.Value; } set { this.JustNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("bars")]
         [Obsolete]
-        public List<string> Bars { get { return this.BarsOption; } set { this.BarsOption = new(value); } }
+        public List<string> Bars { get { return this.BarsOption.Value; } set { this.BarsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DeprecatedRef
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("deprecatedRef")]
         [Obsolete]
-        public DeprecatedObject DeprecatedRef { get { return this.DeprecatedRefOption; } set { this.DeprecatedRefOption = new(value); } }
+        public DeprecatedObject DeprecatedRef { get { return this.DeprecatedRefOption.Value; } set { this.DeprecatedRefOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("id")]
         [Obsolete]
-        public decimal? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public decimal? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Order.cs
@@ -158,7 +158,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Complete
         /// </summary>
         [JsonPropertyName("complete")]
-        public bool? Complete { get { return this.CompleteOption; } set { this.CompleteOption = new(value); } }
+        public bool? Complete { get { return this.CompleteOption.Value; } set { this.CompleteOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -171,7 +171,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PetId
@@ -184,7 +184,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets PetId
         /// </summary>
         [JsonPropertyName("petId")]
-        public long? PetId { get { return this.PetIdOption; } set { this.PetIdOption = new(value); } }
+        public long? PetId { get { return this.PetIdOption.Value; } set { this.PetIdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Quantity
@@ -197,7 +197,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Quantity
         /// </summary>
         [JsonPropertyName("quantity")]
-        public int? Quantity { get { return this.QuantityOption; } set { this.QuantityOption = new(value); } }
+        public int? Quantity { get { return this.QuantityOption.Value; } set { this.QuantityOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ShipDate
@@ -211,7 +211,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2020-02-02T20:20:20.000222Z</example> */
         [JsonPropertyName("shipDate")]
-        public DateTime? ShipDate { get { return this.ShipDateOption; } set { this.ShipDateOption = new(value); } }
+        public DateTime? ShipDate { get { return this.ShipDateOption.Value; } set { this.ShipDateOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyBoolean
         /// </summary>
         [JsonPropertyName("my_boolean")]
-        public bool? MyBoolean { get { return this.MyBooleanOption; } set { this.MyBooleanOption = new(value); } }
+        public bool? MyBoolean { get { return this.MyBooleanOption.Value; } set { this.MyBooleanOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MyNumber
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [JsonPropertyName("my_number")]
-        public decimal? MyNumber { get { return this.MyNumberOption; } set { this.MyNumberOption = new(value); } }
+        public decimal? MyNumber { get { return this.MyNumberOption.Value; } set { this.MyNumberOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MyString
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyString
         /// </summary>
         [JsonPropertyName("my_string")]
-        public string MyString { get { return this.MyStringOption; } set { this.MyStringOption = new(value); } }
+        public string MyString { get { return this.MyStringOption.Value; } set { this.MyStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -171,7 +171,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Category
         /// </summary>
         [JsonPropertyName("category")]
-        public Category Category { get { return this.CategoryOption; } set { this.CategoryOption = new(value); } }
+        public Category Category { get { return this.CategoryOption.Value; } set { this.CategoryOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -184,7 +184,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Tags
@@ -197,7 +197,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Tags
         /// </summary>
         [JsonPropertyName("tags")]
-        public List<Tag> Tags { get { return this.TagsOption; } set { this.TagsOption = new(value); } }
+        public List<Tag> Tags { get { return this.TagsOption.Value; } set { this.TagsOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } }
+        public string Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Baz
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Baz
         /// </summary>
         [JsonPropertyName("baz")]
-        public string Baz { get { return this.BazOption; } set { this.BazOption = new(value); } }
+        public string Baz { get { return this.BazOption.Value; } set { this.BazOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -1412,7 +1412,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_notnullable_date_prop")]
-        public DateOnly? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption; } set { this.NotRequiredNotnullableDatePropOption = new(value); } }
+        public DateOnly? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption.Value; } set { this.NotRequiredNotnullableDatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNotnullableintegerProp
@@ -1425,7 +1425,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [JsonPropertyName("not_required_notnullableinteger_prop")]
-        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption; } set { this.NotRequiredNotnullableintegerPropOption = new(value); } }
+        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption.Value; } set { this.NotRequiredNotnullableintegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableDateProp
@@ -1438,7 +1438,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_date_prop")]
-        public DateOnly? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption; } set { this.NotRequiredNullableDatePropOption = new(value); } }
+        public DateOnly? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption.Value; } set { this.NotRequiredNullableDatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableIntegerProp
@@ -1451,7 +1451,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableIntegerProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_integer_prop")]
-        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption; } set { this.NotRequiredNullableIntegerPropOption = new(value); } }
+        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption.Value; } set { this.NotRequiredNullableIntegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableArrayOfString
@@ -1464,7 +1464,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_array_of_string")]
-        public List<string> NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption; } set { this.NotrequiredNotnullableArrayOfStringOption = new(value); } }
+        public List<string> NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption.Value; } set { this.NotrequiredNotnullableArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableBooleanProp
@@ -1477,7 +1477,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_boolean_prop")]
-        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption; } set { this.NotrequiredNotnullableBooleanPropOption = new(value); } }
+        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption.Value; } set { this.NotrequiredNotnullableBooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableDatetimeProp
@@ -1490,7 +1490,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_datetime_prop")]
-        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption; } set { this.NotrequiredNotnullableDatetimePropOption = new(value); } }
+        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption.Value; } set { this.NotrequiredNotnullableDatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableStringProp
@@ -1503,7 +1503,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_string_prop")]
-        public string NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption; } set { this.NotrequiredNotnullableStringPropOption = new(value); } }
+        public string NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption.Value; } set { this.NotrequiredNotnullableStringPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableUuid
@@ -1517,7 +1517,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_notnullable_uuid")]
-        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption; } set { this.NotrequiredNotnullableUuidOption = new(value); } }
+        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption.Value; } set { this.NotrequiredNotnullableUuidOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableArrayOfString
@@ -1530,7 +1530,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_nullable_array_of_string")]
-        public List<string> NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption; } set { this.NotrequiredNullableArrayOfStringOption = new(value); } }
+        public List<string> NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption.Value; } set { this.NotrequiredNullableArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableBooleanProp
@@ -1543,7 +1543,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_boolean_prop")]
-        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption; } set { this.NotrequiredNullableBooleanPropOption = new(value); } }
+        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption.Value; } set { this.NotrequiredNullableBooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableDatetimeProp
@@ -1556,7 +1556,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_datetime_prop")]
-        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption; } set { this.NotrequiredNullableDatetimePropOption = new(value); } }
+        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption.Value; } set { this.NotrequiredNullableDatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableStringProp
@@ -1569,7 +1569,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_string_prop")]
-        public string NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption; } set { this.NotrequiredNullableStringPropOption = new(value); } }
+        public string NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption.Value; } set { this.NotrequiredNullableStringPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableUuid
@@ -1583,7 +1583,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_nullable_uuid")]
-        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption; } set { this.NotrequiredNullableUuidOption = new(value); } }
+        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption.Value; } set { this.NotrequiredNullableUuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets RequiredNullableArrayOfString

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Result.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result code</value>
         [JsonPropertyName("code")]
-        public string Code { get { return this.CodeOption; } set { this.CodeOption = new(value); } }
+        public string Code { get { return this.CodeOption.Value; } set { this.CodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Data
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string> Data { get { return this.DataOption; } set { this.DataOption = new(value); } }
+        public Dictionary<string, string> Data { get { return this.DataOption.Value; } set { this.DataOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [JsonPropertyName("return")]
-        public int? VarReturn { get { return this.VarReturnOption; } set { this.VarReturnOption = new(value); } }
+        public int? VarReturn { get { return this.VarReturnOption.Value; } set { this.VarReturnOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Unsafe
@@ -84,7 +84,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Unsafe
         /// </summary>
         [JsonPropertyName("unsafe")]
-        public string Unsafe { get { return this.UnsafeOption; } set { this.UnsafeOption = new(value); } }
+        public string Unsafe { get { return this.UnsafeOption.Value; } set { this.UnsafeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Role
         /// </summary>
         [JsonPropertyName("role")]
-        public RolesReportsHashRole Role { get { return this.RoleOption; } set { this.RoleOption = new(value); } }
+        public RolesReportsHashRole Role { get { return this.RoleOption.Value; } set { this.RoleOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of RoleUuid
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [JsonPropertyName("role_uuid")]
-        public Guid? RoleUuid { get { return this.RoleUuidOption; } set { this.RoleUuidOption = new(value); } }
+        public Guid? RoleUuid { get { return this.RoleUuidOption.Value; } set { this.RoleUuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarSpecialModelName
         /// </summary>
         [JsonPropertyName("_special_model.name_")]
-        public string VarSpecialModelName { get { return this.VarSpecialModelNameOption; } set { this.VarSpecialModelNameOption = new(value); } }
+        public string VarSpecialModelName { get { return this.VarSpecialModelNameOption.Value; } set { this.VarSpecialModelNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SpecialPropertyName
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [JsonPropertyName("$special[property.name]")]
-        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption; } set { this.SpecialPropertyNameOption = new(value); } }
+        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption.Value; } set { this.SpecialPropertyNameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Value
         /// </summary>
         [JsonPropertyName("value")]
-        public string Value { get { return this.ValueOption; } set { this.ValueOption = new(value); } }
+        public string Value { get { return this.ValueOption.Value; } set { this.ValueOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets TestCollectionEndingWithWordList
         /// </summary>
         [JsonPropertyName("TestCollectionEndingWithWordList")]
-        public List<TestCollectionEndingWithWordList> TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption; } set { this.TestCollectionEndingWithWordListOption = new(value); } }
+        public List<TestCollectionEndingWithWordList> TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption.Value; } set { this.TestCollectionEndingWithWordListOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SomeProperty
         /// </summary>
         [JsonPropertyName("someProperty")]
-        public string SomeProperty { get { return this.SomePropertyOption; } set { this.SomePropertyOption = new(value); } }
+        public string SomeProperty { get { return this.SomePropertyOption.Value; } set { this.SomePropertyOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string> Data { get { return this.DataOption; } set { this.DataOption = new(value); } }
+        public Dictionary<string, string> Data { get { return this.DataOption.Value; } set { this.DataOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
         [JsonPropertyName("anyTypeProp")]
-        public Object AnyTypeProp { get { return this.AnyTypePropOption; } set { this.AnyTypePropOption = new(value); } }
+        public Object AnyTypeProp { get { return this.AnyTypePropOption.Value; } set { this.AnyTypePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of AnyTypePropNullable
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values.</value>
         [JsonPropertyName("anyTypePropNullable")]
-        public Object AnyTypePropNullable { get { return this.AnyTypePropNullableOption; } set { this.AnyTypePropNullableOption = new(value); } }
+        public Object AnyTypePropNullable { get { return this.AnyTypePropNullableOption.Value; } set { this.AnyTypePropNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Email
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Email
         /// </summary>
         [JsonPropertyName("email")]
-        public string Email { get { return this.EmailOption; } set { this.EmailOption = new(value); } }
+        public string Email { get { return this.EmailOption.Value; } set { this.EmailOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of FirstName
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets FirstName
         /// </summary>
         [JsonPropertyName("firstName")]
-        public string FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new(value); } }
+        public string FirstName { get { return this.FirstNameOption.Value; } set { this.FirstNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of LastName
@@ -142,7 +142,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LastName
         /// </summary>
         [JsonPropertyName("lastName")]
-        public string LastName { get { return this.LastNameOption; } set { this.LastNameOption = new(value); } }
+        public string LastName { get { return this.LastNameOption.Value; } set { this.LastNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredProps
@@ -156,7 +156,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredProps")]
-        public Object ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption; } set { this.ObjectWithNoDeclaredPropsOption = new(value); } }
+        public Object ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption.Value; } set { this.ObjectWithNoDeclaredPropsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredPropsNullable
@@ -170,7 +170,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredPropsNullable")]
-        public Object ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption; } set { this.ObjectWithNoDeclaredPropsNullableOption = new(value); } }
+        public Object ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption.Value; } set { this.ObjectWithNoDeclaredPropsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Password
@@ -183,7 +183,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Password
         /// </summary>
         [JsonPropertyName("password")]
-        public string Password { get { return this.PasswordOption; } set { this.PasswordOption = new(value); } }
+        public string Password { get { return this.PasswordOption.Value; } set { this.PasswordOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Phone
@@ -196,7 +196,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Phone
         /// </summary>
         [JsonPropertyName("phone")]
-        public string Phone { get { return this.PhoneOption; } set { this.PhoneOption = new(value); } }
+        public string Phone { get { return this.PhoneOption.Value; } set { this.PhoneOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UserStatus
@@ -210,7 +210,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [JsonPropertyName("userStatus")]
-        public int? UserStatus { get { return this.UserStatusOption; } set { this.UserStatusOption = new(value); } }
+        public int? UserStatus { get { return this.UserStatusOption.Value; } set { this.UserStatusOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Username
@@ -223,7 +223,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Username
         /// </summary>
         [JsonPropertyName("username")]
-        public string Username { get { return this.UsernameOption; } set { this.UsernameOption = new(value); } }
+        public string Username { get { return this.UsernameOption.Value; } set { this.UsernameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [JsonPropertyName("hasBaleen")]
-        public bool? HasBaleen { get { return this.HasBaleenOption; } set { this.HasBaleenOption = new(value); } }
+        public bool? HasBaleen { get { return this.HasBaleenOption.Value; } set { this.HasBaleenOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of HasTeeth
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasTeeth
         /// </summary>
         [JsonPropertyName("hasTeeth")]
-        public bool? HasTeeth { get { return this.HasTeethOption; } set { this.HasTeethOption = new(value); } }
+        public bool? HasTeeth { get { return this.HasTeethOption.Value; } set { this.HasTeethOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Activity.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ActivityOutputs
         /// </summary>
         [JsonPropertyName("activity_outputs")]
-        public Dictionary<string, List<ActivityOutputElementRepresentation>>? ActivityOutputs { get { return this.ActivityOutputsOption; } set { this.ActivityOutputsOption = new(value); } }
+        public Dictionary<string, List<ActivityOutputElementRepresentation>>? ActivityOutputs { get { return this.ActivityOutputsOption.Value; } set { this.ActivityOutputsOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop1
         /// </summary>
         [JsonPropertyName("prop1")]
-        public string? Prop1 { get { return this.Prop1Option; } set { this.Prop1Option = new(value); } }
+        public string? Prop1 { get { return this.Prop1Option.Value; } set { this.Prop1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Prop2
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop2
         /// </summary>
         [JsonPropertyName("prop2")]
-        public Object? Prop2 { get { return this.Prop2Option; } set { this.Prop2Option = new(value); } }
+        public Object? Prop2 { get { return this.Prop2Option.Value; } set { this.Prop2Option = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Anytype1
         /// </summary>
         [JsonPropertyName("anytype_1")]
-        public Object? Anytype1 { get { return this.Anytype1Option; } set { this.Anytype1Option = new(value); } }
+        public Object? Anytype1 { get { return this.Anytype1Option.Value; } set { this.Anytype1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of EmptyMap
@@ -84,7 +84,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>an object with no declared properties and no undeclared properties, hence it&#39;s an empty map.</value>
         [JsonPropertyName("empty_map")]
-        public Object? EmptyMap { get { return this.EmptyMapOption; } set { this.EmptyMapOption = new(value); } }
+        public Object? EmptyMap { get { return this.EmptyMapOption.Value; } set { this.EmptyMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfMapProperty
@@ -97,7 +97,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfMapProperty
         /// </summary>
         [JsonPropertyName("map_of_map_property")]
-        public Dictionary<string, Dictionary<string, string>>? MapOfMapProperty { get { return this.MapOfMapPropertyOption; } set { this.MapOfMapPropertyOption = new(value); } }
+        public Dictionary<string, Dictionary<string, string>>? MapOfMapProperty { get { return this.MapOfMapPropertyOption.Value; } set { this.MapOfMapPropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapProperty
@@ -110,7 +110,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapProperty
         /// </summary>
         [JsonPropertyName("map_property")]
-        public Dictionary<string, string>? MapProperty { get { return this.MapPropertyOption; } set { this.MapPropertyOption = new(value); } }
+        public Dictionary<string, string>? MapProperty { get { return this.MapPropertyOption.Value; } set { this.MapPropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype1
@@ -123,7 +123,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype1
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_1")]
-        public Object? MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new(value); } }
+        public Object? MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype2
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype2
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_2")]
-        public Object? MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new(value); } }
+        public Object? MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype3
@@ -149,7 +149,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype3
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_3")]
-        public Dictionary<string, Object>? MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new(value); } }
+        public Dictionary<string, Object>? MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesString
@@ -162,7 +162,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesString
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_string")]
-        public Dictionary<string, string>? MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption; } set { this.MapWithUndeclaredPropertiesStringOption = new(value); } }
+        public Dictionary<string, string>? MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption.Value; } set { this.MapWithUndeclaredPropertiesStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Animal.cs
@@ -64,7 +64,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [JsonPropertyName("code")]
-        public int? Code { get { return this.CodeOption; } set { this.CodeOption = new(value); } }
+        public int? Code { get { return this.CodeOption.Value; } set { this.CodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Message
@@ -73,7 +73,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Message
         /// </summary>
         [JsonPropertyName("message")]
-        public string? Message { get { return this.MessageOption; } set { this.MessageOption = new(value); } }
+        public string? Message { get { return this.MessageOption.Value; } set { this.MessageOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Type
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Type
         /// </summary>
         [JsonPropertyName("type")]
-        public string? Type { get { return this.TypeOption; } set { this.TypeOption = new(value); } }
+        public string? Type { get { return this.TypeOption.Value; } set { this.TypeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Apple.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ColorCode
         /// </summary>
         [JsonPropertyName("color_code")]
-        public string? ColorCode { get { return this.ColorCodeOption; } set { this.ColorCodeOption = new(value); } }
+        public string? ColorCode { get { return this.ColorCodeOption.Value; } set { this.ColorCodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Cultivar
@@ -73,7 +73,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Cultivar
         /// </summary>
         [JsonPropertyName("cultivar")]
-        public string? Cultivar { get { return this.CultivarOption; } set { this.CultivarOption = new(value); } }
+        public string? Cultivar { get { return this.CultivarOption.Value; } set { this.CultivarOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Origin
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Origin
         /// </summary>
         [JsonPropertyName("origin")]
-        public string? Origin { get { return this.OriginOption; } set { this.OriginOption = new(value); } }
+        public string? Origin { get { return this.OriginOption.Value; } set { this.OriginOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -64,7 +64,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [JsonPropertyName("mealy")]
-        public bool? Mealy { get { return this.MealyOption; } set { this.MealyOption = new(value); } }
+        public bool? Mealy { get { return this.MealyOption.Value; } set { this.MealyOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayArrayNumber")]
-        public List<List<decimal>>? ArrayArrayNumber { get { return this.ArrayArrayNumberOption; } set { this.ArrayArrayNumberOption = new(value); } }
+        public List<List<decimal>>? ArrayArrayNumber { get { return this.ArrayArrayNumberOption.Value; } set { this.ArrayArrayNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayNumber")]
-        public List<decimal>? ArrayNumber { get { return this.ArrayNumberOption; } set { this.ArrayNumberOption = new(value); } }
+        public List<decimal>? ArrayNumber { get { return this.ArrayNumberOption.Value; } set { this.ArrayNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfInteger
         /// </summary>
         [JsonPropertyName("array_array_of_integer")]
-        public List<List<long>>? ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption; } set { this.ArrayArrayOfIntegerOption = new(value); } }
+        public List<List<long>>? ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption.Value; } set { this.ArrayArrayOfIntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayArrayOfModel
@@ -73,7 +73,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfModel
         /// </summary>
         [JsonPropertyName("array_array_of_model")]
-        public List<List<ReadOnlyFirst>>? ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption; } set { this.ArrayArrayOfModelOption = new(value); } }
+        public List<List<ReadOnlyFirst>>? ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption.Value; } set { this.ArrayArrayOfModelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayOfString
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayOfString
         /// </summary>
         [JsonPropertyName("array_of_string")]
-        public List<string>? ArrayOfString { get { return this.ArrayOfStringOption; } set { this.ArrayOfStringOption = new(value); } }
+        public List<string>? ArrayOfString { get { return this.ArrayOfStringOption.Value; } set { this.ArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Banana.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [JsonPropertyName("lengthCm")]
-        public decimal? LengthCm { get { return this.LengthCmOption; } set { this.LengthCmOption = new(value); } }
+        public decimal? LengthCm { get { return this.LengthCmOption.Value; } set { this.LengthCmOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -64,7 +64,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [JsonPropertyName("sweet")]
-        public bool? Sweet { get { return this.SweetOption; } set { this.SweetOption = new(value); } }
+        public bool? Sweet { get { return this.SweetOption.Value; } set { this.SweetOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Name of the pet </value>
         [JsonPropertyName("ATT_NAME")]
-        public string? ATT_NAME { get { return this.ATT_NAMEOption; } set { this.ATT_NAMEOption = new(value); } }
+        public string? ATT_NAME { get { return this.ATT_NAMEOption.Value; } set { this.ATT_NAMEOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalCamel
@@ -80,7 +80,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalCamel
         /// </summary>
         [JsonPropertyName("CapitalCamel")]
-        public string? CapitalCamel { get { return this.CapitalCamelOption; } set { this.CapitalCamelOption = new(value); } }
+        public string? CapitalCamel { get { return this.CapitalCamelOption.Value; } set { this.CapitalCamelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalSnake
@@ -93,7 +93,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalSnake
         /// </summary>
         [JsonPropertyName("Capital_Snake")]
-        public string? CapitalSnake { get { return this.CapitalSnakeOption; } set { this.CapitalSnakeOption = new(value); } }
+        public string? CapitalSnake { get { return this.CapitalSnakeOption.Value; } set { this.CapitalSnakeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SCAETHFlowPoints
@@ -106,7 +106,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SCAETHFlowPoints
         /// </summary>
         [JsonPropertyName("SCA_ETH_Flow_Points")]
-        public string? SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption; } set { this.SCAETHFlowPointsOption = new(value); } }
+        public string? SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption.Value; } set { this.SCAETHFlowPointsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SmallCamel
@@ -119,7 +119,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallCamel
         /// </summary>
         [JsonPropertyName("smallCamel")]
-        public string? SmallCamel { get { return this.SmallCamelOption; } set { this.SmallCamelOption = new(value); } }
+        public string? SmallCamel { get { return this.SmallCamelOption.Value; } set { this.SmallCamelOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SmallSnake
@@ -132,7 +132,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallSnake
         /// </summary>
         [JsonPropertyName("small_Snake")]
-        public string? SmallSnake { get { return this.SmallSnakeOption; } set { this.SmallSnakeOption = new(value); } }
+        public string? SmallSnake { get { return this.SmallSnakeOption.Value; } set { this.SmallSnakeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [JsonPropertyName("declawed")]
-        public bool? Declawed { get { return this.DeclawedOption; } set { this.DeclawedOption = new(value); } }
+        public bool? Declawed { get { return this.DeclawedOption.Value; } set { this.DeclawedOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -109,7 +109,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// The discriminator

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("_class")]
-        public string? Class { get { return this.ClassOption; } set { this.ClassOption = new(value); } }
+        public string? Class { get { return this.ClassOption.Value; } set { this.ClassOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>Fri Jul 21 00:00:00 UTC 2017</example> */
         [JsonPropertyName("dateOnlyProperty")]
-        public DateOnly? DateOnlyProperty { get { return this.DateOnlyPropertyOption; } set { this.DateOnlyPropertyOption = new(value); } }
+        public DateOnly? DateOnlyProperty { get { return this.DateOnlyPropertyOption.Value; } set { this.DateOnlyPropertyOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Dog.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Breed
         /// </summary>
         [JsonPropertyName("breed")]
-        public string? Breed { get { return this.BreedOption; } set { this.BreedOption = new(value); } }
+        public string? Breed { get { return this.BreedOption.Value; } set { this.BreedOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Drawing.cs
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MainShape
         /// </summary>
         [JsonPropertyName("mainShape")]
-        public Shape? MainShape { get { return this.MainShapeOption; } set { this.MainShapeOption = new(value); } }
+        public Shape? MainShape { get { return this.MainShapeOption.Value; } set { this.MainShapeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NullableShape
@@ -75,7 +75,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableShape
         /// </summary>
         [JsonPropertyName("nullableShape")]
-        public NullableShape? NullableShape { get { return this.NullableShapeOption; } set { this.NullableShapeOption = new(value); } }
+        public NullableShape? NullableShape { get { return this.NullableShapeOption.Value; } set { this.NullableShapeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ShapeOrNull
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ShapeOrNull
         /// </summary>
         [JsonPropertyName("shapeOrNull")]
-        public ShapeOrNull? ShapeOrNull { get { return this.ShapeOrNullOption; } set { this.ShapeOrNullOption = new(value); } }
+        public ShapeOrNull? ShapeOrNull { get { return this.ShapeOrNullOption.Value; } set { this.ShapeOrNullOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Shapes
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Shapes
         /// </summary>
         [JsonPropertyName("shapes")]
-        public List<Shape>? Shapes { get { return this.ShapesOption; } set { this.ShapesOption = new(value); } }
+        public List<Shape>? Shapes { get { return this.ShapesOption.Value; } set { this.ShapesOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -203,7 +203,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayEnum
         /// </summary>
         [JsonPropertyName("array_enum")]
-        public List<EnumArrays.ArrayEnumEnum>? ArrayEnum { get { return this.ArrayEnumOption; } set { this.ArrayEnumOption = new(value); } }
+        public List<EnumArrays.ArrayEnumEnum>? ArrayEnum { get { return this.ArrayEnumOption.Value; } set { this.ArrayEnumOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/File.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Test capitalization</value>
         [JsonPropertyName("sourceURI")]
-        public string? SourceURI { get { return this.SourceURIOption; } set { this.SourceURIOption = new(value); } }
+        public string? SourceURI { get { return this.SourceURIOption.Value; } set { this.SourceURIOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets File
         /// </summary>
         [JsonPropertyName("file")]
-        public File? File { get { return this.FileOption; } set { this.FileOption = new(value); } }
+        public File? File { get { return this.FileOption.Value; } set { this.FileOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Files
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Files
         /// </summary>
         [JsonPropertyName("files")]
-        public List<File>? Files { get { return this.FilesOption; } set { this.FilesOption = new(value); } }
+        public List<File>? Files { get { return this.FilesOption.Value; } set { this.FilesOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Foo.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string? Bar { get { return this.BarOption; } set { this.BarOption = new(value); } }
+        public string? Bar { get { return this.BarOption.Value; } set { this.BarOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public Foo? String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public Foo? String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -141,7 +141,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Binary
         /// </summary>
         [JsonPropertyName("binary")]
-        public System.IO.Stream? Binary { get { return this.BinaryOption; } set { this.BinaryOption = new(value); } }
+        public System.IO.Stream? Binary { get { return this.BinaryOption.Value; } set { this.BinaryOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DateTime
@@ -155,7 +155,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2007-12-03T10:15:30+01:00</example> */
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Decimal
@@ -168,7 +168,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Decimal
         /// </summary>
         [JsonPropertyName("decimal")]
-        public decimal? Decimal { get { return this.DecimalOption; } set { this.DecimalOption = new(value); } }
+        public decimal? Decimal { get { return this.DecimalOption.Value; } set { this.DecimalOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Double
@@ -181,7 +181,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Double
         /// </summary>
         [JsonPropertyName("double")]
-        public double? Double { get { return this.DoubleOption; } set { this.DoubleOption = new(value); } }
+        public double? Double { get { return this.DoubleOption.Value; } set { this.DoubleOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName2
@@ -194,7 +194,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName2
         /// </summary>
         [JsonPropertyName("duplicate_property_name")]
-        public string? DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option; } set { this.DuplicatePropertyName2Option = new(value); } }
+        public string? DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option.Value; } set { this.DuplicatePropertyName2Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName
@@ -207,7 +207,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName
         /// </summary>
         [JsonPropertyName("@duplicate_property_name")]
-        public string? DuplicatePropertyName { get { return this.DuplicatePropertyNameOption; } set { this.DuplicatePropertyNameOption = new(value); } }
+        public string? DuplicatePropertyName { get { return this.DuplicatePropertyNameOption.Value; } set { this.DuplicatePropertyNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Float
@@ -220,7 +220,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Float
         /// </summary>
         [JsonPropertyName("float")]
-        public float? Float { get { return this.FloatOption; } set { this.FloatOption = new(value); } }
+        public float? Float { get { return this.FloatOption.Value; } set { this.FloatOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int32
@@ -233,7 +233,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32
         /// </summary>
         [JsonPropertyName("int32")]
-        public int? Int32 { get { return this.Int32Option; } set { this.Int32Option = new(value); } }
+        public int? Int32 { get { return this.Int32Option.Value; } set { this.Int32Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int32Range
@@ -246,7 +246,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32Range
         /// </summary>
         [JsonPropertyName("int32Range")]
-        public int? Int32Range { get { return this.Int32RangeOption; } set { this.Int32RangeOption = new(value); } }
+        public int? Int32Range { get { return this.Int32RangeOption.Value; } set { this.Int32RangeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64
@@ -259,7 +259,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64
         /// </summary>
         [JsonPropertyName("int64")]
-        public long? Int64 { get { return this.Int64Option; } set { this.Int64Option = new(value); } }
+        public long? Int64 { get { return this.Int64Option.Value; } set { this.Int64Option = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Negative
@@ -272,7 +272,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Negative
         /// </summary>
         [JsonPropertyName("int64Negative")]
-        public long? Int64Negative { get { return this.Int64NegativeOption; } set { this.Int64NegativeOption = new(value); } }
+        public long? Int64Negative { get { return this.Int64NegativeOption.Value; } set { this.Int64NegativeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64NegativeExclusive
@@ -285,7 +285,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64NegativeExclusive
         /// </summary>
         [JsonPropertyName("int64NegativeExclusive")]
-        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption; } set { this.Int64NegativeExclusiveOption = new(value); } }
+        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption.Value; } set { this.Int64NegativeExclusiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Positive
@@ -298,7 +298,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Positive
         /// </summary>
         [JsonPropertyName("int64Positive")]
-        public long? Int64Positive { get { return this.Int64PositiveOption; } set { this.Int64PositiveOption = new(value); } }
+        public long? Int64Positive { get { return this.Int64PositiveOption.Value; } set { this.Int64PositiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Int64PositiveExclusive
@@ -311,7 +311,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64PositiveExclusive
         /// </summary>
         [JsonPropertyName("int64PositiveExclusive")]
-        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption; } set { this.Int64PositiveExclusiveOption = new(value); } }
+        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption.Value; } set { this.Int64PositiveExclusiveOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Integer
@@ -324,7 +324,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [JsonPropertyName("integer")]
-        public int? Integer { get { return this.IntegerOption; } set { this.IntegerOption = new(value); } }
+        public int? Integer { get { return this.IntegerOption.Value; } set { this.IntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithBackslash
@@ -338,7 +338,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>None</value>
         [JsonPropertyName("pattern_with_backslash")]
-        public string? PatternWithBackslash { get { return this.PatternWithBackslashOption; } set { this.PatternWithBackslashOption = new(value); } }
+        public string? PatternWithBackslash { get { return this.PatternWithBackslashOption.Value; } set { this.PatternWithBackslashOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigits
@@ -352,7 +352,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string that is a 10 digit number. Can have leading zeros.</value>
         [JsonPropertyName("pattern_with_digits")]
-        public string? PatternWithDigits { get { return this.PatternWithDigitsOption; } set { this.PatternWithDigitsOption = new(value); } }
+        public string? PatternWithDigits { get { return this.PatternWithDigitsOption.Value; } set { this.PatternWithDigitsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigitsAndDelimiter
@@ -366,7 +366,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.</value>
         [JsonPropertyName("pattern_with_digits_and_delimiter")]
-        public string? PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption; } set { this.PatternWithDigitsAndDelimiterOption = new(value); } }
+        public string? PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption.Value; } set { this.PatternWithDigitsAndDelimiterOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of String
@@ -379,7 +379,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public string? String { get { return this.StringOption; } set { this.StringOption = new(value); } }
+        public string? String { get { return this.StringOption.Value; } set { this.StringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of StringFormattedAsDecimal
@@ -392,7 +392,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringFormattedAsDecimal
         /// </summary>
         [JsonPropertyName("string_formatted_as_decimal")]
-        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption; } set { this.StringFormattedAsDecimalOption = new(value); } }
+        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption.Value; } set { this.StringFormattedAsDecimalOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedInteger
@@ -405,7 +405,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [JsonPropertyName("unsigned_integer")]
-        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption; } set { this.UnsignedIntegerOption = new(value); } }
+        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption.Value; } set { this.UnsignedIntegerOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedLong
@@ -418,7 +418,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedLong
         /// </summary>
         [JsonPropertyName("unsigned_long")]
-        public ulong? UnsignedLong { get { return this.UnsignedLongOption; } set { this.UnsignedLongOption = new(value); } }
+        public ulong? UnsignedLong { get { return this.UnsignedLongOption.Value; } set { this.UnsignedLongOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -432,7 +432,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
@@ -79,7 +79,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string? Color { get { return this.ColorOption; } set { this.ColorOption = new(value); } }
+        public string? Color { get { return this.ColorOption.Value; } set { this.ColorOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string? Bar { get { return this.BarOption; } }
+        public string? Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Foo
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Foo
         /// </summary>
         [JsonPropertyName("foo")]
-        public string? Foo { get { return this.FooOption; } }
+        public string? Foo { get { return this.FooOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableMessage
         /// </summary>
         [JsonPropertyName("NullableMessage")]
-        public string? NullableMessage { get { return this.NullableMessageOption; } set { this.NullableMessageOption = new(value); } }
+        public string? NullableMessage { get { return this.NullableMessageOption.Value; } set { this.NullableMessageOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/List.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123List
         /// </summary>
         [JsonPropertyName("123-list")]
-        public string? Var123List { get { return this.Var123ListOption; } set { this.Var123ListOption = new(value); } }
+        public string? Var123List { get { return this.Var123ListOption.Value; } set { this.Var123ListOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets EscapedLiteralString
         /// </summary>
         [JsonPropertyName("escapedLiteralString")]
-        public string? EscapedLiteralString { get { return this.EscapedLiteralStringOption; } set { this.EscapedLiteralStringOption = new(value); } }
+        public string? EscapedLiteralString { get { return this.EscapedLiteralStringOption.Value; } set { this.EscapedLiteralStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UnescapedLiteralString
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnescapedLiteralString
         /// </summary>
         [JsonPropertyName("unescapedLiteralString")]
-        public string? UnescapedLiteralString { get { return this.UnescapedLiteralStringOption; } set { this.UnescapedLiteralStringOption = new(value); } }
+        public string? UnescapedLiteralString { get { return this.UnescapedLiteralStringOption.Value; } set { this.UnescapedLiteralStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MapTest.cs
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DirectMap
         /// </summary>
         [JsonPropertyName("direct_map")]
-        public Dictionary<string, bool>? DirectMap { get { return this.DirectMapOption; } set { this.DirectMapOption = new(value); } }
+        public Dictionary<string, bool>? DirectMap { get { return this.DirectMapOption.Value; } set { this.DirectMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of IndirectMap
@@ -141,7 +141,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IndirectMap
         /// </summary>
         [JsonPropertyName("indirect_map")]
-        public Dictionary<string, bool>? IndirectMap { get { return this.IndirectMapOption; } set { this.IndirectMapOption = new(value); } }
+        public Dictionary<string, bool>? IndirectMap { get { return this.IndirectMapOption.Value; } set { this.IndirectMapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapMapOfString
@@ -154,7 +154,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapMapOfString
         /// </summary>
         [JsonPropertyName("map_map_of_string")]
-        public Dictionary<string, Dictionary<string, string>>? MapMapOfString { get { return this.MapMapOfStringOption; } set { this.MapMapOfStringOption = new(value); } }
+        public Dictionary<string, Dictionary<string, string>>? MapMapOfString { get { return this.MapMapOfStringOption.Value; } set { this.MapMapOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfEnumString
@@ -167,7 +167,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfEnumString
         /// </summary>
         [JsonPropertyName("map_of_enum_string")]
-        public Dictionary<string, MapTest.InnerEnum>? MapOfEnumString { get { return this.MapOfEnumStringOption; } set { this.MapOfEnumStringOption = new(value); } }
+        public Dictionary<string, MapTest.InnerEnum>? MapOfEnumString { get { return this.MapOfEnumStringOption.Value; } set { this.MapOfEnumStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedAnyOfContent? Content { get { return this.ContentOption; } set { this.ContentOption = new(value); } }
+        public MixedAnyOfContent? Content { get { return this.ContentOption.Value; } set { this.ContentOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedOneOfContent? Content { get { return this.ContentOption; } set { this.ContentOption = new(value); } }
+        public MixedOneOfContent? Content { get { return this.ContentOption.Value; } set { this.ContentOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateTime
         /// </summary>
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Map
@@ -75,7 +75,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Map
         /// </summary>
         [JsonPropertyName("map")]
-        public Dictionary<string, Animal>? Map { get { return this.MapOption; } set { this.MapOption = new(value); } }
+        public Dictionary<string, Animal>? Map { get { return this.MapOption.Value; } set { this.MapOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UuidWithPattern
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [JsonPropertyName("uuid_with_pattern")]
-        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption; } set { this.UuidWithPatternOption = new(value); } }
+        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption.Value; } set { this.UuidWithPatternOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public string? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public string? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("class")]
-        public string? Class { get { return this.ClassOption; } set { this.ClassOption = new(value); } }
+        public string? Class { get { return this.ClassOption.Value; } set { this.ClassOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public int? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public int? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarClient
         /// </summary>
         [JsonPropertyName("client")]
-        public string? VarClient { get { return this.VarClientOption; } set { this.VarClientOption = new(value); } }
+        public string? VarClient { get { return this.VarClientOption.Value; } set { this.VarClientOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Property
         /// </summary>
         [JsonPropertyName("property")]
-        public string? Property { get { return this.PropertyOption; } set { this.PropertyOption = new(value); } }
+        public string? Property { get { return this.PropertyOption.Value; } set { this.PropertyOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SnakeCase
@@ -81,7 +81,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [JsonPropertyName("snake_case")]
-        public int? SnakeCase { get { return this.SnakeCaseOption; } }
+        public int? SnakeCase { get { return this.SnakeCaseOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Var123Number
@@ -94,7 +94,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123Number
         /// </summary>
         [JsonPropertyName("123Number")]
-        public int? Var123Number { get { return this.Var123NumberOption; } }
+        public int? Var123Number { get { return this.Var123NumberOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("array_and_items_nullable_prop")]
-        public List<Object>? ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption; } set { this.ArrayAndItemsNullablePropOption = new(value); } }
+        public List<Object>? ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption.Value; } set { this.ArrayAndItemsNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayItemsNullable
@@ -91,7 +91,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayItemsNullable
         /// </summary>
         [JsonPropertyName("array_items_nullable")]
-        public List<Object>? ArrayItemsNullable { get { return this.ArrayItemsNullableOption; } set { this.ArrayItemsNullableOption = new(value); } }
+        public List<Object>? ArrayItemsNullable { get { return this.ArrayItemsNullableOption.Value; } set { this.ArrayItemsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayNullableProp
@@ -104,7 +104,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNullableProp
         /// </summary>
         [JsonPropertyName("array_nullable_prop")]
-        public List<Object>? ArrayNullableProp { get { return this.ArrayNullablePropOption; } set { this.ArrayNullablePropOption = new(value); } }
+        public List<Object>? ArrayNullableProp { get { return this.ArrayNullablePropOption.Value; } set { this.ArrayNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of BooleanProp
@@ -117,7 +117,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BooleanProp
         /// </summary>
         [JsonPropertyName("boolean_prop")]
-        public bool? BooleanProp { get { return this.BooleanPropOption; } set { this.BooleanPropOption = new(value); } }
+        public bool? BooleanProp { get { return this.BooleanPropOption.Value; } set { this.BooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DateProp
@@ -130,7 +130,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateProp
         /// </summary>
         [JsonPropertyName("date_prop")]
-        public DateOnly? DateProp { get { return this.DatePropOption; } set { this.DatePropOption = new(value); } }
+        public DateOnly? DateProp { get { return this.DatePropOption.Value; } set { this.DatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DatetimeProp
@@ -143,7 +143,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DatetimeProp
         /// </summary>
         [JsonPropertyName("datetime_prop")]
-        public DateTime? DatetimeProp { get { return this.DatetimePropOption; } set { this.DatetimePropOption = new(value); } }
+        public DateTime? DatetimeProp { get { return this.DatetimePropOption.Value; } set { this.DatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of IntegerProp
@@ -156,7 +156,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IntegerProp
         /// </summary>
         [JsonPropertyName("integer_prop")]
-        public int? IntegerProp { get { return this.IntegerPropOption; } set { this.IntegerPropOption = new(value); } }
+        public int? IntegerProp { get { return this.IntegerPropOption.Value; } set { this.IntegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NumberProp
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NumberProp
         /// </summary>
         [JsonPropertyName("number_prop")]
-        public decimal? NumberProp { get { return this.NumberPropOption; } set { this.NumberPropOption = new(value); } }
+        public decimal? NumberProp { get { return this.NumberPropOption.Value; } set { this.NumberPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectAndItemsNullableProp
@@ -182,7 +182,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("object_and_items_nullable_prop")]
-        public Dictionary<string, Object>? ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption; } set { this.ObjectAndItemsNullablePropOption = new(value); } }
+        public Dictionary<string, Object>? ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption.Value; } set { this.ObjectAndItemsNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectItemsNullable
@@ -195,7 +195,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectItemsNullable
         /// </summary>
         [JsonPropertyName("object_items_nullable")]
-        public Dictionary<string, Object>? ObjectItemsNullable { get { return this.ObjectItemsNullableOption; } set { this.ObjectItemsNullableOption = new(value); } }
+        public Dictionary<string, Object>? ObjectItemsNullable { get { return this.ObjectItemsNullableOption.Value; } set { this.ObjectItemsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectNullableProp
@@ -208,7 +208,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectNullableProp
         /// </summary>
         [JsonPropertyName("object_nullable_prop")]
-        public Dictionary<string, Object>? ObjectNullableProp { get { return this.ObjectNullablePropOption; } set { this.ObjectNullablePropOption = new(value); } }
+        public Dictionary<string, Object>? ObjectNullableProp { get { return this.ObjectNullablePropOption.Value; } set { this.ObjectNullablePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of StringProp
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringProp
         /// </summary>
         [JsonPropertyName("string_prop")]
-        public string? StringProp { get { return this.StringPropOption; } set { this.StringPropOption = new(value); } }
+        public string? StringProp { get { return this.StringPropOption.Value; } set { this.StringPropOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [JsonPropertyName("JustNumber")]
-        public decimal? JustNumber { get { return this.JustNumberOption; } set { this.JustNumberOption = new(value); } }
+        public decimal? JustNumber { get { return this.JustNumberOption.Value; } set { this.JustNumberOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("bars")]
         [Obsolete]
-        public List<string>? Bars { get { return this.BarsOption; } set { this.BarsOption = new(value); } }
+        public List<string>? Bars { get { return this.BarsOption.Value; } set { this.BarsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of DeprecatedRef
@@ -77,7 +77,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("deprecatedRef")]
         [Obsolete]
-        public DeprecatedObject? DeprecatedRef { get { return this.DeprecatedRefOption; } set { this.DeprecatedRefOption = new(value); } }
+        public DeprecatedObject? DeprecatedRef { get { return this.DeprecatedRefOption.Value; } set { this.DeprecatedRefOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -91,7 +91,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("id")]
         [Obsolete]
-        public decimal? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public decimal? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -104,7 +104,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public string? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Order.cs
@@ -161,7 +161,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Complete
         /// </summary>
         [JsonPropertyName("complete")]
-        public bool? Complete { get { return this.CompleteOption; } set { this.CompleteOption = new(value); } }
+        public bool? Complete { get { return this.CompleteOption.Value; } set { this.CompleteOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -174,7 +174,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of PetId
@@ -187,7 +187,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets PetId
         /// </summary>
         [JsonPropertyName("petId")]
-        public long? PetId { get { return this.PetIdOption; } set { this.PetIdOption = new(value); } }
+        public long? PetId { get { return this.PetIdOption.Value; } set { this.PetIdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Quantity
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Quantity
         /// </summary>
         [JsonPropertyName("quantity")]
-        public int? Quantity { get { return this.QuantityOption; } set { this.QuantityOption = new(value); } }
+        public int? Quantity { get { return this.QuantityOption.Value; } set { this.QuantityOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ShipDate
@@ -214,7 +214,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2020-02-02T20:20:20.000222Z</example> */
         [JsonPropertyName("shipDate")]
-        public DateTime? ShipDate { get { return this.ShipDateOption; } set { this.ShipDateOption = new(value); } }
+        public DateTime? ShipDate { get { return this.ShipDateOption.Value; } set { this.ShipDateOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyBoolean
         /// </summary>
         [JsonPropertyName("my_boolean")]
-        public bool? MyBoolean { get { return this.MyBooleanOption; } set { this.MyBooleanOption = new(value); } }
+        public bool? MyBoolean { get { return this.MyBooleanOption.Value; } set { this.MyBooleanOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MyNumber
@@ -73,7 +73,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [JsonPropertyName("my_number")]
-        public decimal? MyNumber { get { return this.MyNumberOption; } set { this.MyNumberOption = new(value); } }
+        public decimal? MyNumber { get { return this.MyNumberOption.Value; } set { this.MyNumberOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of MyString
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyString
         /// </summary>
         [JsonPropertyName("my_string")]
-        public string? MyString { get { return this.MyStringOption; } set { this.MyStringOption = new(value); } }
+        public string? MyString { get { return this.MyStringOption.Value; } set { this.MyStringOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
@@ -174,7 +174,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Category
         /// </summary>
         [JsonPropertyName("category")]
-        public Category? Category { get { return this.CategoryOption; } set { this.CategoryOption = new(value); } }
+        public Category? Category { get { return this.CategoryOption.Value; } set { this.CategoryOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -187,7 +187,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Tags
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Tags
         /// </summary>
         [JsonPropertyName("tags")]
-        public List<Tag>? Tags { get { return this.TagsOption; } set { this.TagsOption = new(value); } }
+        public List<Tag>? Tags { get { return this.TagsOption.Value; } set { this.TagsOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string? Bar { get { return this.BarOption; } }
+        public string? Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Baz
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Baz
         /// </summary>
         [JsonPropertyName("baz")]
-        public string? Baz { get { return this.BazOption; } set { this.BazOption = new(value); } }
+        public string? Baz { get { return this.BazOption.Value; } set { this.BazOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -1415,7 +1415,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_notnullable_date_prop")]
-        public DateOnly? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption; } set { this.NotRequiredNotnullableDatePropOption = new(value); } }
+        public DateOnly? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption.Value; } set { this.NotRequiredNotnullableDatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNotnullableintegerProp
@@ -1428,7 +1428,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [JsonPropertyName("not_required_notnullableinteger_prop")]
-        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption; } set { this.NotRequiredNotnullableintegerPropOption = new(value); } }
+        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption.Value; } set { this.NotRequiredNotnullableintegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableDateProp
@@ -1441,7 +1441,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_date_prop")]
-        public DateOnly? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption; } set { this.NotRequiredNullableDatePropOption = new(value); } }
+        public DateOnly? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption.Value; } set { this.NotRequiredNullableDatePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableIntegerProp
@@ -1454,7 +1454,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableIntegerProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_integer_prop")]
-        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption; } set { this.NotRequiredNullableIntegerPropOption = new(value); } }
+        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption.Value; } set { this.NotRequiredNullableIntegerPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableArrayOfString
@@ -1467,7 +1467,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_array_of_string")]
-        public List<string>? NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption; } set { this.NotrequiredNotnullableArrayOfStringOption = new(value); } }
+        public List<string>? NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption.Value; } set { this.NotrequiredNotnullableArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableBooleanProp
@@ -1480,7 +1480,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_boolean_prop")]
-        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption; } set { this.NotrequiredNotnullableBooleanPropOption = new(value); } }
+        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption.Value; } set { this.NotrequiredNotnullableBooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableDatetimeProp
@@ -1493,7 +1493,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_datetime_prop")]
-        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption; } set { this.NotrequiredNotnullableDatetimePropOption = new(value); } }
+        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption.Value; } set { this.NotrequiredNotnullableDatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableStringProp
@@ -1506,7 +1506,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_string_prop")]
-        public string? NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption; } set { this.NotrequiredNotnullableStringPropOption = new(value); } }
+        public string? NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption.Value; } set { this.NotrequiredNotnullableStringPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableUuid
@@ -1520,7 +1520,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_notnullable_uuid")]
-        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption; } set { this.NotrequiredNotnullableUuidOption = new(value); } }
+        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption.Value; } set { this.NotrequiredNotnullableUuidOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableArrayOfString
@@ -1533,7 +1533,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_nullable_array_of_string")]
-        public List<string>? NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption; } set { this.NotrequiredNullableArrayOfStringOption = new(value); } }
+        public List<string>? NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption.Value; } set { this.NotrequiredNullableArrayOfStringOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableBooleanProp
@@ -1546,7 +1546,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_boolean_prop")]
-        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption; } set { this.NotrequiredNullableBooleanPropOption = new(value); } }
+        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption.Value; } set { this.NotrequiredNullableBooleanPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableDatetimeProp
@@ -1559,7 +1559,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_datetime_prop")]
-        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption; } set { this.NotrequiredNullableDatetimePropOption = new(value); } }
+        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption.Value; } set { this.NotrequiredNullableDatetimePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableStringProp
@@ -1572,7 +1572,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_string_prop")]
-        public string? NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption; } set { this.NotrequiredNullableStringPropOption = new(value); } }
+        public string? NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption.Value; } set { this.NotrequiredNullableStringPropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableUuid
@@ -1586,7 +1586,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_nullable_uuid")]
-        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption; } set { this.NotrequiredNullableUuidOption = new(value); } }
+        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption.Value; } set { this.NotrequiredNullableUuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets RequiredNullableArrayOfString

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Result.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result code</value>
         [JsonPropertyName("code")]
-        public string? Code { get { return this.CodeOption; } set { this.CodeOption = new(value); } }
+        public string? Code { get { return this.CodeOption.Value; } set { this.CodeOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Data
@@ -75,7 +75,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string>? Data { get { return this.DataOption; } set { this.DataOption = new(value); } }
+        public Dictionary<string, string>? Data { get { return this.DataOption.Value; } set { this.DataOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -89,7 +89,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [JsonPropertyName("return")]
-        public int? VarReturn { get { return this.VarReturnOption; } set { this.VarReturnOption = new(value); } }
+        public int? VarReturn { get { return this.VarReturnOption.Value; } set { this.VarReturnOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Unsafe
@@ -87,7 +87,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Unsafe
         /// </summary>
         [JsonPropertyName("unsafe")]
-        public string? Unsafe { get { return this.UnsafeOption; } set { this.UnsafeOption = new(value); } }
+        public string? Unsafe { get { return this.UnsafeOption.Value; } set { this.UnsafeOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Role
         /// </summary>
         [JsonPropertyName("role")]
-        public RolesReportsHashRole? Role { get { return this.RoleOption; } set { this.RoleOption = new(value); } }
+        public RolesReportsHashRole? Role { get { return this.RoleOption.Value; } set { this.RoleOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of RoleUuid
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [JsonPropertyName("role_uuid")]
-        public Guid? RoleUuid { get { return this.RoleUuidOption; } set { this.RoleUuidOption = new(value); } }
+        public Guid? RoleUuid { get { return this.RoleUuidOption.Value; } set { this.RoleUuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarSpecialModelName
         /// </summary>
         [JsonPropertyName("_special_model.name_")]
-        public string? VarSpecialModelName { get { return this.VarSpecialModelNameOption; } set { this.VarSpecialModelNameOption = new(value); } }
+        public string? VarSpecialModelName { get { return this.VarSpecialModelNameOption.Value; } set { this.VarSpecialModelNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of SpecialPropertyName
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [JsonPropertyName("$special[property.name]")]
-        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption; } set { this.SpecialPropertyNameOption = new(value); } }
+        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption.Value; } set { this.SpecialPropertyNameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string? Name { get { return this.NameOption; } set { this.NameOption = new(value); } }
+        public string? Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Value
         /// </summary>
         [JsonPropertyName("value")]
-        public string? Value { get { return this.ValueOption; } set { this.ValueOption = new(value); } }
+        public string? Value { get { return this.ValueOption.Value; } set { this.ValueOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets TestCollectionEndingWithWordList
         /// </summary>
         [JsonPropertyName("TestCollectionEndingWithWordList")]
-        public List<TestCollectionEndingWithWordList>? TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption; } set { this.TestCollectionEndingWithWordListOption = new(value); } }
+        public List<TestCollectionEndingWithWordList>? TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption.Value; } set { this.TestCollectionEndingWithWordListOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SomeProperty
         /// </summary>
         [JsonPropertyName("someProperty")]
-        public string? SomeProperty { get { return this.SomePropertyOption; } set { this.SomePropertyOption = new(value); } }
+        public string? SomeProperty { get { return this.SomePropertyOption.Value; } set { this.SomePropertyOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string>? Data { get { return this.DataOption; } set { this.DataOption = new(value); } }
+        public Dictionary<string, string>? Data { get { return this.DataOption.Value; } set { this.DataOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string? Uuid { get { return this.UuidOption; } set { this.UuidOption = new(value); } }
+        public string? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
@@ -79,7 +79,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
         [JsonPropertyName("anyTypeProp")]
-        public Object? AnyTypeProp { get { return this.AnyTypePropOption; } set { this.AnyTypePropOption = new(value); } }
+        public Object? AnyTypeProp { get { return this.AnyTypePropOption.Value; } set { this.AnyTypePropOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of AnyTypePropNullable
@@ -93,7 +93,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values.</value>
         [JsonPropertyName("anyTypePropNullable")]
-        public Object? AnyTypePropNullable { get { return this.AnyTypePropNullableOption; } set { this.AnyTypePropNullableOption = new(value); } }
+        public Object? AnyTypePropNullable { get { return this.AnyTypePropNullableOption.Value; } set { this.AnyTypePropNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Email
@@ -106,7 +106,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Email
         /// </summary>
         [JsonPropertyName("email")]
-        public string? Email { get { return this.EmailOption; } set { this.EmailOption = new(value); } }
+        public string? Email { get { return this.EmailOption.Value; } set { this.EmailOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of FirstName
@@ -119,7 +119,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets FirstName
         /// </summary>
         [JsonPropertyName("firstName")]
-        public string? FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new(value); } }
+        public string? FirstName { get { return this.FirstNameOption.Value; } set { this.FirstNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -132,7 +132,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of LastName
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LastName
         /// </summary>
         [JsonPropertyName("lastName")]
-        public string? LastName { get { return this.LastNameOption; } set { this.LastNameOption = new(value); } }
+        public string? LastName { get { return this.LastNameOption.Value; } set { this.LastNameOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredProps
@@ -159,7 +159,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredProps")]
-        public Object? ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption; } set { this.ObjectWithNoDeclaredPropsOption = new(value); } }
+        public Object? ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption.Value; } set { this.ObjectWithNoDeclaredPropsOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredPropsNullable
@@ -173,7 +173,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredPropsNullable")]
-        public Object? ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption; } set { this.ObjectWithNoDeclaredPropsNullableOption = new(value); } }
+        public Object? ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption.Value; } set { this.ObjectWithNoDeclaredPropsNullableOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Password
@@ -186,7 +186,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Password
         /// </summary>
         [JsonPropertyName("password")]
-        public string? Password { get { return this.PasswordOption; } set { this.PasswordOption = new(value); } }
+        public string? Password { get { return this.PasswordOption.Value; } set { this.PasswordOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Phone
@@ -199,7 +199,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Phone
         /// </summary>
         [JsonPropertyName("phone")]
-        public string? Phone { get { return this.PhoneOption; } set { this.PhoneOption = new(value); } }
+        public string? Phone { get { return this.PhoneOption.Value; } set { this.PhoneOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of UserStatus
@@ -213,7 +213,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [JsonPropertyName("userStatus")]
-        public int? UserStatus { get { return this.UserStatusOption; } set { this.UserStatusOption = new(value); } }
+        public int? UserStatus { get { return this.UserStatusOption.Value; } set { this.UserStatusOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Username
@@ -226,7 +226,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Username
         /// </summary>
         [JsonPropertyName("username")]
-        public string? Username { get { return this.UsernameOption; } set { this.UsernameOption = new(value); } }
+        public string? Username { get { return this.UsernameOption.Value; } set { this.UsernameOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
@@ -66,7 +66,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [JsonPropertyName("hasBaleen")]
-        public bool? HasBaleen { get { return this.HasBaleenOption; } set { this.HasBaleenOption = new(value); } }
+        public bool? HasBaleen { get { return this.HasBaleenOption.Value; } set { this.HasBaleenOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of HasTeeth
@@ -79,7 +79,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasTeeth
         /// </summary>
         [JsonPropertyName("hasTeeth")]
-        public bool? HasTeeth { get { return this.HasTeethOption; } set { this.HasTeethOption = new(value); } }
+        public bool? HasTeeth { get { return this.HasTeethOption.Value; } set { this.HasTeethOption = new(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate/src/Org.OpenAPITools/Model/NowGet200Response.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Now
         /// </summary>
         [JsonPropertyName("now")]
-        public DateTime? Now { get { return this.NowOption; } set { this.NowOption = new(value); } }
+        public DateTime? Now { get { return this.NowOption.Value; } set { this.NowOption = new(value); } }
 
         /// <summary>
         /// Used to track the state of Today
@@ -69,7 +69,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Today
         /// </summary>
         [JsonPropertyName("today")]
-        public DateTime? Today { get { return this.TodayOption; } set { this.TodayOption = new(value); } }
+        public DateTime? Today { get { return this.TodayOption.Value; } set { this.TodayOption = new(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Activity.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ActivityOutputs
         /// </summary>
         [JsonPropertyName("activity_outputs")]
-        public Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs { get { return this.ActivityOutputsOption; } set { this.ActivityOutputsOption = new Option<Dictionary<string, List<ActivityOutputElementRepresentation>>>(value); } }
+        public Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs { get { return this.ActivityOutputsOption.Value; } set { this.ActivityOutputsOption = new Option<Dictionary<string, List<ActivityOutputElementRepresentation>>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop1
         /// </summary>
         [JsonPropertyName("prop1")]
-        public string Prop1 { get { return this.Prop1Option; } set { this.Prop1Option = new Option<string>(value); } }
+        public string Prop1 { get { return this.Prop1Option.Value; } set { this.Prop1Option = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Prop2
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop2
         /// </summary>
         [JsonPropertyName("prop2")]
-        public Object Prop2 { get { return this.Prop2Option; } set { this.Prop2Option = new Option<Object>(value); } }
+        public Object Prop2 { get { return this.Prop2Option.Value; } set { this.Prop2Option = new Option<Object>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Anytype1
         /// </summary>
         [JsonPropertyName("anytype_1")]
-        public Object Anytype1 { get { return this.Anytype1Option; } set { this.Anytype1Option = new Option<Object>(value); } }
+        public Object Anytype1 { get { return this.Anytype1Option.Value; } set { this.Anytype1Option = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of EmptyMap
@@ -81,7 +81,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>an object with no declared properties and no undeclared properties, hence it&#39;s an empty map.</value>
         [JsonPropertyName("empty_map")]
-        public Object EmptyMap { get { return this.EmptyMapOption; } set { this.EmptyMapOption = new Option<Object>(value); } }
+        public Object EmptyMap { get { return this.EmptyMapOption.Value; } set { this.EmptyMapOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfMapProperty
@@ -94,7 +94,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfMapProperty
         /// </summary>
         [JsonPropertyName("map_of_map_property")]
-        public Dictionary<string, Dictionary<string, string>> MapOfMapProperty { get { return this.MapOfMapPropertyOption; } set { this.MapOfMapPropertyOption = new Option<Dictionary<string, Dictionary<string, string>>>(value); } }
+        public Dictionary<string, Dictionary<string, string>> MapOfMapProperty { get { return this.MapOfMapPropertyOption.Value; } set { this.MapOfMapPropertyOption = new Option<Dictionary<string, Dictionary<string, string>>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapProperty
@@ -107,7 +107,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapProperty
         /// </summary>
         [JsonPropertyName("map_property")]
-        public Dictionary<string, string> MapProperty { get { return this.MapPropertyOption; } set { this.MapPropertyOption = new Option<Dictionary<string, string>>(value); } }
+        public Dictionary<string, string> MapProperty { get { return this.MapPropertyOption.Value; } set { this.MapPropertyOption = new Option<Dictionary<string, string>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype1
@@ -120,7 +120,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype1
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_1")]
-        public Object MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new Option<Object>(value); } }
+        public Object MapWithUndeclaredPropertiesAnytype1 { get { return this.MapWithUndeclaredPropertiesAnytype1Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype1Option = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype2
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype2
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_2")]
-        public Object MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new Option<Object>(value); } }
+        public Object MapWithUndeclaredPropertiesAnytype2 { get { return this.MapWithUndeclaredPropertiesAnytype2Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype2Option = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesAnytype3
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype3
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_anytype_3")]
-        public Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new Option<Dictionary<string, Object>>(value); } }
+        public Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 { get { return this.MapWithUndeclaredPropertiesAnytype3Option.Value; } set { this.MapWithUndeclaredPropertiesAnytype3Option = new Option<Dictionary<string, Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapWithUndeclaredPropertiesString
@@ -159,7 +159,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapWithUndeclaredPropertiesString
         /// </summary>
         [JsonPropertyName("map_with_undeclared_properties_string")]
-        public Dictionary<string, string> MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption; } set { this.MapWithUndeclaredPropertiesStringOption = new Option<Dictionary<string, string>>(value); } }
+        public Dictionary<string, string> MapWithUndeclaredPropertiesString { get { return this.MapWithUndeclaredPropertiesStringOption.Value; } set { this.MapWithUndeclaredPropertiesStringOption = new Option<Dictionary<string, string>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Animal.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new Option<string>(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [JsonPropertyName("code")]
-        public int? Code { get { return this.CodeOption; } set { this.CodeOption = new Option<int?>(value); } }
+        public int? Code { get { return this.CodeOption.Value; } set { this.CodeOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Message
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Message
         /// </summary>
         [JsonPropertyName("message")]
-        public string Message { get { return this.MessageOption; } set { this.MessageOption = new Option<string>(value); } }
+        public string Message { get { return this.MessageOption.Value; } set { this.MessageOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Type
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Type
         /// </summary>
         [JsonPropertyName("type")]
-        public string Type { get { return this.TypeOption; } set { this.TypeOption = new Option<string>(value); } }
+        public string Type { get { return this.TypeOption.Value; } set { this.TypeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Apple.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ColorCode
         /// </summary>
         [JsonPropertyName("color_code")]
-        public string ColorCode { get { return this.ColorCodeOption; } set { this.ColorCodeOption = new Option<string>(value); } }
+        public string ColorCode { get { return this.ColorCodeOption.Value; } set { this.ColorCodeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Cultivar
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Cultivar
         /// </summary>
         [JsonPropertyName("cultivar")]
-        public string Cultivar { get { return this.CultivarOption; } set { this.CultivarOption = new Option<string>(value); } }
+        public string Cultivar { get { return this.CultivarOption.Value; } set { this.CultivarOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Origin
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Origin
         /// </summary>
         [JsonPropertyName("origin")]
-        public string Origin { get { return this.OriginOption; } set { this.OriginOption = new Option<string>(value); } }
+        public string Origin { get { return this.OriginOption.Value; } set { this.OriginOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [JsonPropertyName("mealy")]
-        public bool? Mealy { get { return this.MealyOption; } set { this.MealyOption = new Option<bool?>(value); } }
+        public bool? Mealy { get { return this.MealyOption.Value; } set { this.MealyOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayArrayNumber")]
-        public List<List<decimal>> ArrayArrayNumber { get { return this.ArrayArrayNumberOption; } set { this.ArrayArrayNumberOption = new Option<List<List<decimal>>>(value); } }
+        public List<List<decimal>> ArrayArrayNumber { get { return this.ArrayArrayNumberOption.Value; } set { this.ArrayArrayNumberOption = new Option<List<List<decimal>>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNumber
         /// </summary>
         [JsonPropertyName("ArrayNumber")]
-        public List<decimal> ArrayNumber { get { return this.ArrayNumberOption; } set { this.ArrayNumberOption = new Option<List<decimal>>(value); } }
+        public List<decimal> ArrayNumber { get { return this.ArrayNumberOption.Value; } set { this.ArrayNumberOption = new Option<List<decimal>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfInteger
         /// </summary>
         [JsonPropertyName("array_array_of_integer")]
-        public List<List<long>> ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption; } set { this.ArrayArrayOfIntegerOption = new Option<List<List<long>>>(value); } }
+        public List<List<long>> ArrayArrayOfInteger { get { return this.ArrayArrayOfIntegerOption.Value; } set { this.ArrayArrayOfIntegerOption = new Option<List<List<long>>>(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayArrayOfModel
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfModel
         /// </summary>
         [JsonPropertyName("array_array_of_model")]
-        public List<List<ReadOnlyFirst>> ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption; } set { this.ArrayArrayOfModelOption = new Option<List<List<ReadOnlyFirst>>>(value); } }
+        public List<List<ReadOnlyFirst>> ArrayArrayOfModel { get { return this.ArrayArrayOfModelOption.Value; } set { this.ArrayArrayOfModelOption = new Option<List<List<ReadOnlyFirst>>>(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayOfString
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayOfString
         /// </summary>
         [JsonPropertyName("array_of_string")]
-        public List<string> ArrayOfString { get { return this.ArrayOfStringOption; } set { this.ArrayOfStringOption = new Option<List<string>>(value); } }
+        public List<string> ArrayOfString { get { return this.ArrayOfStringOption.Value; } set { this.ArrayOfStringOption = new Option<List<string>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Banana.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [JsonPropertyName("lengthCm")]
-        public decimal? LengthCm { get { return this.LengthCmOption; } set { this.LengthCmOption = new Option<decimal?>(value); } }
+        public decimal? LengthCm { get { return this.LengthCmOption.Value; } set { this.LengthCmOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [JsonPropertyName("sweet")]
-        public bool? Sweet { get { return this.SweetOption; } set { this.SweetOption = new Option<bool?>(value); } }
+        public bool? Sweet { get { return this.SweetOption.Value; } set { this.SweetOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -64,7 +64,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Name of the pet </value>
         [JsonPropertyName("ATT_NAME")]
-        public string ATT_NAME { get { return this.ATT_NAMEOption; } set { this.ATT_NAMEOption = new Option<string>(value); } }
+        public string ATT_NAME { get { return this.ATT_NAMEOption.Value; } set { this.ATT_NAMEOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalCamel
@@ -77,7 +77,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalCamel
         /// </summary>
         [JsonPropertyName("CapitalCamel")]
-        public string CapitalCamel { get { return this.CapitalCamelOption; } set { this.CapitalCamelOption = new Option<string>(value); } }
+        public string CapitalCamel { get { return this.CapitalCamelOption.Value; } set { this.CapitalCamelOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of CapitalSnake
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets CapitalSnake
         /// </summary>
         [JsonPropertyName("Capital_Snake")]
-        public string CapitalSnake { get { return this.CapitalSnakeOption; } set { this.CapitalSnakeOption = new Option<string>(value); } }
+        public string CapitalSnake { get { return this.CapitalSnakeOption.Value; } set { this.CapitalSnakeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SCAETHFlowPoints
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SCAETHFlowPoints
         /// </summary>
         [JsonPropertyName("SCA_ETH_Flow_Points")]
-        public string SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption; } set { this.SCAETHFlowPointsOption = new Option<string>(value); } }
+        public string SCAETHFlowPoints { get { return this.SCAETHFlowPointsOption.Value; } set { this.SCAETHFlowPointsOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SmallCamel
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallCamel
         /// </summary>
         [JsonPropertyName("smallCamel")]
-        public string SmallCamel { get { return this.SmallCamelOption; } set { this.SmallCamelOption = new Option<string>(value); } }
+        public string SmallCamel { get { return this.SmallCamelOption.Value; } set { this.SmallCamelOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SmallSnake
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallSnake
         /// </summary>
         [JsonPropertyName("small_Snake")]
-        public string SmallSnake { get { return this.SmallSnakeOption; } set { this.SmallSnakeOption = new Option<string>(value); } }
+        public string SmallSnake { get { return this.SmallSnakeOption.Value; } set { this.SmallSnakeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [JsonPropertyName("declawed")]
-        public bool? Declawed { get { return this.DeclawedOption; } set { this.DeclawedOption = new Option<bool?>(value); } }
+        public bool? Declawed { get { return this.DeclawedOption.Value; } set { this.DeclawedOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -106,7 +106,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new Option<string>(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<string>(value); } }
 
         /// <summary>
         /// The discriminator

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("_class")]
-        public string Class { get { return this.ClassOption; } set { this.ClassOption = new Option<string>(value); } }
+        public string Class { get { return this.ClassOption.Value; } set { this.ClassOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>Fri Jul 21 00:00:00 UTC 2017</example> */
         [JsonPropertyName("dateOnlyProperty")]
-        public DateTime? DateOnlyProperty { get { return this.DateOnlyPropertyOption; } set { this.DateOnlyPropertyOption = new Option<DateTime?>(value); } }
+        public DateTime? DateOnlyProperty { get { return this.DateOnlyPropertyOption.Value; } set { this.DateOnlyPropertyOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new Option<string>(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Breed
         /// </summary>
         [JsonPropertyName("breed")]
-        public string Breed { get { return this.BreedOption; } set { this.BreedOption = new Option<string>(value); } }
+        public string Breed { get { return this.BreedOption.Value; } set { this.BreedOption = new Option<string>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MainShape
         /// </summary>
         [JsonPropertyName("mainShape")]
-        public Shape MainShape { get { return this.MainShapeOption; } set { this.MainShapeOption = new Option<Shape>(value); } }
+        public Shape MainShape { get { return this.MainShapeOption.Value; } set { this.MainShapeOption = new Option<Shape>(value); } }
 
         /// <summary>
         /// Used to track the state of NullableShape
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableShape
         /// </summary>
         [JsonPropertyName("nullableShape")]
-        public NullableShape NullableShape { get { return this.NullableShapeOption; } set { this.NullableShapeOption = new Option<NullableShape>(value); } }
+        public NullableShape NullableShape { get { return this.NullableShapeOption.Value; } set { this.NullableShapeOption = new Option<NullableShape>(value); } }
 
         /// <summary>
         /// Used to track the state of ShapeOrNull
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ShapeOrNull
         /// </summary>
         [JsonPropertyName("shapeOrNull")]
-        public ShapeOrNull ShapeOrNull { get { return this.ShapeOrNullOption; } set { this.ShapeOrNullOption = new Option<ShapeOrNull>(value); } }
+        public ShapeOrNull ShapeOrNull { get { return this.ShapeOrNullOption.Value; } set { this.ShapeOrNullOption = new Option<ShapeOrNull>(value); } }
 
         /// <summary>
         /// Used to track the state of Shapes
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Shapes
         /// </summary>
         [JsonPropertyName("shapes")]
-        public List<Shape> Shapes { get { return this.ShapesOption; } set { this.ShapesOption = new Option<List<Shape>>(value); } }
+        public List<Shape> Shapes { get { return this.ShapesOption.Value; } set { this.ShapesOption = new Option<List<Shape>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayEnum
         /// </summary>
         [JsonPropertyName("array_enum")]
-        public List<EnumArrays.ArrayEnumEnum> ArrayEnum { get { return this.ArrayEnumOption; } set { this.ArrayEnumOption = new Option<List<EnumArrays.ArrayEnumEnum>>(value); } }
+        public List<EnumArrays.ArrayEnumEnum> ArrayEnum { get { return this.ArrayEnumOption.Value; } set { this.ArrayEnumOption = new Option<List<EnumArrays.ArrayEnumEnum>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/File.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Test capitalization</value>
         [JsonPropertyName("sourceURI")]
-        public string SourceURI { get { return this.SourceURIOption; } set { this.SourceURIOption = new Option<string>(value); } }
+        public string SourceURI { get { return this.SourceURIOption.Value; } set { this.SourceURIOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets File
         /// </summary>
         [JsonPropertyName("file")]
-        public File File { get { return this.FileOption; } set { this.FileOption = new Option<File>(value); } }
+        public File File { get { return this.FileOption.Value; } set { this.FileOption = new Option<File>(value); } }
 
         /// <summary>
         /// Used to track the state of Files
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Files
         /// </summary>
         [JsonPropertyName("files")]
-        public List<File> Files { get { return this.FilesOption; } set { this.FilesOption = new Option<List<File>>(value); } }
+        public List<File> Files { get { return this.FilesOption.Value; } set { this.FilesOption = new Option<List<File>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Foo.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } set { this.BarOption = new Option<string>(value); } }
+        public string Bar { get { return this.BarOption.Value; } set { this.BarOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public Foo String { get { return this.StringOption; } set { this.StringOption = new Option<Foo>(value); } }
+        public Foo String { get { return this.StringOption.Value; } set { this.StringOption = new Option<Foo>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -138,7 +138,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Binary
         /// </summary>
         [JsonPropertyName("binary")]
-        public System.IO.Stream Binary { get { return this.BinaryOption; } set { this.BinaryOption = new Option<System.IO.Stream>(value); } }
+        public System.IO.Stream Binary { get { return this.BinaryOption.Value; } set { this.BinaryOption = new Option<System.IO.Stream>(value); } }
 
         /// <summary>
         /// Used to track the state of DateTime
@@ -152,7 +152,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2007-12-03T10:15:30+01:00</example> */
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new Option<DateTime?>(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of Decimal
@@ -165,7 +165,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Decimal
         /// </summary>
         [JsonPropertyName("decimal")]
-        public decimal? Decimal { get { return this.DecimalOption; } set { this.DecimalOption = new Option<decimal?>(value); } }
+        public decimal? Decimal { get { return this.DecimalOption.Value; } set { this.DecimalOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of Double
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Double
         /// </summary>
         [JsonPropertyName("double")]
-        public double? Double { get { return this.DoubleOption; } set { this.DoubleOption = new Option<double?>(value); } }
+        public double? Double { get { return this.DoubleOption.Value; } set { this.DoubleOption = new Option<double?>(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName2
@@ -191,7 +191,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName2
         /// </summary>
         [JsonPropertyName("duplicate_property_name")]
-        public string DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option; } set { this.DuplicatePropertyName2Option = new Option<string>(value); } }
+        public string DuplicatePropertyName2 { get { return this.DuplicatePropertyName2Option.Value; } set { this.DuplicatePropertyName2Option = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of DuplicatePropertyName
@@ -204,7 +204,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DuplicatePropertyName
         /// </summary>
         [JsonPropertyName("@duplicate_property_name")]
-        public string DuplicatePropertyName { get { return this.DuplicatePropertyNameOption; } set { this.DuplicatePropertyNameOption = new Option<string>(value); } }
+        public string DuplicatePropertyName { get { return this.DuplicatePropertyNameOption.Value; } set { this.DuplicatePropertyNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Float
@@ -217,7 +217,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Float
         /// </summary>
         [JsonPropertyName("float")]
-        public float? Float { get { return this.FloatOption; } set { this.FloatOption = new Option<float?>(value); } }
+        public float? Float { get { return this.FloatOption.Value; } set { this.FloatOption = new Option<float?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int32
@@ -230,7 +230,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32
         /// </summary>
         [JsonPropertyName("int32")]
-        public int? Int32 { get { return this.Int32Option; } set { this.Int32Option = new Option<int?>(value); } }
+        public int? Int32 { get { return this.Int32Option.Value; } set { this.Int32Option = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int32Range
@@ -243,7 +243,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32Range
         /// </summary>
         [JsonPropertyName("int32Range")]
-        public int? Int32Range { get { return this.Int32RangeOption; } set { this.Int32RangeOption = new Option<int?>(value); } }
+        public int? Int32Range { get { return this.Int32RangeOption.Value; } set { this.Int32RangeOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64
@@ -256,7 +256,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64
         /// </summary>
         [JsonPropertyName("int64")]
-        public long? Int64 { get { return this.Int64Option; } set { this.Int64Option = new Option<long?>(value); } }
+        public long? Int64 { get { return this.Int64Option.Value; } set { this.Int64Option = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Negative
@@ -269,7 +269,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Negative
         /// </summary>
         [JsonPropertyName("int64Negative")]
-        public long? Int64Negative { get { return this.Int64NegativeOption; } set { this.Int64NegativeOption = new Option<long?>(value); } }
+        public long? Int64Negative { get { return this.Int64NegativeOption.Value; } set { this.Int64NegativeOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64NegativeExclusive
@@ -282,7 +282,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64NegativeExclusive
         /// </summary>
         [JsonPropertyName("int64NegativeExclusive")]
-        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption; } set { this.Int64NegativeExclusiveOption = new Option<long?>(value); } }
+        public long? Int64NegativeExclusive { get { return this.Int64NegativeExclusiveOption.Value; } set { this.Int64NegativeExclusiveOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64Positive
@@ -295,7 +295,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64Positive
         /// </summary>
         [JsonPropertyName("int64Positive")]
-        public long? Int64Positive { get { return this.Int64PositiveOption; } set { this.Int64PositiveOption = new Option<long?>(value); } }
+        public long? Int64Positive { get { return this.Int64PositiveOption.Value; } set { this.Int64PositiveOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Int64PositiveExclusive
@@ -308,7 +308,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64PositiveExclusive
         /// </summary>
         [JsonPropertyName("int64PositiveExclusive")]
-        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption; } set { this.Int64PositiveExclusiveOption = new Option<long?>(value); } }
+        public long? Int64PositiveExclusive { get { return this.Int64PositiveExclusiveOption.Value; } set { this.Int64PositiveExclusiveOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Integer
@@ -321,7 +321,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [JsonPropertyName("integer")]
-        public int? Integer { get { return this.IntegerOption; } set { this.IntegerOption = new Option<int?>(value); } }
+        public int? Integer { get { return this.IntegerOption.Value; } set { this.IntegerOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithBackslash
@@ -335,7 +335,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>None</value>
         [JsonPropertyName("pattern_with_backslash")]
-        public string PatternWithBackslash { get { return this.PatternWithBackslashOption; } set { this.PatternWithBackslashOption = new Option<string>(value); } }
+        public string PatternWithBackslash { get { return this.PatternWithBackslashOption.Value; } set { this.PatternWithBackslashOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigits
@@ -349,7 +349,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string that is a 10 digit number. Can have leading zeros.</value>
         [JsonPropertyName("pattern_with_digits")]
-        public string PatternWithDigits { get { return this.PatternWithDigitsOption; } set { this.PatternWithDigitsOption = new Option<string>(value); } }
+        public string PatternWithDigits { get { return this.PatternWithDigitsOption.Value; } set { this.PatternWithDigitsOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of PatternWithDigitsAndDelimiter
@@ -363,7 +363,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.</value>
         [JsonPropertyName("pattern_with_digits_and_delimiter")]
-        public string PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption; } set { this.PatternWithDigitsAndDelimiterOption = new Option<string>(value); } }
+        public string PatternWithDigitsAndDelimiter { get { return this.PatternWithDigitsAndDelimiterOption.Value; } set { this.PatternWithDigitsAndDelimiterOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of String
@@ -376,7 +376,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets String
         /// </summary>
         [JsonPropertyName("string")]
-        public string String { get { return this.StringOption; } set { this.StringOption = new Option<string>(value); } }
+        public string String { get { return this.StringOption.Value; } set { this.StringOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of StringFormattedAsDecimal
@@ -389,7 +389,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringFormattedAsDecimal
         /// </summary>
         [JsonPropertyName("string_formatted_as_decimal")]
-        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption; } set { this.StringFormattedAsDecimalOption = new Option<decimal?>(value); } }
+        public decimal? StringFormattedAsDecimal { get { return this.StringFormattedAsDecimalOption.Value; } set { this.StringFormattedAsDecimalOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedInteger
@@ -402,7 +402,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [JsonPropertyName("unsigned_integer")]
-        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption; } set { this.UnsignedIntegerOption = new Option<uint?>(value); } }
+        public uint? UnsignedInteger { get { return this.UnsignedIntegerOption.Value; } set { this.UnsignedIntegerOption = new Option<uint?>(value); } }
 
         /// <summary>
         /// Used to track the state of UnsignedLong
@@ -415,7 +415,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedLong
         /// </summary>
         [JsonPropertyName("unsigned_long")]
-        public ulong? UnsignedLong { get { return this.UnsignedLongOption; } set { this.UnsignedLongOption = new Option<ulong?>(value); } }
+        public ulong? UnsignedLong { get { return this.UnsignedLongOption.Value; } set { this.UnsignedLongOption = new Option<ulong?>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -429,7 +429,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<Guid?>(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new Option<string>(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new Option<string>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -80,7 +80,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [JsonPropertyName("color")]
-        public string Color { get { return this.ColorOption; } set { this.ColorOption = new Option<string>(value); } }
+        public string Color { get { return this.ColorOption.Value; } set { this.ColorOption = new Option<string>(value); } }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } }
+        public string Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Foo
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Foo
         /// </summary>
         [JsonPropertyName("foo")]
-        public string Foo { get { return this.FooOption; } }
+        public string Foo { get { return this.FooOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableMessage
         /// </summary>
         [JsonPropertyName("NullableMessage")]
-        public string NullableMessage { get { return this.NullableMessageOption; } set { this.NullableMessageOption = new Option<string>(value); } }
+        public string NullableMessage { get { return this.NullableMessageOption.Value; } set { this.NullableMessageOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/List.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123List
         /// </summary>
         [JsonPropertyName("123-list")]
-        public string Var123List { get { return this.Var123ListOption; } set { this.Var123ListOption = new Option<string>(value); } }
+        public string Var123List { get { return this.Var123ListOption.Value; } set { this.Var123ListOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets EscapedLiteralString
         /// </summary>
         [JsonPropertyName("escapedLiteralString")]
-        public string EscapedLiteralString { get { return this.EscapedLiteralStringOption; } set { this.EscapedLiteralStringOption = new Option<string>(value); } }
+        public string EscapedLiteralString { get { return this.EscapedLiteralStringOption.Value; } set { this.EscapedLiteralStringOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of UnescapedLiteralString
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnescapedLiteralString
         /// </summary>
         [JsonPropertyName("unescapedLiteralString")]
-        public string UnescapedLiteralString { get { return this.UnescapedLiteralStringOption; } set { this.UnescapedLiteralStringOption = new Option<string>(value); } }
+        public string UnescapedLiteralString { get { return this.UnescapedLiteralStringOption.Value; } set { this.UnescapedLiteralStringOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -125,7 +125,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DirectMap
         /// </summary>
         [JsonPropertyName("direct_map")]
-        public Dictionary<string, bool> DirectMap { get { return this.DirectMapOption; } set { this.DirectMapOption = new Option<Dictionary<string, bool>>(value); } }
+        public Dictionary<string, bool> DirectMap { get { return this.DirectMapOption.Value; } set { this.DirectMapOption = new Option<Dictionary<string, bool>>(value); } }
 
         /// <summary>
         /// Used to track the state of IndirectMap
@@ -138,7 +138,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IndirectMap
         /// </summary>
         [JsonPropertyName("indirect_map")]
-        public Dictionary<string, bool> IndirectMap { get { return this.IndirectMapOption; } set { this.IndirectMapOption = new Option<Dictionary<string, bool>>(value); } }
+        public Dictionary<string, bool> IndirectMap { get { return this.IndirectMapOption.Value; } set { this.IndirectMapOption = new Option<Dictionary<string, bool>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapMapOfString
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapMapOfString
         /// </summary>
         [JsonPropertyName("map_map_of_string")]
-        public Dictionary<string, Dictionary<string, string>> MapMapOfString { get { return this.MapMapOfStringOption; } set { this.MapMapOfStringOption = new Option<Dictionary<string, Dictionary<string, string>>>(value); } }
+        public Dictionary<string, Dictionary<string, string>> MapMapOfString { get { return this.MapMapOfStringOption.Value; } set { this.MapMapOfStringOption = new Option<Dictionary<string, Dictionary<string, string>>>(value); } }
 
         /// <summary>
         /// Used to track the state of MapOfEnumString
@@ -164,7 +164,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapOfEnumString
         /// </summary>
         [JsonPropertyName("map_of_enum_string")]
-        public Dictionary<string, MapTest.InnerEnum> MapOfEnumString { get { return this.MapOfEnumStringOption; } set { this.MapOfEnumStringOption = new Option<Dictionary<string, MapTest.InnerEnum>>(value); } }
+        public Dictionary<string, MapTest.InnerEnum> MapOfEnumString { get { return this.MapOfEnumStringOption.Value; } set { this.MapOfEnumStringOption = new Option<Dictionary<string, MapTest.InnerEnum>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedAnyOfContent Content { get { return this.ContentOption; } set { this.ContentOption = new Option<MixedAnyOfContent>(value); } }
+        public MixedAnyOfContent Content { get { return this.ContentOption.Value; } set { this.ContentOption = new Option<MixedAnyOfContent>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Content
         /// </summary>
         [JsonPropertyName("content")]
-        public MixedOneOfContent Content { get { return this.ContentOption; } set { this.ContentOption = new Option<MixedOneOfContent>(value); } }
+        public MixedOneOfContent Content { get { return this.ContentOption.Value; } set { this.ContentOption = new Option<MixedOneOfContent>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateTime
         /// </summary>
         [JsonPropertyName("dateTime")]
-        public DateTime? DateTime { get { return this.DateTimeOption; } set { this.DateTimeOption = new Option<DateTime?>(value); } }
+        public DateTime? DateTime { get { return this.DateTimeOption.Value; } set { this.DateTimeOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of Map
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Map
         /// </summary>
         [JsonPropertyName("map")]
-        public Dictionary<string, Animal> Map { get { return this.MapOption; } set { this.MapOption = new Option<Dictionary<string, Animal>>(value); } }
+        public Dictionary<string, Animal> Map { get { return this.MapOption.Value; } set { this.MapOption = new Option<Dictionary<string, Animal>>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<Guid?>(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Used to track the state of UuidWithPattern
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [JsonPropertyName("uuid_with_pattern")]
-        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption; } set { this.UuidWithPatternOption = new Option<Guid?>(value); } }
+        public Guid? UuidWithPattern { get { return this.UuidWithPatternOption.Value; } set { this.UuidWithPatternOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public string Id { get { return this.IdOption; } set { this.IdOption = new Option<string>(value); } }
+        public string Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Class
         /// </summary>
         [JsonPropertyName("class")]
-        public string Class { get { return this.ClassOption; } set { this.ClassOption = new Option<string>(value); } }
+        public string Class { get { return this.ClassOption.Value; } set { this.ClassOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public int? Name { get { return this.NameOption; } set { this.NameOption = new Option<int?>(value); } }
+        public int? Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarClient
         /// </summary>
         [JsonPropertyName("client")]
-        public string VarClient { get { return this.VarClientOption; } set { this.VarClientOption = new Option<string>(value); } }
+        public string VarClient { get { return this.VarClientOption.Value; } set { this.VarClientOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -65,7 +65,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Property
         /// </summary>
         [JsonPropertyName("property")]
-        public string Property { get { return this.PropertyOption; } set { this.PropertyOption = new Option<string>(value); } }
+        public string Property { get { return this.PropertyOption.Value; } set { this.PropertyOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SnakeCase
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [JsonPropertyName("snake_case")]
-        public int? SnakeCase { get { return this.SnakeCaseOption; } }
+        public int? SnakeCase { get { return this.SnakeCaseOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Var123Number
@@ -91,7 +91,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123Number
         /// </summary>
         [JsonPropertyName("123Number")]
-        public int? Var123Number { get { return this.Var123NumberOption; } }
+        public int? Var123Number { get { return this.Var123NumberOption.Value; } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -75,7 +75,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("array_and_items_nullable_prop")]
-        public List<Object> ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption; } set { this.ArrayAndItemsNullablePropOption = new Option<List<Object>>(value); } }
+        public List<Object> ArrayAndItemsNullableProp { get { return this.ArrayAndItemsNullablePropOption.Value; } set { this.ArrayAndItemsNullablePropOption = new Option<List<Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayItemsNullable
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayItemsNullable
         /// </summary>
         [JsonPropertyName("array_items_nullable")]
-        public List<Object> ArrayItemsNullable { get { return this.ArrayItemsNullableOption; } set { this.ArrayItemsNullableOption = new Option<List<Object>>(value); } }
+        public List<Object> ArrayItemsNullable { get { return this.ArrayItemsNullableOption.Value; } set { this.ArrayItemsNullableOption = new Option<List<Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of ArrayNullableProp
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNullableProp
         /// </summary>
         [JsonPropertyName("array_nullable_prop")]
-        public List<Object> ArrayNullableProp { get { return this.ArrayNullablePropOption; } set { this.ArrayNullablePropOption = new Option<List<Object>>(value); } }
+        public List<Object> ArrayNullableProp { get { return this.ArrayNullablePropOption.Value; } set { this.ArrayNullablePropOption = new Option<List<Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of BooleanProp
@@ -114,7 +114,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BooleanProp
         /// </summary>
         [JsonPropertyName("boolean_prop")]
-        public bool? BooleanProp { get { return this.BooleanPropOption; } set { this.BooleanPropOption = new Option<bool?>(value); } }
+        public bool? BooleanProp { get { return this.BooleanPropOption.Value; } set { this.BooleanPropOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of DateProp
@@ -127,7 +127,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateProp
         /// </summary>
         [JsonPropertyName("date_prop")]
-        public DateTime? DateProp { get { return this.DatePropOption; } set { this.DatePropOption = new Option<DateTime?>(value); } }
+        public DateTime? DateProp { get { return this.DatePropOption.Value; } set { this.DatePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of DatetimeProp
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DatetimeProp
         /// </summary>
         [JsonPropertyName("datetime_prop")]
-        public DateTime? DatetimeProp { get { return this.DatetimePropOption; } set { this.DatetimePropOption = new Option<DateTime?>(value); } }
+        public DateTime? DatetimeProp { get { return this.DatetimePropOption.Value; } set { this.DatetimePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of IntegerProp
@@ -153,7 +153,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets IntegerProp
         /// </summary>
         [JsonPropertyName("integer_prop")]
-        public int? IntegerProp { get { return this.IntegerPropOption; } set { this.IntegerPropOption = new Option<int?>(value); } }
+        public int? IntegerProp { get { return this.IntegerPropOption.Value; } set { this.IntegerPropOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of NumberProp
@@ -166,7 +166,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NumberProp
         /// </summary>
         [JsonPropertyName("number_prop")]
-        public decimal? NumberProp { get { return this.NumberPropOption; } set { this.NumberPropOption = new Option<decimal?>(value); } }
+        public decimal? NumberProp { get { return this.NumberPropOption.Value; } set { this.NumberPropOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectAndItemsNullableProp
@@ -179,7 +179,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectAndItemsNullableProp
         /// </summary>
         [JsonPropertyName("object_and_items_nullable_prop")]
-        public Dictionary<string, Object> ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption; } set { this.ObjectAndItemsNullablePropOption = new Option<Dictionary<string, Object>>(value); } }
+        public Dictionary<string, Object> ObjectAndItemsNullableProp { get { return this.ObjectAndItemsNullablePropOption.Value; } set { this.ObjectAndItemsNullablePropOption = new Option<Dictionary<string, Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectItemsNullable
@@ -192,7 +192,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectItemsNullable
         /// </summary>
         [JsonPropertyName("object_items_nullable")]
-        public Dictionary<string, Object> ObjectItemsNullable { get { return this.ObjectItemsNullableOption; } set { this.ObjectItemsNullableOption = new Option<Dictionary<string, Object>>(value); } }
+        public Dictionary<string, Object> ObjectItemsNullable { get { return this.ObjectItemsNullableOption.Value; } set { this.ObjectItemsNullableOption = new Option<Dictionary<string, Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectNullableProp
@@ -205,7 +205,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ObjectNullableProp
         /// </summary>
         [JsonPropertyName("object_nullable_prop")]
-        public Dictionary<string, Object> ObjectNullableProp { get { return this.ObjectNullablePropOption; } set { this.ObjectNullablePropOption = new Option<Dictionary<string, Object>>(value); } }
+        public Dictionary<string, Object> ObjectNullableProp { get { return this.ObjectNullablePropOption.Value; } set { this.ObjectNullablePropOption = new Option<Dictionary<string, Object>>(value); } }
 
         /// <summary>
         /// Used to track the state of StringProp
@@ -218,7 +218,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringProp
         /// </summary>
         [JsonPropertyName("string_prop")]
-        public string StringProp { get { return this.StringPropOption; } set { this.StringPropOption = new Option<string>(value); } }
+        public string StringProp { get { return this.StringPropOption.Value; } set { this.StringPropOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("uuid")]
-        public Guid? Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<Guid?>(value); } }
+        public Guid? Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [JsonPropertyName("JustNumber")]
-        public decimal? JustNumber { get { return this.JustNumberOption; } set { this.JustNumberOption = new Option<decimal?>(value); } }
+        public decimal? JustNumber { get { return this.JustNumberOption.Value; } set { this.JustNumberOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("bars")]
         [Obsolete]
-        public List<string> Bars { get { return this.BarsOption; } set { this.BarsOption = new Option<List<string>>(value); } }
+        public List<string> Bars { get { return this.BarsOption.Value; } set { this.BarsOption = new Option<List<string>>(value); } }
 
         /// <summary>
         /// Used to track the state of DeprecatedRef
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("deprecatedRef")]
         [Obsolete]
-        public DeprecatedObject DeprecatedRef { get { return this.DeprecatedRefOption; } set { this.DeprecatedRefOption = new Option<DeprecatedObject>(value); } }
+        public DeprecatedObject DeprecatedRef { get { return this.DeprecatedRefOption.Value; } set { this.DeprecatedRefOption = new Option<DeprecatedObject>(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("id")]
         [Obsolete]
-        public decimal? Id { get { return this.IdOption; } set { this.IdOption = new Option<decimal?>(value); } }
+        public decimal? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<string>(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Order.cs
@@ -158,7 +158,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Complete
         /// </summary>
         [JsonPropertyName("complete")]
-        public bool? Complete { get { return this.CompleteOption; } set { this.CompleteOption = new Option<bool?>(value); } }
+        public bool? Complete { get { return this.CompleteOption.Value; } set { this.CompleteOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -171,7 +171,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of PetId
@@ -184,7 +184,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets PetId
         /// </summary>
         [JsonPropertyName("petId")]
-        public long? PetId { get { return this.PetIdOption; } set { this.PetIdOption = new Option<long?>(value); } }
+        public long? PetId { get { return this.PetIdOption.Value; } set { this.PetIdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Quantity
@@ -197,7 +197,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Quantity
         /// </summary>
         [JsonPropertyName("quantity")]
-        public int? Quantity { get { return this.QuantityOption; } set { this.QuantityOption = new Option<int?>(value); } }
+        public int? Quantity { get { return this.QuantityOption.Value; } set { this.QuantityOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of ShipDate
@@ -211,7 +211,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>2020-02-02T20:20:20.000222Z</example> */
         [JsonPropertyName("shipDate")]
-        public DateTime? ShipDate { get { return this.ShipDateOption; } set { this.ShipDateOption = new Option<DateTime?>(value); } }
+        public DateTime? ShipDate { get { return this.ShipDateOption.Value; } set { this.ShipDateOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyBoolean
         /// </summary>
         [JsonPropertyName("my_boolean")]
-        public bool? MyBoolean { get { return this.MyBooleanOption; } set { this.MyBooleanOption = new Option<bool?>(value); } }
+        public bool? MyBoolean { get { return this.MyBooleanOption.Value; } set { this.MyBooleanOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of MyNumber
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [JsonPropertyName("my_number")]
-        public decimal? MyNumber { get { return this.MyNumberOption; } set { this.MyNumberOption = new Option<decimal?>(value); } }
+        public decimal? MyNumber { get { return this.MyNumberOption.Value; } set { this.MyNumberOption = new Option<decimal?>(value); } }
 
         /// <summary>
         /// Used to track the state of MyString
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyString
         /// </summary>
         [JsonPropertyName("my_string")]
-        public string MyString { get { return this.MyStringOption; } set { this.MyStringOption = new Option<string>(value); } }
+        public string MyString { get { return this.MyStringOption.Value; } set { this.MyStringOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -171,7 +171,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Category
         /// </summary>
         [JsonPropertyName("category")]
-        public Category Category { get { return this.CategoryOption; } set { this.CategoryOption = new Option<Category>(value); } }
+        public Category Category { get { return this.CategoryOption.Value; } set { this.CategoryOption = new Option<Category>(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -184,7 +184,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Tags
@@ -197,7 +197,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Tags
         /// </summary>
         [JsonPropertyName("tags")]
-        public List<Tag> Tags { get { return this.TagsOption; } set { this.TagsOption = new Option<List<Tag>>(value); } }
+        public List<Tag> Tags { get { return this.TagsOption.Value; } set { this.TagsOption = new Option<List<Tag>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [JsonPropertyName("bar")]
-        public string Bar { get { return this.BarOption; } }
+        public string Bar { get { return this.BarOption.Value; } }
 
         /// <summary>
         /// Used to track the state of Baz
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Baz
         /// </summary>
         [JsonPropertyName("baz")]
-        public string Baz { get { return this.BazOption; } set { this.BazOption = new Option<string>(value); } }
+        public string Baz { get { return this.BazOption.Value; } set { this.BazOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -1412,7 +1412,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_notnullable_date_prop")]
-        public DateTime? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption; } set { this.NotRequiredNotnullableDatePropOption = new Option<DateTime?>(value); } }
+        public DateTime? NotRequiredNotnullableDateProp { get { return this.NotRequiredNotnullableDatePropOption.Value; } set { this.NotRequiredNotnullableDatePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNotnullableintegerProp
@@ -1425,7 +1425,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [JsonPropertyName("not_required_notnullableinteger_prop")]
-        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption; } set { this.NotRequiredNotnullableintegerPropOption = new Option<int?>(value); } }
+        public int? NotRequiredNotnullableintegerProp { get { return this.NotRequiredNotnullableintegerPropOption.Value; } set { this.NotRequiredNotnullableintegerPropOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableDateProp
@@ -1438,7 +1438,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableDateProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_date_prop")]
-        public DateTime? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption; } set { this.NotRequiredNullableDatePropOption = new Option<DateTime?>(value); } }
+        public DateTime? NotRequiredNullableDateProp { get { return this.NotRequiredNullableDatePropOption.Value; } set { this.NotRequiredNullableDatePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotRequiredNullableIntegerProp
@@ -1451,7 +1451,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNullableIntegerProp
         /// </summary>
         [JsonPropertyName("not_required_nullable_integer_prop")]
-        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption; } set { this.NotRequiredNullableIntegerPropOption = new Option<int?>(value); } }
+        public int? NotRequiredNullableIntegerProp { get { return this.NotRequiredNullableIntegerPropOption.Value; } set { this.NotRequiredNullableIntegerPropOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableArrayOfString
@@ -1464,7 +1464,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_array_of_string")]
-        public List<string> NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption; } set { this.NotrequiredNotnullableArrayOfStringOption = new Option<List<string>>(value); } }
+        public List<string> NotrequiredNotnullableArrayOfString { get { return this.NotrequiredNotnullableArrayOfStringOption.Value; } set { this.NotrequiredNotnullableArrayOfStringOption = new Option<List<string>>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableBooleanProp
@@ -1477,7 +1477,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_boolean_prop")]
-        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption; } set { this.NotrequiredNotnullableBooleanPropOption = new Option<bool?>(value); } }
+        public bool? NotrequiredNotnullableBooleanProp { get { return this.NotrequiredNotnullableBooleanPropOption.Value; } set { this.NotrequiredNotnullableBooleanPropOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableDatetimeProp
@@ -1490,7 +1490,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_datetime_prop")]
-        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption; } set { this.NotrequiredNotnullableDatetimePropOption = new Option<DateTime?>(value); } }
+        public DateTime? NotrequiredNotnullableDatetimeProp { get { return this.NotrequiredNotnullableDatetimePropOption.Value; } set { this.NotrequiredNotnullableDatetimePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableStringProp
@@ -1503,7 +1503,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_notnullable_string_prop")]
-        public string NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption; } set { this.NotrequiredNotnullableStringPropOption = new Option<string>(value); } }
+        public string NotrequiredNotnullableStringProp { get { return this.NotrequiredNotnullableStringPropOption.Value; } set { this.NotrequiredNotnullableStringPropOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNotnullableUuid
@@ -1517,7 +1517,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_notnullable_uuid")]
-        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption; } set { this.NotrequiredNotnullableUuidOption = new Option<Guid?>(value); } }
+        public Guid? NotrequiredNotnullableUuid { get { return this.NotrequiredNotnullableUuidOption.Value; } set { this.NotrequiredNotnullableUuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableArrayOfString
@@ -1530,7 +1530,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableArrayOfString
         /// </summary>
         [JsonPropertyName("notrequired_nullable_array_of_string")]
-        public List<string> NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption; } set { this.NotrequiredNullableArrayOfStringOption = new Option<List<string>>(value); } }
+        public List<string> NotrequiredNullableArrayOfString { get { return this.NotrequiredNullableArrayOfStringOption.Value; } set { this.NotrequiredNullableArrayOfStringOption = new Option<List<string>>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableBooleanProp
@@ -1543,7 +1543,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableBooleanProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_boolean_prop")]
-        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption; } set { this.NotrequiredNullableBooleanPropOption = new Option<bool?>(value); } }
+        public bool? NotrequiredNullableBooleanProp { get { return this.NotrequiredNullableBooleanPropOption.Value; } set { this.NotrequiredNullableBooleanPropOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableDatetimeProp
@@ -1556,7 +1556,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableDatetimeProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_datetime_prop")]
-        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption; } set { this.NotrequiredNullableDatetimePropOption = new Option<DateTime?>(value); } }
+        public DateTime? NotrequiredNullableDatetimeProp { get { return this.NotrequiredNullableDatetimePropOption.Value; } set { this.NotrequiredNullableDatetimePropOption = new Option<DateTime?>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableStringProp
@@ -1569,7 +1569,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableStringProp
         /// </summary>
         [JsonPropertyName("notrequired_nullable_string_prop")]
-        public string NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption; } set { this.NotrequiredNullableStringPropOption = new Option<string>(value); } }
+        public string NotrequiredNullableStringProp { get { return this.NotrequiredNullableStringPropOption.Value; } set { this.NotrequiredNullableStringPropOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of NotrequiredNullableUuid
@@ -1583,7 +1583,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /* <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example> */
         [JsonPropertyName("notrequired_nullable_uuid")]
-        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption; } set { this.NotrequiredNullableUuidOption = new Option<Guid?>(value); } }
+        public Guid? NotrequiredNullableUuid { get { return this.NotrequiredNullableUuidOption.Value; } set { this.NotrequiredNullableUuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets RequiredNullableArrayOfString

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Result.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result code</value>
         [JsonPropertyName("code")]
-        public string Code { get { return this.CodeOption; } set { this.CodeOption = new Option<string>(value); } }
+        public string Code { get { return this.CodeOption.Value; } set { this.CodeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Data
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string> Data { get { return this.DataOption; } set { this.DataOption = new Option<Dictionary<string, string>>(value); } }
+        public Dictionary<string, string> Data { get { return this.DataOption.Value; } set { this.DataOption = new Option<Dictionary<string, string>>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<string>(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [JsonPropertyName("return")]
-        public int? VarReturn { get { return this.VarReturnOption; } set { this.VarReturnOption = new Option<int?>(value); } }
+        public int? VarReturn { get { return this.VarReturnOption.Value; } set { this.VarReturnOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Unsafe
@@ -84,7 +84,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Unsafe
         /// </summary>
         [JsonPropertyName("unsafe")]
-        public string Unsafe { get { return this.UnsafeOption; } set { this.UnsafeOption = new Option<string>(value); } }
+        public string Unsafe { get { return this.UnsafeOption.Value; } set { this.UnsafeOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Role
         /// </summary>
         [JsonPropertyName("role")]
-        public RolesReportsHashRole Role { get { return this.RoleOption; } set { this.RoleOption = new Option<RolesReportsHashRole>(value); } }
+        public RolesReportsHashRole Role { get { return this.RoleOption.Value; } set { this.RoleOption = new Option<RolesReportsHashRole>(value); } }
 
         /// <summary>
         /// Used to track the state of RoleUuid
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [JsonPropertyName("role_uuid")]
-        public Guid? RoleUuid { get { return this.RoleUuidOption; } set { this.RoleUuidOption = new Option<Guid?>(value); } }
+        public Guid? RoleUuid { get { return this.RoleUuidOption.Value; } set { this.RoleUuidOption = new Option<Guid?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new Option<string>(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarSpecialModelName
         /// </summary>
         [JsonPropertyName("_special_model.name_")]
-        public string VarSpecialModelName { get { return this.VarSpecialModelNameOption; } set { this.VarSpecialModelNameOption = new Option<string>(value); } }
+        public string VarSpecialModelName { get { return this.VarSpecialModelNameOption.Value; } set { this.VarSpecialModelNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of SpecialPropertyName
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [JsonPropertyName("$special[property.name]")]
-        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption; } set { this.SpecialPropertyNameOption = new Option<long?>(value); } }
+        public long? SpecialPropertyName { get { return this.SpecialPropertyNameOption.Value; } set { this.SpecialPropertyNameOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of Name
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get { return this.NameOption; } set { this.NameOption = new Option<string>(value); } }
+        public string Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Value
         /// </summary>
         [JsonPropertyName("value")]
-        public string Value { get { return this.ValueOption; } set { this.ValueOption = new Option<string>(value); } }
+        public string Value { get { return this.ValueOption.Value; } set { this.ValueOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets TestCollectionEndingWithWordList
         /// </summary>
         [JsonPropertyName("TestCollectionEndingWithWordList")]
-        public List<TestCollectionEndingWithWordList> TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption; } set { this.TestCollectionEndingWithWordListOption = new Option<List<TestCollectionEndingWithWordList>>(value); } }
+        public List<TestCollectionEndingWithWordList> TestCollectionEndingWithWordList { get { return this.TestCollectionEndingWithWordListOption.Value; } set { this.TestCollectionEndingWithWordListOption = new Option<List<TestCollectionEndingWithWordList>>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SomeProperty
         /// </summary>
         [JsonPropertyName("someProperty")]
-        public string SomeProperty { get { return this.SomePropertyOption; } set { this.SomePropertyOption = new Option<string>(value); } }
+        public string SomeProperty { get { return this.SomePropertyOption.Value; } set { this.SomePropertyOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>list of named parameters for current message</value>
         [JsonPropertyName("data")]
-        public Dictionary<string, string> Data { get { return this.DataOption; } set { this.DataOption = new Option<Dictionary<string, string>>(value); } }
+        public Dictionary<string, string> Data { get { return this.DataOption.Value; } set { this.DataOption = new Option<Dictionary<string, string>>(value); } }
 
         /// <summary>
         /// Used to track the state of Uuid
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Result unique identifier</value>
         [JsonPropertyName("uuid")]
-        public string Uuid { get { return this.UuidOption; } set { this.UuidOption = new Option<string>(value); } }
+        public string Uuid { get { return this.UuidOption.Value; } set { this.UuidOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
         [JsonPropertyName("anyTypeProp")]
-        public Object AnyTypeProp { get { return this.AnyTypePropOption; } set { this.AnyTypePropOption = new Option<Object>(value); } }
+        public Object AnyTypeProp { get { return this.AnyTypePropOption.Value; } set { this.AnyTypePropOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of AnyTypePropNullable
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values.</value>
         [JsonPropertyName("anyTypePropNullable")]
-        public Object AnyTypePropNullable { get { return this.AnyTypePropNullableOption; } set { this.AnyTypePropNullableOption = new Option<Object>(value); } }
+        public Object AnyTypePropNullable { get { return this.AnyTypePropNullableOption.Value; } set { this.AnyTypePropNullableOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of Email
@@ -103,7 +103,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Email
         /// </summary>
         [JsonPropertyName("email")]
-        public string Email { get { return this.EmailOption; } set { this.EmailOption = new Option<string>(value); } }
+        public string Email { get { return this.EmailOption.Value; } set { this.EmailOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of FirstName
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets FirstName
         /// </summary>
         [JsonPropertyName("firstName")]
-        public string FirstName { get { return this.FirstNameOption; } set { this.FirstNameOption = new Option<string>(value); } }
+        public string FirstName { get { return this.FirstNameOption.Value; } set { this.FirstNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Id
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [JsonPropertyName("id")]
-        public long? Id { get { return this.IdOption; } set { this.IdOption = new Option<long?>(value); } }
+        public long? Id { get { return this.IdOption.Value; } set { this.IdOption = new Option<long?>(value); } }
 
         /// <summary>
         /// Used to track the state of LastName
@@ -142,7 +142,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LastName
         /// </summary>
         [JsonPropertyName("lastName")]
-        public string LastName { get { return this.LastNameOption; } set { this.LastNameOption = new Option<string>(value); } }
+        public string LastName { get { return this.LastNameOption.Value; } set { this.LastNameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredProps
@@ -156,7 +156,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredProps")]
-        public Object ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption; } set { this.ObjectWithNoDeclaredPropsOption = new Option<Object>(value); } }
+        public Object ObjectWithNoDeclaredProps { get { return this.ObjectWithNoDeclaredPropsOption.Value; } set { this.ObjectWithNoDeclaredPropsOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of ObjectWithNoDeclaredPropsNullable
@@ -170,7 +170,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value.</value>
         [JsonPropertyName("objectWithNoDeclaredPropsNullable")]
-        public Object ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption; } set { this.ObjectWithNoDeclaredPropsNullableOption = new Option<Object>(value); } }
+        public Object ObjectWithNoDeclaredPropsNullable { get { return this.ObjectWithNoDeclaredPropsNullableOption.Value; } set { this.ObjectWithNoDeclaredPropsNullableOption = new Option<Object>(value); } }
 
         /// <summary>
         /// Used to track the state of Password
@@ -183,7 +183,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Password
         /// </summary>
         [JsonPropertyName("password")]
-        public string Password { get { return this.PasswordOption; } set { this.PasswordOption = new Option<string>(value); } }
+        public string Password { get { return this.PasswordOption.Value; } set { this.PasswordOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of Phone
@@ -196,7 +196,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Phone
         /// </summary>
         [JsonPropertyName("phone")]
-        public string Phone { get { return this.PhoneOption; } set { this.PhoneOption = new Option<string>(value); } }
+        public string Phone { get { return this.PhoneOption.Value; } set { this.PhoneOption = new Option<string>(value); } }
 
         /// <summary>
         /// Used to track the state of UserStatus
@@ -210,7 +210,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [JsonPropertyName("userStatus")]
-        public int? UserStatus { get { return this.UserStatusOption; } set { this.UserStatusOption = new Option<int?>(value); } }
+        public int? UserStatus { get { return this.UserStatusOption.Value; } set { this.UserStatusOption = new Option<int?>(value); } }
 
         /// <summary>
         /// Used to track the state of Username
@@ -223,7 +223,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Username
         /// </summary>
         [JsonPropertyName("username")]
-        public string Username { get { return this.UsernameOption; } set { this.UsernameOption = new Option<string>(value); } }
+        public string Username { get { return this.UsernameOption.Value; } set { this.UsernameOption = new Option<string>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [JsonPropertyName("hasBaleen")]
-        public bool? HasBaleen { get { return this.HasBaleenOption; } set { this.HasBaleenOption = new Option<bool?>(value); } }
+        public bool? HasBaleen { get { return this.HasBaleenOption.Value; } set { this.HasBaleenOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Used to track the state of HasTeeth
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasTeeth
         /// </summary>
         [JsonPropertyName("hasTeeth")]
-        public bool? HasTeeth { get { return this.HasTeethOption; } set { this.HasTeethOption = new Option<bool?>(value); } }
+        public bool? HasTeeth { get { return this.HasTeethOption.Value; } set { this.HasTeethOption = new Option<bool?>(value); } }
 
         /// <summary>
         /// Gets or Sets additional properties


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix C# GenericHost models to use Option<T>.Value in property getters for optional fields. This removes invalid implicit casts and makes generated clients compile cleanly.

- **Bug Fixes**
  - Updated C# `generichost` model template (`modelGeneric.mustache`) so getters return the underlying value, not the `Option<>` wrapper.
  - Regenerated C# Petstore samples to reflect the change.

<sup>Written for commit 99c84789e503fa060c91c91b0ff0ebcc7cc6a2ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

