### PR TITLE
ci: upload openapi-generator-cli.jar as GitHub Release asset

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+    tags:
+      - 'v*'
+
 jobs:
   build:
     name: Build
@@ -12,17 +15,20 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
       - name: Set up JDK 11
         uses: actions/setup-java@v5
         with:
           java-version: 11
           distribution: 'zulu'
+
       - name: Cache Maven packages
         uses: actions/cache@v5
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
+
       - name: Build
         run: ./mvnw clean install -DskipTests=true
         #run: ./mvnw clean install
@@ -38,7 +44,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
- 
+
       - id: install-secret-key
         name: Install gpg secret key
         run: |
@@ -59,3 +65,47 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSS_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSS_PASSWORD }}
+
+  upload-release-asset:
+    runs-on: ubuntu-latest
+    name: Upload CLI JAR to GitHub Release
+    needs: publish
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v5
+        with:
+          java-version: 11
+          distribution: 'zulu'
+
+      - name: Cache Maven packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Build CLI JAR
+        run: ./mvnw clean package -pl modules/openapi-generator-cli -am -DskipTests=true
+
+      - name: Get project version
+        id: get_version
+        run: |
+          VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Upload JAR as GitHub Release asset
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          JAR="modules/openapi-generator-cli/target/openapi-generator-cli.jar"
+          ASSET="openapi-generator-cli-${VERSION}.jar"
+          cp "$JAR" "$ASSET"
+          gh release upload "${{ github.ref_name }}" "$ASSET" --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
\## Summary
Adds a new `upload-release-asset` job to the Maven release workflow that 
uploads `openapi-generator-cli.jar` as an asset to each GitHub Release tag.

## Motivation
Tools like [aqua](https://github.com/aquaproj/aqua) (a declarative CLI version 
manager) rely on GitHub Release assets to install and manage CLI tools. 
Since `openapi-generator-cli.jar` was only published to Maven Central and not 
attached to GitHub Releases, it was not possible to manage it via aqua or 
similar GitHub-Releases-based version managers.

This change makes it possible to register `openapi-generator-cli` in the 
[aqua registry](https://github.com/aquaproj/aqua-registry), following the same 
pattern already established by tools like `ktfmt`.

## Changes
- Added `tags: 'v*'` trigger so the workflow also runs on version tag pushes
- Changed `contents` permission to `write` in the `publish` job to allow 
  uploading release assets
- Added a new `upload-release-asset` job that:
  - Runs only on tag pushes (not on every master push)
  - Builds the CLI JAR via Maven
  - Renames it to `openapi-generator-cli-{version}.jar`
  - Uploads it to the corresponding GitHub Release using the GitHub CLI

## Related Issue
Closes #23519 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attach `openapi-generator-cli.jar` to each GitHub Release so the CLI can be installed via tools like `aqua`. Adds a tag-triggered job that builds and uploads the JAR as a release asset.

- **New Features**
  - Workflow now triggers on `v*` tags.
  - New `upload-release-asset` job runs only on tag pushes.
  - Builds and publishes `openapi-generator-cli-{version}.jar` to the matching GitHub Release via `gh`, with `contents: write` permission.

<sup>Written for commit adda3dc6cc08555e44b168baf118b2d59f530148. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

