### PR TITLE
add support for sealed response interfaces for spring-declarative-http-interface

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/httpInterfaceReturnTypes.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/httpInterfaceReturnTypes.mustache
@@ -1,26 +1,26 @@
 {{! handle reactive map and array}}
 {{#reactive}}
 {{#isMap}}
-{{#reactiveModeReactor}}Mono<{{/reactiveModeReactor}}{{#useResponseEntity}}ResponseEntity<{{/useResponseEntity}}Map<String, {{{returnType}}}>{{#useResponseEntity}}>{{/useResponseEntity}}{{#reactiveModeReactor}}>{{/reactiveModeReactor}}
+{{#reactiveModeReactor}}Mono<{{/reactiveModeReactor}}{{#useResponseEntity}}ResponseEntity<{{/useResponseEntity}}Map<String, {{#useSealedResponseInterfaces}}{{#vendorExtensions.x-sealed-response-interface}}{{vendorExtensions.x-sealed-response-interface}}{{/vendorExtensions.x-sealed-response-interface}}{{^vendorExtensions.x-sealed-response-interface}}{{{returnType}}}{{/vendorExtensions.x-sealed-response-interface}}{{/useSealedResponseInterfaces}}{{^useSealedResponseInterfaces}}{{{returnType}}}{{/useSealedResponseInterfaces}}>{{#useResponseEntity}}>{{/useResponseEntity}}{{#reactiveModeReactor}}>{{/reactiveModeReactor}}
 {{/isMap}}
 {{#isArray}}
 {{! array handle reactive - reactor with/without ResponseEntity wrapper}}
 {{#reactiveModeReactor}}
-{{#useResponseEntity}}Mono<ResponseEntity<{{/useResponseEntity}}Flux<{{{returnType}}}>{{#useResponseEntity}}>>{{/useResponseEntity}}
+{{#useResponseEntity}}Mono<ResponseEntity<{{/useResponseEntity}}Flux<{{#useSealedResponseInterfaces}}{{#vendorExtensions.x-sealed-response-interface}}{{vendorExtensions.x-sealed-response-interface}}{{/vendorExtensions.x-sealed-response-interface}}{{^vendorExtensions.x-sealed-response-interface}}{{{returnType}}}{{/vendorExtensions.x-sealed-response-interface}}{{/useSealedResponseInterfaces}}{{^useSealedResponseInterfaces}}{{{returnType}}}{{/useSealedResponseInterfaces}}>{{#useResponseEntity}}>>{{/useResponseEntity}}
 {{/reactiveModeReactor}}
 {{! array handle reactive - coroutines with/without ResponseEntity wrapper}}
 {{#reactiveModeCoroutines}}
-{{#useResponseEntity}}ResponseEntity<{{/useResponseEntity}}{{{returnContainer}}}<{{{returnType}}}>{{#useResponseEntity}}>{{/useResponseEntity}}
+{{#useResponseEntity}}ResponseEntity<{{/useResponseEntity}}{{{returnContainer}}}<{{#useSealedResponseInterfaces}}{{#vendorExtensions.x-sealed-response-interface}}{{vendorExtensions.x-sealed-response-interface}}{{/vendorExtensions.x-sealed-response-interface}}{{^vendorExtensions.x-sealed-response-interface}}{{{returnType}}}{{/vendorExtensions.x-sealed-response-interface}}{{/useSealedResponseInterfaces}}{{^useSealedResponseInterfaces}}{{{returnType}}}{{/useSealedResponseInterfaces}}>{{#useResponseEntity}}>{{/useResponseEntity}}
 {{/reactiveModeCoroutines}}
 {{/isArray}}
 {{! handle reactive non-container - with/without ResponseEntity wrapper}}
 {{^returnContainer}}
 {{#reactiveModeReactor}}
-Mono<{{#useResponseEntity}}ResponseEntity<{{/useResponseEntity}}{{{returnType}}}{{#useResponseEntity}}>{{/useResponseEntity}}>
+Mono<{{#useResponseEntity}}ResponseEntity<{{/useResponseEntity}}{{#useSealedResponseInterfaces}}{{#vendorExtensions.x-sealed-response-interface}}{{vendorExtensions.x-sealed-response-interface}}{{/vendorExtensions.x-sealed-response-interface}}{{^vendorExtensions.x-sealed-response-interface}}{{{returnType}}}{{/vendorExtensions.x-sealed-response-interface}}{{/useSealedResponseInterfaces}}{{^useSealedResponseInterfaces}}{{{returnType}}}{{/useSealedResponseInterfaces}}{{#useResponseEntity}}>{{/useResponseEntity}}>
 {{/reactiveModeReactor}}
 {{#reactiveModeCoroutines}}
 {{#useResponseEntity}}
-ResponseEntity<{{/useResponseEntity}}{{{returnType}}}{{#useResponseEntity}}>
+ResponseEntity<{{/useResponseEntity}}{{#useSealedResponseInterfaces}}{{#vendorExtensions.x-sealed-response-interface}}{{vendorExtensions.x-sealed-response-interface}}{{/vendorExtensions.x-sealed-response-interface}}{{^vendorExtensions.x-sealed-response-interface}}{{{returnType}}}{{/vendorExtensions.x-sealed-response-interface}}{{/useSealedResponseInterfaces}}{{^useSealedResponseInterfaces}}{{{returnType}}}{{/useSealedResponseInterfaces}}{{#useResponseEntity}}>
 {{/useResponseEntity}}
 {{/reactiveModeCoroutines}}
 {{/returnContainer}}
@@ -29,19 +29,19 @@ ResponseEntity<{{/useResponseEntity}}{{{returnType}}}{{#useResponseEntity}}>
 {{! handle non-reactive map and array}}
 {{#isMap}}
 {{#useResponseEntity}}
-ResponseEntity<{{/useResponseEntity}}Map<String, {{{returnType}}}>{{#useResponseEntity}}>
+ResponseEntity<{{/useResponseEntity}}Map<String, {{#useSealedResponseInterfaces}}{{#vendorExtensions.x-sealed-response-interface}}{{vendorExtensions.x-sealed-response-interface}}{{/vendorExtensions.x-sealed-response-interface}}{{^vendorExtensions.x-sealed-response-interface}}{{{returnType}}}{{/vendorExtensions.x-sealed-response-interface}}{{/useSealedResponseInterfaces}}{{^useSealedResponseInterfaces}}{{{returnType}}}{{/useSealedResponseInterfaces}}>{{#useResponseEntity}}>
 {{/useResponseEntity}}
 {{/isMap}}
 {{#isArray}}
 {{! array handle non-reactive - with/without ResponseEntity wrapper}}
 {{#useResponseEntity}}
-ResponseEntity<{{/useResponseEntity}}{{{returnContainer}}}<{{{returnType}}}>{{#useResponseEntity}}>
+ResponseEntity<{{/useResponseEntity}}{{{returnContainer}}}<{{#useSealedResponseInterfaces}}{{#vendorExtensions.x-sealed-response-interface}}{{vendorExtensions.x-sealed-response-interface}}{{/vendorExtensions.x-sealed-response-interface}}{{^vendorExtensions.x-sealed-response-interface}}{{{returnType}}}{{/vendorExtensions.x-sealed-response-interface}}{{/useSealedResponseInterfaces}}{{^useSealedResponseInterfaces}}{{{returnType}}}{{/useSealedResponseInterfaces}}>{{#useResponseEntity}}>
 {{/useResponseEntity}}
 {{/isArray}}
 {{! handle reactive non-container - with/without ResponseEntity wrapper}}
 {{^returnContainer}}
 {{#useResponseEntity}}
-ResponseEntity<{{/useResponseEntity}}{{{returnType}}}{{#useResponseEntity}}>
+ResponseEntity<{{/useResponseEntity}}{{#useSealedResponseInterfaces}}{{#vendorExtensions.x-sealed-response-interface}}{{vendorExtensions.x-sealed-response-interface}}{{/vendorExtensions.x-sealed-response-interface}}{{^vendorExtensions.x-sealed-response-interface}}{{{returnType}}}{{/vendorExtensions.x-sealed-response-interface}}{{/useSealedResponseInterfaces}}{{^useSealedResponseInterfaces}}{{{returnType}}}{{/useSealedResponseInterfaces}}{{#useResponseEntity}}>
 {{/useResponseEntity}}
 {{/returnContainer}}
 {{/reactive}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
@@ -5946,4 +5946,39 @@ public class KotlinSpringServerCodegenTest {
                 "override val vehicleType: VehicleType = VehicleType.TRUCK"
         );
     }
+
+    @Test
+    public void testSealedResponseInterfacesWithDeclarativeHttpInterface() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/kotlin/sealed-response-interfaces.yaml", null, new ParseOptions()).getOpenAPI();
+
+        KotlinSpringServerCodegen codegen = new KotlinSpringServerCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(CodegenConstants.MODEL_PACKAGE, "org.openapitools.model");
+        codegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "org.openapitools.api");
+        codegen.additionalProperties().put(CodegenConstants.LIBRARY, "spring-declarative-http-interface");
+        codegen.additionalProperties().put(USE_SEALED_RESPONSE_INTERFACES, "true");
+        codegen.additionalProperties().put(USE_RESPONSE_ENTITY, "true");
+        codegen.additionalProperties().put(REACTIVE, "false");
+        codegen.additionalProperties().put(USE_FLOW_FOR_ARRAY_RETURN_TYPE, "false");
+
+        ClientOptInput input = new ClientOptInput();
+        input.openAPI(openAPI);
+        input.config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.opts(input).generate();
+
+        assertFileContains(Paths.get(outputPath + "/src/main/kotlin/org/openapitools/api/DefaultApi.kt"),
+                "import org.openapitools.model.CreateUserResponse",
+                "import org.openapitools.model.GetUserResponse",
+                "fun createUser(",
+                "): ResponseEntity<CreateUserResponse>",
+                "fun getUser(",
+                "): ResponseEntity<GetUserResponse>");
+    }
 }


### PR DESCRIPTION
fixes #23548

https://github.com/OpenAPITools/openapi-generator/pull/23003 Added support for sealed response interfaces, but it is not supported for spring-declarative-http-interface

This PR adds support for it. I had some trouble running the mvnw clean package command locally on my mac, but KotlinSpringServerCodegenTest passes

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds sealed response interface support to Kotlin Spring `spring-declarative-http-interface` when `useSealedResponseInterfaces` is enabled, so generated APIs can return sealed interfaces instead of concrete models. Fixes #23548.

- New Features
  - Applies `vendorExtensions.x-sealed-response-interface` to return types for maps, arrays, and single values across reactive (Reactor, coroutines) and non-reactive modes, with or without `ResponseEntity`.
  - Adds a generator test for the declarative HTTP interface asserting `ResponseEntity<CreateUserResponse>` and `ResponseEntity<GetUserResponse>` outputs.

<sup>Written for commit 6ebb1f7e7bae054f242f3ddaa3105252ad1527f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

