### PR TITLE
[PHP][php-symfony] Fix native enum default value expression in AbstractPhpCodegen

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -790,16 +790,37 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
      * <p>
      * Execution: {@code datatype} is produced upstream (e.g. {@link DefaultCodegen#updateCodegenPropertyEnum}) via
      * {@link #getTypeDeclaration(Schema)} for the referenced enum schema; {@code value} is the sanitized case name
-     * from {@link #toEnumVarName}. We concatenate with {@code ::} so templates emit valid PHP (e.g.
-     * {@code \Vendor\Model\Status::AVAILABLE}).
+     * from {@link #toEnumVarName}. When the enum class sits under {@link #modelPackage}, we emit only the short class
+     * name plus {@code ::} so it matches sibling model references in generated files ({@code namespace} is
+     * {@code modelPackage}; unqualified names resolve correctly). A fully qualified body without a leading
+     * {@code \} would be resolved relative to the file namespace and is invalid PHP for defaults.
      *
      * @param value    enum case name (e.g. {@code AVAILABLE})
-     * @param datatype enum class as in generated PHP (often leading {@code \} + FQCN)
-     * @return PHP default expression for that case
+     * @param datatype enum class as produced by {@link #getTypeDeclaration(Schema)} (may include {@code modelPackage})
+     * @return PHP default expression for that case (e.g. {@code PetStatus::AVAILABLE})
      */
     @Override
     public String toEnumDefaultValue(String value, String datatype) {
-        return datatype + "::" + value;
+        return unqualifiedEnumClassForModelDefault(datatype) + "::" + value;
+    }
+
+    /**
+     * Strips {@link #modelPackage} from a declared enum class name so defaults use the same unqualified form as
+     * property type hints in model templates.
+     *
+     * @param datatype enum class string from codegen (optional leading {@code \})
+     * @return short class name if under {@code modelPackage}, otherwise the original {@code datatype}
+     */
+    private String unqualifiedEnumClassForModelDefault(String datatype) {
+        if (StringUtils.isBlank(datatype) || StringUtils.isBlank(modelPackage)) {
+            return datatype;
+        }
+        String normalized = datatype.charAt(0) == '\\' ? datatype.substring(1) : datatype;
+        String prefix = modelPackage + "\\";
+        if (normalized.startsWith(prefix)) {
+            return normalized.substring(prefix.length());
+        }
+        return datatype;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -781,9 +781,25 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         }
     }
 
+    /**
+     * Builds the PHP expression for a backed enum case default (PHP 8.1+ {@code enum}).
+     * <p>
+     * The legacy {@code self::}{@code <datatype>_<CASE>} form came from class-constant style enums (#10273) and is
+     * invalid when {@code datatype} is a namespaced class: {@code self::} only resolves constants on the current
+     * class. Native enums must use {@code EnumType::CASE}.
+     * <p>
+     * Execution: {@code datatype} is produced upstream (e.g. {@link DefaultCodegen#updateCodegenPropertyEnum}) via
+     * {@link #getTypeDeclaration(Schema)} for the referenced enum schema; {@code value} is the sanitized case name
+     * from {@link #toEnumVarName}. We concatenate with {@code ::} so templates emit valid PHP (e.g.
+     * {@code \Vendor\Model\Status::AVAILABLE}).
+     *
+     * @param value    enum case name (e.g. {@code AVAILABLE})
+     * @param datatype enum class as in generated PHP (often leading {@code \} + FQCN)
+     * @return PHP default expression for that case
+     */
     @Override
     public String toEnumDefaultValue(String value, String datatype) {
-        return "self::" + datatype + "_" + value;
+        return datatype + "::" + value;
     }
 
     @Override

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpSymfonyServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpSymfonyServerCodegenTest.java
@@ -17,8 +17,11 @@
 
 package org.openapitools.codegen.php;
 
+import io.swagger.v3.oas.models.media.Schema;
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.CodegenConstants;
+import org.openapitools.codegen.CodegenModel;
+import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.DefaultGenerator;
 import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.config.CodegenConfigurator;
@@ -326,6 +329,44 @@ public class PhpSymfonyServerCodegenTest {
         assertGeneratedPhpSyntaxValid(controllerFile);
 
         output.deleteOnExit();
+    }
+
+    /**
+     * Model property: string enum {@code $ref} with sibling {@code default} must produce a valid PHP 8.1 backed-enum
+     * default expression ({@code Type::CASE}), not {@code self::} + FQCN + {@code _CASE} from
+     * {@link AbstractPhpCodegen#toEnumDefaultValue}.
+     * <p>
+     * Spec: {@code src/test/resources/3_1/php-symfony/optional-enum-query-ref-default.yaml} ({@code Pet.HTTP.CreatePetRequest.status}).
+     */
+    @Test
+    public void testModelPropertyEnumRefWithDefaultUsesNativeEnumCaseInCodegen() {
+        final var openAPI = TestUtils.parseFlattenSpec(
+                "src/test/resources/3_1/php-symfony/optional-enum-query-ref-default.yaml");
+        final PhpSymfonyServerCodegen codegen = new PhpSymfonyServerCodegen();
+        codegen.setOpenAPI(openAPI);
+        codegen.processOpts();
+
+        Schema createPet = openAPI.getComponents().getSchemas().get("Pet.HTTP.CreatePetRequest");
+        Assert.assertNotNull(createPet, "Fixture must define Pet.HTTP.CreatePetRequest");
+
+        CodegenModel cm = codegen.fromModel("Pet.HTTP.CreatePetRequest", createPet);
+        codegen.postProcessModels(TestUtils.createCodegenModelWrapper(cm));
+
+        CodegenProperty status = cm.getVars().stream()
+                .filter(v -> "status".equals(v.getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Expected status property on CreatePetRequest model"));
+
+        Assert.assertNotNull(
+                status.getDefaultValue(),
+                "Enum ref + OpenAPI default should set CodegenProperty.defaultValue (see AbstractPhpCodegen.toDefaultValue"
+                        + " ref+default handling and updateCodegenPropertyEnum)");
+        Assert.assertFalse(
+                status.getDefaultValue().startsWith("self::"),
+                "Invalid PHP: backed enum default must not use self:: prefix, got: " + status.getDefaultValue());
+        Assert.assertTrue(
+                status.getDefaultValue().contains("::AVAILABLE"),
+                "Expected PetModelPetStatus::AVAILABLE (or FQCN::AVAILABLE), got: " + status.getDefaultValue());
     }
 
     /**

--- a/modules/openapi-generator/src/test/resources/3_1/php-symfony/optional-enum-query-ref-default.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/php-symfony/optional-enum-query-ref-default.yaml
@@ -1,13 +1,32 @@
-# Minimal OpenAPI 3.1 spec: optional query with enum $ref + default (components.parameters).
-# Repro pattern: omitting the query key should behave like the declared default; php-symfony
-# may still validate null as enum type before business logic. See project troubleshooting doc.
+# Minimal OpenAPI 3.1 spec (pet store style):
+# - Optional query: enum $ref + default (components.parameters) — regression for query/controller path.
+# - Model property: enum $ref + sibling default on an object schema — invalid PHP may be emitted for the
+#   property initializer (e.g. self::..._CASE) when default flows through AbstractPhpCodegen.toEnumDefaultValue.
 openapi: 3.1.0
 info:
   title: Optional enum query ref with default (php-symfony repro)
   version: '1.0'
+servers:
+  - url: https://petstore.example.com/api
+# Explicit empty security for minimal test fixtures (no global auth).
+security: []
 paths:
+  /pets:
+    post:
+      summary: Create a pet (request body uses enum ref + default on a property)
+      operationId: createPet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet.HTTP.CreatePetRequest'
+      responses:
+        '201':
+          description: Created
   /pets/feed-hints:
     get:
+      summary: List feed hints (optional enum query ref + default)
       operationId: listFeedHints
       parameters:
         - $ref: '#/components/parameters/ToneQuery'
@@ -35,6 +54,19 @@ components:
         $ref: '#/components/schemas/PetAnnouncementTone'
         default: friendly
   schemas:
+    Pet.Model.PetStatus:
+      type: string
+      enum:
+        - available
+        - pending
+        - sold
+    Pet.HTTP.CreatePetRequest:
+      type: object
+      properties:
+        # OAS 3.1: sibling keys beside $ref are allowed.
+        status:
+          $ref: '#/components/schemas/Pet.Model.PetStatus'
+          default: available
     PetAnnouncementTone:
       type: string
       enum:


### PR DESCRIPTION
### Summary

`AbstractPhpCodegen.toEnumDefaultValue` historically returned `self::{datatype}_{case}`, which matches old class-constant style enums (#10273) but is **invalid** for **PHP 8.1 backed enums** when `datatype` is a namespaced class name. After #23541, OpenAPI `default` beside an enum `$ref` on model properties flows through `updateCodegenPropertyEnum`, so the wrong expression is emitted into `model_variables.mustache` (#16605) and breaks `php -l` / static analysis.

This change emits **`{datatype}::{case}`** (native enum case reference), documents the data flow in Javadoc, extends the existing php-symfony fixture `optional-enum-query-ref-default.yaml` with a pet-store `POST /pets` + `Pet.HTTP.CreatePetRequest` example, and adds `PhpSymfonyServerCodegenTest#testModelPropertyEnumRefWithDefaultUsesNativeEnumCaseInCodegen` to lock the behavior.

**Branch vs `master` (this workspace):** 1 commit touching `AbstractPhpCodegen.java`, `PhpSymfonyServerCodegenTest.java`, `optional-enum-query-ref-default.yaml`.

### How to validate

1. **Unit / generator tests:**  
   `./mvnw -pl modules/openapi-generator '-Dtest=org.openapitools.codegen.php.**' test`
2. **Manual / CLI:** Generate `php-symfony` from `modules/openapi-generator/src/test/resources/3_1/php-symfony/optional-enum-query-ref-default.yaml` and confirm `PetHTTPCreatePetRequest` (or equivalent) uses `…::AVAILABLE` (or FQCN `::CASE`) for the defaulted enum property, not `self::…_AVAILABLE`.
3. **Regression:** Existing `testOptionalEnumRefQueryParameterWithDefaultAppliesOpenApiSemantics` on the same YAML still passes (optional enum query + default).

### Related

- Root cause and options: internal analysis `fix_php_enum_ref_default_backed_enum.md`.
- Related upstream history: #23541 (`toDefaultValue` + `$ref` + `default`), #10273 (`toEnumDefaultValue` shape), #16605 (php-symfony property initializer uses `defaultValue`).
- If a GitHub issue is filed for this bug, add `fixes #NNNN` here.

cc PHP committee: @jebentier @dkarlovi @mandrean @jfastnacht @ybelenko @renepardon  
cc PHP Symfony: @ksm2 @BenjaminHae

---

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.

  **Done (local workspace, `JAVA_HOME=$(mise where java@11)`):** All three commands completed successfully (`generate-samples` reported 742 generators finished). The tree had **no** extra diffs afterward—commit any sample/doc changes if your branch differs after rebasing on latest `master`.

- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks) — **intended target: `master`**.
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description) — *add when issue exists*.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes generation of PHP 8.1 backed-enum defaults in `php-symfony`. We now emit `Type::CASE` (using the short class name under `modelPackage`) instead of `self::FQCN_CASE`, so enum defaults on `$ref`-backed model properties compile and lint correctly.

- **Bug Fixes**
  - Update `AbstractPhpCodegen.toEnumDefaultValue` to return `{datatype}::{case}` for native enums and strip `modelPackage` so model defaults use the short class name.
  - Add Javadoc explaining enum default flow via `updateCodegenPropertyEnum`.
  - Extend `optional-enum-query-ref-default.yaml` with `Pet.HTTP.CreatePetRequest` using an enum `$ref` + `default`.
  - Add regression test `PhpSymfonyServerCodegenTest#testModelPropertyEnumRefWithDefaultUsesNativeEnumCaseInCodegen`.

<sup>Written for commit 6fbc3b7e9cbc79521b97f865cfd11b2f520c1860. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

