### PR TITLE
[php-nextgen] Remove invalid @implements ArrayAccess tag in models with parents

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/model.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/model.mustache
@@ -40,9 +40,11 @@ use {{invokerPackage}}\ObjectSerializer;
  * @package  {{invokerPackage}}
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
+{{^parentSchema}}
 {{^isEnum}}
  * @implements ArrayAccess<string, mixed>
 {{/isEnum}}
+{{/parentSchema}}
  */
 {{#isEnum}}{{>model_enum}}{{/isEnum}}{{^isEnum}}{{>model_generic}}{{/isEnum}}
 {{/model}}{{/models}}

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/DataQuery.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/DataQuery.php
@@ -38,7 +38,6 @@ use OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements ArrayAccess<string, mixed>
  */
 class DataQuery extends Query
 {

--- a/samples/client/echo_api/php-nextgen/src/Model/DataQuery.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/DataQuery.php
@@ -38,7 +38,6 @@ use OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements ArrayAccess<string, mixed>
  */
 class DataQuery extends Query
 {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Cat.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Cat.php
@@ -37,7 +37,6 @@ use OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements ArrayAccess<string, mixed>
  */
 class Cat extends Animal
 {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ChildWithNullable.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ChildWithNullable.php
@@ -37,7 +37,6 @@ use OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements ArrayAccess<string, mixed>
  */
 class ChildWithNullable extends ParentWithNullable
 {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/DiscriminatorChild.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/DiscriminatorChild.php
@@ -37,7 +37,6 @@ use OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements ArrayAccess<string, mixed>
  */
 class DiscriminatorChild extends DiscriminatorBase
 {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Dog.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Dog.php
@@ -37,7 +37,6 @@ use OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements ArrayAccess<string, mixed>
  */
 class Dog extends Animal
 {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This comment is currently invalid on classes with parent models as the import is missing. Since the parent already has this comment, I decided to just remove it here.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the invalid `@implements ArrayAccess` docblock from generated PHP `php-nextgen` models that extend a parent. This prevents duplicate/incorrect annotations and fixes static analysis/IDE warnings.

- **Bug Fixes**
  - Emit `@implements ArrayAccess<string, mixed>` only for models without a parent (guarded with `{{^parentSchema}}` in `model.mustache`).
  - Regenerated PHP samples to remove the tag from child classes (e.g., `Cat`, `Dog`, `DataQuery`).

<sup>Written for commit 753250b9b156eaf06868433ffce7de92d020781c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

