### PR TITLE
fix(typescript-fetch): prevent HTML-escaping of pattern in validationAttributes

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/validationAttributes.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/validationAttributes.mustache
@@ -25,7 +25,7 @@ export const {{classname}}PropertyValidationAttributesMap: {
         minLength: {{minLength}},
         {{/minLength}}
         {{#pattern}}
-        pattern: '{{pattern}}',
+        pattern: '{{{pattern}}}',
         {{/pattern}}
         {{#maximum}}
         maximum: {{maximum}},

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -459,6 +459,19 @@ public class TypeScriptFetchClientCodegenTest {
         TestUtils.assertFileContains(modelsIndex, "[property: string]:");
     }
 
+    @Test(description = "Verify pattern is not HTML-escaped in validationAttributes")
+    public void testValidationAttributesPatternIsNotHtmlEscaped() throws IOException {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(TypeScriptFetchClientCodegen.VALIDATION_ATTRIBUTES, true);
+        properties.put(TypeScriptFetchClientCodegen.WITHOUT_RUNTIME_CHECKS, true);
+
+        File output = generate(properties, "src/test/resources/3_0/typescript-fetch/validation-attributes.yaml");
+
+        Path modelsIndex = Paths.get(output + "/models/index.ts");
+        TestUtils.assertFileNotContains(modelsIndex, "pattern: '/^[a-z&amp;]+$/'");
+        TestUtils.assertFileContains(modelsIndex, "pattern: '/^[a-z&]+$/'");
+    }
+
     @Test(description = "Verify withRequestOptsInInterface=true (default) includes RequestOpts in interface")
     public void testRequestOptsInInterfaceByDefault() throws IOException {
         Map<String, Object> properties = new HashMap<>();

--- a/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/validation-attributes.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/validation-attributes.yaml
@@ -675,6 +675,9 @@ components:
           maxLength: 256
         phone:
           type: string
+        nickname:
+          type: string
+          pattern: '^[a-z&]+$'
         userStatus:
           type: integer
           format: int32

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/docs/User.md
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/docs/User.md
@@ -14,6 +14,7 @@ Name | Type
 `email` | string
 `password` | string
 `phone` | string
+`nickname` | string
 `userStatus` | number
 
 ## Example
@@ -30,6 +31,7 @@ const example = {
   "email": null,
   "password": null,
   "phone": null,
+  "nickname": null,
   "userStatus": null,
 } satisfies User
 

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/User.ts
@@ -62,6 +62,12 @@ export interface User {
      */
     phone?: string;
     /**
+     * 
+     * @type {string}
+     * @memberof User
+     */
+    nickname?: string;
+    /**
      * User Status
      * @type {number}
      * @memberof User
@@ -86,6 +92,9 @@ export const UserPropertyValidationAttributesMap: {
     password: {
         maxLength: 256,
         minLength: 8,
+    },
+    nickname: {
+        pattern: '/^[a-z&]+$/',
     },
     userStatus: {
         maximum: 100,
@@ -121,6 +130,7 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
         'email': json['email'] == null ? undefined : json['email'],
         'password': json['password'] == null ? undefined : json['password'],
         'phone': json['phone'] == null ? undefined : json['phone'],
+        'nickname': json['nickname'] == null ? undefined : json['nickname'],
         'userStatus': json['userStatus'] == null ? undefined : json['userStatus'],
     };
 }
@@ -143,6 +153,7 @@ export function UserToJSONTyped(value?: User | null, ignoreDiscriminator: boolea
         'email': value['email'],
         'password': value['password'],
         'phone': value['phone'],
+        'nickname': value['nickname'],
         'userStatus': value['userStatus'],
     };
 }


### PR DESCRIPTION

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Fixes issue where pattern in validationAttributes is HTML-escaped, resulting in invalid patterns like `&amp;`.

**cc**:
@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04) @joscha (2024/10) @dennisameling (2026/02)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes HTML-escaping of regex patterns in validationAttributes for the `typescript-fetch` generator. Generated `pattern` values now keep characters like `&` intact (e.g., '/^[a-z&]+$/').

- **Bug Fixes**
  - Render `pattern` with `{{{pattern}}}` in `validationAttributes.mustache` to avoid HTML-escaping.
  - Add test to confirm raw pattern output (not `&amp;`), and update test spec/samples with `nickname` using pattern '/^[a-z&]+$/'.

<sup>Written for commit 9dbde5bb446d59334ed7e35df6931578e0b344c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

