### PR TITLE
[php-nextgen] Fix validity checks for nullable properties that are required

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/model_generic.mustache
@@ -275,7 +275,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
         {{#vars}}
         {{#required}}
         if ($this->container['{{name}}'] === null{{#isNullable}} && !$this->isNullableSetToNull('{{name}}'){{/isNullable}}) {
-            $invalidProperties[] = "'{{name}}' can't be null";
+            $invalidProperties[] = "'{{name}}' {{^isNullable}}can't be null"{{/isNullable}}{{#isNullable}}is required"{{/isNullable}};
         }
         {{/required}}
         {{#isEnum}}

--- a/modules/openapi-generator/src/main/resources/php/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_generic.mustache
@@ -285,7 +285,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
         {{#vars}}
         {{#required}}
         if ($this->container['{{name}}'] === null{{#isNullable}} && !$this->isNullableSetToNull('{{name}}'){{/isNullable}}) {
-            $invalidProperties[] = "'{{name}}' can't be null";
+            $invalidProperties[] = "'{{name}}' {{^isNullable}}can't be null"{{/isNullable}}{{#isNullable}}is required"{{/isNullable}};
         }
         {{/required}}
         {{#isEnum}}


### PR DESCRIPTION
If you have properties that are required which are set to null, the listInvalidProperties method will return them as invalid, even if they are nullable and therefore valid.
This seemingly was fixed for nullable properties without validation in the main php generator, but when using the php-nextgen generator (or the php generator with properties that have validation), the problem persisted.

I also updated the message for nullable properties, as the previous one didn't really make sense.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes validation in generated PHP models so required nullable properties set to null are not flagged as invalid. Also clarifies the error for missing required nullable fields.

- **Bug Fixes**
  - Respect `isNullableSetToNull()` for required nullable props; null set explicitly is valid.
  - Skip length/pattern/range/item checks when value is null and the field is nullable or not required.
  - Update message: non-nullable required → "can't be null"; nullable required and missing → "is required".
  - Apply the same logic to both `php-nextgen` and `php` templates.

<sup>Written for commit 5d1bc864796eb33cdf4f9f8d5f6d6aed3703a688. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

