### PR TITLE
Warning log when an enum value cannot be parsed

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -772,7 +772,11 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
     private String numericEnumValuesToEnumTypeUnion(List<Number> values) {
         List<String> stringValues = new ArrayList<>();
         for (Number value : values) {
-            stringValues.add(value.toString());
+            if (value == null) {
+                LOGGER.warn("An enum value was null. See https://github.com/swagger-api/swagger-core/issues/4223");
+            } else {
+                stringValues.add(value.toString());
+            }
         }
         return enumValuesToEnumTypeUnion(stringValues, "number");
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/N4jsClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/N4jsClientCodegen.java
@@ -595,7 +595,11 @@ public class N4jsClientCodegen extends DefaultCodegen implements CodegenConfig {
     private String numericEnumValuesToEnumTypeUnion(List<Number> values) {
         List<String> stringValues = new ArrayList<>();
         for (Number value : values) {
-            stringValues.add(value.toString());
+            if (value == null) {
+                LOGGER.warn("An enum value was null. See https://github.com/swagger-api/swagger-core/issues/4223");
+            } else {
+                stringValues.add(value.toString());
+            }
         }
         return enumValuesToEnumTypeUnion(stringValues, "number");
     }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

I [face issues back and forth](https://github.com/OpenAPITools/openapi-generator/pull/20833#issuecomment-3169036577) with how negative enums are treated. The cause of it is due to my locale, and the exact cause is described [here](https://github.com/swagger-api/swagger-core/pull/4178). A recent [PR](https://github.com/OpenAPITools/openapi-generator/pull/23275) made so that a TypeScriptAxios test references a schema with a negative enum, which means that a developer with a "bad locale" will have an unexpected nullpointer when running the tests.

This PR changes so that this case is handled with a warning log and that processing continues, as per the behavior of most other enum interpreters. This change makes it so someone encountering this issue is less like to suffer from it and makes it clearer to them why it is occurring.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Log a warning and continue when a numeric enum value is null to prevent crashes caused by locale-specific parsing of negative enums. This stabilizes TypeScript and N4JS client generation and avoids unexpected NPEs in tests.

- **Bug Fixes**
  - Skip null values in `numericEnumValuesToEnumTypeUnion` and log a warning instead of calling `toString`.
  - Applies to `AbstractTypeScriptClientCodegen` and `N4jsClientCodegen`; avoids NPEs with schemas that include negative enums (e.g., TypeScriptAxios test).

<sup>Written for commit 48f464a8c2719b06d0cc120958f5e26b8fab43d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

