### PR TITLE
fix [Kotlin]: handle nullable response.body in jvm-okhttp ApiClient

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
@@ -340,7 +340,7 @@ import com.squareup.moshi.adapter
     @OptIn(ExperimentalStdlibApi::class)
     {{/moshi}}
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -285,7 +285,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     @OptIn(ExperimentalStdlibApi::class)
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/others/kotlin-integer-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/others/kotlin-integer-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -285,7 +285,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     @OptIn(ExperimentalStdlibApi::class)
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -285,7 +285,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     @OptIn(ExperimentalStdlibApi::class)
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/others/kotlin-jvm-okhttp-parameter-tests/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-parameter-tests/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -285,7 +285,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     @OptIn(ExperimentalStdlibApi::class)
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/others/kotlin-jvm-okhttp-path-comments/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-path-comments/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -285,7 +285,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     @OptIn(ExperimentalStdlibApi::class)
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/petstore/kotlin-allOf-discriminator-kotlinx-serialization/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-allOf-discriminator-kotlinx-serialization/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -287,7 +287,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         }
 
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/petstore/kotlin-allOf-discriminator/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-allOf-discriminator/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -285,7 +285,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     @OptIn(ExperimentalStdlibApi::class)
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/petstore/kotlin-array-integer-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-array-integer-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -285,7 +285,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     @OptIn(ExperimentalStdlibApi::class)
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -285,7 +285,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     @OptIn(ExperimentalStdlibApi::class)
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -285,7 +285,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     @OptIn(ExperimentalStdlibApi::class)
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -285,7 +285,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     @OptIn(ExperimentalStdlibApi::class)
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -285,7 +285,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     @OptIn(ExperimentalStdlibApi::class)
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -285,7 +285,7 @@ public open class ApiClient(public val baseUrl: String, public val client: Call.
 
     @OptIn(ExperimentalStdlibApi::class)
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -284,7 +284,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         }
 
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -284,7 +284,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         }
 
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -288,7 +288,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         }
 
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -287,7 +287,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         }
 
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -285,7 +285,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     @OptIn(ExperimentalStdlibApi::class)
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -285,7 +285,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     @OptIn(ExperimentalStdlibApi::class)
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -285,7 +285,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     @OptIn(ExperimentalStdlibApi::class)
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/petstore/kotlin-name-parameter-mappings/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-name-parameter-mappings/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -285,7 +285,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     @OptIn(ExperimentalStdlibApi::class)
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -285,7 +285,7 @@ internal open class ApiClient(val baseUrl: String, val client: Call.Factory = de
 
     @OptIn(ExperimentalStdlibApi::class)
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -285,7 +285,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     @OptIn(ExperimentalStdlibApi::class)
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -285,7 +285,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     @OptIn(ExperimentalStdlibApi::class)
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -285,7 +285,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     @OptIn(ExperimentalStdlibApi::class)
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -287,7 +287,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         }
 
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -285,7 +285,7 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     @OptIn(ExperimentalStdlibApi::class)
     protected inline fun <reified T: Any?> responseBody(response: Response, mediaType: String? = JSON_MEDIA_TYPE): T? {
-        val body = response.body
+        val body = response.body ?: return null
 
         if (T::class.java == Unit::class.java) {
             // No need to parse the body when we're not interested in the body


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

One-liner fix of issue 23514, allowing Kotlin 2.x to build generated code.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

fixes #23514 
This is my first contribution, so any feedback is much appreciated.
@dennisameling, @e5l, @stefankoppier, @yutaka0m, @4brunu, @andrewemery, @Zomzog, @karismann

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle nullable OkHttp `response.body` in the Kotlin jvm-okhttp `ApiClient.responseBody` to prevent NPEs and Kotlin 2.x compile errors. Fixes #23514.

- **Bug Fixes**
  - In `kotlin-client/libraries/jvm-okhttp` `ApiClient.kt.mustache`, return `null` when `response.body` is `null` in `responseBody`.
  - Regenerated Kotlin jvm-okhttp sample clients to reflect the template change.

<sup>Written for commit 5d16e35f11ca06957d1ed287b4dac1bffe9e6910. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

