### PR TITLE
Add scalafmt plugin to scala-pekko client generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaPekkoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaPekkoClientCodegen.java
@@ -179,6 +179,8 @@ public class ScalaPekkoClientCodegen extends AbstractScalaCodegen implements Cod
         supportingFiles.add(new SupportingFile("apiSettings.mustache", invokerFolder, "ApiSettings.scala"));
         final String apiFolder = (sourceFolder + File.separator + apiPackage).replace(".", File.separator);
         supportingFiles.add(new SupportingFile("project/build.properties.mustache", "project", "build.properties"));
+        supportingFiles.add(new SupportingFile("project/plugins.mustache", "project", "plugins.sbt"));
+        supportingFiles.add(new SupportingFile("scalafmt.mustache", "", ".scalafmt.conf"));
         supportingFiles.add(new SupportingFile("enumsSerializers.mustache", apiFolder, "EnumsSerializers.scala"));
         supportingFiles.add(new SupportingFile("serializers.mustache", invokerFolder, "Serializers.scala"));
     }

--- a/modules/openapi-generator/src/main/resources/scala-pekko-client/project/plugins.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-pekko-client/project/plugins.mustache
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")

--- a/modules/openapi-generator/src/main/resources/scala-pekko-client/scalafmt.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-pekko-client/scalafmt.mustache
@@ -1,0 +1,58 @@
+version=3.10.6
+runner.dialect = scala213
+project {
+  git = false
+  excludeFilters = [
+    scalafmt-benchmarks/src/resources,
+    sbt-test
+    bin/issue
+  ]
+  layout = StandardConvention
+}
+align {
+  preset = none
+  stripMargin = true
+}
+binPack {
+  importSelectors = fold
+}
+newlines {
+  avoidForSimpleOverflow = all
+  ignoreInSyntax = false
+  source = fold
+}
+rewrite {
+  rules = [
+    AvoidInfix,
+    Imports,
+    RedundantBraces,
+    RedundantParens,
+    SortModifiers,
+  ]
+  imports {
+    selectors = fold
+    removeRedundantSelectors = true
+    sort = ascii
+    groups = [
+      ["org\\.scalafmt\\..*"],
+      ["scala\\.meta\\..*", "org\\.scalameta\\..*"],
+      ["sbt\\..*"],
+      ["java.?\\..*"],
+      ["scala\\..*"],
+      ["org\\..*"],
+      ["com\\..*"],
+    ]
+  }
+  redundantBraces {
+    preset = all
+    oneStatApply {
+      parensMaxSpan = 300
+      bracesMinSpan = 300
+    }
+  }
+  redundantParens {
+    preset = all
+  }
+  sortModifiers.preset = styleGuide
+  trailingCommas.style = "always"
+}

--- a/samples/client/petstore/scala-pekko/.openapi-generator/FILES
+++ b/samples/client/petstore/scala-pekko/.openapi-generator/FILES
@@ -1,3 +1,4 @@
+.scalafmt.conf
 README.md
 build.sbt
 docs/ApiResponse.md
@@ -11,6 +12,7 @@ docs/User.md
 docs/UserApi.md
 pom.xml
 project/build.properties
+project/plugins.sbt
 src/main/resources/reference.conf
 src/main/scala/org/openapitools/client/api/EnumsSerializers.scala
 src/main/scala/org/openapitools/client/api/PetApi.scala

--- a/samples/client/petstore/scala-pekko/.scalafmt.conf
+++ b/samples/client/petstore/scala-pekko/.scalafmt.conf
@@ -1,0 +1,58 @@
+version=3.10.6
+runner.dialect = scala213
+project {
+  git = false
+  excludeFilters = [
+    scalafmt-benchmarks/src/resources,
+    sbt-test
+    bin/issue
+  ]
+  layout = StandardConvention
+}
+align {
+  preset = none
+  stripMargin = true
+}
+binPack {
+  importSelectors = fold
+}
+newlines {
+  avoidForSimpleOverflow = all
+  ignoreInSyntax = false
+  source = fold
+}
+rewrite {
+  rules = [
+    AvoidInfix,
+    Imports,
+    RedundantBraces,
+    RedundantParens,
+    SortModifiers,
+  ]
+  imports {
+    selectors = fold
+    removeRedundantSelectors = true
+    sort = ascii
+    groups = [
+      ["org\\.scalafmt\\..*"],
+      ["scala\\.meta\\..*", "org\\.scalameta\\..*"],
+      ["sbt\\..*"],
+      ["java.?\\..*"],
+      ["scala\\..*"],
+      ["org\\..*"],
+      ["com\\..*"],
+    ]
+  }
+  redundantBraces {
+    preset = all
+    oneStatApply {
+      parensMaxSpan = 300
+      bracesMinSpan = 300
+    }
+  }
+  redundantParens {
+    preset = all
+  }
+  sortModifiers.preset = styleGuide
+  trailingCommas.style = "always"
+}

--- a/samples/client/petstore/scala-pekko/project/plugins.sbt
+++ b/samples/client/petstore/scala-pekko/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")


### PR DESCRIPTION
Adds scalafmt (Scalafmt 3.10.6, Scala 2.13 dialect) and sbt-scalafmt plugin (2.5.6) to the scala-pekko client generator, following the same pattern as #23273 (scala-sttp4).

Part of #23274

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `scalafmt` support to the Scala Pekko client generator to enforce consistent formatting in generated clients. Uses Scalafmt 3.10.6 with the Scala 2.13 dialect and the `sbt-scalafmt` plugin 2.5.6. Part of #23274 to standardize formatting across Scala generators.

- New Features
  - Generate `.scalafmt.conf` with the shared config (version 3.10.6, Scala 2.13).
  - Add `project/plugins.sbt` with `sbt-scalafmt` 2.5.6.
  - Wire templates in `ScalaPekkoClientCodegen` so new clients include both files.
  - Update Scala Pekko petstore sample to reflect the new files.

<sup>Written for commit ea4438003ff348a1d38741700775639fc4db3492. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

