### PR TITLE
fix: preserve parent description when simplifying nullable anyOf/oneOf

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -2268,6 +2268,10 @@ public class ModelUtils {
         // if only one element left, simplify to just the element (schema)
         if (subSchemas.size() == 1) {
             Schema<?> subSchema = subSchemas.get(0);
+            // Preserve parent-level docs when nullable anyOf/oneOf collapses to a single child schema.
+            if (subSchema.getDescription() == null && schema.getDescription() != null) {
+                subSchema.setDescription(schema.getDescription());
+            }
             if (Boolean.TRUE.equals(schema.getNullable())) { // retain nullable setting
                 subSchema.setNullable(true);
             }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -27,6 +27,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -580,6 +581,38 @@ public class ModelUtilsTest {
         assertTrue(schema.getReadOnly());
         assertNull(schema.getWriteOnly());
         assertEquals(schema.get$ref(), "#/components/schemas/IntegerRef");
+    }
+
+    @Test
+    public void simplifyOneOfAnyOfWithOnlyOneNonNullSubSchemaKeepsParentDescription() {
+        OpenAPI openAPI = new OpenAPI();
+
+        Schema anyOfParent = new Schema().description("Access token");
+        anyOfParent.setAnyOf(new ArrayList<>(Arrays.asList(
+                new StringSchema(),
+                new Schema<>().type("null")
+        )));
+        Schema anyOfSchema = ModelUtils.simplifyOneOfAnyOfWithOnlyOneNonNullSubSchema(openAPI, anyOfParent, anyOfParent.getAnyOf());
+        assertEquals(anyOfSchema.getDescription(), "Access token");
+
+        Schema oneOfParent = new Schema().description("Expires at");
+        oneOfParent.setOneOf(new ArrayList<>(Arrays.asList(
+                new IntegerSchema(),
+                new Schema<>().type("null")
+        )));
+        Schema oneOfSchema = ModelUtils.simplifyOneOfAnyOfWithOnlyOneNonNullSubSchema(openAPI, oneOfParent, oneOfParent.getOneOf());
+        assertEquals(oneOfSchema.getDescription(), "Expires at");
+
+        Schema anyOfParentWithChildDescription = new Schema().description("Parent description");
+        anyOfParentWithChildDescription.setAnyOf(new ArrayList<>(Arrays.asList(
+                new StringSchema().description("Child description"),
+                new Schema<>().type("null")
+        )));
+        Schema anyOfSchemaWithChildDescription = ModelUtils.simplifyOneOfAnyOfWithOnlyOneNonNullSubSchema(
+                openAPI,
+                anyOfParentWithChildDescription,
+                anyOfParentWithChildDescription.getAnyOf());
+        assertEquals(anyOfSchemaWithChildDescription.getDescription(), "Child description");
     }
 
     @Test


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
## Summary

This PR fixes a schema simplification edge case in `ModelUtils.simplifyOneOfAnyOfWithOnlyOneNonNullSubSchema(...)`.

When `anyOf`/`oneOf` contains one non-null schema and one `null` schema, the logic collapses to the non-null child.  
Before this change, parent-level description could be lost during collapse.  
Now, parent description is preserved when the child has no description, while still preserving child description precedence if already set.

## Changes

- Preserve parent-level `description` when simplifying nullable `anyOf`/`oneOf` to a single child schema.
- Keep existing nullable propagation behavior.
- Add unit tests to verify:
  - parent description is preserved for `anyOf`
  - parent description is preserved for `oneOf`
  - child description is not overwritten by parent description

## Validation

- Added/updated unit tests in `ModelUtilsTest`.
- Verified expected behavior for nullable union simplification and description precedence.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes loss of parent description when simplifying nullable `anyOf`/`oneOf` unions to a single schema. The parent description is copied only if the child has none; nullable propagation remains unchanged.

- **Bug Fixes**
  - Updated `ModelUtils.simplifyOneOfAnyOfWithOnlyOneNonNullSubSchema(...)` to preserve parent `description` while keeping child description precedence.
  - Added tests for `anyOf`, `oneOf`, and child-overrides-parent cases in `ModelUtilsTest`.

<sup>Written for commit 751ab5c7da469310c7a8a270ceba976c8377d727. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

