### PR TITLE
refactor: simplify schema name retrieval in validation messages

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
@@ -96,13 +96,9 @@ class OpenApiSchemaValidations extends GenericValidator<SchemaWrapper> {
                 // OAS spec is 3.0.x
                 if (ModelUtils.isNullType(schema)) {
                     result = new ValidationRule.Fail();
-                    String name = schema.getName();
-                    if (name == null) {
-                        name = schema.getTitle();
-                    }
                     result.setDetails(String.format(Locale.ROOT,
                             "Schema '%s' uses a 'null' type, which is specified in OAS 3.1 and above, but OAS document is version %s",
-                            name, schemaWrapper.getOpenAPI().getOpenapi()));
+                            nameOf(schema), schemaWrapper.getOpenAPI().getOpenapi()));
                     return result;
                 }
             }
@@ -126,18 +122,18 @@ class OpenApiSchemaValidations extends GenericValidator<SchemaWrapper> {
             if (version.atLeast("3.1")) {
                 if (ModelUtils.isNullable(schema)) {
                     result = new ValidationRule.Fail();
-                    String name = schema.getName();
-                    if (name == null) {
-                        name = schema.getTitle();
-                    }
                     result.setDetails(String.format(Locale.ROOT,
                             "OAS document is version '%s'. Schema '%s' uses 'nullable' attribute, which has been deprecated in OAS 3.1.",
-                            schemaWrapper.getOpenAPI().getOpenapi(), name));
+                            schemaWrapper.getOpenAPI().getOpenapi(), nameOf(schema)));
                     return result;
                 }
             }
         }
         return result;
+    }
+
+    private static String nameOf(Schema schema) {
+        return schema.getName() != null ? schema.getName() : schema.getTitle();
     }
 
     // The set of valid OAS values for the 'type' attribute.
@@ -157,13 +153,9 @@ class OpenApiSchemaValidations extends GenericValidator<SchemaWrapper> {
         ValidationRule.Result result = ValidationRule.Pass.empty();
         if (schema.getType() != null && !validTypes.contains(schema.getType())) {
             result = new ValidationRule.Fail();
-            String name = schema.getName();
-            if (name == null) {
-                name = schema.getTitle();
-            }
             result.setDetails(String.format(Locale.ROOT,
                     "Schema '%s' uses the '%s' type, which is not a valid type.",
-                    name, schema.getType()));
+                    nameOf(schema), schema.getType()));
             return result;
         }
         return result;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified schema name retrieval in OAS validation messages by adding a single `nameOf(Schema)` helper to reduce duplication and keep messages consistent.

- **Refactors**
  - Added private `nameOf(Schema)` that returns `name` or `title`.
  - Replaced inline lookups in null type, nullable attribute, and invalid type checks.

<sup>Written for commit 8772729e5ade3442968a3d35f2ef35aecda27af6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

