### PR TITLE
Fix discriminator model lookup when used together with model name suffix

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenDiscriminator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenDiscriminator.java
@@ -76,16 +76,25 @@ public class CodegenDiscriminator {
         // is converted to a sanitized, internal representation within codegen.
         @Getter @Setter
         private String modelName;
+        // The raw schema name as it appears in the OAS document, before any
+        // modelNamePrefix/Suffix transformation.
+        @Getter
+        private String schemaName;
 
         @Getter @Setter
         private CodegenModel model;
 
         private final boolean explicitMapping;
 
-        public MappedModel(String mappingName, String modelName, boolean explicitMapping) {
+        public MappedModel(String mappingName, String modelName, String schemaName, boolean explicitMapping) {
             this.mappingName = mappingName;
             this.modelName = modelName;
+            this.schemaName = schemaName;
             this.explicitMapping = explicitMapping;
+        }
+
+        public MappedModel(String mappingName, String modelName, boolean explicitMapping) {
+            this(mappingName, modelName, null, explicitMapping);
         }
 
         public boolean isExplicitMapping() {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -507,7 +507,8 @@ public class DefaultCodegen implements CodegenConfig {
             // add the model to the discriminator's mapping so templates have access to more than just the string to string mapping
             if (model.discriminator != null && model.discriminator.getMappedModels() != null) {
                 for (CodegenDiscriminator.MappedModel mappedModel : model.discriminator.getMappedModels()) {
-                    CodegenModel mappedCodegenModel = ModelUtils.getModelByName(mappedModel.getModelName(), objs);
+                    String lookupName = mappedModel.getSchemaName() != null ? mappedModel.getSchemaName() : mappedModel.getModelName();
+                    CodegenModel mappedCodegenModel = ModelUtils.getModelByName(lookupName, objs);
                     mappedModel.setModel(mappedCodegenModel);
                 }
             }
@@ -3574,7 +3575,7 @@ public class DefaultCodegen implements CodegenConfig {
                     once(LOGGER).warn("'{}' defines discriminator '{}', but the referenced schema '{}' is incorrect. {}",
                             composedSchemaName, discPropName, modelName, msgSuffix);
                 }
-                MappedModel mm = new MappedModel(modelName, toModelName(modelName));
+                MappedModel mm = new MappedModel(modelName, toModelName(modelName), modelName, false);
                 descendentSchemas.add(mm);
                 Schema cs = ModelUtils.getSchema(openAPI, modelName);
                 if (cs == null) { // cannot lookup the model based on the name
@@ -3583,7 +3584,7 @@ public class DefaultCodegen implements CodegenConfig {
                     Map<String, Object> vendorExtensions = cs.getExtensions();
                     if (vendorExtensions != null && !vendorExtensions.isEmpty() && vendorExtensions.containsKey(X_DISCRIMINATOR_VALUE)) {
                         String xDiscriminatorValue = (String) vendorExtensions.get(X_DISCRIMINATOR_VALUE);
-                        mm = new MappedModel(xDiscriminatorValue, toModelName(modelName), true);
+                        mm = new MappedModel(xDiscriminatorValue, toModelName(modelName), modelName, true);
                         descendentSchemas.add(mm);
                     }
                 }
@@ -3641,7 +3642,7 @@ public class DefaultCodegen implements CodegenConfig {
                             .map(ve -> ve.get(X_DISCRIMINATOR_VALUE))
                             .map(discriminatorValue -> (String) discriminatorValue)
                             .orElse(currentSchemaName);
-            MappedModel mm = new MappedModel(mappingName, toModelName(currentSchemaName), !mappingName.equals(currentSchemaName));
+            MappedModel mm = new MappedModel(mappingName, toModelName(currentSchemaName), currentSchemaName, !mappingName.equals(currentSchemaName));
             descendentSchemas.add(mm);
         }
         return descendentSchemas;
@@ -3687,7 +3688,7 @@ public class DefaultCodegen implements CodegenConfig {
                 } else {
                     name = e.getValue();
                 }
-                uniqueDescendants.add(new MappedModel(e.getKey(), toModelName(name), true));
+                uniqueDescendants.add(new MappedModel(e.getKey(), toModelName(name), name, true));
             }
         }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -1681,6 +1681,47 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void testDiscriminatorMappedModelWithModelNameSuffix() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/oneOfDiscriminator.yaml");
+        DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setLegacyDiscriminatorBehavior(false);
+        codegen.setOpenAPI(openAPI);
+        codegen.setModelNameSuffix("Dto");
+
+        // Build allProcessedModels map keyed by raw schema name (as DefaultGenerator does)
+        Map<String, ModelsMap> allProcessedModels = new TreeMap<>();
+        String[] schemaNames = {"FruitReqDisc", "AppleReqDisc", "BananaReqDisc"};
+        for (String name : schemaNames) {
+            Schema schema = openAPI.getComponents().getSchemas().get(name);
+            CodegenModel cm = codegen.fromModel(name, schema);
+            ModelMap mo = new ModelMap();
+            mo.setModel(cm);
+            ModelsMap models = new ModelsMap();
+            models.setModels(Collections.singletonList(mo));
+            allProcessedModels.put(name, models);
+        }
+
+        // Verify schemaName is stored and differs from modelName
+        CodegenModel fruitModel = ModelUtils.getModelByName("FruitReqDisc", allProcessedModels);
+        assertNotNull(fruitModel.discriminator);
+        for (CodegenDiscriminator.MappedModel mm : fruitModel.discriminator.getMappedModels()) {
+            assertNotNull(mm.getSchemaName(),
+                    "MappedModel.getSchemaName() should not be null for " + mm.getModelName());
+            assertNotEquals(mm.getSchemaName(), mm.getModelName(),
+                    "schemaName should differ from modelName when modelNameSuffix is set");
+        }
+
+        // Verify postProcessAllModels resolves MappedModel.model via schemaName
+        Map<String, ModelsMap> result = codegen.postProcessAllModels(allProcessedModels);
+        fruitModel = ModelUtils.getModelByName("FruitReqDisc", result);
+        for (CodegenDiscriminator.MappedModel mm : fruitModel.discriminator.getMappedModels()) {
+            assertNotNull(mm.getModel(),
+                    "MappedModel.getModel() should not be null for " + mm.getModelName()
+                            + " (mappingName=" + mm.getMappingName() + ")");
+        }
+    }
+
+    @Test
     public void testComposedSchemaMyPetsOneOfDiscriminatorMap() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/allOf_composition_discriminator.yaml");
 


### PR DESCRIPTION
When `modelNamePrefix` or `modelNameSuffix` is configured, `MappedModel.modelName` stores the transformed name (e.g. `AppleReqDiscDto`), while the `allProcessedModels` map in `postProcessAllModels` is keyed by the raw OAS schema name (e.g. `AppleReqDisc`). This mismatch caused `ModelUtils.getModelByName` to return null, leaving
  `MappedModel.model` unresolved — breaking discriminator-based serialization in generated code.

  The fix adds a `schemaName` field to `CodegenDiscriminator.MappedModel` that preserves the original OAS schema name before any prefix/suffix transformation. During `postProcessAllModels`, the lookup now uses `schemaName` (falling back to `modelName` for backward compatibility), enabling a direct O(1) map key hit instead of
  requiring a linear scan.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description) **(It is not, or more specifically, I'm not sure. Some seem related, though.)**
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. (it is not)
