### PR TITLE
[BUG][DART] fix nullable nested array item handling

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
@@ -554,13 +554,17 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
 
     @Override
     public String getTypeDeclaration(Schema p) {
+        return getTypeDeclaration(p, false);
+    }
+
+    private String getTypeDeclaration(Schema p, boolean includeNullableSuffix) {
         Schema<?> schema = unaliasSchema(p);
         Schema<?> target = ModelUtils.isGenerateAliasAsModel() ? p : schema;
+        String typeDeclaration;
         if (ModelUtils.isArraySchema(target)) {
             Schema<?> items = ModelUtils.getSchemaItems(schema);
-            return getSchemaType(target) + "<" + getTypeDeclaration(items) + ">";
-        }
-        if (ModelUtils.isMapSchema(target)) {
+            typeDeclaration = getSchemaType(target) + "<" + getTypeDeclaration(items, true) + ">";
+        } else if (ModelUtils.isMapSchema(target)) {
             // Note: ModelUtils.isMapSchema(p) returns true when p is a composed schema that also defines
             // additionalproperties: true
             Schema<?> inner = ModelUtils.getAdditionalProperties(target);
@@ -569,9 +573,16 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
                 inner = new StringSchema().description("TODO default missing map inner type to string");
                 p.setAdditionalProperties(inner);
             }
-            return getSchemaType(target) + "<String, " + getTypeDeclaration(inner) + ">";
+            typeDeclaration = getSchemaType(target) + "<String, " + getTypeDeclaration(inner, true) + ">";
+        } else {
+            typeDeclaration = super.getTypeDeclaration(p);
         }
-        return super.getTypeDeclaration(p);
+
+        if (includeNullableSuffix && ModelUtils.isNullable(schema)) {
+            return typeDeclaration + "?";
+        }
+
+        return typeDeclaration;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
@@ -198,10 +198,10 @@ class {{{classname}}} {
         {{{name}}}: json[r'{{{baseName}}}'] is List
           ? (json[r'{{{baseName}}}'] as List).map((e) =>
               {{#items.complexType}}
-              {{items.complexType}}.listFromJson(json[r'{{{baseName}}}']){{#uniqueItems}}.toSet(){{/uniqueItems}}
+              e == null ? {{#items.isNullable}}null{{/items.isNullable}}{{^items.isNullable}}const <{{items.complexType}}>[]{{/items.isNullable}} : {{items.complexType}}.listFromJson(e){{#uniqueItems}}.toSet(){{/uniqueItems}}
               {{/items.complexType}}
               {{^items.complexType}}
-              e == null ? {{#items.isNullable}}null{{/items.isNullable}}{{^items.isNullable}}const  <{{items.items.dataType}}>[]{{/items.isNullable}} : (e as List).cast<{{items.items.dataType}}>()
+              e == null ? {{#items.isNullable}}null{{/items.isNullable}}{{^items.isNullable}}const <{{items.items.dataType}}{{#items.items.isNullable}}?{{/items.items.isNullable}}>[]{{/items.isNullable}} : (e as List).map((value) => value as {{items.items.dataType}}{{#items.items.isNullable}}?{{/items.items.isNullable}}).toList(growable: false)
               {{/items.complexType}}
             ).toList()
           :  {{#isNullable}}null{{/isNullable}}{{^isNullable}}const []{{/isNullable}},
@@ -219,7 +219,7 @@ class {{{classname}}} {
             : {{items.complexType}}.mapListFromJson(json[r'{{{baseName}}}']),
                 {{/items.complexType}}
                 {{^items.complexType}}
-            : (json[r'{{{baseName}}}'] as Map<String, dynamic>).map((k, v) => MapEntry(k, v == null ? {{#items.isNullable}}null{{/items.isNullable}}{{^items.isNullable}}const <{{items.items.dataType}}>[]{{/items.isNullable}} : (v as List).cast<{{items.items.dataType}}>())),
+            : (json[r'{{{baseName}}}'] as Map<String, dynamic>).map((k, v) => MapEntry(k, v == null ? {{#items.isNullable}}null{{/items.isNullable}}{{^items.isNullable}}const <{{items.items.dataType}}{{#items.items.isNullable}}?{{/items.items.isNullable}}>[]{{/items.isNullable}} : (v as List).map((value) => value as {{items.items.dataType}}{{#items.items.isNullable}}?{{/items.items.isNullable}}).toList(growable: false))),
                 {{/items.complexType}}
               {{/items.isArray}}
               {{^items.isArray}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartClientCodegenTest.java
@@ -169,4 +169,18 @@ public class DartClientCodegenTest {
         TestUtils.assertFileNotContains(modelFile.toPath(),
                 "json[r'nickname'] != null");
     }
+
+    @Test(description = "Nullable nested arrays of complex types should preserve null entries")
+    public void testNullableNestedComplexArraysPreserveNullEntries() throws Exception {
+        List<File> files = generateDartNativeFromSpec(
+                "src/test/resources/3_0/dart/dart-native-deserialization-bugs.yaml");
+
+        File modelFile = files.stream()
+                .filter(f -> f.getName().equals("complex_nested_array_nullable_model.dart"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("complex_nested_array_nullable_model.dart not found in generated files"));
+
+        TestUtils.assertFileContains(modelFile.toPath(),
+                "e == null ? null : NullableRequiredModel.listFromJson(e)");
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartModelTest.java
@@ -716,4 +716,28 @@ public class DartModelTest {
         Assert.assertFalse(filterParam.dataType.startsWith("Optional<"),
                 "Query parameter should not be wrapped with Optional");
     }
+
+    @Test(description = "array items can be nullable")
+    public void arrayItemsCanBeNullable() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/array-nullable-items.yaml");
+        final DefaultCodegen codegen = new DartClientCodegen();
+        codegen.setOpenAPI(openAPI);
+        final ArraySchema schema = (ArraySchema) openAPI.getComponents().getSchemas().get("ArrayWithNullableItemsModel")
+                .getProperties()
+                .get("foo");
+
+        Assert.assertEquals(codegen.getTypeDeclaration(schema), "List<String?>");
+    }
+
+    @Test(description = "nested array items can be nullable")
+    public void nestedArrayItemsCanBeNullable() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/nested-array-nullable-items.yaml");
+        final DefaultCodegen codegen = new DartClientCodegen();
+        codegen.setOpenAPI(openAPI);
+        final ArraySchema schema = (ArraySchema) openAPI.getComponents().getSchemas().get("NestedArrayWithNullableItemsModel")
+                .getProperties()
+                .get("foo");
+
+        Assert.assertEquals(codegen.getTypeDeclaration(schema), "List<List<String?>>");
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/dio/DartDioModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/dio/DartDioModelTest.java
@@ -492,4 +492,32 @@ public class DartDioModelTest {
         Assert.assertEquals(dateTimeDefault.name, "dateTime");
         Assert.assertNull(dateTimeDefault.defaultValue);
     }
+
+    @Test(description = "array items can be nullable")
+    public void arrayItemsCanBeNullable() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/array-nullable-items.yaml");
+        final DartDioClientCodegen codegen = new DartDioClientCodegen();
+        codegen.additionalProperties().put(CodegenConstants.SERIALIZATION_LIBRARY, DartDioClientCodegen.SERIALIZATION_LIBRARY_BUILT_VALUE);
+        codegen.processOpts();
+        codegen.setOpenAPI(openAPI);
+        final ArraySchema schema = (ArraySchema) openAPI.getComponents().getSchemas().get("ArrayWithNullableItemsModel")
+                .getProperties()
+                .get("foo");
+
+        Assert.assertEquals(codegen.getTypeDeclaration(schema), "BuiltList<String?>");
+    }
+
+    @Test(description = "nested array items can be nullable")
+    public void nestedArrayItemsCanBeNullable() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/nested-array-nullable-items.yaml");
+        final DartDioClientCodegen codegen = new DartDioClientCodegen();
+        codegen.additionalProperties().put(CodegenConstants.SERIALIZATION_LIBRARY, DartDioClientCodegen.SERIALIZATION_LIBRARY_BUILT_VALUE);
+        codegen.processOpts();
+        codegen.setOpenAPI(openAPI);
+        final ArraySchema schema = (ArraySchema) openAPI.getComponents().getSchemas().get("NestedArrayWithNullableItemsModel")
+                .getProperties()
+                .get("foo");
+
+        Assert.assertEquals(codegen.getTypeDeclaration(schema), "BuiltList<BuiltList<String?>>");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/dart/dart-native-deserialization-bugs.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/dart/dart-native-deserialization-bugs.yaml
@@ -32,3 +32,13 @@ components:
         nickname:
           type: string
           nullable: true
+    ComplexNestedArrayNullableModel:
+      type: object
+      properties:
+        matrix:
+          type: array
+          items:
+            type: array
+            nullable: true
+            items:
+              $ref: '#/components/schemas/NullableRequiredModel'

--- a/modules/openapi-generator/src/test/resources/3_0/nested-array-nullable-items.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/nested-array-nullable-items.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.0
+info:
+  title: Nested array nullable items
+  version: latest
+paths:
+  '/':
+    get:
+      operationId: operation
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NestedArrayWithNullableItemsModel'
+components:
+  schemas:
+    NestedArrayWithNullableItemsModel:
+      required:
+        - foo
+      properties:
+        foo:
+          type: array
+          items:
+            type: array
+            items:
+              type: string
+              nullable: true

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/doc/NullableClass.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/doc/NullableClass.md
@@ -15,11 +15,11 @@ Name | Type | Description | Notes
 **dateProp** | [**DateTime**](DateTime.md) |  | [optional] 
 **datetimeProp** | [**DateTime**](DateTime.md) |  | [optional] 
 **arrayNullableProp** | **List&lt;Object&gt;** |  | [optional] 
-**arrayAndItemsNullableProp** | **List&lt;Object&gt;** |  | [optional] 
-**arrayItemsNullable** | **List&lt;Object&gt;** |  | [optional] 
+**arrayAndItemsNullableProp** | **List&lt;Object?&gt;** |  | [optional] 
+**arrayItemsNullable** | **List&lt;Object?&gt;** |  | [optional] 
 **objectNullableProp** | **Map&lt;String, Object&gt;** |  | [optional] 
-**objectAndItemsNullableProp** | **Map&lt;String, Object&gt;** |  | [optional] 
-**objectItemsNullable** | **Map&lt;String, Object&gt;** |  | [optional] 
+**objectAndItemsNullableProp** | **Map&lt;String, Object?&gt;** |  | [optional] 
+**objectItemsNullable** | **Map&lt;String, Object?&gt;** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/nullable_class.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/nullable_class.dart
@@ -137,7 +137,7 @@ class NullableClass {
   )
 
 
-  final List<Object>? arrayAndItemsNullableProp;
+  final List<Object?>? arrayAndItemsNullableProp;
 
 
 
@@ -149,7 +149,7 @@ class NullableClass {
   )
 
 
-  final List<Object>? arrayItemsNullable;
+  final List<Object?>? arrayItemsNullable;
 
 
 
@@ -173,7 +173,7 @@ class NullableClass {
   )
 
 
-  final Map<String, Object>? objectAndItemsNullableProp;
+  final Map<String, Object?>? objectAndItemsNullableProp;
 
 
 
@@ -185,7 +185,7 @@ class NullableClass {
   )
 
 
-  final Map<String, Object>? objectItemsNullable;
+  final Map<String, Object?>? objectItemsNullable;
 
 
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/NullableClass.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/NullableClass.md
@@ -15,11 +15,11 @@ Name | Type | Description | Notes
 **dateProp** | [**Date**](Date.md) |  | [optional] 
 **datetimeProp** | [**DateTime**](DateTime.md) |  | [optional] 
 **arrayNullableProp** | [**BuiltList&lt;JsonObject&gt;**](JsonObject.md) |  | [optional] 
-**arrayAndItemsNullableProp** | [**BuiltList&lt;JsonObject&gt;**](JsonObject.md) |  | [optional] 
-**arrayItemsNullable** | [**BuiltList&lt;JsonObject&gt;**](JsonObject.md) |  | [optional] 
+**arrayAndItemsNullableProp** | [**BuiltList&lt;JsonObject?&gt;**](JsonObject.md) |  | [optional] 
+**arrayItemsNullable** | [**BuiltList&lt;JsonObject?&gt;**](JsonObject.md) |  | [optional] 
 **objectNullableProp** | [**BuiltMap&lt;String, JsonObject&gt;**](JsonObject.md) |  | [optional] 
-**objectAndItemsNullableProp** | [**BuiltMap&lt;String, JsonObject&gt;**](JsonObject.md) |  | [optional] 
-**objectItemsNullable** | [**BuiltMap&lt;String, JsonObject&gt;**](JsonObject.md) |  | [optional] 
+**objectAndItemsNullableProp** | [**BuiltMap&lt;String, JsonObject?&gt;**](JsonObject.md) |  | [optional] 
+**objectItemsNullable** | [**BuiltMap&lt;String, JsonObject?&gt;**](JsonObject.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/doc/NullableClass.md
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/doc/NullableClass.md
@@ -15,11 +15,11 @@ Name | Type | Description | Notes
 **dateProp** | [**DateTime**](DateTime.md) |  | [optional] 
 **datetimeProp** | [**DateTime**](DateTime.md) |  | [optional] 
 **arrayNullableProp** | **List<Object>** |  | [optional] [default to const []]
-**arrayAndItemsNullableProp** | **List<Object>** |  | [optional] [default to const []]
-**arrayItemsNullable** | **List<Object>** |  | [optional] [default to const []]
+**arrayAndItemsNullableProp** | **List<Object?>** |  | [optional] [default to const []]
+**arrayItemsNullable** | **List<Object?>** |  | [optional] [default to const []]
 **objectNullableProp** | **Map<String, Object>** |  | [optional] [default to const {}]
-**objectAndItemsNullableProp** | **Map<String, Object>** |  | [optional] [default to const {}]
-**objectItemsNullable** | **Map<String, Object>** |  | [optional] [default to const {}]
+**objectAndItemsNullableProp** | **Map<String, Object?>** |  | [optional] [default to const {}]
+**objectItemsNullable** | **Map<String, Object?>** |  | [optional] [default to const {}]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/additional_properties_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/additional_properties_class.dart
@@ -67,7 +67,7 @@ class AdditionalPropertiesClass {
         mapOfMapProperty: mapCastOfType<String, dynamic>(json, r'map_of_map_property') ?? const {},
         mapOfArrayInteger: json[r'map_of_array_integer'] == null
           ? const {}
-            : (json[r'map_of_array_integer'] as Map<String, dynamic>).map((k, v) => MapEntry(k, v == null ? const <int>[] : (v as List).cast<int>())),
+            : (json[r'map_of_array_integer'] as Map<String, dynamic>).map((k, v) => MapEntry(k, v == null ? const <int>[] : (v as List).map((value) => value as int).toList(growable: false))),
       );
     }
     return null;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_array_of_number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_array_of_number_only.dart
@@ -53,7 +53,7 @@ class ArrayOfArrayOfNumberOnly {
       return ArrayOfArrayOfNumberOnly(
         arrayArrayNumber: json[r'ArrayArrayNumber'] is List
           ? (json[r'ArrayArrayNumber'] as List).map((e) =>
-              e == null ? const  <num>[] : (e as List).cast<num>()
+              e == null ? const <num>[] : (e as List).map((value) => value as num).toList(growable: false)
             ).toList()
           :  const [],
       );

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_test.dart
@@ -68,12 +68,12 @@ class ArrayTest {
             : const [],
         arrayArrayOfInteger: json[r'array_array_of_integer'] is List
           ? (json[r'array_array_of_integer'] as List).map((e) =>
-              e == null ? const  <int>[] : (e as List).cast<int>()
+              e == null ? const <int>[] : (e as List).map((value) => value as int).toList(growable: false)
             ).toList()
           :  const [],
         arrayArrayOfModel: json[r'array_array_of_model'] is List
           ? (json[r'array_array_of_model'] as List).map((e) =>
-              ReadOnlyFirst.listFromJson(json[r'array_array_of_model'])
+              e == null ? const <ReadOnlyFirst>[] : ReadOnlyFirst.listFromJson(e)
             ).toList()
           :  const [],
       );

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
@@ -41,15 +41,15 @@ class NullableClass {
 
   List<Object>? arrayNullableProp;
 
-  List<Object>? arrayAndItemsNullableProp;
+  List<Object?>? arrayAndItemsNullableProp;
 
-  List<Object> arrayItemsNullable;
+  List<Object?> arrayItemsNullable;
 
   Map<String, Object>? objectNullableProp;
 
-  Map<String, Object>? objectAndItemsNullableProp;
+  Map<String, Object?>? objectAndItemsNullableProp;
 
-  Map<String, Object> objectItemsNullable;
+  Map<String, Object?> objectItemsNullable;
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is NullableClass &&


### PR DESCRIPTION
### Summary

This PR fixes Dart generator handling of nullable array items, including nested arrays/maps.

Specifically:
- Preserves nullable item markers in Dart type declarations for nested array/map item schemas (e.g. `List<String?>`, `List<List<String?>>`, built-value equivalents).
- Fixes native deserialization template logic for nested array/map branches to avoid nullability/type mismatches.
- Fixes nested complex-array mapping to deserialize each element (`e`) instead of incorrectly reusing the full source array.

### Validation

Ran targeted Dart tests successfully:

```bash
mise x java@temurin-21 -- ./mvnw -pl modules/openapi-generator -am \
  -Dtest=org.openapitools.codegen.dart.DartModelTest,org.openapitools.codegen.dart.dio.DartDioModelTest \
  -Dsurefire.failIfNoSpecifiedTests=false test
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves nullable item types in nested arrays/maps and fixes native decoding to keep nulls and correct defaults. Prevents type mismatches and bad casts in Dart2 and `DartDio` `built_value` models.

- **Bug Fixes**
  - Preserve nullable item markers in nested type declarations (e.g., List<String?>, List<List<String?>>, `BuiltList<BuiltList<String?>>`; also `Map<String, T?>` and collections of nullable items).
  - Fix native deserialization for nested arrays/maps: map each element `e`, cast to nullable element types, use typed const defaults, and pass `e` into `listFromJson` for complex items.

- **Tests/Samples**
  - Add tests for nullable items in arrays and nested arrays (incl. complex types) and new `nested-array-nullable-items.yaml`.
  - Update petstore samples and docs to reflect `?` in item types and element-wise mapping.

<sup>Written for commit 44692081c595a0745831de31d5ef8e6f7542ad78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

