### PR TITLE
[BUG][java][restclient] Fix NPE when query param with value null is exploded

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/api.mustache
@@ -115,9 +115,11 @@ public class {{classname}} {
             {{^queryIsJsonMimeType}}
             {{#isExplode}}
                 {{#hasVars}}
+        if ({{paramName}} != null) {
                     {{#vars}}
-        queryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}.{{getter}}()));
+            queryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}.{{getter}}()));
                     {{/vars}}
+        }
                 {{/hasVars}}
                 {{^hasVars}}
         queryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}));

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -2643,6 +2643,22 @@ public class JavaClientCodegenTest {
     }
 
     @Test
+    public void testQueryParamsExploded_whenQueryParamIsNull_restclient() {
+        final Path output = newTempFolder();
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(JAVA_GENERATOR)
+                .setLibrary(JavaClientCodegen.RESTCLIENT)
+                .setAdditionalProperties(Map.of(CodegenConstants.API_PACKAGE, "xyz.abcdef.api"))
+                .setInputSpec("src/test/resources/3_0/issue_17555.yaml")
+                .setOutputDir(output.toString().replace("\\", "/"));
+
+        List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+
+        validateJavaSourceFiles(files);
+        assertFileContains(output.resolve("src/main/java/xyz/abcdef/api/DepartmentApi.java"), "if (filter != null) {");
+    }
+
+    @Test
     public void generateAllArgsConstructor() {
         Map<String, File> files = generateFromContract("src/test/resources/3_0/java/all_args_constructor.yaml", JavaClientCodegen.RESTTEMPLATE,
                 Map.of(AbstractJavaCodegen.GENERATE_CONSTRUCTOR_WITH_ALL_ARGS, Boolean.TRUE),

--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/QueryApi.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/QueryApi.java
@@ -306,12 +306,14 @@ public class QueryApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "id", queryObject.getId()));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "name", queryObject.getName()));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "category", queryObject.getCategory()));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "photoUrls", queryObject.getPhotoUrls()));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "tags", queryObject.getTags()));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "status", queryObject.getStatus()));
+        if (queryObject != null) {
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "id", queryObject.getId()));
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "name", queryObject.getName()));
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "category", queryObject.getCategory()));
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "photoUrls", queryObject.getPhotoUrls()));
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "tags", queryObject.getTags()));
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "status", queryObject.getStatus()));
+        }
 
         final String[] localVarAccepts = { 
             "text/plain"
@@ -595,7 +597,9 @@ public class QueryApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "values", queryObject.getValues()));
+        if (queryObject != null) {
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "values", queryObject.getValues()));
+        }
 
         final String[] localVarAccepts = { 
             "text/plain"
@@ -666,12 +670,14 @@ public class QueryApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "id", queryObject.getId()));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "name", queryObject.getName()));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "category", queryObject.getCategory()));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "photoUrls", queryObject.getPhotoUrls()));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "tags", queryObject.getTags()));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "status", queryObject.getStatus()));
+        if (queryObject != null) {
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "id", queryObject.getId()));
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "name", queryObject.getName()));
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "category", queryObject.getCategory()));
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "photoUrls", queryObject.getPhotoUrls()));
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "tags", queryObject.getTags()));
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "status", queryObject.getStatus()));
+        }
 
         final String[] localVarAccepts = { 
             "text/plain"


### PR DESCRIPTION

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Closes #23504 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a NullPointerException in the Java `restclient` generator when exploded query parameters are null. Generated APIs now guard exploded object/array query params with a null check for `form` and `deepObject` styles.

- **Bug Fixes**
  - In `Java/libraries/restclient/api.mustache`, wrap exploded param mapping with `if (param != null) { ... }` when `isExplode` and the param has fields.
  - Updated sample `QueryApi.java` to add the same null guards for exploded objects and arrays.
  - Added a test to ensure `JavaClientCodegen.RESTCLIENT` generates the null check for exploded query params.

<sup>Written for commit 8f927df6421943d8bd612a78ed8efe9ab166f1ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

