### PR TITLE
fix(kotlin-spring): use Jackson 3 annotation package in model imports

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-spring/homeController.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/homeController.mustache
@@ -4,7 +4,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.RequestMapping
 {{#sourceDocumentationProvider}}
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import {{jacksonPackage}}.dataformat.yaml.YAMLMapper
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.io.Resource
 import org.springframework.util.StreamUtils

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/buildGradle-sb4-Kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/buildGradle-sb4-Kts.mustache
@@ -46,9 +46,10 @@ dependencies {
 
     implementation("com.google.code.findbugs:jsr305:3.0.2")
 {{#useJackson3}}
-    implementation("tools.jackson.dataformat:jackson-dataformat-yaml")
-    implementation("tools.jackson.dataformat:jackson-dataformat-xml")
-    implementation("tools.jackson.module:jackson-module-kotlin")
+    val jackson3Version = "3.1.0"
+    implementation("tools.jackson.dataformat:jackson-dataformat-yaml:$jackson3Version")
+    implementation("tools.jackson.dataformat:jackson-dataformat-xml:$jackson3Version")
+    implementation("tools.jackson.module:jackson-module-kotlin:$jackson3Version")
 {{/useJackson3}}
 {{^useJackson3}}
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/pom-sb4.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/pom-sb4.mustache
@@ -11,7 +11,8 @@
         <swagger-ui.version>5.17.14</swagger-ui.version>{{/springDocDocumentationProvider}}{{/useSwaggerUI}}{{^springDocDocumentationProvider}}{{#swagger1AnnotationLibrary}}
         <swagger-annotations.version>1.6.6</swagger-annotations.version>{{/swagger1AnnotationLibrary}}{{#swagger2AnnotationLibrary}}
         <swagger-annotations.version>2.2.28</swagger-annotations.version>{{/swagger2AnnotationLibrary}}{{/springDocDocumentationProvider}}
-        <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
+        <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>{{#useJackson3}}
+        <jackson3.version>3.1.0</jackson3.version>{{/useJackson3}}
         <jakarta-annotation.version>3.0.0</jakarta-annotation.version>
         <kotlin-test-junit5.version>2.2.0</kotlin-test-junit5.version>
 
@@ -158,6 +159,23 @@
             <artifactId>jsr305</artifactId>
             <version>${findbugs-jsr305.version}</version>
         </dependency>
+{{#useJackson3}}
+        <dependency>
+            <groupId>{{jacksonPackage}}.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${jackson3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>{{jacksonPackage}}.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>${jackson3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>{{jacksonPackage}}.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+            <version>${jackson3.version}</version>
+        </dependency>
+{{/useJackson3}}{{^useJackson3}}
         <dependency>
             <groupId>{{jacksonPackage}}.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
@@ -165,15 +183,16 @@
         <dependency>
             <groupId>{{jacksonPackage}}.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
-        </dependency>{{^useJackson3}}
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-        </dependency>{{/useJackson3}}
+        </dependency>
         <dependency>
             <groupId>{{jacksonPackage}}.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
         </dependency>
+{{/useJackson3}}
 {{#useBeanValidation}}
         <!-- Bean Validation API support -->
         <dependency>

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradle-sb4-Kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradle-sb4-Kts.mustache
@@ -54,9 +54,10 @@ dependencies {
 
     implementation("com.google.code.findbugs:jsr305:3.0.2")
 {{#useJackson3}}
-    implementation("tools.jackson.dataformat:jackson-dataformat-yaml")
-    implementation("tools.jackson.dataformat:jackson-dataformat-xml")
-    implementation("tools.jackson.module:jackson-module-kotlin")
+    val jackson3Version = "3.1.0"
+    implementation("tools.jackson.dataformat:jackson-dataformat-yaml:$jackson3Version")
+    implementation("tools.jackson.dataformat:jackson-dataformat-xml:$jackson3Version")
+    implementation("tools.jackson.module:jackson-module-kotlin:$jackson3Version")
 {{/useJackson3}}
 {{^useJackson3}}
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom-sb4.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom-sb4.mustache
@@ -17,7 +17,8 @@
         </swagger-annotations.version>{{/swagger1AnnotationLibrary}}{{#swagger2AnnotationLibrary}}
         <swagger-annotations.version>2.2.28
         </swagger-annotations.version>{{/swagger2AnnotationLibrary}}{{/springDocDocumentationProvider}}
-        <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
+        <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>{{#useJackson3}}
+        <jackson3.version>3.1.0</jackson3.version>{{/useJackson3}}
         <jakarta-annotation.version>3.0.0</jakarta-annotation.version>
         <kotlin-test-junit5.version>2.2.0</kotlin-test-junit5.version>
 
@@ -183,6 +184,23 @@
             <artifactId>spring-boot-starter-oauth2-client</artifactId>
         </dependency>
         {{/hasAuthMethods}}
+{{#useJackson3}}
+        <dependency>
+            <groupId>{{jacksonPackage}}.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${jackson3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>{{jacksonPackage}}.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>${jackson3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>{{jacksonPackage}}.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+            <version>${jackson3.version}</version>
+        </dependency>
+{{/useJackson3}}{{^useJackson3}}
         <dependency>
             <groupId>{{jacksonPackage}}.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
@@ -190,15 +208,16 @@
         <dependency>
             <groupId>{{jacksonPackage}}.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
-        </dependency>{{^useJackson3}}
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-        </dependency>{{/useJackson3}}
+        </dependency>
         <dependency>
             <groupId>{{jacksonPackage}}.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
         </dependency>
+{{/useJackson3}}
 {{#useBeanValidation}}
         <!-- Bean Validation API support -->
         <dependency>

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/buildGradle-sb4-Kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/buildGradle-sb4-Kts.mustache
@@ -54,9 +54,10 @@ dependencies {
 
     implementation("com.google.code.findbugs:jsr305:3.0.2")
 {{#useJackson3}}
-    implementation("tools.jackson.dataformat:jackson-dataformat-yaml")
-    implementation("tools.jackson.dataformat:jackson-dataformat-xml")
-    implementation("tools.jackson.module:jackson-module-kotlin")
+    val jackson3Version = "3.1.0"
+    implementation("tools.jackson.dataformat:jackson-dataformat-yaml:$jackson3Version")
+    implementation("tools.jackson.dataformat:jackson-dataformat-xml:$jackson3Version")
+    implementation("tools.jackson.module:jackson-module-kotlin:$jackson3Version")
 {{/useJackson3}}
 {{^useJackson3}}
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/pom-sb4.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/pom-sb4.mustache
@@ -17,7 +17,8 @@
         </swagger-annotations.version>{{/swagger1AnnotationLibrary}}{{#swagger2AnnotationLibrary}}
         <swagger-annotations.version>2.2.28
         </swagger-annotations.version>{{/swagger2AnnotationLibrary}}{{/springDocDocumentationProvider}}
-        <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
+        <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>{{#useJackson3}}
+        <jackson3.version>3.1.0</jackson3.version>{{/useJackson3}}
         <jakarta-annotation.version>3.0.0</jakarta-annotation.version>
         <kotlin-test-junit5.version>2.2.0</kotlin-test-junit5.version>
 
@@ -179,6 +180,23 @@
             <artifactId>spring-boot-starter-oauth2-client</artifactId>
         </dependency>
         {{/hasAuthMethods}}
+{{#useJackson3}}
+        <dependency>
+            <groupId>{{jacksonPackage}}.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${jackson3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>{{jacksonPackage}}.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>${jackson3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>{{jacksonPackage}}.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+            <version>${jackson3.version}</version>
+        </dependency>
+{{/useJackson3}}{{^useJackson3}}
         <dependency>
             <groupId>{{jacksonPackage}}.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
@@ -186,15 +204,16 @@
         <dependency>
             <groupId>{{jacksonPackage}}.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
-        </dependency>{{^useJackson3}}
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-        </dependency>{{/useJackson3}}
+        </dependency>
         <dependency>
             <groupId>{{jacksonPackage}}.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
         </dependency>
+{{/useJackson3}}
 {{#useBeanValidation}}
         <!-- Bean Validation API support -->
         <dependency>

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
@@ -4826,6 +4826,42 @@ public class KotlinSpringServerCodegenTest {
     }
 
     @Test
+    public void shouldGenerateJackson3BuildDepsWithVersions() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/petstore.yaml");
+        final KotlinSpringServerCodegen codegen = new KotlinSpringServerCodegen();
+        codegen.setOpenAPI(openAPI);
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        codegen.additionalProperties().put(KotlinSpringServerCodegen.USE_SPRING_BOOT4, "true");
+        codegen.additionalProperties().put(AbstractKotlinCodegen.USE_JACKSON_3, "true");
+        codegen.additionalProperties().put(DOCUMENTATION_PROVIDER, DocumentationProvider.NONE.toCliOptValue());
+        codegen.additionalProperties().put(ANNOTATION_LIBRARY, AnnotationLibrary.NONE.toCliOptValue());
+
+        ClientOptInput input = new ClientOptInput();
+        input.openAPI(openAPI);
+        input.config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.setGenerateMetadata(false);
+        generator.opts(input).generate();
+
+        // Gradle build file must have Jackson 3 deps with explicit versions
+        Path gradlePath = Paths.get(outputPath + "/build.gradle.kts");
+        assertFileContains(gradlePath, "tools.jackson.dataformat:jackson-dataformat-yaml:");
+        assertFileContains(gradlePath, "tools.jackson.module:jackson-module-kotlin:");
+        // Should NOT include non-existent tools.jackson.core:jackson-annotations
+        assertFileNotContains(gradlePath, "tools.jackson.core:jackson-annotations");
+
+        // Annotations stay in com.fasterxml.jackson.annotation even with Jackson 3
+        Path petModelPath = Paths.get(outputPath + "/src/main/kotlin/org/openapitools/model/Pet.kt");
+        assertFileContains(petModelPath, "com.fasterxml.jackson.annotation.JsonProperty");
+    }
+
+    @Test
     public void shouldDefaultToJackson3WhenSpringBoot4Enabled() throws IOException {
         File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
         output.deleteOnExit();

--- a/samples/server/petstore/kotlin-springboot-4/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-4/build.gradle.kts
@@ -29,9 +29,10 @@ dependencies {
         implementation("org.springframework.boot:spring-boot-starter-webmvc")
 
     implementation("com.google.code.findbugs:jsr305:3.0.2")
-    implementation("tools.jackson.dataformat:jackson-dataformat-yaml")
-    implementation("tools.jackson.dataformat:jackson-dataformat-xml")
-    implementation("tools.jackson.module:jackson-module-kotlin")
+    val jackson3Version = "3.1.0"
+    implementation("tools.jackson.dataformat:jackson-dataformat-yaml:$jackson3Version")
+    implementation("tools.jackson.dataformat:jackson-dataformat-xml:$jackson3Version")
+    implementation("tools.jackson.module:jackson-module-kotlin:$jackson3Version")
     implementation("org.springframework.data:spring-data-commons")
     implementation("jakarta.validation:jakarta.validation-api")
     implementation("jakarta.annotation:jakarta.annotation-api:3.0.0")

--- a/samples/server/petstore/kotlin-springboot-4/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-4/pom.xml
@@ -7,6 +7,7 @@
     <version>1.0.0</version>
     <properties>
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
+        <jackson3.version>3.1.0</jackson3.version>
         <jakarta-annotation.version>3.0.0</jakarta-annotation.version>
         <kotlin-test-junit5.version>2.2.0</kotlin-test-junit5.version>
 
@@ -101,14 +102,17 @@
         <dependency>
             <groupId>tools.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${jackson3.version}</version>
         </dependency>
         <dependency>
             <groupId>tools.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
+            <version>${jackson3.version}</version>
         </dependency>
         <dependency>
             <groupId>tools.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
+            <version>${jackson3.version}</version>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>


### PR DESCRIPTION
  ## Summary                                                                                                                                                                    
  - Fixes `importMapping` in `KotlinSpringServerCodegen` to derive Jackson annotation package from `useJackson3` flag instead of hardcoding `com.fasterxml.jackson`
  - Adds missing `tools.jackson.core:jackson-annotations` dependency to all Spring Boot 4 build templates (Gradle + Maven) for spring-boot, spring-cloud, and spring-declarative-http-interface libraries                                                                                                                                   
  - Fixes hardcoded `com.fasterxml.jackson.dataformat.yaml.YAMLMapper` import in `homeController.mustache` to use `{{jacksonPackage}}`                                          
  - Adds test verifying generated model files use `tools.jackson.annotation` when Jackson 3 is enabled                                                                          
  - Regenerates `kotlin-springboot-4` sample with corrected imports and dependencies                                                                                          
                                                                                                                                                                                
  ## Bug                                                                                                                                                                      
  When using `useSpringBoot4: true` / `useJackson3: true` with the kotlin-spring generator:
  1. Generated model source files imported `com.fasterxml.jackson.annotation.*` (Jackson 2) instead of `tools.jackson.annotation.*` (Jackson 3)                                 
  2. Build files were missing the `tools.jackson.core:jackson-annotations` dependency, causing compile failures even after fixing the imports                                                                 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Kotlin Spring generation for Jackson 3 on Spring Boot 4: keep model annotations in `com.fasterxml.jackson.annotation`, use `{{jacksonPackage}}` for `YAMLMapper`, and pin Jackson 3 dataformat/module versions. Tests and Spring Boot 4 samples updated.

- **Bug Fixes**
  - `KotlinSpringServerCodegen`: always import `JsonProperty`/`JsonCreator`/`JsonValue` from `com.fasterxml.jackson.annotation` (annotations did not move in Jackson 3).
  - `homeController.mustache`: import `{{jacksonPackage}}.dataformat.yaml.YAMLMapper`.

- **Dependencies**
  - Spring Boot 4 templates: set `3.1.0` for `tools.jackson.dataformat:jackson-dataformat-yaml`, `tools.jackson.dataformat:jackson-dataformat-xml`, and `tools.jackson.module:jackson-module-kotlin` via `val jackson3Version` / `<jackson3.version>`.
  - Do not add `tools.jackson.core:jackson-annotations`.

<sup>Written for commit 9e9bff461f525ae2836996517816e16bd38dfb98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



