### PR TITLE
[Kotlin] Replace deprecated Ktor base64 encoding with Kotlin std library call 

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-ktor/auth/HttpBasicAuth.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-ktor/auth/HttpBasicAuth.kt.mustache
@@ -1,6 +1,6 @@
 package {{packageName}}.auth
 
-import io.ktor.util.encodeBase64
+import kotlin.io.encoding.Base64
 
 {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}class HttpBasicAuth : Authentication {
     {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}var username: String? = null
@@ -9,7 +9,7 @@ import io.ktor.util.encodeBase64
     override fun apply(query: MutableMap<String, List<String>>, headers: MutableMap<String, String>) {
         if (username == null && password == null) return
         val str = (username ?: "") + ":" + (password ?: "")
-        val auth = str.encodeBase64()
+        val auth = Base64.encode(str.encodeToByteArray())
         headers["Authorization"] = "Basic $auth"
     }
 }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/auth/HttpBasicAuth.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/auth/HttpBasicAuth.kt.mustache
@@ -1,6 +1,6 @@
 package {{packageName}}.auth
 
-import io.ktor.util.encodeBase64
+import kotlin.io.encoding.Base64
 
 {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}class HttpBasicAuth : Authentication {
     {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}var username: String? = null
@@ -9,7 +9,7 @@ import io.ktor.util.encodeBase64
     override fun apply(query: MutableMap<String, List<String>>, headers: MutableMap<String, String>) {
         if (username == null && password == null) return
         val str = (username ?: "") + ":" + (password ?: "")
-        val auth = str.encodeBase64()
+        val auth = Base64.encode(str.encodeToByteArray())
         headers["Authorization"] = "Basic $auth"
     }
 }

--- a/samples/client/petstore/kotlin-array-simple-string-multiplatform/src/commonMain/kotlin/org/openapitools/client/auth/HttpBasicAuth.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-multiplatform/src/commonMain/kotlin/org/openapitools/client/auth/HttpBasicAuth.kt
@@ -1,6 +1,6 @@
 package org.openapitools.client.auth
 
-import io.ktor.util.encodeBase64
+import kotlin.io.encoding.Base64
 
 class HttpBasicAuth : Authentication {
     var username: String? = null
@@ -9,7 +9,7 @@ class HttpBasicAuth : Authentication {
     override fun apply(query: MutableMap<String, List<String>>, headers: MutableMap<String, String>) {
         if (username == null && password == null) return
         val str = (username ?: "") + ":" + (password ?: "")
-        val auth = str.encodeBase64()
+        val auth = Base64.encode(str.encodeToByteArray())
         headers["Authorization"] = "Basic $auth"
     }
 }

--- a/samples/client/petstore/kotlin-bigdecimal-default-multiplatform/src/commonMain/kotlin/org/openapitools/client/auth/HttpBasicAuth.kt
+++ b/samples/client/petstore/kotlin-bigdecimal-default-multiplatform/src/commonMain/kotlin/org/openapitools/client/auth/HttpBasicAuth.kt
@@ -1,6 +1,6 @@
 package org.openapitools.client.auth
 
-import io.ktor.util.encodeBase64
+import kotlin.io.encoding.Base64
 
 class HttpBasicAuth : Authentication {
     var username: String? = null
@@ -9,7 +9,7 @@ class HttpBasicAuth : Authentication {
     override fun apply(query: MutableMap<String, List<String>>, headers: MutableMap<String, String>) {
         if (username == null && password == null) return
         val str = (username ?: "") + ":" + (password ?: "")
-        val auth = str.encodeBase64()
+        val auth = Base64.encode(str.encodeToByteArray())
         headers["Authorization"] = "Basic $auth"
     }
 }

--- a/samples/client/petstore/kotlin-default-values-multiplatform/src/commonMain/kotlin/org/openapitools/client/auth/HttpBasicAuth.kt
+++ b/samples/client/petstore/kotlin-default-values-multiplatform/src/commonMain/kotlin/org/openapitools/client/auth/HttpBasicAuth.kt
@@ -1,6 +1,6 @@
 package org.openapitools.client.auth
 
-import io.ktor.util.encodeBase64
+import kotlin.io.encoding.Base64
 
 class HttpBasicAuth : Authentication {
     var username: String? = null
@@ -9,7 +9,7 @@ class HttpBasicAuth : Authentication {
     override fun apply(query: MutableMap<String, List<String>>, headers: MutableMap<String, String>) {
         if (username == null && password == null) return
         val str = (username ?: "") + ":" + (password ?: "")
-        val auth = str.encodeBase64()
+        val auth = Base64.encode(str.encodeToByteArray())
         headers["Authorization"] = "Basic $auth"
     }
 }

--- a/samples/client/petstore/kotlin-enum-integers-multiplatform/src/commonMain/kotlin/org/openapitools/client/auth/HttpBasicAuth.kt
+++ b/samples/client/petstore/kotlin-enum-integers-multiplatform/src/commonMain/kotlin/org/openapitools/client/auth/HttpBasicAuth.kt
@@ -1,6 +1,6 @@
 package org.openapitools.client.auth
 
-import io.ktor.util.encodeBase64
+import kotlin.io.encoding.Base64
 
 class HttpBasicAuth : Authentication {
     var username: String? = null
@@ -9,7 +9,7 @@ class HttpBasicAuth : Authentication {
     override fun apply(query: MutableMap<String, List<String>>, headers: MutableMap<String, String>) {
         if (username == null && password == null) return
         val str = (username ?: "") + ":" + (password ?: "")
-        val auth = str.encodeBase64()
+        val auth = Base64.encode(str.encodeToByteArray())
         headers["Authorization"] = "Basic $auth"
     }
 }

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/auth/HttpBasicAuth.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/auth/HttpBasicAuth.kt
@@ -1,6 +1,6 @@
 package org.openapitools.client.auth
 
-import io.ktor.util.encodeBase64
+import kotlin.io.encoding.Base64
 
 class HttpBasicAuth : Authentication {
     var username: String? = null
@@ -9,7 +9,7 @@ class HttpBasicAuth : Authentication {
     override fun apply(query: MutableMap<String, List<String>>, headers: MutableMap<String, String>) {
         if (username == null && password == null) return
         val str = (username ?: "") + ":" + (password ?: "")
-        val auth = str.encodeBase64()
+        val auth = Base64.encode(str.encodeToByteArray())
         headers["Authorization"] = "Basic $auth"
     }
 }

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/auth/HttpBasicAuth.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/auth/HttpBasicAuth.kt
@@ -1,6 +1,6 @@
 package org.openapitools.client.auth
 
-import io.ktor.util.encodeBase64
+import kotlin.io.encoding.Base64
 
 class HttpBasicAuth : Authentication {
     var username: String? = null
@@ -9,7 +9,7 @@ class HttpBasicAuth : Authentication {
     override fun apply(query: MutableMap<String, List<String>>, headers: MutableMap<String, String>) {
         if (username == null && password == null) return
         val str = (username ?: "") + ":" + (password ?: "")
-        val auth = str.encodeBase64()
+        val auth = Base64.encode(str.encodeToByteArray())
         headers["Authorization"] = "Basic $auth"
     }
 }

--- a/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/src/main/kotlin/org/openapitools/client/auth/HttpBasicAuth.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/src/main/kotlin/org/openapitools/client/auth/HttpBasicAuth.kt
@@ -1,6 +1,6 @@
 package org.openapitools.client.auth
 
-import io.ktor.util.encodeBase64
+import kotlin.io.encoding.Base64
 
 class HttpBasicAuth : Authentication {
     var username: String? = null
@@ -9,7 +9,7 @@ class HttpBasicAuth : Authentication {
     override fun apply(query: MutableMap<String, List<String>>, headers: MutableMap<String, String>) {
         if (username == null && password == null) return
         val str = (username ?: "") + ":" + (password ?: "")
-        val auth = str.encodeBase64()
+        val auth = Base64.encode(str.encodeToByteArray())
         headers["Authorization"] = "Basic $auth"
     }
 }

--- a/samples/client/petstore/kotlin-multiplatform-allOf-discriminator/src/commonMain/kotlin/org/openapitools/client/auth/HttpBasicAuth.kt
+++ b/samples/client/petstore/kotlin-multiplatform-allOf-discriminator/src/commonMain/kotlin/org/openapitools/client/auth/HttpBasicAuth.kt
@@ -1,6 +1,6 @@
 package org.openapitools.client.auth
 
-import io.ktor.util.encodeBase64
+import kotlin.io.encoding.Base64
 
 class HttpBasicAuth : Authentication {
     var username: String? = null
@@ -9,7 +9,7 @@ class HttpBasicAuth : Authentication {
     override fun apply(query: MutableMap<String, List<String>>, headers: MutableMap<String, String>) {
         if (username == null && password == null) return
         val str = (username ?: "") + ":" + (password ?: "")
-        val auth = str.encodeBase64()
+        val auth = Base64.encode(str.encodeToByteArray())
         headers["Authorization"] = "Basic $auth"
     }
 }

--- a/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/src/commonMain/kotlin/org/openapitools/client/auth/HttpBasicAuth.kt
+++ b/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/src/commonMain/kotlin/org/openapitools/client/auth/HttpBasicAuth.kt
@@ -1,6 +1,6 @@
 package org.openapitools.client.auth
 
-import io.ktor.util.encodeBase64
+import kotlin.io.encoding.Base64
 
 class HttpBasicAuth : Authentication {
     var username: String? = null
@@ -9,7 +9,7 @@ class HttpBasicAuth : Authentication {
     override fun apply(query: MutableMap<String, List<String>>, headers: MutableMap<String, String>) {
         if (username == null && password == null) return
         val str = (username ?: "") + ":" + (password ?: "")
-        val auth = str.encodeBase64()
+        val auth = Base64.encode(str.encodeToByteArray())
         headers["Authorization"] = "Basic $auth"
     }
 }

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/auth/HttpBasicAuth.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/auth/HttpBasicAuth.kt
@@ -1,6 +1,6 @@
 package org.openapitools.client.auth
 
-import io.ktor.util.encodeBase64
+import kotlin.io.encoding.Base64
 
 class HttpBasicAuth : Authentication {
     var username: String? = null
@@ -9,7 +9,7 @@ class HttpBasicAuth : Authentication {
     override fun apply(query: MutableMap<String, List<String>>, headers: MutableMap<String, String>) {
         if (username == null && password == null) return
         val str = (username ?: "") + ":" + (password ?: "")
-        val auth = str.encodeBase64()
+        val auth = Base64.encode(str.encodeToByteArray())
         headers["Authorization"] = "Basic $auth"
     }
 }


### PR DESCRIPTION
based on #23334 with updated samples


<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace deprecated `io.ktor.util.encodeBase64` with Kotlin stdlib `kotlin.io.encoding.Base64` in Kotlin client templates and samples. This removes deprecation warnings and future-proofs generated clients, and fixes #22808.

<sup>Written for commit 369e6ea858526bba4d55027da4f3220d0e51f155. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

