### PR TITLE
[java] Support 'time-local' format

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -661,6 +661,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             additionalProperties.put("jsr310", "true");
             typeMapping.put("date", "LocalDate");
             importMapping.put("LocalDate", "java.time.LocalDate");
+            typeMapping.put("time-local","LocalTime");
             importMapping.put("LocalTime", "java.time.LocalTime");
             if ("java8-localdatetime".equals(dateLibrary)) {
                 typeMapping.put("DateTime", "LocalDateTime");
@@ -1411,6 +1412,13 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                 return "URI.create(\"" + escapeText(String.valueOf(schema.getDefault())) + "\")";
             }
             return null;
+        } else if (ModelUtils.isTimeLocalSchema(schema)) {
+            if (schema.getDefault() != null) {
+                if ("java8".equals(getDateLibrary())) {
+                    return String.format(Locale.ROOT, "LocalTime.parse(\"%s\")", schema.getDefault());
+                }
+            }
+            return null;
         } else if (ModelUtils.isStringSchema(schema)) {
             if (schema.getDefault() != null) {
                 String _default;
@@ -1492,6 +1500,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                                     defaultPropertyExpression = String.format(Locale.ROOT, "java.time.OffsetDateTime.parse(\"%s\", %s)",
                                             value.asText(),
                                             "java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME.withZone(java.time.ZoneId.systemDefault())");
+                                }
+                            } else if(ModelUtils.isTimeLocalSchema(propertySchema)) {
+                                if("java8".equals(getDateLibrary())) {
+                                    defaultPropertyExpression = String.format(Locale.ROOT, "java.time.LocalTime.parse(\"%s\")", value.asText());
                                 }
                             } else if(ModelUtils.isUUIDSchema(propertySchema)) {
                                 defaultPropertyExpression = "java.util.UUID.fromString(\"" + value.asText() + "\")";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -696,6 +696,12 @@ public class ModelUtils {
                         && SchemaTypeUtil.DATE_TIME_FORMAT.equals(schema.getFormat()));
     }
 
+    public static boolean isTimeLocalSchema(Schema schema) {
+        // format: time-local, see https://spec.openapis.org/registry/format/time-local.html
+        return (SchemaTypeUtil.STRING_TYPE.equals(getType(schema))
+                        && "time-local".equals(schema.getFormat()));
+    }
+
     public static boolean isPasswordSchema(Schema schema) {
         return (schema instanceof PasswordSchema) ||
                 // double

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -38,10 +38,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -531,6 +528,15 @@ public class AbstractJavaCodegenTest {
 
         // dateLibrary <> java8
         Assert.assertEquals(defaultValue, "1984-12-19T03:39:57-09:00");
+
+        // Test default value for time-local format
+        StringSchema timeLocalSchema = new StringSchema();
+        timeLocalSchema.setFormat("time-local");
+        timeLocalSchema.setDefault(LocalTime.parse("10:15:30"));
+        defaultValue = codegen.toDefaultValue(timeLocalSchema);
+
+        // dateLibrary <> java8
+        Assert.assertEquals(defaultValue, "10:15:30");
     }
 
     @Test
@@ -593,6 +599,13 @@ public class AbstractJavaCodegenTest {
         numberSchema.setFormat("double");
         defaultValue = codegen.toDefaultValue(codegen.fromProperty("", schema), numberSchema);
         Assert.assertEquals(defaultValue, doubleValue + "d");
+
+        // Test default value for time-local format
+        StringSchema timeLocalSchema = new StringSchema();
+        timeLocalSchema.setFormat("time-local");
+        timeLocalSchema.setDefault("10:15:30");
+        defaultValue = codegen.toDefaultValue(codegen.fromProperty("", timeLocalSchema), timeLocalSchema);
+        Assert.assertEquals(defaultValue, "LocalTime.parse(\"10:15:30\")");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -382,6 +382,35 @@ public class SpringCodegenTest {
     }
 
     @Test
+    public void generateLocalTimeForTimeLocalFormat() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/spring/date-time-parameter-types-for-testing.yml", null, new ParseOptions()).getOpenAPI();
+
+        SpringCodegen codegen = new SpringCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput input = new ClientOptInput();
+        input.openAPI(openAPI);
+        input.config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "false");
+        generator.setGenerateMetadata(false);
+        generator.opts(input).generate();
+
+        JavaFileAssert.assertThat(Paths.get(outputPath + "/src/main/java/org/openapitools/model/Pet.java"))
+                .hasImports("java.time.LocalTime")
+                .assertProperty("feedingTime").withType("LocalTime");
+    }
+
+    @Test
     public void interfaceDefaultImplDisableWithResponseWrapper() {
         final SpringCodegen codegen = new SpringCodegen();
         codegen.additionalProperties().put(RESPONSE_WRAPPER, "aWrapper");

--- a/modules/openapi-generator/src/test/resources/3_0/spring/date-time-parameter-types-for-testing.yml
+++ b/modules/openapi-generator/src/test/resources/3_0/spring/date-time-parameter-types-for-testing.yml
@@ -102,3 +102,7 @@ components:
           type: string
           format: date
           default: '2021-01-01'
+        feedingTime:
+          type: string
+          format: time-local
+          default: '10:15:30'

--- a/samples/client/petstore/spring-cloud-date-time/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud-date-time/src/main/java/org/openapitools/model/Pet.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.lang.Nullable;
@@ -39,6 +40,8 @@ public class Pet {
 
   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
   private LocalDate dateOfBirth = LocalDate.parse("2021-01-01");
+
+  private LocalTime feedingTime = LocalTime.parse("10:15:30");
 
   public Pet() {
     super();
@@ -177,6 +180,27 @@ public class Pet {
     this.dateOfBirth = dateOfBirth;
   }
 
+  public Pet feedingTime(LocalTime feedingTime) {
+    this.feedingTime = feedingTime;
+    return this;
+  }
+
+  /**
+   * Get feedingTime
+   * @return feedingTime
+   */
+  @Valid 
+  @Schema(name = "feedingTime", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("feedingTime")
+  public LocalTime getFeedingTime() {
+    return feedingTime;
+  }
+
+  @JsonProperty("feedingTime")
+  public void setFeedingTime(LocalTime feedingTime) {
+    this.feedingTime = feedingTime;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -191,12 +215,13 @@ public class Pet {
         Objects.equals(this.happy, pet.happy) &&
         Objects.equals(this.price, pet.price) &&
         Objects.equals(this.lastFeed, pet.lastFeed) &&
-        Objects.equals(this.dateOfBirth, pet.dateOfBirth);
+        Objects.equals(this.dateOfBirth, pet.dateOfBirth) &&
+        Objects.equals(this.feedingTime, pet.feedingTime);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(atType, age, happy, price, lastFeed, dateOfBirth);
+    return Objects.hash(atType, age, happy, price, lastFeed, dateOfBirth, feedingTime);
   }
 
   @Override
@@ -209,6 +234,7 @@ public class Pet {
     sb.append("    price: ").append(toIndentedString(price)).append("\n");
     sb.append("    lastFeed: ").append(toIndentedString(lastFeed)).append("\n");
     sb.append("    dateOfBirth: ").append(toIndentedString(dateOfBirth)).append("\n");
+    sb.append("    feedingTime: ").append(toIndentedString(feedingTime)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/openapi3/client/petstore/spring-cloud-date-time/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-date-time/src/main/java/org/openapitools/model/Pet.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.lang.Nullable;
@@ -39,6 +40,8 @@ public class Pet {
 
   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
   private LocalDate dateOfBirth = LocalDate.parse("2021-01-01");
+
+  private LocalTime feedingTime = LocalTime.parse("10:15:30");
 
   public Pet() {
     super();
@@ -177,6 +180,27 @@ public class Pet {
     this.dateOfBirth = dateOfBirth;
   }
 
+  public Pet feedingTime(LocalTime feedingTime) {
+    this.feedingTime = feedingTime;
+    return this;
+  }
+
+  /**
+   * Get feedingTime
+   * @return feedingTime
+   */
+  @Valid 
+  @Schema(name = "feedingTime", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("feedingTime")
+  public LocalTime getFeedingTime() {
+    return feedingTime;
+  }
+
+  @JsonProperty("feedingTime")
+  public void setFeedingTime(LocalTime feedingTime) {
+    this.feedingTime = feedingTime;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -191,12 +215,13 @@ public class Pet {
         Objects.equals(this.happy, pet.happy) &&
         Objects.equals(this.price, pet.price) &&
         Objects.equals(this.lastFeed, pet.lastFeed) &&
-        Objects.equals(this.dateOfBirth, pet.dateOfBirth);
+        Objects.equals(this.dateOfBirth, pet.dateOfBirth) &&
+        Objects.equals(this.feedingTime, pet.feedingTime);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(atType, age, happy, price, lastFeed, dateOfBirth);
+    return Objects.hash(atType, age, happy, price, lastFeed, dateOfBirth, feedingTime);
   }
 
   @Override
@@ -209,6 +234,7 @@ public class Pet {
     sb.append("    price: ").append(toIndentedString(price)).append("\n");
     sb.append("    lastFeed: ").append(toIndentedString(lastFeed)).append("\n");
     sb.append("    dateOfBirth: ").append(toIndentedString(dateOfBirth)).append("\n");
+    sb.append("    feedingTime: ").append(toIndentedString(feedingTime)).append("\n");
     sb.append("}");
     return sb.toString();
   }


### PR DESCRIPTION
See https://spec.openapis.org/registry/format/time-local.html

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for the OpenAPI `time-local` format in Java generators. Models now use `java.time.LocalTime` with correct default handling when using the `java8` date library.

- **New Features**
  - Map `time-local` to `LocalTime` and add the import when using the `java8` date library.
  - Generate defaults with `LocalTime.parse(...)`; keep string defaults for non-`java8`.
  - Add `ModelUtils.isTimeLocalSchema` and handle nested property defaults.
  - Update Spring tests and petstore samples (new `feedingTime` property).

<sup>Written for commit 97fe053a8110f274cb0624186b8a2f74ddeb2da1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

