### PR TITLE
[PHP-SYMFONY] Align invalid BackedEnum query deserialization with SerializerRuntimeException (fixes #23552)

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/serialization/JmsSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/serialization/JmsSerializer.mustache
@@ -9,6 +9,7 @@ use JMS\Serializer\Serializer;
 use JMS\Serializer\Visitor\Factory\XmlDeserializationVisitorFactory;
 use DateTime;
 use RuntimeException;
+use JMS\Serializer\Exception\RuntimeException as SerializerRuntimeException;
 
 class JmsSerializer implements SerializerInterface
 {
@@ -122,7 +123,7 @@ class JmsSerializer implements SerializerInterface
 
                 $enum = $type::tryFrom($data);
                 if (!$enum) {
-                    throw new RuntimeException(sprintf("Unknown %s value in %s enum", $data, $type));
+                    throw new SerializerRuntimeException(sprintf("Unknown %s value in %s enum", $data, $type));
                 }
 
                 return $enum;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpSymfonyServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpSymfonyServerCodegenTest.java
@@ -243,6 +243,76 @@ public class PhpSymfonyServerCodegenTest {
     }
 
     /**
+     * Guards {@code php-symfony} {@code JmsSerializer.mustache}: invalid query values for a generated PHP
+     * {@code BackedEnum} are deserialized in {@code JmsSerializer::deserializeString()}. The generated
+     * {@code DefaultController} wraps {@code deserialize(...)} with {@code catch (SerializerRuntimeException)},
+     * an alias of {@code JMS\Serializer\Exception\RuntimeException}. Only the unknown-enum branch must throw that
+     * type; other string-deserialization errors may keep using PHP's global {@code RuntimeException}.
+     * <p>
+     * This test asserts the generated {@code JmsSerializer.php} keeps {@code use RuntimeException;} and adds
+     * {@code use JMS\Serializer\Exception\RuntimeException as SerializerRuntimeException;}, throws
+     * {@code SerializerRuntimeException} for {@code tryFrom} failure, and that {@code DefaultController.php} still
+     * catches {@code SerializerRuntimeException}.
+     * <p>
+     * Spec: {@code src/test/resources/3_1/php-symfony/jms-enum-query-invalid-deserialization.yaml}. Background:
+     * {@code fix_jms_enum_ex.md}.
+     */
+    @Test
+    public void testJmsSerializerUsesJmsRuntimeExceptionForBackedEnumStringDeserializationErrors() throws Exception {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("invokerPackage", "Org\\OpenAPITools\\PetstoreEnum");
+
+        File output = Files.createTempDirectory("test").toFile();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("php-symfony")
+                .setAdditionalProperties(properties)
+                .setInputSpec("src/test/resources/3_1/php-symfony/jms-enum-query-invalid-deserialization.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(clientOptInput).generate();
+
+        File jmsSerializer = files.stream()
+                .filter(f -> "JmsSerializer.php".equals(f.getName()) && f.getPath().contains("Service" + File.separator))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("JmsSerializer.php not generated"));
+
+        String jms = Files.readString(jmsSerializer.toPath(), StandardCharsets.UTF_8);
+
+        Assert.assertTrue(
+                jms.contains("Unknown %s value in %s enum"),
+                "Expected BackedEnum tryFrom failure message in generated JmsSerializer");
+        Assert.assertTrue(
+                Pattern.compile("^use RuntimeException;\\s*$", Pattern.MULTILINE).matcher(jms).find(),
+                "JmsSerializer should keep use RuntimeException for generic unsupported-type errors");
+        Assert.assertTrue(
+                jms.contains("use JMS\\Serializer\\Exception\\RuntimeException as SerializerRuntimeException;"),
+                "JmsSerializer must alias JMS RuntimeException as SerializerRuntimeException (same as DefaultController)");
+        Assert.assertTrue(
+                jms.contains("throw new SerializerRuntimeException(sprintf(\"Unknown %s value in %s enum\", $data, $type));"),
+                "Invalid BackedEnum tryFrom must throw SerializerRuntimeException so DefaultController catch applies");
+
+        File defaultController = files.stream()
+                .filter(f -> "DefaultController.php".equals(f.getName()) && f.getPath().contains("Controller" + File.separator))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("DefaultController.php not generated"));
+        String controller = Files.readString(defaultController.toPath(), StandardCharsets.UTF_8);
+        Assert.assertTrue(
+                controller.contains("use JMS\\Serializer\\Exception\\RuntimeException as SerializerRuntimeException;"),
+                "Expected DefaultController to catch SerializerRuntimeException alias");
+        Assert.assertTrue(
+                controller.contains("catch (SerializerRuntimeException $exception)"),
+                "Expected deserialize() to catch SerializerRuntimeException");
+
+        assertGeneratedPhpSyntaxValid(jmsSerializer);
+        assertGeneratedPhpSyntaxValid(defaultController);
+
+        output.deleteOnExit();
+    }
+
+    /**
      * Optional {@code in: query} parameter: {@code required: false}, schema is an enum {@code $ref} with a valid
      * {@code default} (see OpenAPI 3.x). Omitting the query key must be equivalent to sending that default; the
      * generated controller must not reject the request in validation solely because the value was absent.

--- a/modules/openapi-generator/src/test/resources/3_1/php-symfony/jms-enum-query-invalid-deserialization.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/php-symfony/jms-enum-query-invalid-deserialization.yaml
@@ -1,0 +1,25 @@
+openapi: 3.1.0
+info:
+  title: php-symfony JMS invalid query enum deserialization
+  version: '1.0'
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      parameters:
+        - name: status
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/Pet.Model.PetStatus'
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Pet.Model.PetStatus:
+      type: string
+      enum:
+        - available
+        - pending
+        - sold

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Service/JmsSerializer.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Service/JmsSerializer.php
@@ -9,6 +9,7 @@ use JMS\Serializer\Serializer;
 use JMS\Serializer\Visitor\Factory\XmlDeserializationVisitorFactory;
 use DateTime;
 use RuntimeException;
+use JMS\Serializer\Exception\RuntimeException as SerializerRuntimeException;
 
 class JmsSerializer implements SerializerInterface
 {
@@ -122,7 +123,7 @@ class JmsSerializer implements SerializerInterface
 
                 $enum = $type::tryFrom($data);
                 if (!$enum) {
-                    throw new RuntimeException(sprintf("Unknown %s value in %s enum", $data, $type));
+                    throw new SerializerRuntimeException(sprintf("Unknown %s value in %s enum", $data, $type));
                 }
 
                 return $enum;


### PR DESCRIPTION

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

fixes #23552

### What changed

The generated **`php-symfony`** **`JmsSerializer`** used **`use RuntimeException`** and threw **`new RuntimeException(...)`** when a **`BackedEnum::tryFrom($data)`** failed for **`deserialize(..., 'string')`** (typical for **`in: query`** enums). The generated **`DefaultController`** only catches **`JMS\Serializer\Exception\RuntimeException`** as **`SerializerRuntimeException`**, so PHP’s **`catch`** did not match a **global `\RuntimeException`**, often surfacing as **HTTP 500** instead of the bad-request path.

**Template change** (`modules/openapi-generator/src/main/resources/php-symfony/serialization/JmsSerializer.mustache`):

- Keep **`use RuntimeException;`** and existing **`throw new RuntimeException(...)`** for unsupported-type branches.
- Add **`use JMS\Serializer\Exception\RuntimeException as SerializerRuntimeException;`**.
- Only the **`tryFrom`** failure branch now throws **`new SerializerRuntimeException(sprintf('Unknown %s value in %s enum', ...))`**, matching the controller’s **`catch`**.

**Tests / fixture**

- New minimal OpenAPI 3.1 fixture: **`modules/openapi-generator/src/test/resources/3_1/php-symfony/jms-enum-query-invalid-deserialization.yaml`**.
- New **`PhpSymfonyServerCodegenTest#testJmsSerializerUsesJmsRuntimeExceptionForBackedEnumStringDeserializationErrors`**: asserts imports, the **`SerializerRuntimeException`** throw for unknown enum values, and that **`DefaultController`** still declares **`SerializerRuntimeException`**; runs **`php -l`** when **`php`** is on **`PATH`**.

### How to validate

1. Build the generator (Java 11 per project docs), generate **`php-symfony`** from the new YAML fixture (or any spec with query **`BackedEnum`**).
2. Confirm **`Service/JmsSerializer.php`** contains both **`use`** lines and **`throw new SerializerRuntimeException`** only in the unknown-enum branch.
3. In a Symfony app wired to the bundle, **`GET ...?status=<invalid>`** should hit **`createBadRequestResponse`** (typically **400**), not an unhandled **500** from **`deserialize`**.

```bash
./mvnw -pl modules/openapi-generator -Dtest=PhpSymfonyServerCodegenTest test
```

---

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.

  **Pre-submit (local fork):** `./mvnw -pl modules/openapi-generator -Dtest=PhpSymfonyServerCodegenTest test` was run successfully with Java 11. Full **`clean package`**, **`generate-samples.sh`**, and **`export_docs_generators.sh`** were **not** run in this workspace; run the full sequence before opening / updating the upstream PR so CI sample expectations stay in sync.

- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks) — **intended target: `master`**.
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description) — **`fixes #23552`** above.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc PHP technical committee: @jebentier @dkarlovi @mandrean @jfastnacht @ybelenko @renepardon · PHP Symfony generator: @ksm2


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes invalid query `BackedEnum` values in `php-symfony` deserialize to `SerializerRuntimeException`, so `DefaultController` catches them and returns 400 instead of 500. Fixes #23552.

- **Bug Fixes**
  - In `JmsSerializer.mustache`, added `use JMS\Serializer\Exception\RuntimeException as SerializerRuntimeException;` and throw it only when `BackedEnum::tryFrom($data)` fails; kept `use RuntimeException;` for other unsupported types.
  - Added a minimal OpenAPI 3.1 fixture and a test to assert the import, thrown exception, and controller `catch`; validated generated PHP syntax.
  - Updated sample `Service/JmsSerializer.php` to match the new behavior.

<sup>Written for commit 410c3844bda4f941054962cc7e7e03a26ad22249. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

