### PR TITLE
[typescript-fetch] Fix nested oneOf generating uncompilable `interface extends` on union type

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -460,6 +460,22 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
             }
         }
 
+        // Build a set of classnames that are oneOf models (union types)
+        Set<String> oneOfModelNames = allModels.stream()
+                .filter(m -> !m.oneOf.isEmpty())
+                .map(m -> m.classname)
+                .collect(Collectors.toSet());
+
+        // Mark models whose parent is a oneOf model — these cannot use
+        // "interface X extends Parent" because TypeScript does not allow
+        // an interface to extend a union type.  They use
+        // "type X = Parent & { ... }" instead.
+        for (ExtendedCodegenModel m : allModels) {
+            if (m.parent != null && oneOfModelNames.contains(m.parent)) {
+                m.parentIsOneOf = true;
+            }
+        }
+
         for (ExtendedCodegenModel rootModel : allModels) {
             for (String curImport : rootModel.imports) {
                 boolean isModelImport = false;
@@ -1545,6 +1561,8 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         public Set<CodegenProperty> oneOfPrimitives = new HashSet<>();
         @Getter @Setter
         public CodegenDiscriminator.MappedModel selfReferencingDiscriminatorMapping;
+        @Getter @Setter
+        public boolean parentIsOneOf; // true when this model's parent is a oneOf union type
 
         public boolean isEntity; // Is a model containing an "id" property marked as isUniqueId
         public String returnPassthrough;

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGenericInterfaces.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGenericInterfaces.mustache
@@ -1,9 +1,15 @@
 /**
  * {{#lambda.indented_star_1}}{{{unescapedDescription}}}{{/lambda.indented_star_1}}
  * @export
+{{^parentIsOneOf}}
  * @interface {{classname}}
  */
 export interface {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
+{{/parentIsOneOf}}
+{{#parentIsOneOf}}
+ */
+export type {{classname}} = {{{parent}}} & {
+{{/parentIsOneOf}}
 {{#additionalPropertiesType}}
     [key: string]: {{{additionalPropertiesType}}}{{#hasVars}} | any{{/hasVars}};
 {{/additionalPropertiesType}}
@@ -18,7 +24,7 @@ export interface {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
      */
     {{#isReadOnly}}readonly {{/isReadOnly}}{{name}}{{^required}}?{{/required}}: {{{datatypeWithEnum}}}{{#isNullable}} | null{{/isNullable}};
 {{/vars}}
-}{{#hasEnums}}
+}{{#parentIsOneOf}};{{/parentIsOneOf}}{{#hasEnums}}
 
 {{#vars}}
 {{#isEnum}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -521,6 +521,43 @@ public class TypeScriptFetchClientCodegenTest {
         assertThat(classSection).contains("async addPetRequestOpts(");
     }
 
+    /**
+     * When a oneOf variant uses allOf to reference another oneOf (nested discriminated unions),
+     * the child model must be generated as a type alias with intersection rather than an
+     * interface with extends, because TypeScript does not allow interfaces to extend union types.
+     */
+    @Test(description = "Verify nested oneOf generates type alias instead of interface extends")
+    public void testNestedOneOfGeneratesTypeAliasForOneOfParent() throws IOException {
+        File output = generate(
+            Collections.emptyMap(),
+            "src/test/resources/3_0/typescript-fetch/nested-oneOf.yaml"
+        );
+
+        // OuterComposed's parent is Inner (a oneOf union type), so it must use
+        // "type OuterComposed = Inner & { ... }" instead of "interface OuterComposed extends Inner"
+        Path outerComposed = Paths.get(output + "/models/OuterComposed.ts");
+        TestUtils.assertFileExists(outerComposed);
+        TestUtils.assertFileContains(outerComposed, "export type OuterComposed = Inner & {");
+        TestUtils.assertFileNotContains(outerComposed, "export interface OuterComposed extends Inner");
+
+        // Inner should still be a proper oneOf union type with discriminator dispatch
+        Path inner = Paths.get(output + "/models/Inner.ts");
+        TestUtils.assertFileExists(inner);
+        TestUtils.assertFileContains(inner, "export type Inner = { innerDiscriminator: 'a' } & InnerA | { innerDiscriminator: 'b' } & InnerB");
+        TestUtils.assertFileContains(inner, "switch (json['innerDiscriminator'])");
+
+        // Outer should dispatch on outerDiscriminator, including the composed variant
+        Path outer = Paths.get(output + "/models/Outer.ts");
+        TestUtils.assertFileExists(outer);
+        TestUtils.assertFileContains(outer, "switch (json['outerDiscriminator'])");
+        TestUtils.assertFileContains(outer, "case 'composed':");
+
+        // Regular models (not extending a oneOf parent) should still use interface
+        Path outerPlain = Paths.get(output + "/models/OuterPlain.ts");
+        TestUtils.assertFileExists(outerPlain);
+        TestUtils.assertFileContains(outerPlain, "export interface OuterPlain {");
+    }
+
     private static File generate(
         Map<String, Object> properties
     ) throws IOException {

--- a/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/nested-oneOf.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/nested-oneOf.yaml
@@ -1,0 +1,84 @@
+openapi: "3.0.3"
+info:
+  title: Nested OneOf Test
+  description: >
+    Tests that a oneOf variant referencing another oneOf via allOf generates
+    correct TypeScript types.  The outer union (Outer) is discriminated by
+    "outerDiscriminator"; one of its variants (OuterComposed) uses allOf to
+    compose a fixed discriminator value with a $ref to an inner union (Inner)
+    discriminated by "innerDiscriminator".  A plain variant (OuterPlain) is
+    included to verify normal interface generation is unaffected.
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: getItems
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Outer"
+components:
+  schemas:
+    # ── Outer oneOf (discriminated by "outerDiscriminator") ──────────────
+    Outer:
+      oneOf:
+        - $ref: "#/components/schemas/OuterPlain"
+        - $ref: "#/components/schemas/OuterComposed"
+      discriminator:
+        propertyName: outerDiscriminator
+        mapping:
+          plain: "#/components/schemas/OuterPlain"
+          composed: "#/components/schemas/OuterComposed"
+
+    OuterPlain:
+      type: object
+      required: [outerDiscriminator, plainValue]
+      properties:
+        outerDiscriminator:
+          type: string
+        plainValue:
+          type: string
+
+    # Uses allOf to merge a fixed discriminator value with a nested oneOf ref
+    OuterComposed:
+      allOf:
+        - type: object
+          required: [outerDiscriminator]
+          properties:
+            outerDiscriminator:
+              type: string
+        - $ref: "#/components/schemas/Inner"
+
+    # ── Inner oneOf (discriminated by "innerDiscriminator") ─────────────
+    Inner:
+      oneOf:
+        - $ref: "#/components/schemas/InnerA"
+        - $ref: "#/components/schemas/InnerB"
+      discriminator:
+        propertyName: innerDiscriminator
+        mapping:
+          a: "#/components/schemas/InnerA"
+          b: "#/components/schemas/InnerB"
+
+    InnerA:
+      type: object
+      required: [innerDiscriminator, fieldA]
+      properties:
+        innerDiscriminator:
+          type: string
+        fieldA:
+          type: string
+
+    InnerB:
+      type: object
+      required: [innerDiscriminator, fieldB]
+      properties:
+        innerDiscriminator:
+          type: string
+        fieldB:
+          type: integer


### PR DESCRIPTION
When a `oneOf` discriminated union has a variant that references another `oneOf` via `allOf` (nested discriminated unions), the generator produces `interface Child extends Parent` where `Parent` is a TypeScript union type. This fails to compile with **TS2312**: *"An interface can only extend an object type or intersection of object types with statically known members."*

For example, given an outer `oneOf` discriminated by `outerDiscriminator` where one variant composes (via `allOf`) a fixed discriminator value with a `$ref` to an inner `oneOf` discriminated by `innerDiscriminator`:

```yaml
OuterComposed:
  allOf:
    - type: object
      properties:
        outerDiscriminator: { type: string }
    - $ref: "#/components/schemas/Inner"   # Inner is a oneOf

Inner:
  oneOf:
    - $ref: "#/components/schemas/InnerA"
    - $ref: "#/components/schemas/InnerB"
  discriminator:
    propertyName: innerDiscriminator
```

**Before:**
```ts
// TS2312: An interface can only extend an object type or intersection of object types.
export interface OuterComposed extends Inner { ... }
```

**After:**
```ts
export type OuterComposed = Inner & { ... };
```

### Changes

- **`TypeScriptFetchClientCodegen.java`**: In `postProcessAllModels()`, detect when a model's parent is a `oneOf` model and set a `parentIsOneOf` flag on the model.
- **`modelGenericInterfaces.mustache`**: When `parentIsOneOf` is true, emit `export type X = Parent & { ... };` instead of `export interface X extends Parent { ... }`. Models with non-oneOf parents are unaffected.
- **`TypeScriptFetchClientCodegenTest.java`**: New test verifying the composed variant uses a type alias, the inner/outer discriminator dispatch is preserved, and plain models still generate as interfaces.
- **`nested-oneOf.yaml`**: Test spec exercising the nested discriminated union pattern.

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix TS2312 compile errors in the TypeScript Fetch generator when a model extends a `oneOf` union. Models with a `oneOf` parent now emit `type X = Parent & { ... }` instead of `interface X extends Parent`.

- **Bug Fixes**
  - Detect `oneOf` parents during post-processing and set `parentIsOneOf`, switching the template to emit an intersection type alias.
  - Added tests and a `nested-oneOf.yaml` spec to verify the alias is used, discriminators still dispatch correctly, and non-`oneOf` parents still generate `interface`.

<sup>Written for commit b4a4ecf09f007f9ccd6a36a02b4e66806f81164f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

