### PR TITLE
Add scalafmt plugin to scala-sttp client generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaSttpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaSttpClientCodegen.java
@@ -172,6 +172,8 @@ public class ScalaSttpClientCodegen extends AbstractScalaCodegen implements Code
         supportingFiles.add(new SupportingFile("jsonSupport.mustache", invokerFolder, "JsonSupport.scala"));
         supportingFiles.add(new SupportingFile("additionalTypeSerializers.mustache", invokerFolder, "AdditionalTypeSerializers.scala"));
         supportingFiles.add(new SupportingFile("project/build.properties.mustache", "project", "build.properties"));
+        supportingFiles.add(new SupportingFile("project/plugins.mustache", "project", "plugins.sbt"));
+        supportingFiles.add(new SupportingFile("scalafmt.mustache", "", ".scalafmt.conf"));
         supportingFiles.add(new SupportingFile("dateSerializers.mustache", invokerFolder, "DateSerializers.scala"));
     }
 

--- a/modules/openapi-generator/src/main/resources/scala-sttp/project/plugins.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp/project/plugins.mustache
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")

--- a/modules/openapi-generator/src/main/resources/scala-sttp/scalafmt.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp/scalafmt.mustache
@@ -1,0 +1,58 @@
+version=3.10.6
+runner.dialect = scala213
+project {
+  git = false
+  excludeFilters = [
+    scalafmt-benchmarks/src/resources,
+    sbt-test
+    bin/issue
+  ]
+  layout = StandardConvention
+}
+align {
+  preset = none
+  stripMargin = true
+}
+binPack {
+  importSelectors = fold
+}
+newlines {
+  avoidForSimpleOverflow = all
+  ignoreInSyntax = false
+  source = fold
+}
+rewrite {
+  rules = [
+    AvoidInfix,
+    Imports,
+    RedundantBraces,
+    RedundantParens,
+    SortModifiers,
+  ]
+  imports {
+    selectors = fold
+    removeRedundantSelectors = true
+    sort = ascii
+    groups = [
+      ["org\\.scalafmt\\..*"],
+      ["scala\\.meta\\..*", "org\\.scalameta\\..*"],
+      ["sbt\\..*"],
+      ["java.?\\..*"],
+      ["scala\\..*"],
+      ["org\\..*"],
+      ["com\\..*"],
+    ]
+  }
+  redundantBraces {
+    preset = all
+    oneStatApply {
+      parensMaxSpan = 300
+      bracesMinSpan = 300
+    }
+  }
+  redundantParens {
+    preset = all
+  }
+  sortModifiers.preset = styleGuide
+  trailingCommas.style = "always"
+}

--- a/samples/client/petstore/scala-sttp-circe/.openapi-generator/FILES
+++ b/samples/client/petstore/scala-sttp-circe/.openapi-generator/FILES
@@ -1,6 +1,8 @@
+.scalafmt.conf
 README.md
 build.sbt
 project/build.properties
+project/plugins.sbt
 src/main/scala/org/openapitools/client/api/FakeApi.scala
 src/main/scala/org/openapitools/client/api/PetApi.scala
 src/main/scala/org/openapitools/client/api/StoreApi.scala

--- a/samples/client/petstore/scala-sttp-circe/.scalafmt.conf
+++ b/samples/client/petstore/scala-sttp-circe/.scalafmt.conf
@@ -1,0 +1,58 @@
+version=3.10.6
+runner.dialect = scala213
+project {
+  git = false
+  excludeFilters = [
+    scalafmt-benchmarks/src/resources,
+    sbt-test
+    bin/issue
+  ]
+  layout = StandardConvention
+}
+align {
+  preset = none
+  stripMargin = true
+}
+binPack {
+  importSelectors = fold
+}
+newlines {
+  avoidForSimpleOverflow = all
+  ignoreInSyntax = false
+  source = fold
+}
+rewrite {
+  rules = [
+    AvoidInfix,
+    Imports,
+    RedundantBraces,
+    RedundantParens,
+    SortModifiers,
+  ]
+  imports {
+    selectors = fold
+    removeRedundantSelectors = true
+    sort = ascii
+    groups = [
+      ["org\\.scalafmt\\..*"],
+      ["scala\\.meta\\..*", "org\\.scalameta\\..*"],
+      ["sbt\\..*"],
+      ["java.?\\..*"],
+      ["scala\\..*"],
+      ["org\\..*"],
+      ["com\\..*"],
+    ]
+  }
+  redundantBraces {
+    preset = all
+    oneStatApply {
+      parensMaxSpan = 300
+      bracesMinSpan = 300
+    }
+  }
+  redundantParens {
+    preset = all
+  }
+  sortModifiers.preset = styleGuide
+  trailingCommas.style = "always"
+}

--- a/samples/client/petstore/scala-sttp-circe/project/plugins.sbt
+++ b/samples/client/petstore/scala-sttp-circe/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")

--- a/samples/client/petstore/scala-sttp/.openapi-generator/FILES
+++ b/samples/client/petstore/scala-sttp/.openapi-generator/FILES
@@ -1,6 +1,8 @@
+.scalafmt.conf
 README.md
 build.sbt
 project/build.properties
+project/plugins.sbt
 src/main/scala/org/openapitools/client/api/FakeApi.scala
 src/main/scala/org/openapitools/client/api/PetApi.scala
 src/main/scala/org/openapitools/client/api/StoreApi.scala

--- a/samples/client/petstore/scala-sttp/.scalafmt.conf
+++ b/samples/client/petstore/scala-sttp/.scalafmt.conf
@@ -1,0 +1,58 @@
+version=3.10.6
+runner.dialect = scala213
+project {
+  git = false
+  excludeFilters = [
+    scalafmt-benchmarks/src/resources,
+    sbt-test
+    bin/issue
+  ]
+  layout = StandardConvention
+}
+align {
+  preset = none
+  stripMargin = true
+}
+binPack {
+  importSelectors = fold
+}
+newlines {
+  avoidForSimpleOverflow = all
+  ignoreInSyntax = false
+  source = fold
+}
+rewrite {
+  rules = [
+    AvoidInfix,
+    Imports,
+    RedundantBraces,
+    RedundantParens,
+    SortModifiers,
+  ]
+  imports {
+    selectors = fold
+    removeRedundantSelectors = true
+    sort = ascii
+    groups = [
+      ["org\\.scalafmt\\..*"],
+      ["scala\\.meta\\..*", "org\\.scalameta\\..*"],
+      ["sbt\\..*"],
+      ["java.?\\..*"],
+      ["scala\\..*"],
+      ["org\\..*"],
+      ["com\\..*"],
+    ]
+  }
+  redundantBraces {
+    preset = all
+    oneStatApply {
+      parensMaxSpan = 300
+      bracesMinSpan = 300
+    }
+  }
+  redundantParens {
+    preset = all
+  }
+  sortModifiers.preset = styleGuide
+  trailingCommas.style = "always"
+}

--- a/samples/client/petstore/scala-sttp/project/plugins.sbt
+++ b/samples/client/petstore/scala-sttp/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")


### PR DESCRIPTION
Adds scalafmt (Scalafmt 3.10.6, Scala 2.13 dialect) and sbt-scalafmt plugin (2.5.6) to the scala-sttp client generator, following the same pattern as #23273 (scala-sttp4).

Part of #23274


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Scalafmt support to the scala-sttp client generator. The generator now writes `.scalafmt.conf` and enables `sbt-scalafmt` for consistent formatting, aligning with scala-sttp4 and contributing to #23274.

- **New Features**
  - Emit root `.scalafmt.conf` (Scalafmt 3.10.6, Scala 2.13 dialect) and `project/plugins.sbt` with `sbt-scalafmt` 2.5.6.
  - Add templates (`project/plugins.mustache`, `scalafmt.mustache`) and wire them in `ScalaSttpClientCodegen`; update `scala-sttp` and `scala-sttp-circe` samples.

<sup>Written for commit 4bad43becadb132812196ca63bf0db520c143cb1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

