### PR TITLE
fix(java-spring): add missing imports for converter (#23325)

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/converter.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/converter.mustache
@@ -1,5 +1,9 @@
 package {{configPackage}};
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+
 {{#models}}
     {{#model}}
         {{#isEnum}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -3058,6 +3058,36 @@ public class SpringCodegenTest {
     }
 
     @Test
+    public void contractWithUriEnumContainsEnumConverterWithUriImport() throws IOException {
+        Map<String, File> output = generateFromContract("src/test/resources/3_0/enum_uri.yaml", SPRING_BOOT);
+
+        JavaFileAssert.assertThat(output.get("EnumConverterConfiguration.java"))
+                .hasImports("java.net.URI")
+                .fileContains("Converter<URI, ExampleUriEnum>")
+                .assertMethod("exampleUriEnumConverter");
+    }
+
+    @Test
+    public void contractWithUuidEnumContainsEnumConverterWithUuidImport() throws IOException {
+        Map<String, File> output = generateFromContract("src/test/resources/3_0/enum_uuid.yaml", SPRING_BOOT);
+
+        JavaFileAssert.assertThat(output.get("EnumConverterConfiguration.java"))
+                .hasImports("java.util.UUID")
+                .fileContains("Converter<UUID, ExampleUuidEnum>")
+                .assertMethod("exampleUuidEnumConverter");
+    }
+
+    @Test
+    public void contractWithNumberEnumContainsEnumConverterWithBigDecimalImport() throws IOException {
+        Map<String, File> output = generateFromContract("src/test/resources/3_0/enum_number.yaml", SPRING_BOOT);
+
+        JavaFileAssert.assertThat(output.get("EnumConverterConfiguration.java"))
+                .hasImports("java.math.BigDecimal")
+                .fileContains("Converter<BigDecimal, ExampleNumberEnum>")
+                .assertMethod("exampleNumberEnumConverter");
+    }
+
+    @Test
     public void contractWithoutEnumDoesNotContainEnumConverter() throws IOException {
         Map<String, File> output = generateFromContract("src/test/resources/3_0/generic.yaml", SPRING_BOOT);
 

--- a/modules/openapi-generator/src/test/resources/3_0/enum_number.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/enum_number.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  description: API with number enum.
+  version: 1.0.0
+paths:
+  /resources:
+    get:
+      summary: Returns resources.
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Resource'
+components:
+  schemas:
+    Resource:
+      type: object
+      properties:
+        source:
+          $ref: '#/components/schemas/ExampleNumberEnum'
+    ExampleNumberEnum:
+      type: number
+      description: Example of an Enum with number values
+      enum:
+        - 1.1
+        - 2.2
+        - 3.3
+

--- a/modules/openapi-generator/src/test/resources/3_0/enum_uri.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/enum_uri.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  description: API with URI enum.
+  version: 1.0.0
+paths:
+  /resources:
+    get:
+      summary: Returns resources.
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Resource'
+components:
+  schemas:
+    Resource:
+      type: object
+      properties:
+        source:
+          $ref: '#/components/schemas/ExampleUriEnum'
+    ExampleUriEnum:
+      type: string
+      format: uri
+      description: Example of an Enum with URI values
+      enum:
+        - "https://another-example.com"
+        - "https://example.com"
+

--- a/modules/openapi-generator/src/test/resources/3_0/enum_uuid.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/enum_uuid.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  description: API with UUID enum.
+  version: 1.0.0
+paths:
+  /resources:
+    get:
+      summary: Returns resources.
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Resource'
+components:
+  schemas:
+    Resource:
+      type: object
+      properties:
+        source:
+          $ref: '#/components/schemas/ExampleUuidEnum'
+    ExampleUuidEnum:
+      type: string
+      format: uuid
+      description: Example of an Enum with UUID values
+      enum:
+        - "d6a8f2b0-1c34-4e56-a789-0abcdef12345"
+        - "e7b9c3d1-2d45-5f67-b890-1bcdef023456"
+

--- a/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -1,5 +1,9 @@
 package org.openapitools.configuration;
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+
 import org.openapitools.model.FruitType;
 
 import org.springframework.context.annotation.Bean;

--- a/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -1,5 +1,9 @@
 package org.openapitools.configuration;
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+
 import org.openapitools.model.FruitType;
 
 import org.springframework.context.annotation.Bean;

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -1,5 +1,9 @@
 package org.openapitools.configuration;
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+
 import org.openapitools.model.FruitType;
 
 import org.springframework.context.annotation.Bean;

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -1,5 +1,9 @@
 package org.openapitools.configuration;
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+
 import org.openapitools.model.EnumClass;
 import org.openapitools.model.OuterEnum;
 

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -1,5 +1,9 @@
 package org.openapitools.configuration;
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+
 import org.openapitools.model.EnumClass;
 import org.openapitools.model.OuterEnum;
 

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -1,5 +1,9 @@
 package org.openapitools.configuration;
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+
 import org.openapitools.model.EnumClass;
 import org.openapitools.model.OuterEnum;
 

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -1,5 +1,9 @@
 package org.openapitools.configuration;
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+
 import org.openapitools.model.EnumClass;
 import org.openapitools.model.OuterEnum;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -1,5 +1,9 @@
 package org.openapitools.configuration;
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+
 import org.openapitools.model.EnumClass;
 import org.openapitools.model.OuterEnum;
 

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -1,5 +1,9 @@
 package org.openapitools.configuration;
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+
 import org.openapitools.model.EnumClass;
 import org.openapitools.model.OuterEnum;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -1,5 +1,9 @@
 package org.openapitools.configuration;
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+
 import org.openapitools.model.EnumClass;
 import org.openapitools.model.OuterEnum;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -1,5 +1,9 @@
 package org.openapitools.configuration;
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+
 import org.openapitools.model.EnumClass;
 import org.openapitools.model.OuterEnum;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -1,5 +1,9 @@
 package org.openapitools.configuration;
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+
 import org.openapitools.model.EnumClass;
 import org.openapitools.model.OuterEnum;
 

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -1,5 +1,9 @@
 package org.openapitools.configuration;
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+
 import org.openapitools.model.EnumClassDto;
 import org.openapitools.model.OuterEnumDto;
 

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -1,5 +1,9 @@
 package org.openapitools.configuration;
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+
 import org.openapitools.model.EnumClass;
 import org.openapitools.model.OuterEnum;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -1,5 +1,9 @@
 package org.openapitools.configuration;
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+
 import org.openapitools.model.EnumClass;
 import org.openapitools.model.OuterEnum;
 

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -1,5 +1,9 @@
 package org.openapitools.configuration;
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+
 import org.openapitools.model.EnumClass;
 import org.openapitools.model.OuterEnum;
 

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -1,5 +1,9 @@
 package org.openapitools.configuration;
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+
 import org.openapitools.model.EnumClass;
 import org.openapitools.model.OuterEnum;
 

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -1,5 +1,9 @@
 package org.openapitools.configuration;
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+
 import org.openapitools.model.EnumClass;
 import org.openapitools.model.OuterEnum;
 

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -1,5 +1,9 @@
 package org.openapitools.configuration;
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+
 import org.openapitools.model.EnumClass;
 import org.openapitools.model.OuterEnum;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -1,5 +1,9 @@
 package org.openapitools.configuration;
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+
 import org.openapitools.model.EnumClass;
 import org.openapitools.model.OuterEnum;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -1,5 +1,9 @@
 package org.openapitools.configuration;
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+
 import org.openapitools.virtualan.model.EnumClass;
 import org.openapitools.virtualan.model.OuterEnum;
 

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -1,5 +1,9 @@
 package org.openapitools.configuration;
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+
 import org.openapitools.model.EnumClassDto;
 import org.openapitools.model.OuterEnumDefaultValueDto;
 import org.openapitools.model.OuterEnumDto;

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -1,5 +1,9 @@
 package org.openapitools.configuration;
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+
 import org.openapitools.model.EnumClassDto;
 import org.openapitools.model.OuterEnumDto;
 


### PR DESCRIPTION
closes #23325

The converter.mustache template uses {{{dataType}}} which resolves to short names like `URI`, `UUID` or `BigDecimal` for Java, but the template never imported those types.
A previous fix attempt in `SpringCodegen.postProcessModelsEnum()` tried to work around this by overwriting cm.dataType with the fully qualified name from importMapping (e.g. `URI` → `java.net.URI`). However, this approach pollutes the `dataType` globally — the FQN then also leaks into the enum model classes themselves, which is undesirable. An alternative would be to use vendor-extensions if desired.

But this PR follows the same pattern already established by model.mustache, which hardcodes commonly needed imports like `java.net.URI` and `java.util.*` (line 44) rather than dynamically resolving them. The fix:
`converter.mustache`: Add `import java.net.URI;` and import `java.util.UUID`; — the two non-java.lang types that can appear as enum dataType values.

Tests: Updated to assert that imports are present and short names are used in the converter.


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@cachescrubber (2022/02) @welshm (2022/02) @MelleD (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02) @borsch (2022/02) @banlevente (2022/02) @Zomzog (2022/09) @martin-mfg (2023/08)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds missing imports to Spring `converter.mustache` so generated enum converters compile for `URI`, `UUID`, and numeric enums. Adds `java.math.BigDecimal`, `java.net.URI`, and `java.util.UUID` imports; updates samples and adds tests asserting the imports and short type names in `EnumConverterConfiguration.java`.

<sup>Written for commit 41aa7db5ef0e046a200e65ae154a9486fafe4794. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

