### PR TITLE
[Java][jaxrs-spec] Fix `JsonTypeName` Generation With `allOf` and `oneOf` Combination to Match Key Instead of Schema Name

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
@@ -26,6 +26,7 @@ import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.features.DocumentationFeature;
 import org.openapitools.codegen.meta.features.SecurityFeature;
 import org.openapitools.codegen.model.ModelMap;
+import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationsMap;
 
 import java.io.File;
@@ -328,10 +329,36 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
     }
 
     @Override
+    public ModelsMap postProcessModels(ModelsMap objs) {
+        return super.postProcessModels(objs);
+    }
+
+    @Override
     public OperationsMap postProcessOperationsWithModels(OperationsMap objs, List<ModelMap> allModels) {
         objs = super.postProcessOperationsWithModels(objs, allModels);
         removeImport(objs, "java.util.List");
         return objs;
     }
 
+    @Override
+    public Map<String, ModelsMap> postProcessAllModels(Map<String, ModelsMap> objs) {
+        Map<String, ModelsMap> result = super.postProcessAllModels(objs);
+        for (ModelsMap modelsMap : result.values()) {
+            for (ModelMap modelMap : modelsMap.getModels()) {
+                CodegenModel model = modelMap.getModel();
+                if (model.parentModel != null) {
+                    CodegenDiscriminator discriminator = model.parentModel.getDiscriminator();
+                    if (discriminator != null) {
+                        for (CodegenDiscriminator.MappedModel mappedModel : discriminator.getMappedModels()) {
+                            if (mappedModel.getModelName().equals(model.name)) {
+                                model.getVendorExtensions().put("x-discriminator-value", mappedModel.getMappingName());
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return result;
+    }
 }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
@@ -38,7 +38,7 @@ import {{javaxPackage}}.xml.bind.annotation.XmlEnumValue;
 @Schema({{#title}}title="{{{.}}}", {{/title}}{{#description}}description="{{{.}}}"{{/description}}{{^description}}description=""{{/description}}){{/useSwaggerV3Annotations}}{{#useMicroProfileOpenAPIAnnotations}}
 @org.eclipse.microprofile.openapi.annotations.media.Schema({{#title}}title="{{{.}}}", {{/title}}{{#description}}description="{{{.}}}"{{/description}}{{^description}}description=""{{/description}}){{/useMicroProfileOpenAPIAnnotations}}
 {{#jackson}}
-@JsonTypeName("{{name}}")
+@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
 {{#additionalProperties}}
 @JsonFormat(shape=JsonFormat.Shape.OBJECT)
 {{/additionalProperties}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
@@ -1237,13 +1237,13 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
         assertFileNotContains(files.get("RequiredProperties.java").toPath(), "@JsonCreator");
     }
     
-        @Test
+    @Test
     public void testDiscriminatorMappingUsedInJsonTypeName() throws Exception {
         File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
         output.deleteOnExit();
 
         OpenAPI openAPI = new OpenAPIParser()
-                .readLocation("src/test/resources/3_0/jaxrs/pestore.yaml", null, new ParseOptions()).getOpenAPI();
+                .readLocation("src/test/resources/3_0/jaxrs/petstore.yaml", null, new ParseOptions()).getOpenAPI();
 
         codegen.setOutputDir(output.getAbsolutePath());
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
@@ -1237,6 +1237,38 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
         assertFileNotContains(files.get("RequiredProperties.java").toPath(), "@JsonCreator");
     }
     
+        @Test
+    public void testDiscriminatorMappingUsedInJsonTypeName() throws Exception {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/jaxrs/pestore.yaml", null, new ParseOptions()).getOpenAPI();
+
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput input = new ClientOptInput()
+                .openAPI(openAPI)
+                .config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        Map<String, File> files = generator.opts(input).generate().stream()
+                .collect(Collectors.toMap(File::getName, Function.identity()));
+
+        // Parent model uses its own name
+        JavaFileAssert.assertThat(files.get("PetRequest.java"))
+                .fileContains("@JsonTypeName(\"PetRequest\")");
+
+        // Child models must use the discriminator mapping value (e.g. "CAT"), not the class name (e.g. "CatRequest")
+        JavaFileAssert.assertThat(files.get("CatRequest.java"))
+                .fileContains("@JsonTypeName(\"CAT\")")
+                .fileDoesNotContain("@JsonTypeName(\"CatRequest\")");
+
+        JavaFileAssert.assertThat(files.get("DogRequest.java"))
+                .fileContains("@JsonTypeName(\"DOG\")")
+                .fileDoesNotContain("@JsonTypeName(\"DogRequest\")");
+    }
+
     @Test
     public void testGenerateJsonNullableListFieldsHelperMethodReferences_issue23251() throws Exception {
         Map<String, Object> properties = new HashMap<>();

--- a/modules/openapi-generator/src/test/resources/3_0/jaxrs/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/jaxrs/petstore.yaml
@@ -157,6 +157,24 @@ paths:
         - petstore_auth:
             - 'read:pets'
       deprecated: true
+  '/pet/request':
+      post:
+          operationId: createPetRequest
+          security: []
+          tags: [ pet ]
+          requestBody:
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/PetRequest'
+          responses:
+            '201':
+              description: Pet created successfully
+              content:
+                application/json:
+                  schema:
+                    $ref: '#/components/schemas/PetRequest'
   '/pet/{petId}':
     get:
       tags:
@@ -742,6 +760,37 @@ components:
             - sold
       xml:
         name: Pet
+    PetRequest:
+      type: object
+      required:
+        - petType
+      properties:
+        petType:
+          type: string
+        name:
+          type: string
+      oneOf:
+        - $ref: '#/components/schemas/CatRequest'
+        - $ref: '#/components/schemas/DogRequest'
+      discriminator:
+        propertyName: petType
+        mapping:
+          CAT: '#/components/schemas/CatRequest'
+          DOG: '#/components/schemas/DogRequest'
+    CatRequest:
+      allOf:
+        - $ref: '#/components/schemas/PetRequest'
+        - type: object
+          properties:
+            indoor:
+              type: boolean
+    DogRequest:
+      allOf:
+        - $ref: '#/components/schemas/PetRequest'
+        - type: object
+          properties:
+            bark:
+              type: string
     ApiResponse:
       title: An uploaded response
       description: Describes the result of uploading an image resource

--- a/samples/server/petstore/jaxrs-cxf-cdi/.openapi-generator/FILES
+++ b/samples/server/petstore/jaxrs-cxf-cdi/.openapi-generator/FILES
@@ -7,10 +7,13 @@ src/gen/java/org/openapitools/api/TestApi.java
 src/gen/java/org/openapitools/api/TestApiService.java
 src/gen/java/org/openapitools/api/UserApi.java
 src/gen/java/org/openapitools/api/UserApiService.java
+src/gen/java/org/openapitools/model/CatRequest.java
 src/gen/java/org/openapitools/model/Category.java
+src/gen/java/org/openapitools/model/DogRequest.java
 src/gen/java/org/openapitools/model/ModelApiResponse.java
 src/gen/java/org/openapitools/model/Order.java
 src/gen/java/org/openapitools/model/Pet.java
+src/gen/java/org/openapitools/model/PetRequest.java
 src/gen/java/org/openapitools/model/Tag.java
 src/gen/java/org/openapitools/model/User.java
 src/main/java/org/openapitools/api/RestApplication.java

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/api/PetApi.java
@@ -2,6 +2,7 @@ package org.openapitools.api;
 
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
+import org.openapitools.model.PetRequest;
 import org.openapitools.api.PetApiService;
 
 import javax.ws.rs.*;
@@ -51,6 +52,17 @@ public class PetApi  {
         @ApiResponse(code = 405, message = "Invalid input", response = Void.class) })
     public Response addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true) Pet pet) {
         return delegate.addPet(pet, securityContext);
+    }
+
+    @POST
+    @Path("/request")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "", notes = "", response = PetRequest.class, tags={ "pet" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 201, message = "Pet created successfully", response = PetRequest.class) })
+    public Response createPetRequest(@ApiParam(value = "" ,required=true) PetRequest petRequest) {
+        return delegate.createPetRequest(petRequest, securityContext);
     }
 
     @DELETE

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/api/PetApiService.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/api/PetApiService.java
@@ -8,6 +8,7 @@ import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
+import org.openapitools.model.PetRequest;
 
 import java.util.List;
 
@@ -22,6 +23,7 @@ import javax.ws.rs.core.SecurityContext;
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSCXFCDIServerCodegen", comments = "Generator version: 7.22.0-SNAPSHOT")
 public interface PetApiService {
       public Response addPet(Pet pet, SecurityContext securityContext);
+      public Response createPetRequest(PetRequest petRequest, SecurityContext securityContext);
       public Response deletePet(Long petId, SecurityContext securityContext);
       public Response findPetsByStatus(List<String> status, SecurityContext securityContext);
       @Deprecated public Response findPetsByTags(List<String> tags, SecurityContext securityContext);

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/CatRequest.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/CatRequest.java
@@ -1,0 +1,75 @@
+package org.openapitools.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.model.PetRequest;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+
+
+public class CatRequest extends PetRequest  {
+  
+  private Boolean indoor;
+
+  /**
+   **/
+  public CatRequest indoor(Boolean indoor) {
+    this.indoor = indoor;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("indoor")
+  public Boolean getIndoor() {
+    return indoor;
+  }
+  public void setIndoor(Boolean indoor) {
+    this.indoor = indoor;
+  }
+
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CatRequest catRequest = (CatRequest) o;
+    return super.equals(o) && Objects.equals(this.indoor, catRequest.indoor);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), indoor);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class CatRequest {\n");
+    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    sb.append("    indoor: ").append(toIndentedString(indoor)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/DogRequest.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/DogRequest.java
@@ -1,0 +1,75 @@
+package org.openapitools.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.model.PetRequest;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+
+
+public class DogRequest extends PetRequest  {
+  
+  private String bark;
+
+  /**
+   **/
+  public DogRequest bark(String bark) {
+    this.bark = bark;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("bark")
+  public String getBark() {
+    return bark;
+  }
+  public void setBark(String bark) {
+    this.bark = bark;
+  }
+
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DogRequest dogRequest = (DogRequest) o;
+    return super.equals(o) && Objects.equals(this.bark, dogRequest.bark);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), bark);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class DogRequest {\n");
+    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    sb.append("    bark: ").append(toIndentedString(bark)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/PetRequest.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/PetRequest.java
@@ -1,0 +1,151 @@
+package org.openapitools.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.model.CatRequest;
+import org.openapitools.model.DogRequest;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "petType", visible = true)
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = CatRequest.class, name = "CAT"),
+  @JsonSubTypes.Type(value = DogRequest.class, name = "DOG"),
+})
+
+public class PetRequest   {
+  
+  private String petType;
+
+  private String name;
+
+  private String bark;
+
+  private Boolean indoor;
+
+  /**
+   **/
+  public PetRequest petType(String petType) {
+    this.petType = petType;
+    return this;
+  }
+
+  
+  @ApiModelProperty(required = true, value = "")
+  @JsonProperty("petType")
+  @NotNull
+  public String getPetType() {
+    return petType;
+  }
+  public void setPetType(String petType) {
+    this.petType = petType;
+  }
+
+
+  /**
+   **/
+  public PetRequest name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("name")
+  public String getName() {
+    return name;
+  }
+  public void setName(String name) {
+    this.name = name;
+  }
+
+
+  /**
+   **/
+  public PetRequest bark(String bark) {
+    this.bark = bark;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("bark")
+  public String getBark() {
+    return bark;
+  }
+  public void setBark(String bark) {
+    this.bark = bark;
+  }
+
+
+  /**
+   **/
+  public PetRequest indoor(Boolean indoor) {
+    this.indoor = indoor;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("indoor")
+  public Boolean getIndoor() {
+    return indoor;
+  }
+  public void setIndoor(Boolean indoor) {
+    this.indoor = indoor;
+  }
+
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PetRequest petRequest = (PetRequest) o;
+    return Objects.equals(this.petType, petRequest.petType) &&
+        Objects.equals(this.name, petRequest.name) &&
+        Objects.equals(this.bark, petRequest.bark) &&
+        Objects.equals(this.indoor, petRequest.indoor);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(petType, name, bark, indoor);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class PetRequest {\n");
+    
+    sb.append("    petType: ").append(toIndentedString(petType)).append("\n");
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    bark: ").append(toIndentedString(bark)).append("\n");
+    sb.append("    indoor: ").append(toIndentedString(indoor)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/main/java/org/openapitools/api/impl/PetApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/main/java/org/openapitools/api/impl/PetApiServiceImpl.java
@@ -7,6 +7,7 @@ import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
+import org.openapitools.model.PetRequest;
 
 import java.util.List;
 
@@ -24,6 +25,11 @@ import javax.ws.rs.core.SecurityContext;
 public class PetApiServiceImpl implements PetApiService {
       @Override
       public Response addPet(Pet pet, SecurityContext securityContext) {
+      // do some magic!
+      return Response.ok().entity("magic!").build();
+  }
+      @Override
+      public Response createPetRequest(PetRequest petRequest, SecurityContext securityContext) {
       // do some magic!
       return Response.ok().entity("magic!").build();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Cat.java
@@ -15,7 +15,7 @@ import org.openapitools.jackson.nullable.JsonNullable;
 
 
 @org.eclipse.microprofile.openapi.annotations.media.Schema(description="")
-@JsonTypeName("Cat")
+@JsonTypeName("CAT")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.22.0-SNAPSHOT")
 public class Cat extends Animal implements Serializable {
   private Boolean declawed;

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Dog.java
@@ -15,7 +15,7 @@ import org.openapitools.jackson.nullable.JsonNullable;
 
 
 @org.eclipse.microprofile.openapi.annotations.media.Schema(description="")
-@JsonTypeName("Dog")
+@JsonTypeName("DOG")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.22.0-SNAPSHOT")
 public class Dog extends Animal implements Serializable {
   private String breed;

--- a/samples/server/petstore/jaxrs-spec-swagger-annotations/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec-swagger-annotations/src/gen/java/org/openapitools/model/Cat.java
@@ -17,7 +17,7 @@ import org.openapitools.jackson.nullable.JsonNullable;
 
 
 
-@JsonTypeName("Cat")
+@JsonTypeName("CAT")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.22.0-SNAPSHOT")
 public class Cat extends Animal implements Serializable {
   private Boolean declawed;

--- a/samples/server/petstore/jaxrs-spec-swagger-annotations/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec-swagger-annotations/src/gen/java/org/openapitools/model/Dog.java
@@ -17,7 +17,7 @@ import org.openapitools.jackson.nullable.JsonNullable;
 
 
 
-@JsonTypeName("Dog")
+@JsonTypeName("DOG")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.22.0-SNAPSHOT")
 public class Dog extends Animal implements Serializable {
   private String breed;

--- a/samples/server/petstore/jaxrs-spec-swagger-v3-annotations-jakarta/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec-swagger-v3-annotations-jakarta/src/gen/java/org/openapitools/model/Cat.java
@@ -16,7 +16,7 @@ import org.openapitools.jackson.nullable.JsonNullable;
 
 
 @Schema(description="")
-@JsonTypeName("Cat")
+@JsonTypeName("CAT")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.22.0-SNAPSHOT")
 public class Cat extends Animal implements Serializable {
   private Boolean declawed;

--- a/samples/server/petstore/jaxrs-spec-swagger-v3-annotations-jakarta/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec-swagger-v3-annotations-jakarta/src/gen/java/org/openapitools/model/Dog.java
@@ -16,7 +16,7 @@ import org.openapitools.jackson.nullable.JsonNullable;
 
 
 @Schema(description="")
-@JsonTypeName("Dog")
+@JsonTypeName("DOG")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.22.0-SNAPSHOT")
 public class Dog extends Animal implements Serializable {
   private String breed;

--- a/samples/server/petstore/jaxrs-spec-swagger-v3-annotations/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec-swagger-v3-annotations/src/gen/java/org/openapitools/model/Cat.java
@@ -16,7 +16,7 @@ import org.openapitools.jackson.nullable.JsonNullable;
 
 
 @Schema(description="")
-@JsonTypeName("Cat")
+@JsonTypeName("CAT")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.22.0-SNAPSHOT")
 public class Cat extends Animal implements Serializable {
   private Boolean declawed;

--- a/samples/server/petstore/jaxrs-spec-swagger-v3-annotations/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec-swagger-v3-annotations/src/gen/java/org/openapitools/model/Dog.java
@@ -16,7 +16,7 @@ import org.openapitools.jackson.nullable.JsonNullable;
 
 
 @Schema(description="")
-@JsonTypeName("Dog")
+@JsonTypeName("DOG")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.22.0-SNAPSHOT")
 public class Dog extends Animal implements Serializable {
   private String breed;

--- a/samples/server/petstore/jaxrs-spec-withxml/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec-withxml/src/gen/java/org/openapitools/model/Cat.java
@@ -24,7 +24,7 @@ import javax.xml.bind.annotation.XmlEnumValue;
 
 
 
-@JsonTypeName("Cat")
+@JsonTypeName("CAT")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.22.0-SNAPSHOT")    @XmlAccessorType(XmlAccessType.FIELD)
      @XmlType(name = "Cat", propOrder =
     { "declawed"

--- a/samples/server/petstore/jaxrs-spec-withxml/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec-withxml/src/gen/java/org/openapitools/model/Dog.java
@@ -24,7 +24,7 @@ import javax.xml.bind.annotation.XmlEnumValue;
 
 
 
-@JsonTypeName("Dog")
+@JsonTypeName("DOG")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.22.0-SNAPSHOT")    @XmlAccessorType(XmlAccessType.FIELD)
      @XmlType(name = "Dog", propOrder =
     { "breed"

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Cat.java
@@ -17,7 +17,7 @@ import org.openapitools.jackson.nullable.JsonNullable;
 
 
 
-@JsonTypeName("Cat")
+@JsonTypeName("CAT")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.22.0-SNAPSHOT")
 public class Cat extends Animal implements Serializable {
   private Boolean declawed;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Dog.java
@@ -17,7 +17,7 @@ import org.openapitools.jackson.nullable.JsonNullable;
 
 
 
-@JsonTypeName("Dog")
+@JsonTypeName("DOG")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.22.0-SNAPSHOT")
 public class Dog extends Animal implements Serializable {
   private String breed;


### PR DESCRIPTION
## Description
When using `allOf` and `oneOf` to generate properly nested classes that extend a parent, the generated `@JsonTypeName` follows the name of the child schemas as opposed to the discriminator used. This serves problematic when sending requests to a server and receiving responses following the same format, because the openapi contract will expect the key but will attempt to deserialize the schema name.

The fix is to set it so it prioritizes a discriminator value being set, but will take the key and finally the schema name if no key is found. 

This MR will fix #10822 and will fix #17343 
## Changes
 - `modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java` holds the logic for determining what should be in the generated `JsonTypeName` field
 - `modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache` is responsible to look for the x-discriminator-value but also not automatically set it as the schema name
 - `modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java` holds testing to verify this works as expected
 - `modules/openapi-generator/src/test/resources/3_0/jaxrs/petstore.yaml` includes generated classes using the `oneOf` and `allOf` logic to ensure the flow works as expected

## How to Reproduce
Add the current changes from petstore.yaml and generate that file and view the generated classes. You will find that `CatRequest.java` and `DogRequest.java` both extend `PetRequest.java` properly, but their `@JsonTypeName` fields contain `CatRequest` and `DogRequest` instead of `CAT` and `DOG`.

Adding the logic you will find the change to be the expected keys instead.
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
