### PR TITLE
[kotlin-server][JAX-RS] useTags: default to false, class names from tags, @Path('/') when useTags=false

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinServerCodegen.java
@@ -18,7 +18,6 @@
 package org.openapitools.codegen.languages;
 
 import com.google.common.collect.ImmutableMap;
-import io.swagger.v3.oas.models.Operation;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
@@ -706,22 +705,29 @@ public class KotlinServerCodegen extends AbstractKotlinCodegen implements BeanVa
     @Override
     public OperationsMap postProcessOperationsWithModels(OperationsMap objs, List<ModelMap> allModels) {
         OperationMap operations = objs.getOperations();
-        // For JAXRS_SPEC library, compute commonPath similar to JavaJaxRS generators
+        // For JAXRS_SPEC library, compute commonPath when useTags=true, otherwise default to "/"
         if (operations != null && Objects.equals(library, Constants.JAXRS_SPEC)) {
-            String commonPath = null;
-            List<CodegenOperation> ops = operations.getOperation();
-            for (CodegenOperation operation : ops) {
-                if (commonPath == null) {
-                    commonPath = operation.path;
-                } else {
-                    commonPath = getCommonPath(commonPath, operation.path);
+            if (useTags) {
+                String commonPath = null;
+                List<CodegenOperation> ops = operations.getOperation();
+                for (CodegenOperation operation : ops) {
+                    if (commonPath == null) {
+                        commonPath = operation.path;
+                    } else {
+                        commonPath = getCommonPath(commonPath, operation.path);
+                    }
                 }
+                for (CodegenOperation co : ops) {
+                    co.path = StringUtils.removeStart(co.path, commonPath);
+                    co.subresourceOperation = co.path.length() > 1;
+                }
+                objs.put("commonPath", "/".equals(commonPath) ? StringUtils.EMPTY : commonPath);
+            } else {
+                for (CodegenOperation co : operations.getOperation()) {
+                    co.subresourceOperation = !co.path.isEmpty();
+                }
+                objs.put("commonPath", "/");
             }
-            for (CodegenOperation co : ops) {
-                co.path = StringUtils.removeStart(co.path, commonPath);
-                co.subresourceOperation = co.path.length() > 1;
-            }
-            objs.put("commonPath", "/".equals(commonPath) ? StringUtils.EMPTY : commonPath);
         }
         // The following processing breaks the JAX-RS spec, so we only do this for the other libs.
         if (operations != null && !Objects.equals(library, Constants.JAXRS_SPEC)) {
@@ -781,24 +787,6 @@ public class KotlinServerCodegen extends AbstractKotlinCodegen implements BeanVa
         }
 
         return objs;
-    }
-
-    @Override
-    public void addOperationToGroup(String tag, String resourcePath, Operation operation, CodegenOperation co, Map<String, List<CodegenOperation>> operations) {
-        if (Objects.equals(library, Constants.JAXRS_SPEC) && additionalProperties.containsKey(USE_TAGS) && !useTags) {
-            String basePath = StringUtils.substringBefore(StringUtils.removeStart(resourcePath, "/"), "/");
-            if (!StringUtils.isEmpty(basePath)) {
-                co.subresourceOperation = !co.path.isEmpty();
-            }
-            co.baseName = basePath;
-            if (StringUtils.isEmpty(co.baseName) || StringUtils.containsAny(co.baseName, "{", "}")) {
-                co.baseName = "default";
-            }
-            final List<CodegenOperation> opList = operations.computeIfAbsent(co.baseName, k -> new ArrayList<>());
-            opList.add(co);
-        } else {
-            super.addOperationToGroup(tag, resourcePath, operation, co, operations);
-        }
     }
 
     private boolean isJavalin() {

--- a/modules/openapi-generator/src/main/resources/kotlin-server/README.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/README.mustache
@@ -35,7 +35,7 @@ All URIs are relative to *{{{basePath}}}*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}*{{classname}}* | [**{{operationId}}**]({{apiDocPath}}{{classname}}.md#{{operationIdLowerCase}}) | **{{httpMethod}}** {{#commonPath}}{{commonPath}}{{/commonPath}}{{path}} | {{{summary}}}
+{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}*{{classname}}* | [**{{operationId}}**]({{apiDocPath}}{{classname}}.md#{{operationIdLowerCase}}) | **{{httpMethod}}** {{#useTags}}{{commonPath}}{{/useTags}}{{path}} | {{{summary}}}
 {{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
 {{/generateApiDocs}}
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinServerCodegenTest.java
@@ -540,7 +540,7 @@ public class KotlinServerCodegenTest {
     }
 
     @Test
-    public void useTags_false_operationsGroupedByPathBaseForJaxrsSpecLibrary() throws IOException {
+    public void useTags_false_classNameFromTagsAndRootPathForJaxrsSpecLibrary() throws IOException {
         File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
         output.deleteOnExit();
 
@@ -557,13 +557,39 @@ public class KotlinServerCodegenTest {
         String outputPath = output.getAbsolutePath() + "/src/main/kotlin/org/openapitools/server";
         Path petApi = Paths.get(outputPath + "/apis/PetApi.kt");
 
-        assertFileContains(
-                petApi,
-                "class PetApi"
+        assertFileContains(petApi,
+                "class PetApi",
+                "@Path(\"/\")",
+                "@Path(\"/pet\")",
+                "@Path(\"/pet/{petId}\")"
         );
-        assertFileNotContains(
-                petApi,
-                "class DefaultApi"
+        assertFileNotContains(petApi, "@Path(\"/pet\")".replace("/pet", "/store"));
+    }
+
+    @Test
+    public void useTags_notSpecified_behavesLikeUseTagsFalseForJaxrsSpecLibrary() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        KotlinServerCodegen codegen = new KotlinServerCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(LIBRARY, JAXRS_SPEC);
+        // useTags intentionally NOT set — must default to false
+
+        new DefaultGenerator().opts(new ClientOptInput()
+                        .openAPI(TestUtils.parseSpec("src/test/resources/2_0/petstore.yaml"))
+                        .config(codegen))
+                .generate();
+
+        String outputPath = output.getAbsolutePath() + "/src/main/kotlin/org/openapitools/server";
+        Path petApi = Paths.get(outputPath + "/apis/PetApi.kt");
+
+        assertFileContains(petApi,
+                "class PetApi",
+                "@Path(\"/\")",
+                "@Path(\"/pet\")",
+                "@Path(\"/pet/{petId}\")"
         );
+        assertFileNotContains(petApi, "@Path(\"/store\")");
     }
 }

--- a/samples/server/others/kotlin-server/jaxrs-spec-array-response/src/main/kotlin/org/openapitools/server/apis/StuffApi.kt
+++ b/samples/server/others/kotlin-server/jaxrs-spec-array-response/src/main/kotlin/org/openapitools/server/apis/StuffApi.kt
@@ -10,7 +10,7 @@ import java.io.InputStream
 
 
 
-@Path("")
+@Path("/")
 @jakarta.annotation.Generated(value = arrayOf("org.openapitools.codegen.languages.KotlinServerCodegen"), comments = "Generator version: 7.22.0-SNAPSHOT")
 interface StuffApi {
 

--- a/samples/server/others/kotlin-server/jaxrs-spec/src/main/kotlin/org/openapitools/server/apis/DefaultApi.kt
+++ b/samples/server/others/kotlin-server/jaxrs-spec/src/main/kotlin/org/openapitools/server/apis/DefaultApi.kt
@@ -9,11 +9,12 @@ import java.io.InputStream
 
 
 
-@Path("/test/parameters/{path_default}/{path_nullable}")
+@Path("/")
 @javax.annotation.Generated(value = arrayOf("org.openapitools.codegen.languages.KotlinServerCodegen"), comments = "Generator version: 7.22.0-SNAPSHOT")
 class DefaultApi {
 
     @GET
+    @Path("/test/parameters/{path_default}/{path_nullable}")
     suspend fun findPetsByStatus(@PathParam("path_default") pathDefault: kotlin.String,@PathParam("path_nullable") pathNullable: kotlin.String,@QueryParam("query_default") @DefaultValue("available")   queryDefault: kotlin.String,@QueryParam("query_default_enum") @DefaultValue("B")   queryDefaultEnum: kotlin.String,@QueryParam("query_default_int") @DefaultValue("3")   queryDefaultInt: java.math.BigDecimal,@HeaderParam("header_default")  @DefaultValue("available")  headerDefault: kotlin.String,@HeaderParam("header_default_enum")  @DefaultValue("B")  headerDefaultEnum: kotlin.String,@HeaderParam("header_default_int")  @DefaultValue("3")  headerDefaultInt: java.math.BigDecimal,@CookieParam("cookie_default") @DefaultValue("available")  cookieDefault: kotlin.String,@CookieParam("cookie_default_enum") @DefaultValue("B")  cookieDefaultEnum: kotlin.String,@CookieParam("cookie_default_int") @DefaultValue("3")  cookieDefaultInt: java.math.BigDecimal,@QueryParam("query_nullable")   queryNullable: kotlin.String?,@HeaderParam("header_nullable")   headerNullable: kotlin.String?,@CookieParam("cookie_nullable")  cookieNullable: kotlin.String?,@QueryParam("\$query-\$dollar-sign")   dollarQueryDollarDollarSign: kotlin.String?): Response {
         return Response.ok().entity("magic!").build();
     }

--- a/samples/server/petstore/kotlin-server/jaxrs-spec-mutiny/src/main/kotlin/org/openapitools/server/apis/PetApi.kt
+++ b/samples/server/petstore/kotlin-server/jaxrs-spec-mutiny/src/main/kotlin/org/openapitools/server/apis/PetApi.kt
@@ -11,46 +11,46 @@ import java.io.InputStream
 
 
 
-@Path("/pet")
+@Path("/")
 @javax.annotation.Generated(value = arrayOf("org.openapitools.codegen.languages.KotlinServerCodegen"), comments = "Generator version: 7.22.0-SNAPSHOT")
 interface PetApi {
 
     @POST
-    @Path("")
+    @Path("/pet")
     @Consumes("application/json", "application/xml")
     fun addPet( body: Pet): io.smallrye.mutiny.Uni<Response>
 
     @DELETE
-    @Path("/{petId}")
+    @Path("/pet/{petId}")
     fun deletePet(@PathParam("petId") petId: kotlin.Long,@HeaderParam("api_key")   apiKey: kotlin.String?): io.smallrye.mutiny.Uni<Response>
 
     @GET
-    @Path("/findByStatus")
+    @Path("/pet/findByStatus")
     @Produces("application/xml", "application/json")
     fun findPetsByStatus(@QueryParam("status")   status: kotlin.collections.List<kotlin.String>): io.smallrye.mutiny.Uni<Response>
 
     @GET
-    @Path("/findByTags")
+    @Path("/pet/findByTags")
     @Produces("application/xml", "application/json")
     fun findPetsByTags(@QueryParam("tags")   tags: kotlin.collections.List<kotlin.String>): io.smallrye.mutiny.Uni<Response>
 
     @GET
-    @Path("/{petId}")
+    @Path("/pet/{petId}")
     @Produces("application/xml", "application/json")
     fun getPetById(@PathParam("petId") petId: kotlin.Long): io.smallrye.mutiny.Uni<Response>
 
     @PUT
-    @Path("")
+    @Path("/pet")
     @Consumes("application/json", "application/xml")
     fun updatePet( body: Pet): io.smallrye.mutiny.Uni<Response>
 
     @POST
-    @Path("/{petId}")
+    @Path("/pet/{petId}")
     @Consumes("application/x-www-form-urlencoded")
     fun updatePetWithForm(@PathParam("petId") petId: kotlin.Long,@FormParam(value = "name") name: kotlin.String?,@FormParam(value = "status") status: kotlin.String?): io.smallrye.mutiny.Uni<Response>
 
     @POST
-    @Path("/{petId}/uploadImage")
+    @Path("/pet/{petId}/uploadImage")
     @Consumes("multipart/form-data")
     @Produces("application/json")
     fun uploadFile(@PathParam("petId") petId: kotlin.Long,@FormParam(value = "additionalMetadata") additionalMetadata: kotlin.String?, @FormParam(value = "file") fileInputStream: InputStream?): io.smallrye.mutiny.Uni<Response>

--- a/samples/server/petstore/kotlin-server/jaxrs-spec-mutiny/src/main/kotlin/org/openapitools/server/apis/StoreApi.kt
+++ b/samples/server/petstore/kotlin-server/jaxrs-spec-mutiny/src/main/kotlin/org/openapitools/server/apis/StoreApi.kt
@@ -10,26 +10,26 @@ import java.io.InputStream
 
 
 
-@Path("/store")
+@Path("/")
 @javax.annotation.Generated(value = arrayOf("org.openapitools.codegen.languages.KotlinServerCodegen"), comments = "Generator version: 7.22.0-SNAPSHOT")
 interface StoreApi {
 
     @DELETE
-    @Path("/order/{orderId}")
+    @Path("/store/order/{orderId}")
     fun deleteOrder(@PathParam("orderId") orderId: kotlin.String): io.smallrye.mutiny.Uni<Response>
 
     @GET
-    @Path("/inventory")
+    @Path("/store/inventory")
     @Produces("application/json")
     fun getInventory(): io.smallrye.mutiny.Uni<Response>
 
     @GET
-    @Path("/order/{orderId}")
+    @Path("/store/order/{orderId}")
     @Produces("application/xml", "application/json")
     fun getOrderById(@PathParam("orderId") orderId: kotlin.Long): io.smallrye.mutiny.Uni<Response>
 
     @POST
-    @Path("/order")
+    @Path("/store/order")
     @Produces("application/xml", "application/json")
     fun placeOrder( body: Order): io.smallrye.mutiny.Uni<Response>
 }

--- a/samples/server/petstore/kotlin-server/jaxrs-spec-mutiny/src/main/kotlin/org/openapitools/server/apis/UserApi.kt
+++ b/samples/server/petstore/kotlin-server/jaxrs-spec-mutiny/src/main/kotlin/org/openapitools/server/apis/UserApi.kt
@@ -10,41 +10,41 @@ import java.io.InputStream
 
 
 
-@Path("/user")
+@Path("/")
 @javax.annotation.Generated(value = arrayOf("org.openapitools.codegen.languages.KotlinServerCodegen"), comments = "Generator version: 7.22.0-SNAPSHOT")
 interface UserApi {
 
     @POST
-    @Path("")
+    @Path("/user")
     fun createUser( body: User): io.smallrye.mutiny.Uni<Response>
 
     @POST
-    @Path("/createWithArray")
+    @Path("/user/createWithArray")
     fun createUsersWithArrayInput( body: kotlin.collections.List<User>): io.smallrye.mutiny.Uni<Response>
 
     @POST
-    @Path("/createWithList")
+    @Path("/user/createWithList")
     fun createUsersWithListInput( body: kotlin.collections.List<User>): io.smallrye.mutiny.Uni<Response>
 
     @DELETE
-    @Path("/{username}")
+    @Path("/user/{username}")
     fun deleteUser(@PathParam("username") username: kotlin.String): io.smallrye.mutiny.Uni<Response>
 
     @GET
-    @Path("/{username}")
+    @Path("/user/{username}")
     @Produces("application/xml", "application/json")
     fun getUserByName(@PathParam("username") username: kotlin.String): io.smallrye.mutiny.Uni<Response>
 
     @GET
-    @Path("/login")
+    @Path("/user/login")
     @Produces("application/xml", "application/json")
     fun loginUser(@QueryParam("username")   username: kotlin.String,@QueryParam("password")   password: kotlin.String): io.smallrye.mutiny.Uni<Response>
 
     @GET
-    @Path("/logout")
+    @Path("/user/logout")
     fun logoutUser(): io.smallrye.mutiny.Uni<Response>
 
     @PUT
-    @Path("/{username}")
+    @Path("/user/{username}")
     fun updateUser(@PathParam("username") username: kotlin.String, body: User): io.smallrye.mutiny.Uni<Response>
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Fixes https://github.com/OpenAPITools/openapi-generator/issues/20342 and issues brought by https://github.com/OpenAPITools/openapi-generator/pull/22970

- Remove addOperationToGroup override: class names now always come from tags
- postProcessOperationsWithModels: compute commonPath only when useTags=true,
  otherwise set commonPath='/' and mark all operations as subresourceOperation
  so full paths are emitted on methods
- Remove unused Operation import
- Update and add tests for useTags=false and useTags not specified
- Regenerate affected samples

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #20342 for Kotlin Server JAX-RS: default `useTags` to false, always name API classes from tags, and when `useTags=false` generate class `@Path("/")` with full method paths. The README docs now show `commonPath` only when `useTags=true`.

- **Bug Fixes**
  - Compute `commonPath` only when `useTags=true`; otherwise set `commonPath` to `/` and keep full method paths.
  - Remove JAX-RS-specific `addOperationToGroup`; grouping/class names always come from tags.
  - Update README template, add tests (including when `useTags` is unspecified), and regenerate samples.

<sup>Written for commit cebef32c8513d2547a259d21ba39648644348783. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

