### PR TITLE
[PHP] Support map/object format for x-enum-varnames and x-enum-descriptions

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -7028,17 +7028,31 @@ public class DefaultCodegen implements CodegenConfig {
 
     protected void updateEnumVarsWithExtensions(List<Map<String, Object>> enumVars, Map<String, Object> vendorExtensions, String dataType) {
         if (vendorExtensions != null) {
-            updateEnumVarsWithExtensions(enumVars, vendorExtensions, "x-enum-varnames", "name");
-            updateEnumVarsWithExtensions(enumVars, vendorExtensions, "x-enum-descriptions", "enumDescription");
+            updateEnumVarsWithExtensions(enumVars, vendorExtensions, "x-enum-varnames", "name", dataType);
+            updateEnumVarsWithExtensions(enumVars, vendorExtensions, "x-enum-descriptions", "enumDescription", dataType);
         }
     }
 
-    private void updateEnumVarsWithExtensions(List<Map<String, Object>> enumVars, Map<String, Object> vendorExtensions, String extensionKey, String key) {
+    private void updateEnumVarsWithExtensions(List<Map<String, Object>> enumVars, Map<String, Object> vendorExtensions, String extensionKey, String key, String dataType) {
         if (vendorExtensions.containsKey(extensionKey)) {
-            List<String> values = (List<String>) vendorExtensions.get(extensionKey);
-            int size = Math.min(enumVars.size(), values.size());
-            for (int i = 0; i < size; i++) {
-                enumVars.get(i).put(key, values.get(i));
+            Object extensionValue = vendorExtensions.get(extensionKey);
+            if (extensionValue instanceof List) {
+                List<String> values = (List<String>) extensionValue;
+                int size = Math.min(enumVars.size(), values.size());
+                for (int i = 0; i < size; i++) {
+                    enumVars.get(i).put(key, values.get(i));
+                }
+            } else if (extensionValue instanceof Map) {
+                Map<String, String> valueMap = (Map<String, String>) extensionValue;
+                for (Map<String, Object> enumVar : enumVars) {
+                    String enumValue = (String) enumVar.get("value");
+                    for (Map.Entry<String, String> entry : valueMap.entrySet()) {
+                        if (toEnumValue(entry.getKey(), dataType).equals(enumValue)) {
+                            enumVar.put(key, entry.getValue());
+                            break;
+                        }
+                    }
+                }
             }
         }
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -711,19 +711,46 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
     protected void updateEnumVarsWithExtensions(List<Map<String, Object>> enumVars, Map<String, Object> vendorExtensions, String dataType) {
         if (vendorExtensions != null) {
             if (vendorExtensions.containsKey("x-enum-varnames")) {
-                List<String> values = (List<String>) vendorExtensions.get("x-enum-varnames");
-                int size = Math.min(enumVars.size(), values.size());
-
-                for (int i = 0; i < size; i++) {
-                    enumVars.get(i).put("name", toEnumVarName(values.get(i), dataType));
+                Object extensionValue = vendorExtensions.get("x-enum-varnames");
+                if (extensionValue instanceof List) {
+                    List<String> values = (List<String>) extensionValue;
+                    int size = Math.min(enumVars.size(), values.size());
+                    for (int i = 0; i < size; i++) {
+                        enumVars.get(i).put("name", toEnumVarName(values.get(i), dataType));
+                    }
+                } else if (extensionValue instanceof Map) {
+                    Map<String, String> valueMap = (Map<String, String>) extensionValue;
+                    for (Map<String, Object> enumVar : enumVars) {
+                        String enumValue = (String) enumVar.get("value");
+                        for (Map.Entry<String, String> entry : valueMap.entrySet()) {
+                            if (toEnumValue(entry.getKey(), dataType).equals(enumValue)) {
+                                enumVar.put("name", toEnumVarName(entry.getValue(), dataType));
+                                break;
+                            }
+                        }
+                    }
                 }
             }
 
             if (vendorExtensions.containsKey("x-enum-descriptions")) {
-                List<String> values = (List<String>) vendorExtensions.get("x-enum-descriptions");
-                int size = Math.min(enumVars.size(), values.size());
-                for (int i = 0; i < size; i++) {
-                    enumVars.get(i).put("enumDescription", values.get(i));
+                Object extensionValue = vendorExtensions.get("x-enum-descriptions");
+                if (extensionValue instanceof List) {
+                    List<String> values = (List<String>) extensionValue;
+                    int size = Math.min(enumVars.size(), values.size());
+                    for (int i = 0; i < size; i++) {
+                        enumVars.get(i).put("enumDescription", values.get(i));
+                    }
+                } else if (extensionValue instanceof Map) {
+                    Map<String, String> valueMap = (Map<String, String>) extensionValue;
+                    for (Map<String, Object> enumVar : enumVars) {
+                        String enumValue = (String) enumVar.get("value");
+                        for (Map.Entry<String, String> entry : valueMap.entrySet()) {
+                            if (toEnumValue(entry.getKey(), dataType).equals(enumValue)) {
+                                enumVar.put("enumDescription", entry.getValue());
+                                break;
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -996,6 +996,26 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void postProcessModelsEnumWithMapExtension() {
+        final DefaultCodegen codegen = new DefaultCodegen();
+        ModelsMap objs = codegenModelWithXEnumVarNameAsMap();
+        CodegenModel cm = objs.getModels().get(0).getModel();
+
+        codegen.postProcessModelsEnum(objs);
+
+        List<Map<String, Object>> enumVars = (List<Map<String, Object>>) cm.getAllowableValues().get("enumVars");
+        Assertions.assertNotNull(enumVars);
+        Assertions.assertNotNull(enumVars.get(0));
+        assertEquals("DOGVAR", enumVars.get(0).getOrDefault("name", ""));
+        assertEquals("\"dog\"", enumVars.get(0).getOrDefault("value", ""));
+        assertEquals("This is a dog", enumVars.get(0).getOrDefault("enumDescription", ""));
+        Assertions.assertNotNull(enumVars.get(1));
+        assertEquals("CATVAR", enumVars.get(1).getOrDefault("name", ""));
+        assertEquals("\"cat\"", enumVars.get(1).getOrDefault("value", ""));
+        assertEquals("This is a cat", enumVars.get(1).getOrDefault("enumDescription", ""));
+    }
+
+    @Test
     public void testExample1() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/examples.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();
@@ -2306,6 +2326,27 @@ public class DefaultCodegenTest {
         cm.dataType = "String";
         final List<String> aliases = Arrays.asList("DOGVAR", "CATVAR");
         final List<String> descriptions = Arrays.asList("This is a dog", "This is a cat");
+        Map<String, Object> extensions = new HashMap<>();
+        extensions.put("x-enum-varnames", aliases);
+        extensions.put("x-enum-descriptions", descriptions);
+        cm.setVendorExtensions(extensions);
+        cm.setVars(Collections.emptyList());
+        return TestUtils.createCodegenModelWrapper(cm);
+    }
+
+    private ModelsMap codegenModelWithXEnumVarNameAsMap() {
+        final CodegenModel cm = new CodegenModel();
+        cm.isEnum = true;
+        final HashMap<String, Object> allowableValues = new HashMap<>();
+        allowableValues.put("values", Arrays.asList("dog", "cat"));
+        cm.setAllowableValues(allowableValues);
+        cm.dataType = "String";
+        Map<String, String> aliases = new LinkedHashMap<>();
+        aliases.put("dog", "DOGVAR");
+        aliases.put("cat", "CATVAR");
+        Map<String, String> descriptions = new LinkedHashMap<>();
+        descriptions.put("dog", "This is a dog");
+        descriptions.put("cat", "This is a cat");
         Map<String, Object> extensions = new HashMap<>();
         extensions.put("x-enum-varnames", aliases);
         extensions.put("x-enum-descriptions", descriptions);


### PR DESCRIPTION
## Summary

When `x-enum-descriptions` or `x-enum-varnames` are provided as a JSON object (map) instead of an array, the generator crashes with a `Exception` because it unconditionally casts the extension value to `List<String>`.

This PR adds support for both formats:
- **Array** (existing, positional): `["desc1", "desc2"]`
- **Map/Object** (new, keyed by enum value): `{"ENUM_VALUE": "description", ...}`

## Motivation

I encountered this when generating a Kotlin client from a real-world API ([Markant public-api](https://api.demo.dva.markant.services/v3/api-docs/public-api)) that uses the map format for `x-enum-descriptions`:

```json
"x-enum-descriptions": {
    "FRUITS_AND_VEGETABLES": "Fruits and vegetables assortment",
    "DRY": "Dry goods assortment",
    "FROZEN": "Frozen goods assortment"
}
```

The map format is also used in the ecosystem and supported by other tools. Since `x-enum-descriptions` is a vendor extension (not part of the official OpenAPI spec), there is no single canonical format — both array and object are valid conventions:

- **Redocly** documents `x-enumDescriptions` exclusively as a map/object format: [Redocly x-enumDescriptions docs](https://redocly.com/docs/realm/content/api-docs/openapi-extensions/x-enum-descriptions)
- **Speakeasy** supports both formats for their equivalent extensions and recommends the map format as it's order-independent and resilient to additions: [Speakeasy enum docs](https://www.speakeasy.com/openapi/schemas/enums)
- **openapi-generator** currently only documents the array format: [templating.md - enum](https://openapi-generator.tech/docs/templating/#enum)

The map format has practical advantages over the array format:
- Order-independent — descriptions stay correct even if enum values are reordered
- Supports partial descriptions — not every enum value needs a description
- No length-mismatch errors

## Changes

- **`DefaultCodegen.java`**: Modified `updateEnumVarsWithExtensions` to check `instanceof List` vs `instanceof Map`. For map format, keys are matched to enum values via `toEnumValue(key, dataType)` to ensure correct matching regardless of language-specific value transformations.
- **`AbstractPhpCodegen.java`**: Same fix applied to the PHP codegen's override of the method.
- **`DefaultCodegenTest.java`**: Added `postProcessModelsEnumWithMapExtension` test mirroring the existing array-based test.

## Test plan

- [x] Existing `postProcessModelsEnumWithExtension` test still passes (array format — no regression)
- [x] New `postProcessModelsEnumWithMapExtension` test passes (map format)
- [x] Both `x-enum-varnames` and `x-enum-descriptions` work with map format