### PR TITLE
[JAVA] Reproducer for issue 23527

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2814,7 +2814,9 @@ public class DefaultCodegen implements CodegenConfig {
                         Map<String, Schema> newProperties = new LinkedHashMap<>();
                         addProperties(newProperties, required, refSchema, new HashSet<>());
                         mergeProperties(properties, newProperties);
-                        addProperties(allProperties, allRequired, refSchema, new HashSet<>());
+                        Map<String, Schema> newAllProperties = new LinkedHashMap<>();
+                        addProperties(newAllProperties, allRequired, refSchema, new HashSet<>());
+                        mergeProperties(allProperties, newAllProperties);
                     }
                 }
 
@@ -2896,15 +2898,29 @@ public class DefaultCodegen implements CodegenConfig {
     /**
      * Combines all previously-detected type entries for a schema with newly-discovered ones, to ensure
      * that schema for items like enum include all possible values.
+     *
+     * Properties that appear in multiple sub-schemas with incompatible types are dropped so that a
+     * parent schema (e.g. a discriminator base type) does not inherit a field whose type differs
+     * across its oneOf variants.
      */
     private void mergeProperties(Map<String, Schema> existingProperties, Map<String, Schema> newProperties) {
         // https://github.com/OpenAPITools/openapi-generator/issues/12545
         if (null != existingProperties && null != newProperties) {
-            Schema existingType = existingProperties.get("type");
             Schema newType = newProperties.get("type");
-            newProperties.forEach((key, value) ->
-                    existingProperties.put(key, ModelUtils.cloneSchema(value, specVersionGreaterThanOrEqualTo310(openAPI)))
-            );
+            newProperties.forEach((key, value) -> {
+                if (!existingProperties.containsKey(key)) {
+                    // Property not seen before: pull it up from this sub-schema.
+                    existingProperties.put(key, ModelUtils.cloneSchema(value, specVersionGreaterThanOrEqualTo310(openAPI)));
+                } else if (!isSchemasTypeCompatible(existingProperties.get(key), value)) {
+                    // Same property name but incompatible types across sub-schemas: drop it so the
+                    // parent does not end up with an ambiguous field (e.g. coordinates: number[]
+                    // in Polygon vs coordinates: number[][] in MultiPolygon).
+                    existingProperties.remove(key);
+                }
+                // Compatible type already present: keep the existing entry unchanged.
+            });
+            // Merge enum values for the 'type' discriminator property if it is still present.
+            Schema existingType = existingProperties.get("type");
             if (null != existingType && null != newType && null != newType.getEnum() && !newType.getEnum().isEmpty()) {
                 for (Object e : newType.getEnum()) {
                     // ensure all interface enum types are added to schema
@@ -2915,6 +2931,25 @@ public class DefaultCodegen implements CodegenConfig {
                 existingProperties.put("type", existingType);
             }
         }
+    }
+
+    /**
+     * Returns true when two schemas share the same base type and, for array types, the same
+     * item-type structure.  Used by {@link #mergeProperties} to decide whether a property that
+     * appears in more than one oneOf/anyOf sub-schema can safely be pulled up into the parent.
+     */
+    private boolean isSchemasTypeCompatible(Schema schema1, Schema schema2) {
+        if (schema1 == null && schema2 == null) return true;
+        if (schema1 == null || schema2 == null) return false;
+        String type1 = ModelUtils.getType(schema1);
+        String type2 = ModelUtils.getType(schema2);
+        if (!Objects.equals(type1, type2)) {
+            return false;
+        }
+        if ("array".equals(type1)) {
+            return isSchemasTypeCompatible(schema1.getItems(), schema2.getItems());
+        }
+        return true;
     }
 
     protected void updateModelForObject(CodegenModel m, Schema schema) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -5107,6 +5107,25 @@ public class DefaultCodegenTest {
         assertTrue(openIdScheme.isOpenId);
     }
 
+    @Test
+    public void testGeoJsonObjectDoesNotContainCoordinates() {
+        // GeoJsonObject with a discriminator and oneOf (Polygon, MultiPolygon)
+        // should not have the 'coordinates' field, even though both subtypes define it (but with incompatible types).
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/geojson_discriminator.yaml");
+        final DefaultCodegen codegen = new DefaultCodegen();
+
+        Schema schema = openAPI.getComponents().getSchemas().get("GeoJsonObject");
+        codegen.setOpenAPI(openAPI);
+        CodegenModel geoJsonObject = codegen.fromModel("GeoJsonObject", schema);
+
+        boolean coordinatesInVars = geoJsonObject.vars.stream()
+                .anyMatch(cp -> "coordinates".equals(cp.baseName));
+        boolean coordinatesInAllVars = geoJsonObject.allVars.stream()
+                .anyMatch(cp -> "coordinates".equals(cp.baseName));
+        assertFalse(coordinatesInVars);
+        assertFalse(coordinatesInAllVars);
+    }
+
     private List<String> getRequiredVars(CodegenModel model) {
         return getNames(model.getRequiredVars());
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -4325,4 +4325,32 @@ public class JavaClientCodegenTest {
                 .fileContains("@org.jspecify.annotations.NullMarked");
 
     }
+
+    @Test
+    public void testGeoJsonObjectDoesNotContainCoordinates() {
+        // The generated GeoJsonObject class should not have a 'coordinates' field,
+        // even though both Polygon and MultiPolygon (its oneOf subtypes) define one.
+        // Polygon has coordinates: List<Double>, MultiPolygon has coordinates: List<List<Double>>,
+        // so the types are incompatible and the field must not be pulled up to the parent.
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/geojson_discriminator.yaml");
+        final JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.setOpenAPI(openAPI);
+        codegen.setOutputDir(newTempFolder().toString());
+
+        Map<String, File> files = new DefaultGenerator()
+                .opts(new ClientOptInput().openAPI(openAPI).config(codegen))
+                .generate()
+                .stream()
+                .collect(Collectors.toMap(File::getName, Function.identity()));
+
+        // GeoJsonObject must not expose coordinates — the types differ across oneOf variants
+        JavaFileAssert.assertThat(files.get("GeoJsonObject.java"))
+                .fileDoesNotContain("coordinates");
+
+        // Each subtype must still carry its own coordinates field
+        JavaFileAssert.assertThat(files.get("Polygon.java"))
+                .assertProperty("coordinates");
+        JavaFileAssert.assertThat(files.get("MultiPolygon.java"))
+                .assertProperty("coordinates");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/geojson_discriminator.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/geojson_discriminator.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.3
+info:
+  title: GeoJSON Discriminator Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    GeoJsonObject:
+      type: object
+      properties:
+        type:
+          type: string
+      required:
+        - type
+      discriminator:
+        propertyName: type
+      oneOf:
+        - $ref: '#/components/schemas/Polygon'
+        - $ref: '#/components/schemas/MultiPolygon'
+    Polygon:
+      allOf:
+        - $ref: '#/components/schemas/GeoJsonObject'
+        - type: object
+          properties:
+            coordinates:
+              type: array
+              items:
+                type: number
+                format: double
+    MultiPolygon:
+      allOf:
+        - $ref: '#/components/schemas/GeoJsonObject'
+        - type: object
+          properties:
+            coordinates:
+              type: array
+              items:
+                type: array
+                items:
+                  type: number
+                  format: double


### PR DESCRIPTION
Provides a reproducer test and a draft of the fix (probably not applicable in general, see the issue) for https://github.com/OpenAPITools/openapi-generator/issues/23527.

The problem can be observed when trying to generate java client code for GeoJSON specification, let's see a simplified case:
- parent `GeoJsonObject` containing only type property also used in the discriminator and `oneOf`,
- child schemas:
  - `Polygon` containing `coordinates` property of type array of double,
  - `MultiPolygon` containing `coordinates` property of type array of arrays of double.

The generated `GeoJsonObject` parent class contains unexpectedly also the coordinates field with one of the above types, but the type cannot be overriden by one of the subclasses leading to compilation errors such as:

name clash: `coordinates(List<Double>)` in `Polygon` and `coordinates(List<List<Double>>)` in `GeoJsonGeometry` have the same erasure, yet neither overrides the other

I would expect the generated `GeoJsonObject` class not to contain any fields (`coordinates` in this case) which do not have the same type in the subclasses (alternatively, it could have a more generic type, but it is hard to say how that could be useful for different use-cases).

Happens to me with generator java and most libraries, the only two libraries which worked for me were okhttp-gson and `jersey3`, but our users would like to use `apache-httpclient`.

##### Suggest a fix

Please see the linked [PR](https://github.com/OpenAPITools/openapi-generator/pull/23528) for a fix which works for our use-case, but I believe it cannot be applied as is to keep backward compatibility. It also breaks two tests:
```
[ERROR] org.openapitools.codegen.java.spring.SpringCodegenTest.allOfDuplicatedProperties -- Time elapsed: 0.044 s <<< FAILURE!
java.lang.AssertionError: No constructor with parameter(s) [String, Integer, Integer, String, String]
        at org.openapitools.codegen.java.assertions.JavaFileAssert.assertConstructor(JavaFileAssert.java:147)
        at org.openapitools.codegen.java.spring.SpringCodegenTest.allOfDuplicatedProperties(SpringCodegenTest.java:5182)
...
```

```
[ERROR] org.openapitools.codegen.ruby.RubyClientCodegenTest.allOfDuplicatedPropertiesTest -- Time elapsed: 0.002 s <<< FAILURE!
java.lang.AssertionError: expected [5] but found [3]
...
```

Perhaps a new configuration property could be introduced to disallow pulling up type-incompatible properties into the common parent class? Or is there a more systemic solution? I am also not sure where to put this functionality (`DefaultCodegen` vs `AbstractJavaCodegen`), I will be happy for any advice here.

@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @martin-mfg

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip pulling up properties with conflicting types when merging `oneOf` sub-schemas into a parent model. This prevents ambiguous fields on discriminator bases and fixes Java generation errors for GeoJSON (e.g., coordinates name-clash).

- **Bug Fixes**
  - Updated `DefaultCodegen.mergeProperties` to drop properties that appear in multiple subtypes with incompatible types; added `isSchemasTypeCompatible` to compare base and nested array item types while keeping enum merging for `type`.
  - Added `geojson_discriminator.yaml` and `DefaultCodegenTest.testGeoJsonObjectDoesNotContainCoordinates` to verify that `GeoJsonObject` does not inherit `coordinates` from `Polygon`/`MultiPolygon`.
  - Added `JavaClientCodegenTest.testGeoJsonObjectDoesNotContainCoordinates` to assert `GeoJsonObject.java` omits `coordinates` while `Polygon.java` and `MultiPolygon.java` keep it.

<sup>Written for commit 05e276a9de072a7b195f9ede549b69aeb58c5a85. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



