### PR TITLE
[java] Support 'date-time-local' format

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -674,9 +674,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             importMapping.put("LocalDate", "java.time.LocalDate");
             typeMapping.put("time-local","LocalTime");
             importMapping.put("LocalTime", "java.time.LocalTime");
+            typeMapping.put("date-time-local", "LocalDateTime");
+            importMapping.put("LocalDateTime", "java.time.LocalDateTime");
             if ("java8-localdatetime".equals(dateLibrary)) {
                 typeMapping.put("DateTime", "LocalDateTime");
-                importMapping.put("LocalDateTime", "java.time.LocalDateTime");
             } else {
                 typeMapping.put("DateTime", "OffsetDateTime");
                 importMapping.put("OffsetDateTime", "java.time.OffsetDateTime");
@@ -1450,6 +1451,13 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                 }
             }
             return null;
+        } else if (ModelUtils.isDateTimeLocalSchema(schema)) {
+            if (schema.getDefault() != null) {
+                if ("java8".equals(getDateLibrary())) {
+                    return String.format(Locale.ROOT, "LocalDateTime.parse(\"%s\")", String.valueOf(schema.getDefault()));
+                }
+            }
+            return null;
         } else if (ModelUtils.isStringSchema(schema)) {
             if (schema.getDefault() != null) {
                 String _default;
@@ -1535,6 +1543,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                             } else if(ModelUtils.isTimeLocalSchema(propertySchema)) {
                                 if("java8".equals(getDateLibrary())) {
                                     defaultPropertyExpression = String.format(Locale.ROOT, "java.time.LocalTime.parse(\"%s\")", value.asText());
+                                }
+                            } else if(ModelUtils.isDateTimeLocalSchema(propertySchema)) {
+                                if("java8".equals(getDateLibrary())) {
+                                    defaultPropertyExpression = String.format(Locale.ROOT, "java.time.LocalDateTime.parse(\"%s\")", value.asText());
                                 }
                             } else if(ModelUtils.isUUIDSchema(propertySchema)) {
                                 defaultPropertyExpression = "java.util.UUID.fromString(\"" + value.asText() + "\")";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -715,6 +715,12 @@ public class ModelUtils {
                         && SchemaTypeUtil.DATE_TIME_FORMAT.equals(schema.getFormat()));
     }
 
+    public static boolean isDateTimeLocalSchema(Schema schema) {
+        // format: date-time-local, see https://spec.openapis.org/registry/format/date-time-local.html
+        return (SchemaTypeUtil.STRING_TYPE.equals(getType(schema))
+                        && "date-time-local".equals(schema.getFormat()));
+    }
+
     public static boolean isTimeLocalSchema(Schema schema) {
         // format: time-local, see https://spec.openapis.org/registry/format/time-local.html
         return (SchemaTypeUtil.STRING_TYPE.equals(getType(schema))

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -537,6 +537,15 @@ public class AbstractJavaCodegenTest {
 
         // dateLibrary <> java8
         Assert.assertEquals(defaultValue, "10:15:30");
+
+        // Test default value for date-time-local format
+        StringSchema dateTimeLocalSchema = new StringSchema();
+        dateTimeLocalSchema.setFormat("date-time-local");
+        dateTimeLocalSchema.setDefault(LocalDateTime.parse("2007-12-03T10:15:30"));
+        defaultValue = codegen.toDefaultValue(dateTimeLocalSchema);
+
+        // dateLibrary <> java8
+        Assert.assertEquals(defaultValue, "2007-12-03T10:15:30");
     }
 
     @Test
@@ -606,6 +615,13 @@ public class AbstractJavaCodegenTest {
         timeLocalSchema.setDefault("10:15:30");
         defaultValue = codegen.toDefaultValue(codegen.fromProperty("", timeLocalSchema), timeLocalSchema);
         Assert.assertEquals(defaultValue, "LocalTime.parse(\"10:15:30\")");
+
+        // Test default value for date-time-local format
+        StringSchema dateTimeLocalSchema = new StringSchema();
+        dateTimeLocalSchema.setFormat("date-time-local");
+        dateTimeLocalSchema.setDefault("2007-12-03T10:15:30");
+        defaultValue = codegen.toDefaultValue(codegen.fromProperty("", dateTimeLocalSchema), dateTimeLocalSchema);
+        Assert.assertEquals(defaultValue, "LocalDateTime.parse(\"2007-12-03T10:15:30\")");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -413,6 +413,35 @@ public class SpringCodegenTest {
     }
 
     @Test
+    public void generateLocalDateTimeForDateTimeLocalFormat() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/spring/date-time-parameter-types-for-testing.yml", null, new ParseOptions()).getOpenAPI();
+
+        SpringCodegen codegen = new SpringCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput input = new ClientOptInput();
+        input.openAPI(openAPI);
+        input.config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "false");
+        generator.setGenerateMetadata(false);
+        generator.opts(input).generate();
+
+        JavaFileAssert.assertThat(Paths.get(outputPath + "/src/main/java/org/openapitools/model/Pet.java"))
+                .hasImports("java.time.LocalDateTime")
+                .assertProperty("adoptionDate").withType("LocalDateTime");
+    }
+
+    @Test
     public void interfaceDefaultImplDisableWithResponseWrapper() {
         final SpringCodegen codegen = new SpringCodegen();
         codegen.additionalProperties().put(RESPONSE_WRAPPER, "aWrapper");

--- a/modules/openapi-generator/src/test/resources/3_0/spring/date-time-parameter-types-for-testing.yml
+++ b/modules/openapi-generator/src/test/resources/3_0/spring/date-time-parameter-types-for-testing.yml
@@ -106,3 +106,7 @@ components:
           type: string
           format: time-local
           default: '10:15:30'
+        adoptionDate:
+          type: string
+          format: date-time-local
+          default: '2007-12-03T10:15:30'

--- a/samples/client/petstore/spring-cloud-date-time/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud-date-time/src/main/java/org/openapitools/model/Pet.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -42,6 +43,8 @@ public class Pet {
   private LocalDate dateOfBirth = LocalDate.parse("2021-01-01");
 
   private LocalTime feedingTime = LocalTime.parse("10:15:30");
+
+  private LocalDateTime adoptionDate = LocalDateTime.parse("2007-12-03T10:15:30");
 
   public Pet() {
     super();
@@ -201,6 +204,27 @@ public class Pet {
     this.feedingTime = feedingTime;
   }
 
+  public Pet adoptionDate(LocalDateTime adoptionDate) {
+    this.adoptionDate = adoptionDate;
+    return this;
+  }
+
+  /**
+   * Get adoptionDate
+   * @return adoptionDate
+   */
+  @Valid 
+  @Schema(name = "adoptionDate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("adoptionDate")
+  public LocalDateTime getAdoptionDate() {
+    return adoptionDate;
+  }
+
+  @JsonProperty("adoptionDate")
+  public void setAdoptionDate(LocalDateTime adoptionDate) {
+    this.adoptionDate = adoptionDate;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -216,12 +240,13 @@ public class Pet {
         Objects.equals(this.price, pet.price) &&
         Objects.equals(this.lastFeed, pet.lastFeed) &&
         Objects.equals(this.dateOfBirth, pet.dateOfBirth) &&
-        Objects.equals(this.feedingTime, pet.feedingTime);
+        Objects.equals(this.feedingTime, pet.feedingTime) &&
+        Objects.equals(this.adoptionDate, pet.adoptionDate);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(atType, age, happy, price, lastFeed, dateOfBirth, feedingTime);
+    return Objects.hash(atType, age, happy, price, lastFeed, dateOfBirth, feedingTime, adoptionDate);
   }
 
   @Override
@@ -235,6 +260,7 @@ public class Pet {
     sb.append("    lastFeed: ").append(toIndentedString(lastFeed)).append("\n");
     sb.append("    dateOfBirth: ").append(toIndentedString(dateOfBirth)).append("\n");
     sb.append("    feedingTime: ").append(toIndentedString(feedingTime)).append("\n");
+    sb.append("    adoptionDate: ").append(toIndentedString(adoptionDate)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/openapi3/client/petstore/spring-cloud-date-time/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-date-time/src/main/java/org/openapitools/model/Pet.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -42,6 +43,8 @@ public class Pet {
   private LocalDate dateOfBirth = LocalDate.parse("2021-01-01");
 
   private LocalTime feedingTime = LocalTime.parse("10:15:30");
+
+  private LocalDateTime adoptionDate = LocalDateTime.parse("2007-12-03T10:15:30");
 
   public Pet() {
     super();
@@ -201,6 +204,27 @@ public class Pet {
     this.feedingTime = feedingTime;
   }
 
+  public Pet adoptionDate(LocalDateTime adoptionDate) {
+    this.adoptionDate = adoptionDate;
+    return this;
+  }
+
+  /**
+   * Get adoptionDate
+   * @return adoptionDate
+   */
+  @Valid 
+  @Schema(name = "adoptionDate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("adoptionDate")
+  public LocalDateTime getAdoptionDate() {
+    return adoptionDate;
+  }
+
+  @JsonProperty("adoptionDate")
+  public void setAdoptionDate(LocalDateTime adoptionDate) {
+    this.adoptionDate = adoptionDate;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -216,12 +240,13 @@ public class Pet {
         Objects.equals(this.price, pet.price) &&
         Objects.equals(this.lastFeed, pet.lastFeed) &&
         Objects.equals(this.dateOfBirth, pet.dateOfBirth) &&
-        Objects.equals(this.feedingTime, pet.feedingTime);
+        Objects.equals(this.feedingTime, pet.feedingTime) &&
+        Objects.equals(this.adoptionDate, pet.adoptionDate);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(atType, age, happy, price, lastFeed, dateOfBirth, feedingTime);
+    return Objects.hash(atType, age, happy, price, lastFeed, dateOfBirth, feedingTime, adoptionDate);
   }
 
   @Override
@@ -235,6 +260,7 @@ public class Pet {
     sb.append("    lastFeed: ").append(toIndentedString(lastFeed)).append("\n");
     sb.append("    dateOfBirth: ").append(toIndentedString(dateOfBirth)).append("\n");
     sb.append("    feedingTime: ").append(toIndentedString(feedingTime)).append("\n");
+    sb.append("    adoptionDate: ").append(toIndentedString(adoptionDate)).append("\n");
     sb.append("}");
     return sb.toString();
   }


### PR DESCRIPTION
See https://spec.openapis.org/registry/format/date-time-local.html

fixes #13889

@cachescrubber (2022/02) @welshm (2022/02) @MelleD (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02) @borsch (2022/02) @banlevente (2022/02) @Zomzog (2022/09) @martin-mfg (2023/08)

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for the OpenAPI `date-time-local` format in the Java/Spring generator. Maps to `LocalDateTime` (`java.time.LocalDateTime`) and parses defaults when the `java8` date library is used; fixes #13889.

- **New Features**
  - Map `date-time-local` → `LocalDateTime` in `AbstractJavaCodegen`; always import `java.time.LocalDateTime`; add `ModelUtils.isDateTimeLocalSchema`.
  - Parse `date-time-local` defaults via `LocalDateTime.parse(...)` when using `java8` (including nested object properties). Add unit tests (Java + Spring) and regenerate samples (`Pet.adoptionDate` with default).

<sup>Written for commit 1674477d4a6577ea3e3e9116ff6b18ba0f0c27b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

