### PR TITLE
Update rust-server Cargo.toml dependencies

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server-deprecated/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server-deprecated/Cargo.mustache
@@ -141,7 +141,7 @@ anyhow = { version = "1", optional = true }
 clap-verbosity-flag = { version = "0.3", optional = true }
 simple_logger = { version = "2.0", features = ["stderr"], optional = true }
 structopt = { version = "0.3", optional = true }
-tokio = { version = "0.2", features = ["rt-threaded", "macros", "stream"], optional = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"], optional = true }
 {{#apiHasDeleteMethods}}
 dialoguer = { version = "0.8", optional = true }
 {{/apiHasDeleteMethods}}

--- a/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
@@ -88,12 +88,12 @@ validate = [{{^apiUsesByteArray}}"regex",{{/apiUsesByteArray}} "serde_valid", "s
 
 [dependencies]
 # Common
-async-trait = "0.1.88"
+async-trait = "0.1.89"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 swagger = { version = "7.0.0", features = ["serdejson", "server", "client"] }
-headers = "0.4.0"
-log = "0.4.27"
+headers = "0.4.1"
+log = "0.4.29"
 
 mime = "0.3"
 mockall = { version = "0.14", optional = true }
@@ -120,14 +120,14 @@ serde-xml-rs = "0.8"
 multipart = { version = "0.18", default-features = false, optional = true }
 {{/apiUsesMultipartFormData}}
 {{#apiUsesUuid}}
-uuid = { version = "1.18.0", features = ["serde", "v4"]}
+uuid = { version = "1.23.0", features = ["serde", "v4"]}
 {{/apiUsesUuid}}
 
 # Common between server and client features
 bytes = "1.11"
 http-body-util = "0.1.3"
-hyper = { version = "1.8", features = ["full"], optional = true }
-hyper-util = { version = "0.1.18", features = ["service"] }
+hyper = { version = "1.9.0", features = ["full"], optional = true }
+hyper-util = { version = "0.1.20", features = ["service"] }
 {{#apiUsesMultipartRelated}}
 mime_multipart = { version = "0.10", optional = true, package = "mime-multipart-hyper1" }
 {{/apiUsesMultipartRelated}}
@@ -149,18 +149,18 @@ percent-encoding = { version = "2.3.2", optional = true }
 
 # CLI-specific
 anyhow = { version = "1", optional = true }
-clap = { version = "4.5", features = ["env"], optional = true }
+clap = { version = "4.6.0", features = ["env"], optional = true }
 clap-verbosity-flag = { version = "3.0", optional = true }
-simple_logger = { version = "5.0", features = ["stderr"], optional = true }
-tokio = { version = "1.49", features = ["rt-multi-thread", "macros"], optional = true }
+simple_logger = { version = "5.2.0", features = ["stderr"], optional = true }
+tokio = { version = "1.50.0", features = ["rt-multi-thread", "macros"], optional = true }
 {{#apiHasDeleteMethods}}
 dialoguer = { version = "0.12", optional = true }
 {{/apiHasDeleteMethods}}
 
 # Conversion
-frunk = { version = "0.4.3", optional = true }
-frunk_derives = { version = "0.4.3", optional = true }
-frunk_core = { version = "0.4.3", optional = true }
+frunk = { version = "0.4.4", optional = true }
+frunk_derives = { version = "0.4.4", optional = true }
+frunk_core = { version = "0.4.4", optional = true }
 frunk-enum-derive = { version = "0.3.0", optional = true }
 frunk-enum-core = { version = "0.3.0", optional = true }
 
@@ -177,14 +177,14 @@ hyper-openssl = { version = "0.10", optional = true }
 
 [dev-dependencies]
 always_send = "0.1.1"
-clap = "4.5"
+clap = "4.6.0"
 env_logger = "0.11"
-tokio = { version = "1.49", features = ["full"] }
+tokio = { version = "1.50.0", features = ["full"] }
 native-tls = "0.2"
-pin-project = "1.1.10"
+pin-project = "1.1.11"
 
 # Bearer authentication, used in examples
-jsonwebtoken = {version = "10.0.0", features = ["rust_crypto"]}
+jsonwebtoken = {version = "10.3.0", features = ["rust_crypto"]}
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dev-dependencies]
 openssl = "0.10"

--- a/samples/server/petstore/rust-server-deprecated/output/multipart-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server-deprecated/output/multipart-v3/Cargo.toml
@@ -70,7 +70,7 @@ anyhow = { version = "1", optional = true }
 clap-verbosity-flag = { version = "0.3", optional = true }
 simple_logger = { version = "2.0", features = ["stderr"], optional = true }
 structopt = { version = "0.3", optional = true }
-tokio = { version = "0.2", features = ["rt-threaded", "macros", "stream"], optional = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"], optional = true }
 
 # Conversion
 frunk = { version = "0.4.0", optional = true }

--- a/samples/server/petstore/rust-server-deprecated/output/no-example-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server-deprecated/output/no-example-v3/Cargo.toml
@@ -60,7 +60,7 @@ anyhow = { version = "1", optional = true }
 clap-verbosity-flag = { version = "0.3", optional = true }
 simple_logger = { version = "2.0", features = ["stderr"], optional = true }
 structopt = { version = "0.3", optional = true }
-tokio = { version = "0.2", features = ["rt-threaded", "macros", "stream"], optional = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"], optional = true }
 
 # Conversion
 frunk = { version = "0.4.0", optional = true }

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/Cargo.toml
@@ -66,7 +66,7 @@ anyhow = { version = "1", optional = true }
 clap-verbosity-flag = { version = "0.3", optional = true }
 simple_logger = { version = "2.0", features = ["stderr"], optional = true }
 structopt = { version = "0.3", optional = true }
-tokio = { version = "0.2", features = ["rt-threaded", "macros", "stream"], optional = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"], optional = true }
 
 # Conversion
 frunk = { version = "0.4.0", optional = true }

--- a/samples/server/petstore/rust-server-deprecated/output/ops-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server-deprecated/output/ops-v3/Cargo.toml
@@ -60,7 +60,7 @@ anyhow = { version = "1", optional = true }
 clap-verbosity-flag = { version = "0.3", optional = true }
 simple_logger = { version = "2.0", features = ["stderr"], optional = true }
 structopt = { version = "0.3", optional = true }
-tokio = { version = "0.2", features = ["rt-threaded", "macros", "stream"], optional = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"], optional = true }
 
 # Conversion
 frunk = { version = "0.4.0", optional = true }

--- a/samples/server/petstore/rust-server-deprecated/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
+++ b/samples/server/petstore/rust-server-deprecated/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
@@ -71,7 +71,7 @@ anyhow = { version = "1", optional = true }
 clap-verbosity-flag = { version = "0.3", optional = true }
 simple_logger = { version = "2.0", features = ["stderr"], optional = true }
 structopt = { version = "0.3", optional = true }
-tokio = { version = "0.2", features = ["rt-threaded", "macros", "stream"], optional = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"], optional = true }
 dialoguer = { version = "0.8", optional = true }
 
 # Conversion

--- a/samples/server/petstore/rust-server-deprecated/output/ping-bearer-auth/Cargo.toml
+++ b/samples/server/petstore/rust-server-deprecated/output/ping-bearer-auth/Cargo.toml
@@ -60,7 +60,7 @@ anyhow = { version = "1", optional = true }
 clap-verbosity-flag = { version = "0.3", optional = true }
 simple_logger = { version = "2.0", features = ["stderr"], optional = true }
 structopt = { version = "0.3", optional = true }
-tokio = { version = "0.2", features = ["rt-threaded", "macros", "stream"], optional = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"], optional = true }
 
 # Conversion
 frunk = { version = "0.4.0", optional = true }

--- a/samples/server/petstore/rust-server-deprecated/output/rust-server-test/Cargo.toml
+++ b/samples/server/petstore/rust-server-deprecated/output/rust-server-test/Cargo.toml
@@ -60,7 +60,7 @@ anyhow = { version = "1", optional = true }
 clap-verbosity-flag = { version = "0.3", optional = true }
 simple_logger = { version = "2.0", features = ["stderr"], optional = true }
 structopt = { version = "0.3", optional = true }
-tokio = { version = "0.2", features = ["rt-threaded", "macros", "stream"], optional = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"], optional = true }
 
 # Conversion
 frunk = { version = "0.4.0", optional = true }

--- a/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
@@ -42,12 +42,12 @@ validate = [ "serde_valid", "swagger/serdevalid"]
 
 [dependencies]
 # Common
-async-trait = "0.1.88"
+async-trait = "0.1.89"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 swagger = { version = "7.0.0", features = ["serdejson", "server", "client"] }
-headers = "0.4.0"
-log = "0.4.27"
+headers = "0.4.1"
+log = "0.4.29"
 
 mime = "0.3"
 mockall = { version = "0.14", optional = true }
@@ -67,8 +67,8 @@ multipart = { version = "0.18", default-features = false, optional = true }
 # Common between server and client features
 bytes = "1.11"
 http-body-util = "0.1.3"
-hyper = { version = "1.8", features = ["full"], optional = true }
-hyper-util = { version = "0.1.18", features = ["service"] }
+hyper = { version = "1.9.0", features = ["full"], optional = true }
+hyper-util = { version = "0.1.20", features = ["service"] }
 mime_multipart = { version = "0.10", optional = true, package = "mime-multipart-hyper1" }
 serde_ignored = { version = "0.1.14", optional = true }
 url = { version = "2.5", optional = true }
@@ -81,15 +81,15 @@ percent-encoding = { version = "2.3.2", optional = true }
 
 # CLI-specific
 anyhow = { version = "1", optional = true }
-clap = { version = "4.5", features = ["env"], optional = true }
+clap = { version = "4.6.0", features = ["env"], optional = true }
 clap-verbosity-flag = { version = "3.0", optional = true }
-simple_logger = { version = "5.0", features = ["stderr"], optional = true }
-tokio = { version = "1.49", features = ["rt-multi-thread", "macros"], optional = true }
+simple_logger = { version = "5.2.0", features = ["stderr"], optional = true }
+tokio = { version = "1.50.0", features = ["rt-multi-thread", "macros"], optional = true }
 
 # Conversion
-frunk = { version = "0.4.3", optional = true }
-frunk_derives = { version = "0.4.3", optional = true }
-frunk_core = { version = "0.4.3", optional = true }
+frunk = { version = "0.4.4", optional = true }
+frunk_derives = { version = "0.4.4", optional = true }
+frunk_core = { version = "0.4.4", optional = true }
 frunk-enum-derive = { version = "0.3.0", optional = true }
 frunk-enum-core = { version = "0.3.0", optional = true }
 
@@ -106,14 +106,14 @@ hyper-openssl = { version = "0.10", optional = true }
 
 [dev-dependencies]
 always_send = "0.1.1"
-clap = "4.5"
+clap = "4.6.0"
 env_logger = "0.11"
-tokio = { version = "1.49", features = ["full"] }
+tokio = { version = "1.50.0", features = ["full"] }
 native-tls = "0.2"
-pin-project = "1.1.10"
+pin-project = "1.1.11"
 
 # Bearer authentication, used in examples
-jsonwebtoken = {version = "10.0.0", features = ["rust_crypto"]}
+jsonwebtoken = {version = "10.3.0", features = ["rust_crypto"]}
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dev-dependencies]
 openssl = "0.10"

--- a/samples/server/petstore/rust-server/output/no-example-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/no-example-v3/Cargo.toml
@@ -38,12 +38,12 @@ validate = ["regex", "serde_valid", "swagger/serdevalid"]
 
 [dependencies]
 # Common
-async-trait = "0.1.88"
+async-trait = "0.1.89"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 swagger = { version = "7.0.0", features = ["serdejson", "server", "client"] }
-headers = "0.4.0"
-log = "0.4.27"
+headers = "0.4.1"
+log = "0.4.29"
 
 mime = "0.3"
 mockall = { version = "0.14", optional = true }
@@ -60,8 +60,8 @@ validator = { version = "0.20", features = ["derive"] }
 # Common between server and client features
 bytes = "1.11"
 http-body-util = "0.1.3"
-hyper = { version = "1.8", features = ["full"], optional = true }
-hyper-util = { version = "0.1.18", features = ["service"] }
+hyper = { version = "1.9.0", features = ["full"], optional = true }
+hyper-util = { version = "0.1.20", features = ["service"] }
 serde_ignored = { version = "0.1.14", optional = true }
 url = { version = "2.5", optional = true }
 
@@ -75,15 +75,15 @@ percent-encoding = { version = "2.3.2", optional = true }
 
 # CLI-specific
 anyhow = { version = "1", optional = true }
-clap = { version = "4.5", features = ["env"], optional = true }
+clap = { version = "4.6.0", features = ["env"], optional = true }
 clap-verbosity-flag = { version = "3.0", optional = true }
-simple_logger = { version = "5.0", features = ["stderr"], optional = true }
-tokio = { version = "1.49", features = ["rt-multi-thread", "macros"], optional = true }
+simple_logger = { version = "5.2.0", features = ["stderr"], optional = true }
+tokio = { version = "1.50.0", features = ["rt-multi-thread", "macros"], optional = true }
 
 # Conversion
-frunk = { version = "0.4.3", optional = true }
-frunk_derives = { version = "0.4.3", optional = true }
-frunk_core = { version = "0.4.3", optional = true }
+frunk = { version = "0.4.4", optional = true }
+frunk_derives = { version = "0.4.4", optional = true }
+frunk_core = { version = "0.4.4", optional = true }
 frunk-enum-derive = { version = "0.3.0", optional = true }
 frunk-enum-core = { version = "0.3.0", optional = true }
 
@@ -100,14 +100,14 @@ hyper-openssl = { version = "0.10", optional = true }
 
 [dev-dependencies]
 always_send = "0.1.1"
-clap = "4.5"
+clap = "4.6.0"
 env_logger = "0.11"
-tokio = { version = "1.49", features = ["full"] }
+tokio = { version = "1.50.0", features = ["full"] }
 native-tls = "0.2"
-pin-project = "1.1.10"
+pin-project = "1.1.11"
 
 # Bearer authentication, used in examples
-jsonwebtoken = {version = "10.0.0", features = ["rust_crypto"]}
+jsonwebtoken = {version = "10.3.0", features = ["rust_crypto"]}
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dev-dependencies]
 openssl = "0.10"

--- a/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
@@ -41,12 +41,12 @@ validate = [ "serde_valid", "swagger/serdevalid"]
 
 [dependencies]
 # Common
-async-trait = "0.1.88"
+async-trait = "0.1.89"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 swagger = { version = "7.0.0", features = ["serdejson", "server", "client"] }
-headers = "0.4.0"
-log = "0.4.27"
+headers = "0.4.1"
+log = "0.4.29"
 
 mime = "0.3"
 mockall = { version = "0.14", optional = true }
@@ -62,13 +62,13 @@ validator = { version = "0.20", features = ["derive"] }
 
 # Crates included if required by the API definition
 serde-xml-rs = "0.8"
-uuid = { version = "1.18.0", features = ["serde", "v4"]}
+uuid = { version = "1.23.0", features = ["serde", "v4"]}
 
 # Common between server and client features
 bytes = "1.11"
 http-body-util = "0.1.3"
-hyper = { version = "1.8", features = ["full"], optional = true }
-hyper-util = { version = "0.1.18", features = ["service"] }
+hyper = { version = "1.9.0", features = ["full"], optional = true }
+hyper-util = { version = "0.1.20", features = ["service"] }
 serde_ignored = { version = "0.1.14", optional = true }
 url = { version = "2.5", optional = true }
 
@@ -81,15 +81,15 @@ percent-encoding = { version = "2.3.2", optional = true }
 
 # CLI-specific
 anyhow = { version = "1", optional = true }
-clap = { version = "4.5", features = ["env"], optional = true }
+clap = { version = "4.6.0", features = ["env"], optional = true }
 clap-verbosity-flag = { version = "3.0", optional = true }
-simple_logger = { version = "5.0", features = ["stderr"], optional = true }
-tokio = { version = "1.49", features = ["rt-multi-thread", "macros"], optional = true }
+simple_logger = { version = "5.2.0", features = ["stderr"], optional = true }
+tokio = { version = "1.50.0", features = ["rt-multi-thread", "macros"], optional = true }
 
 # Conversion
-frunk = { version = "0.4.3", optional = true }
-frunk_derives = { version = "0.4.3", optional = true }
-frunk_core = { version = "0.4.3", optional = true }
+frunk = { version = "0.4.4", optional = true }
+frunk_derives = { version = "0.4.4", optional = true }
+frunk_core = { version = "0.4.4", optional = true }
 frunk-enum-derive = { version = "0.3.0", optional = true }
 frunk-enum-core = { version = "0.3.0", optional = true }
 
@@ -106,14 +106,14 @@ hyper-openssl = { version = "0.10", optional = true }
 
 [dev-dependencies]
 always_send = "0.1.1"
-clap = "4.5"
+clap = "4.6.0"
 env_logger = "0.11"
-tokio = { version = "1.49", features = ["full"] }
+tokio = { version = "1.50.0", features = ["full"] }
 native-tls = "0.2"
-pin-project = "1.1.10"
+pin-project = "1.1.11"
 
 # Bearer authentication, used in examples
-jsonwebtoken = {version = "10.0.0", features = ["rust_crypto"]}
+jsonwebtoken = {version = "10.3.0", features = ["rust_crypto"]}
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dev-dependencies]
 openssl = "0.10"

--- a/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
@@ -38,12 +38,12 @@ validate = ["regex", "serde_valid", "swagger/serdevalid"]
 
 [dependencies]
 # Common
-async-trait = "0.1.88"
+async-trait = "0.1.89"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 swagger = { version = "7.0.0", features = ["serdejson", "server", "client"] }
-headers = "0.4.0"
-log = "0.4.27"
+headers = "0.4.1"
+log = "0.4.29"
 
 mime = "0.3"
 mockall = { version = "0.14", optional = true }
@@ -60,8 +60,8 @@ validator = { version = "0.20", features = ["derive"] }
 # Common between server and client features
 bytes = "1.11"
 http-body-util = "0.1.3"
-hyper = { version = "1.8", features = ["full"], optional = true }
-hyper-util = { version = "0.1.18", features = ["service"] }
+hyper = { version = "1.9.0", features = ["full"], optional = true }
+hyper-util = { version = "0.1.20", features = ["service"] }
 serde_ignored = { version = "0.1.14", optional = true }
 url = { version = "2.5", optional = true }
 
@@ -75,15 +75,15 @@ percent-encoding = { version = "2.3.2", optional = true }
 
 # CLI-specific
 anyhow = { version = "1", optional = true }
-clap = { version = "4.5", features = ["env"], optional = true }
+clap = { version = "4.6.0", features = ["env"], optional = true }
 clap-verbosity-flag = { version = "3.0", optional = true }
-simple_logger = { version = "5.0", features = ["stderr"], optional = true }
-tokio = { version = "1.49", features = ["rt-multi-thread", "macros"], optional = true }
+simple_logger = { version = "5.2.0", features = ["stderr"], optional = true }
+tokio = { version = "1.50.0", features = ["rt-multi-thread", "macros"], optional = true }
 
 # Conversion
-frunk = { version = "0.4.3", optional = true }
-frunk_derives = { version = "0.4.3", optional = true }
-frunk_core = { version = "0.4.3", optional = true }
+frunk = { version = "0.4.4", optional = true }
+frunk_derives = { version = "0.4.4", optional = true }
+frunk_core = { version = "0.4.4", optional = true }
 frunk-enum-derive = { version = "0.3.0", optional = true }
 frunk-enum-core = { version = "0.3.0", optional = true }
 
@@ -100,14 +100,14 @@ hyper-openssl = { version = "0.10", optional = true }
 
 [dev-dependencies]
 always_send = "0.1.1"
-clap = "4.5"
+clap = "4.6.0"
 env_logger = "0.11"
-tokio = { version = "1.49", features = ["full"] }
+tokio = { version = "1.50.0", features = ["full"] }
 native-tls = "0.2"
-pin-project = "1.1.10"
+pin-project = "1.1.11"
 
 # Bearer authentication, used in examples
-jsonwebtoken = {version = "10.0.0", features = ["rust_crypto"]}
+jsonwebtoken = {version = "10.3.0", features = ["rust_crypto"]}
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dev-dependencies]
 openssl = "0.10"

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
@@ -42,12 +42,12 @@ validate = [ "serde_valid", "swagger/serdevalid"]
 
 [dependencies]
 # Common
-async-trait = "0.1.88"
+async-trait = "0.1.89"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 swagger = { version = "7.0.0", features = ["serdejson", "server", "client"] }
-headers = "0.4.0"
-log = "0.4.27"
+headers = "0.4.1"
+log = "0.4.29"
 
 mime = "0.3"
 mockall = { version = "0.14", optional = true }
@@ -65,13 +65,13 @@ validator = { version = "0.20", features = ["derive"] }
 # Crates included if required by the API definition
 serde-xml-rs = "0.8"
 multipart = { version = "0.18", default-features = false, optional = true }
-uuid = { version = "1.18.0", features = ["serde", "v4"]}
+uuid = { version = "1.23.0", features = ["serde", "v4"]}
 
 # Common between server and client features
 bytes = "1.11"
 http-body-util = "0.1.3"
-hyper = { version = "1.8", features = ["full"], optional = true }
-hyper-util = { version = "0.1.18", features = ["service"] }
+hyper = { version = "1.9.0", features = ["full"], optional = true }
+hyper-util = { version = "0.1.20", features = ["service"] }
 serde_ignored = { version = "0.1.14", optional = true }
 url = { version = "2.5", optional = true }
 
@@ -84,16 +84,16 @@ percent-encoding = { version = "2.3.2", optional = true }
 
 # CLI-specific
 anyhow = { version = "1", optional = true }
-clap = { version = "4.5", features = ["env"], optional = true }
+clap = { version = "4.6.0", features = ["env"], optional = true }
 clap-verbosity-flag = { version = "3.0", optional = true }
-simple_logger = { version = "5.0", features = ["stderr"], optional = true }
-tokio = { version = "1.49", features = ["rt-multi-thread", "macros"], optional = true }
+simple_logger = { version = "5.2.0", features = ["stderr"], optional = true }
+tokio = { version = "1.50.0", features = ["rt-multi-thread", "macros"], optional = true }
 dialoguer = { version = "0.12", optional = true }
 
 # Conversion
-frunk = { version = "0.4.3", optional = true }
-frunk_derives = { version = "0.4.3", optional = true }
-frunk_core = { version = "0.4.3", optional = true }
+frunk = { version = "0.4.4", optional = true }
+frunk_derives = { version = "0.4.4", optional = true }
+frunk_core = { version = "0.4.4", optional = true }
 frunk-enum-derive = { version = "0.3.0", optional = true }
 frunk-enum-core = { version = "0.3.0", optional = true }
 
@@ -110,14 +110,14 @@ hyper-openssl = { version = "0.10", optional = true }
 
 [dev-dependencies]
 always_send = "0.1.1"
-clap = "4.5"
+clap = "4.6.0"
 env_logger = "0.11"
-tokio = { version = "1.49", features = ["full"] }
+tokio = { version = "1.50.0", features = ["full"] }
 native-tls = "0.2"
-pin-project = "1.1.10"
+pin-project = "1.1.11"
 
 # Bearer authentication, used in examples
-jsonwebtoken = {version = "10.0.0", features = ["rust_crypto"]}
+jsonwebtoken = {version = "10.3.0", features = ["rust_crypto"]}
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dev-dependencies]
 openssl = "0.10"

--- a/samples/server/petstore/rust-server/output/ping-bearer-auth/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/ping-bearer-auth/Cargo.toml
@@ -38,12 +38,12 @@ validate = ["regex", "serde_valid", "swagger/serdevalid"]
 
 [dependencies]
 # Common
-async-trait = "0.1.88"
+async-trait = "0.1.89"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 swagger = { version = "7.0.0", features = ["serdejson", "server", "client"] }
-headers = "0.4.0"
-log = "0.4.27"
+headers = "0.4.1"
+log = "0.4.29"
 
 mime = "0.3"
 mockall = { version = "0.14", optional = true }
@@ -60,8 +60,8 @@ validator = { version = "0.20", features = ["derive"] }
 # Common between server and client features
 bytes = "1.11"
 http-body-util = "0.1.3"
-hyper = { version = "1.8", features = ["full"], optional = true }
-hyper-util = { version = "0.1.18", features = ["service"] }
+hyper = { version = "1.9.0", features = ["full"], optional = true }
+hyper-util = { version = "0.1.20", features = ["service"] }
 serde_ignored = { version = "0.1.14", optional = true }
 url = { version = "2.5", optional = true }
 
@@ -75,15 +75,15 @@ percent-encoding = { version = "2.3.2", optional = true }
 
 # CLI-specific
 anyhow = { version = "1", optional = true }
-clap = { version = "4.5", features = ["env"], optional = true }
+clap = { version = "4.6.0", features = ["env"], optional = true }
 clap-verbosity-flag = { version = "3.0", optional = true }
-simple_logger = { version = "5.0", features = ["stderr"], optional = true }
-tokio = { version = "1.49", features = ["rt-multi-thread", "macros"], optional = true }
+simple_logger = { version = "5.2.0", features = ["stderr"], optional = true }
+tokio = { version = "1.50.0", features = ["rt-multi-thread", "macros"], optional = true }
 
 # Conversion
-frunk = { version = "0.4.3", optional = true }
-frunk_derives = { version = "0.4.3", optional = true }
-frunk_core = { version = "0.4.3", optional = true }
+frunk = { version = "0.4.4", optional = true }
+frunk_derives = { version = "0.4.4", optional = true }
+frunk_core = { version = "0.4.4", optional = true }
 frunk-enum-derive = { version = "0.3.0", optional = true }
 frunk-enum-core = { version = "0.3.0", optional = true }
 
@@ -100,14 +100,14 @@ hyper-openssl = { version = "0.10", optional = true }
 
 [dev-dependencies]
 always_send = "0.1.1"
-clap = "4.5"
+clap = "4.6.0"
 env_logger = "0.11"
-tokio = { version = "1.49", features = ["full"] }
+tokio = { version = "1.50.0", features = ["full"] }
 native-tls = "0.2"
-pin-project = "1.1.10"
+pin-project = "1.1.11"
 
 # Bearer authentication, used in examples
-jsonwebtoken = {version = "10.0.0", features = ["rust_crypto"]}
+jsonwebtoken = {version = "10.3.0", features = ["rust_crypto"]}
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dev-dependencies]
 openssl = "0.10"

--- a/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
@@ -38,12 +38,12 @@ validate = ["regex", "serde_valid", "swagger/serdevalid"]
 
 [dependencies]
 # Common
-async-trait = "0.1.88"
+async-trait = "0.1.89"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 swagger = { version = "7.0.0", features = ["serdejson", "server", "client"] }
-headers = "0.4.0"
-log = "0.4.27"
+headers = "0.4.1"
+log = "0.4.29"
 
 mime = "0.3"
 mockall = { version = "0.14", optional = true }
@@ -60,8 +60,8 @@ validator = { version = "0.20", features = ["derive"] }
 # Common between server and client features
 bytes = "1.11"
 http-body-util = "0.1.3"
-hyper = { version = "1.8", features = ["full"], optional = true }
-hyper-util = { version = "0.1.18", features = ["service"] }
+hyper = { version = "1.9.0", features = ["full"], optional = true }
+hyper-util = { version = "0.1.20", features = ["service"] }
 serde_ignored = { version = "0.1.14", optional = true }
 url = { version = "2.5", optional = true }
 
@@ -75,15 +75,15 @@ percent-encoding = { version = "2.3.2", optional = true }
 
 # CLI-specific
 anyhow = { version = "1", optional = true }
-clap = { version = "4.5", features = ["env"], optional = true }
+clap = { version = "4.6.0", features = ["env"], optional = true }
 clap-verbosity-flag = { version = "3.0", optional = true }
-simple_logger = { version = "5.0", features = ["stderr"], optional = true }
-tokio = { version = "1.49", features = ["rt-multi-thread", "macros"], optional = true }
+simple_logger = { version = "5.2.0", features = ["stderr"], optional = true }
+tokio = { version = "1.50.0", features = ["rt-multi-thread", "macros"], optional = true }
 
 # Conversion
-frunk = { version = "0.4.3", optional = true }
-frunk_derives = { version = "0.4.3", optional = true }
-frunk_core = { version = "0.4.3", optional = true }
+frunk = { version = "0.4.4", optional = true }
+frunk_derives = { version = "0.4.4", optional = true }
+frunk_core = { version = "0.4.4", optional = true }
 frunk-enum-derive = { version = "0.3.0", optional = true }
 frunk-enum-core = { version = "0.3.0", optional = true }
 
@@ -100,14 +100,14 @@ hyper-openssl = { version = "0.10", optional = true }
 
 [dev-dependencies]
 always_send = "0.1.1"
-clap = "4.5"
+clap = "4.6.0"
 env_logger = "0.11"
-tokio = { version = "1.49", features = ["full"] }
+tokio = { version = "1.50.0", features = ["full"] }
 native-tls = "0.2"
-pin-project = "1.1.10"
+pin-project = "1.1.11"
 
 # Bearer authentication, used in examples
-jsonwebtoken = {version = "10.0.0", features = ["rust_crypto"]}
+jsonwebtoken = {version = "10.3.0", features = ["rust_crypto"]}
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dev-dependencies]
 openssl = "0.10"


### PR DESCRIPTION
Update dependencies for the rust-server generator 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated dependency versions in the `rust-server` Cargo template and regenerated sample `Cargo.toml` files. Also bumped `tokio` in the deprecated server template to v1 to fix CI.

- **Dependencies**
  - HTTP stack: `hyper` 1.9.0, `hyper-util` 0.1.20, `headers` 0.4.1
  - Runtime/CLI/logging: `tokio` 1.50.0, `clap` 4.6.0, `simple_logger` 5.2.0, `log` 0.4.29
  - Core helpers: `async-trait` 0.1.89, `uuid` 1.23.0, `frunk`, `frunk_derives`, `frunk_core` 0.4.4
  - Dev/test: `jsonwebtoken` 10.3.0, `pin-project` 1.1.11 (plus dev `clap` 4.6.0)

- **Bug Fixes**
  - Deprecated template: updated `tokio` to `1` with `rt-multi-thread` and `macros` (replacing v0.2 `rt-threaded`/`stream`) to resolve CI failures.

<sup>Written for commit 8b5ee707400462e5085c0e36ad15a08dab964549. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

