### PR TITLE
fix(typescript-angular): handle Set in query parameter serialization

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.base.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.base.service.mustache
@@ -54,15 +54,16 @@ export class BaseService {
                 return httpParams.append(key, value.toString());
             } else if (value instanceof Date) {
                 return httpParams.append(key, value.toISOString());
-            } else if (Array.isArray(value)) {
-                // Otherwise, if it's an array, add each element.
+            } else if (Array.isArray(value) || value instanceof Set) {
+                // Otherwise, if it's an array or set, add each element.
+                const array = Array.isArray(value) ? value : Array.from(value);
                 if (paramStyle === QueryParamStyle.Form) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ','});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ','});
                 } else if (paramStyle === QueryParamStyle.SpaceDelimited) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ' '});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ' '});
                 } else {
                     // PipeDelimited
-                    return httpParams.set(key, value, {explode: explode, delimiter: '|'});
+                    return httpParams.set(key, array, {explode: explode, delimiter: '|'});
                 }
             } else {
                 // Otherwise, if it's an object, add each field.

--- a/modules/openapi-generator/src/test/resources/3_0/query-param-form.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/query-param-form.yaml
@@ -33,6 +33,17 @@ paths:
           required: false
           schema:
             type: string
+        - in: query
+          name: tags
+          style: form
+          explode: true
+          description: Tags
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+            uniqueItems: true
       responses:
         '200':
           description: Ok
@@ -71,6 +82,17 @@ paths:
           required: false
           schema:
             type: string
+        - in: query
+          name: tags
+          style: form
+          explode: false
+          description: Tags
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+            uniqueItems: true
 
       responses:
         '200':

--- a/samples/client/others/typescript-angular-v20/builds/query-param-deep-object/api.base.service.ts
+++ b/samples/client/others/typescript-angular-v20/builds/query-param-deep-object/api.base.service.ts
@@ -62,15 +62,16 @@ export class BaseService {
                 return httpParams.append(key, value.toString());
             } else if (value instanceof Date) {
                 return httpParams.append(key, value.toISOString());
-            } else if (Array.isArray(value)) {
-                // Otherwise, if it's an array, add each element.
+            } else if (Array.isArray(value) || value instanceof Set) {
+                // Otherwise, if it's an array or set, add each element.
+                const array = Array.isArray(value) ? value : Array.from(value);
                 if (paramStyle === QueryParamStyle.Form) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ','});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ','});
                 } else if (paramStyle === QueryParamStyle.SpaceDelimited) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ' '});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ' '});
                 } else {
                     // PipeDelimited
-                    return httpParams.set(key, value, {explode: explode, delimiter: '|'});
+                    return httpParams.set(key, array, {explode: explode, delimiter: '|'});
                 }
             } else {
                 // Otherwise, if it's an object, add each field.

--- a/samples/client/others/typescript-angular-v20/builds/query-param-form/api.base.service.ts
+++ b/samples/client/others/typescript-angular-v20/builds/query-param-form/api.base.service.ts
@@ -62,15 +62,16 @@ export class BaseService {
                 return httpParams.append(key, value.toString());
             } else if (value instanceof Date) {
                 return httpParams.append(key, value.toISOString());
-            } else if (Array.isArray(value)) {
-                // Otherwise, if it's an array, add each element.
+            } else if (Array.isArray(value) || value instanceof Set) {
+                // Otherwise, if it's an array or set, add each element.
+                const array = Array.isArray(value) ? value : Array.from(value);
                 if (paramStyle === QueryParamStyle.Form) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ','});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ','});
                 } else if (paramStyle === QueryParamStyle.SpaceDelimited) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ' '});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ' '});
                 } else {
                     // PipeDelimited
-                    return httpParams.set(key, value, {explode: explode, delimiter: '|'});
+                    return httpParams.set(key, array, {explode: explode, delimiter: '|'});
                 }
             } else {
                 // Otherwise, if it's an object, add each field.

--- a/samples/client/others/typescript-angular-v20/builds/query-param-form/api/default.service.ts
+++ b/samples/client/others/typescript-angular-v20/builds/query-param-form/api/default.service.ts
@@ -42,14 +42,15 @@ export class DefaultService extends BaseService {
      * @param ids Ids
      * @param filter Filter
      * @param country Filter
+     * @param tags Tags
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      * @param options additional options
      */
-    public searchExplode(ids?: Array<number>, filter?: Filter, country?: string, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<Response>;
-    public searchExplode(ids?: Array<number>, filter?: Filter, country?: string, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<Response>>;
-    public searchExplode(ids?: Array<number>, filter?: Filter, country?: string, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<Response>>;
-    public searchExplode(ids?: Array<number>, filter?: Filter, country?: string, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
+    public searchExplode(ids?: Array<number>, filter?: Filter, country?: string, tags?: Set<string>, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<Response>;
+    public searchExplode(ids?: Array<number>, filter?: Filter, country?: string, tags?: Set<string>, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<Response>>;
+    public searchExplode(ids?: Array<number>, filter?: Filter, country?: string, tags?: Set<string>, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<Response>>;
+    public searchExplode(ids?: Array<number>, filter?: Filter, country?: string, tags?: Set<string>, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
 
         let localVarQueryParameters = new OpenApiHttpParams(this.encoder);
 
@@ -75,6 +76,15 @@ export class DefaultService extends BaseService {
             localVarQueryParameters,
             'country',
             <any>country,
+            QueryParamStyle.Form,
+            true,
+        );
+
+
+        localVarQueryParameters = this.addToHttpParams(
+            localVarQueryParameters,
+            'tags',
+            <any>tags,
             QueryParamStyle.Form,
             true,
         );
@@ -126,14 +136,15 @@ export class DefaultService extends BaseService {
      * @param ids Ids
      * @param filter Filter
      * @param country Filter
+     * @param tags Tags
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      * @param options additional options
      */
-    public searchNotExplode(ids?: Array<number>, filter?: Filter, country?: string, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<Response>;
-    public searchNotExplode(ids?: Array<number>, filter?: Filter, country?: string, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<Response>>;
-    public searchNotExplode(ids?: Array<number>, filter?: Filter, country?: string, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<Response>>;
-    public searchNotExplode(ids?: Array<number>, filter?: Filter, country?: string, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
+    public searchNotExplode(ids?: Array<number>, filter?: Filter, country?: string, tags?: Set<string>, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<Response>;
+    public searchNotExplode(ids?: Array<number>, filter?: Filter, country?: string, tags?: Set<string>, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<Response>>;
+    public searchNotExplode(ids?: Array<number>, filter?: Filter, country?: string, tags?: Set<string>, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<Response>>;
+    public searchNotExplode(ids?: Array<number>, filter?: Filter, country?: string, tags?: Set<string>, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
 
         let localVarQueryParameters = new OpenApiHttpParams(this.encoder);
 
@@ -159,6 +170,15 @@ export class DefaultService extends BaseService {
             localVarQueryParameters,
             'country',
             <any>country,
+            QueryParamStyle.Form,
+            false,
+        );
+
+
+        localVarQueryParameters = this.addToHttpParams(
+            localVarQueryParameters,
+            'tags',
+            <any>tags,
             QueryParamStyle.Form,
             false,
         );

--- a/samples/client/others/typescript-angular-v20/builds/query-param-json/api.base.service.ts
+++ b/samples/client/others/typescript-angular-v20/builds/query-param-json/api.base.service.ts
@@ -62,15 +62,16 @@ export class BaseService {
                 return httpParams.append(key, value.toString());
             } else if (value instanceof Date) {
                 return httpParams.append(key, value.toISOString());
-            } else if (Array.isArray(value)) {
-                // Otherwise, if it's an array, add each element.
+            } else if (Array.isArray(value) || value instanceof Set) {
+                // Otherwise, if it's an array or set, add each element.
+                const array = Array.isArray(value) ? value : Array.from(value);
                 if (paramStyle === QueryParamStyle.Form) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ','});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ','});
                 } else if (paramStyle === QueryParamStyle.SpaceDelimited) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ' '});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ' '});
                 } else {
                     // PipeDelimited
-                    return httpParams.set(key, value, {explode: explode, delimiter: '|'});
+                    return httpParams.set(key, array, {explode: explode, delimiter: '|'});
                 }
             } else {
                 // Otherwise, if it's an object, add each field.

--- a/samples/client/others/typescript-angular-v20/projects/app/src/api.query_param_form.spec.ts
+++ b/samples/client/others/typescript-angular-v20/projects/app/src/api.query_param_form.spec.ts
@@ -8,6 +8,7 @@ const ids: number[] = [4, 5];
 const filter: Filter = {name: 'John', age: 37, nicknames: ['Joe', 'Joey']};
 const filterWithSpecialCharacters: Filter = {name: 'Éléonore &,|+', age: 42, nicknames: ['Elé', 'Ellie']};
 const country: string = "Belgium";
+const tags: Set<string> = new Set(['a', 'b']);
 
 describe('Form Query Param testing', () => {
   let httpTesting: HttpTestingController;
@@ -80,6 +81,18 @@ describe('Form Query Param testing', () => {
     expect(req.request.method).toEqual('GET');
   });
 
+  it('should separate the query parameter with ampersands (set only)', async () => {
+    service.searchExplode(undefined, undefined, undefined, tags).subscribe();
+    const req = httpTesting.expectOne('http://localhost/search_explode?tags=a&tags=b');
+    expect(req.request.method).toEqual('GET');
+  });
+
+  it('should separate the query parameter with ampersands (all set including tags)', async () => {
+    service.searchExplode(ids, filter, country, tags).subscribe();
+    const req = httpTesting.expectOne('http://localhost/search_explode?ids=4&ids=5&name=John&age=37&nicknames=Joe&nicknames=Joey&country=Belgium&tags=a&tags=b');
+    expect(req.request.method).toEqual('GET');
+  });
+
   it('should separate the query parameter with comma (all set)', async () => {
     service.searchNotExplode(ids, filter, country).subscribe();
     const req = httpTesting.expectOne('http://localhost/search_not_explode?ids=4,5&filter=name,John,age,37,nicknames,Joe,Joey&country=Belgium');
@@ -123,6 +136,18 @@ describe('Form Query Param testing', () => {
   it('should separate the query parameter with comma (simple only)', async () => {
     service.searchNotExplode(undefined, undefined, country).subscribe();
     const req = httpTesting.expectOne('http://localhost/search_not_explode?country=Belgium');
+    expect(req.request.method).toEqual('GET');
+  });
+
+  it('should separate the query parameter with comma (set only)', async () => {
+    service.searchNotExplode(undefined, undefined, undefined, tags).subscribe();
+    const req = httpTesting.expectOne('http://localhost/search_not_explode?tags=a,b');
+    expect(req.request.method).toEqual('GET');
+  });
+
+  it('should separate the query parameter with comma (all set including tags)', async () => {
+    service.searchNotExplode(ids, filter, country, tags).subscribe();
+    const req = httpTesting.expectOne('http://localhost/search_not_explode?ids=4,5&filter=name,John,age,37,nicknames,Joe,Joey&country=Belgium&tags=a,b');
     expect(req.request.method).toEqual('GET');
   });
 

--- a/samples/client/others/typescript-angular/builds/composed-schemas-tagged-unions/api.base.service.ts
+++ b/samples/client/others/typescript-angular/builds/composed-schemas-tagged-unions/api.base.service.ts
@@ -62,15 +62,16 @@ export class BaseService {
                 return httpParams.append(key, value.toString());
             } else if (value instanceof Date) {
                 return httpParams.append(key, value.toISOString());
-            } else if (Array.isArray(value)) {
-                // Otherwise, if it's an array, add each element.
+            } else if (Array.isArray(value) || value instanceof Set) {
+                // Otherwise, if it's an array or set, add each element.
+                const array = Array.isArray(value) ? value : Array.from(value);
                 if (paramStyle === QueryParamStyle.Form) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ','});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ','});
                 } else if (paramStyle === QueryParamStyle.SpaceDelimited) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ' '});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ' '});
                 } else {
                     // PipeDelimited
-                    return httpParams.set(key, value, {explode: explode, delimiter: '|'});
+                    return httpParams.set(key, array, {explode: explode, delimiter: '|'});
                 }
             } else {
                 // Otherwise, if it's an object, add each field.

--- a/samples/client/others/typescript-angular/builds/composed-schemas/api.base.service.ts
+++ b/samples/client/others/typescript-angular/builds/composed-schemas/api.base.service.ts
@@ -62,15 +62,16 @@ export class BaseService {
                 return httpParams.append(key, value.toString());
             } else if (value instanceof Date) {
                 return httpParams.append(key, value.toISOString());
-            } else if (Array.isArray(value)) {
-                // Otherwise, if it's an array, add each element.
+            } else if (Array.isArray(value) || value instanceof Set) {
+                // Otherwise, if it's an array or set, add each element.
+                const array = Array.isArray(value) ? value : Array.from(value);
                 if (paramStyle === QueryParamStyle.Form) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ','});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ','});
                 } else if (paramStyle === QueryParamStyle.SpaceDelimited) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ' '});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ' '});
                 } else {
                     // PipeDelimited
-                    return httpParams.set(key, value, {explode: explode, delimiter: '|'});
+                    return httpParams.set(key, array, {explode: explode, delimiter: '|'});
                 }
             } else {
                 // Otherwise, if it's an object, add each field.

--- a/samples/client/petstore/typescript-angular-v16-provided-in-root/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v16-provided-in-root/builds/default/api.base.service.ts
@@ -62,15 +62,16 @@ export class BaseService {
                 return httpParams.append(key, value.toString());
             } else if (value instanceof Date) {
                 return httpParams.append(key, value.toISOString());
-            } else if (Array.isArray(value)) {
-                // Otherwise, if it's an array, add each element.
+            } else if (Array.isArray(value) || value instanceof Set) {
+                // Otherwise, if it's an array or set, add each element.
+                const array = Array.isArray(value) ? value : Array.from(value);
                 if (paramStyle === QueryParamStyle.Form) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ','});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ','});
                 } else if (paramStyle === QueryParamStyle.SpaceDelimited) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ' '});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ' '});
                 } else {
                     // PipeDelimited
-                    return httpParams.set(key, value, {explode: explode, delimiter: '|'});
+                    return httpParams.set(key, array, {explode: explode, delimiter: '|'});
                 }
             } else {
                 // Otherwise, if it's an object, add each field.

--- a/samples/client/petstore/typescript-angular-v17-provided-in-root/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v17-provided-in-root/builds/default/api.base.service.ts
@@ -62,15 +62,16 @@ export class BaseService {
                 return httpParams.append(key, value.toString());
             } else if (value instanceof Date) {
                 return httpParams.append(key, value.toISOString());
-            } else if (Array.isArray(value)) {
-                // Otherwise, if it's an array, add each element.
+            } else if (Array.isArray(value) || value instanceof Set) {
+                // Otherwise, if it's an array or set, add each element.
+                const array = Array.isArray(value) ? value : Array.from(value);
                 if (paramStyle === QueryParamStyle.Form) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ','});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ','});
                 } else if (paramStyle === QueryParamStyle.SpaceDelimited) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ' '});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ' '});
                 } else {
                     // PipeDelimited
-                    return httpParams.set(key, value, {explode: explode, delimiter: '|'});
+                    return httpParams.set(key, array, {explode: explode, delimiter: '|'});
                 }
             } else {
                 // Otherwise, if it's an object, add each field.

--- a/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/api.base.service.ts
@@ -62,15 +62,16 @@ export class BaseService {
                 return httpParams.append(key, value.toString());
             } else if (value instanceof Date) {
                 return httpParams.append(key, value.toISOString());
-            } else if (Array.isArray(value)) {
-                // Otherwise, if it's an array, add each element.
+            } else if (Array.isArray(value) || value instanceof Set) {
+                // Otherwise, if it's an array or set, add each element.
+                const array = Array.isArray(value) ? value : Array.from(value);
                 if (paramStyle === QueryParamStyle.Form) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ','});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ','});
                 } else if (paramStyle === QueryParamStyle.SpaceDelimited) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ' '});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ' '});
                 } else {
                     // PipeDelimited
-                    return httpParams.set(key, value, {explode: explode, delimiter: '|'});
+                    return httpParams.set(key, array, {explode: explode, delimiter: '|'});
                 }
             } else {
                 // Otherwise, if it's an object, add each field.

--- a/samples/client/petstore/typescript-angular-v19-provided-in-root/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v19-provided-in-root/builds/default/api.base.service.ts
@@ -62,15 +62,16 @@ export class BaseService {
                 return httpParams.append(key, value.toString());
             } else if (value instanceof Date) {
                 return httpParams.append(key, value.toISOString());
-            } else if (Array.isArray(value)) {
-                // Otherwise, if it's an array, add each element.
+            } else if (Array.isArray(value) || value instanceof Set) {
+                // Otherwise, if it's an array or set, add each element.
+                const array = Array.isArray(value) ? value : Array.from(value);
                 if (paramStyle === QueryParamStyle.Form) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ','});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ','});
                 } else if (paramStyle === QueryParamStyle.SpaceDelimited) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ' '});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ' '});
                 } else {
                     // PipeDelimited
-                    return httpParams.set(key, value, {explode: explode, delimiter: '|'});
+                    return httpParams.set(key, array, {explode: explode, delimiter: '|'});
                 }
             } else {
                 // Otherwise, if it's an object, add each field.

--- a/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/api.base.service.ts
@@ -62,15 +62,16 @@ export class BaseService {
                 return httpParams.append(key, value.toString());
             } else if (value instanceof Date) {
                 return httpParams.append(key, value.toISOString());
-            } else if (Array.isArray(value)) {
-                // Otherwise, if it's an array, add each element.
+            } else if (Array.isArray(value) || value instanceof Set) {
+                // Otherwise, if it's an array or set, add each element.
+                const array = Array.isArray(value) ? value : Array.from(value);
                 if (paramStyle === QueryParamStyle.Form) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ','});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ','});
                 } else if (paramStyle === QueryParamStyle.SpaceDelimited) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ' '});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ' '});
                 } else {
                     // PipeDelimited
-                    return httpParams.set(key, value, {explode: explode, delimiter: '|'});
+                    return httpParams.set(key, array, {explode: explode, delimiter: '|'});
                 }
             } else {
                 // Otherwise, if it's an object, add each field.

--- a/samples/client/petstore/typescript-angular-v19/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v19/builds/default/api.base.service.ts
@@ -62,15 +62,16 @@ export class BaseService {
                 return httpParams.append(key, value.toString());
             } else if (value instanceof Date) {
                 return httpParams.append(key, value.toISOString());
-            } else if (Array.isArray(value)) {
-                // Otherwise, if it's an array, add each element.
+            } else if (Array.isArray(value) || value instanceof Set) {
+                // Otherwise, if it's an array or set, add each element.
+                const array = Array.isArray(value) ? value : Array.from(value);
                 if (paramStyle === QueryParamStyle.Form) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ','});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ','});
                 } else if (paramStyle === QueryParamStyle.SpaceDelimited) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ' '});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ' '});
                 } else {
                     // PipeDelimited
-                    return httpParams.set(key, value, {explode: explode, delimiter: '|'});
+                    return httpParams.set(key, array, {explode: explode, delimiter: '|'});
                 }
             } else {
                 // Otherwise, if it's an object, add each field.

--- a/samples/client/petstore/typescript-angular-v20-provided-in-root/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v20-provided-in-root/builds/default/api.base.service.ts
@@ -62,15 +62,16 @@ export class BaseService {
                 return httpParams.append(key, value.toString());
             } else if (value instanceof Date) {
                 return httpParams.append(key, value.toISOString());
-            } else if (Array.isArray(value)) {
-                // Otherwise, if it's an array, add each element.
+            } else if (Array.isArray(value) || value instanceof Set) {
+                // Otherwise, if it's an array or set, add each element.
+                const array = Array.isArray(value) ? value : Array.from(value);
                 if (paramStyle === QueryParamStyle.Form) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ','});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ','});
                 } else if (paramStyle === QueryParamStyle.SpaceDelimited) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ' '});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ' '});
                 } else {
                     // PipeDelimited
-                    return httpParams.set(key, value, {explode: explode, delimiter: '|'});
+                    return httpParams.set(key, array, {explode: explode, delimiter: '|'});
                 }
             } else {
                 // Otherwise, if it's an object, add each field.

--- a/samples/client/petstore/typescript-angular-v20/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v20/builds/default/api.base.service.ts
@@ -62,15 +62,16 @@ export class BaseService {
                 return httpParams.append(key, value.toString());
             } else if (value instanceof Date) {
                 return httpParams.append(key, value.toISOString());
-            } else if (Array.isArray(value)) {
-                // Otherwise, if it's an array, add each element.
+            } else if (Array.isArray(value) || value instanceof Set) {
+                // Otherwise, if it's an array or set, add each element.
+                const array = Array.isArray(value) ? value : Array.from(value);
                 if (paramStyle === QueryParamStyle.Form) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ','});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ','});
                 } else if (paramStyle === QueryParamStyle.SpaceDelimited) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ' '});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ' '});
                 } else {
                     // PipeDelimited
-                    return httpParams.set(key, value, {explode: explode, delimiter: '|'});
+                    return httpParams.set(key, array, {explode: explode, delimiter: '|'});
                 }
             } else {
                 // Otherwise, if it's an object, add each field.

--- a/samples/client/petstore/typescript-angular-v21-provided-in-root/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v21-provided-in-root/builds/default/api.base.service.ts
@@ -62,15 +62,16 @@ export class BaseService {
                 return httpParams.append(key, value.toString());
             } else if (value instanceof Date) {
                 return httpParams.append(key, value.toISOString());
-            } else if (Array.isArray(value)) {
-                // Otherwise, if it's an array, add each element.
+            } else if (Array.isArray(value) || value instanceof Set) {
+                // Otherwise, if it's an array or set, add each element.
+                const array = Array.isArray(value) ? value : Array.from(value);
                 if (paramStyle === QueryParamStyle.Form) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ','});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ','});
                 } else if (paramStyle === QueryParamStyle.SpaceDelimited) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ' '});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ' '});
                 } else {
                     // PipeDelimited
-                    return httpParams.set(key, value, {explode: explode, delimiter: '|'});
+                    return httpParams.set(key, array, {explode: explode, delimiter: '|'});
                 }
             } else {
                 // Otherwise, if it's an object, add each field.

--- a/samples/client/petstore/typescript-angular-v21/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v21/builds/default/api.base.service.ts
@@ -62,15 +62,16 @@ export class BaseService {
                 return httpParams.append(key, value.toString());
             } else if (value instanceof Date) {
                 return httpParams.append(key, value.toISOString());
-            } else if (Array.isArray(value)) {
-                // Otherwise, if it's an array, add each element.
+            } else if (Array.isArray(value) || value instanceof Set) {
+                // Otherwise, if it's an array or set, add each element.
+                const array = Array.isArray(value) ? value : Array.from(value);
                 if (paramStyle === QueryParamStyle.Form) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ','});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ','});
                 } else if (paramStyle === QueryParamStyle.SpaceDelimited) {
-                    return httpParams.set(key, value, {explode: explode, delimiter: ' '});
+                    return httpParams.set(key, array, {explode: explode, delimiter: ' '});
                 } else {
                     // PipeDelimited
-                    return httpParams.set(key, value, {explode: explode, delimiter: '|'});
+                    return httpParams.set(key, array, {explode: explode, delimiter: '|'});
                 }
             } else {
                 // Otherwise, if it's an object, add each field.


### PR DESCRIPTION
Fixes #23434

When a query parameter is defined with `type: array` and `uniqueItems: true`, the typescript-angular generator produces a `Set<T>` type. However, `addToHttpParams` only checks `Array.isArray(value)` to detect collections. Since `Array.isArray(new Set())` returns `false`, the `Set` falls through to the object-handling branch and query parameters are silently lost.

This adds a `value instanceof Set` check alongside `Array.isArray(value)` in the `addToHttpParams` method of `api.base.service.mustache`. When a `Set` is detected, it is converted to an `Array` before serialization.

cc @TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka @joscha @dennisameling

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lost query params when `uniqueItems: true` arrays generate `Set<T>` in the `typescript-angular` client by treating `Set` like arrays in `addToHttpParams` across form/space/pipe styles. Fixes #23434.

- **Bug Fixes**
  - In `api.base.service.mustache`, detect `Set` alongside arrays and serialize via `Array.from(...)` for form, space-delimited, and pipe-delimited styles.
  - Extended `query-param-form.yaml` with a `tags` query param (`array`, `uniqueItems: true`) on explode and non-explode routes.
  - Regenerated `typescript-angular` samples and updated services to accept `tags: Set<string>`; added tests for Set-only and combined cases for explode and non-explode.

<sup>Written for commit ee216021b6658f2d9ee38a25e488394008a4ae89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

