### PR TITLE
Fix doc warnings in java okhttp-gson client

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/anyof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/anyof_model.mustache
@@ -238,7 +238,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     /**
      * Set the instance that matches the anyOf child schema, check
      * the instance parameter is valid against the anyOf child schemas:
-     * {{#anyOf}}{{{.}}}{{^-last}}, {{/-last}}{{/anyOf}}
+     * {{#anyOf}}{{.}}{{^-last}}, {{/-last}}{{/anyOf}}
      *
      * It could be an instance of the 'anyOf' schemas.
      */
@@ -276,9 +276,9 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
 
     /**
      * Get the actual instance, which can be the following:
-     * {{#anyOf}}{{{.}}}{{^-last}}, {{/-last}}{{/anyOf}}
+     * {{#anyOf}}{{.}}{{^-last}}, {{/-last}}{{/anyOf}}
      *
-     * @return The actual instance ({{#anyOf}}{{{.}}}{{^-last}}, {{/-last}}{{/anyOf}})
+     * @return The actual instance ({{#anyOf}}{{.}}{{^-last}}, {{/-last}}{{/anyOf}})
      */
     @SuppressWarnings("unchecked")
     @Override
@@ -290,11 +290,11 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     {{#anyOf}}
     {{^vendorExtensions.x-duplicated-data-type-ignoring-erasure}}
     /**
-     * Get the actual instance of `{{{dataType}}}`. If the actual instance is not `{{{dataType}}}`,
+     * Get the actual instance of `{{dataType}}`. If the actual instance is not `{{dataType}}`,
      * the ClassCastException will be thrown.
      *
-     * @return The actual instance of `{{{dataType}}}`
-     * @throws ClassCastException if the instance is not `{{{dataType}}}`
+     * @return The actual instance of `{{dataType}}`
+     * @throws ClassCastException if the instance is not `{{dataType}}`
      */
     public {{{dataType}}} get{{#sanitizeDataType}}{{{dataType}}}{{/sanitizeDataType}}() throws ClassCastException {
         return ({{{dataType}}})super.getActualInstance();

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/oneof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/oneof_model.mustache
@@ -316,7 +316,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     /**
      * Set the instance that matches the oneOf child schema, check
      * the instance parameter is valid against the oneOf child schemas:
-     * {{#oneOf}}{{{.}}}{{^-last}}, {{/-last}}{{/oneOf}}
+     * {{#oneOf}}{{.}}{{^-last}}, {{/-last}}{{/oneOf}}
      *
      * It could be an instance of the 'oneOf' schemas.
      */
@@ -354,9 +354,9 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
 
     /**
      * Get the actual instance, which can be the following:
-     * {{#oneOf}}{{{.}}}{{^-last}}, {{/-last}}{{/oneOf}}
+     * {{#oneOf}}{{.}}{{^-last}}, {{/-last}}{{/oneOf}}
      *
-     * @return The actual instance ({{#oneOf}}{{{.}}}{{^-last}}, {{/-last}}{{/oneOf}})
+     * @return The actual instance ({{#oneOf}}{{.}}{{^-last}}, {{/-last}}{{/oneOf}})
      */
     @SuppressWarnings("unchecked")
     @Override
@@ -368,12 +368,13 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     {{#oneOf}}
     {{^vendorExtensions.x-duplicated-data-type-ignoring-erasure}}
     /**
-     * Get the actual instance of `{{{dataType}}}`. If the actual instance is not `{{{dataType}}}`,
+     * Get the actual instance of `{{dataType}}`. If the actual instance is not `{{dataType}}`,
      * the ClassCastException will be thrown.
      *
-     * @return The actual instance of `{{{dataType}}}`
-     * @throws ClassCastException if the instance is not `{{{dataType}}}`
+     * @return The actual instance of `{{dataType}}`
+     * @throws ClassCastException if the instance is not `{{dataType}}`
      */
+    @SuppressWarnings("unchecked")
     public {{{dataType}}} get{{#sanitizeDataType}}{{{dataType}}}{{/sanitizeDataType}}() throws ClassCastException {
         return ({{{dataType}}})super.getActualInstance();
     }

--- a/samples/client/others/java/okhttp-gson-oneOf-array/src/main/java/org/openapitools/client/model/MyExampleGet200Response.java
+++ b/samples/client/others/java/okhttp-gson-oneOf-array/src/main/java/org/openapitools/client/model/MyExampleGet200Response.java
@@ -183,7 +183,7 @@ public class MyExampleGet200Response extends AbstractOpenApiSchema {
     /**
      * Set the instance that matches the oneOf child schema, check
      * the instance parameter is valid against the oneOf child schemas:
-     * List<@Valid OneOf1>, OneOf1
+     * List&lt;@Valid OneOf1&gt;, OneOf1
      *
      * It could be an instance of the 'oneOf' schemas.
      */
@@ -207,9 +207,9 @@ public class MyExampleGet200Response extends AbstractOpenApiSchema {
 
     /**
      * Get the actual instance, which can be the following:
-     * List<@Valid OneOf1>, OneOf1
+     * List&lt;@Valid OneOf1&gt;, OneOf1
      *
-     * @return The actual instance (List<@Valid OneOf1>, OneOf1)
+     * @return The actual instance (List&lt;@Valid OneOf1&gt;, OneOf1)
      */
     @SuppressWarnings("unchecked")
     @Override
@@ -218,12 +218,13 @@ public class MyExampleGet200Response extends AbstractOpenApiSchema {
     }
 
     /**
-     * Get the actual instance of `List<@Valid OneOf1>`. If the actual instance is not `List<@Valid OneOf1>`,
+     * Get the actual instance of `List&lt;@Valid OneOf1&gt;`. If the actual instance is not `List&lt;@Valid OneOf1&gt;`,
      * the ClassCastException will be thrown.
      *
-     * @return The actual instance of `List<@Valid OneOf1>`
-     * @throws ClassCastException if the instance is not `List<@Valid OneOf1>`
+     * @return The actual instance of `List&lt;@Valid OneOf1&gt;`
+     * @throws ClassCastException if the instance is not `List&lt;@Valid OneOf1&gt;`
      */
+    @SuppressWarnings("unchecked")
     public List<@Valid OneOf1> getListOneOf1() throws ClassCastException {
         return (List<@Valid OneOf1>)super.getActualInstance();
     }
@@ -235,6 +236,7 @@ public class MyExampleGet200Response extends AbstractOpenApiSchema {
      * @return The actual instance of `OneOf1`
      * @throws ClassCastException if the instance is not `OneOf1`
      */
+    @SuppressWarnings("unchecked")
     public OneOf1 getOneOf1() throws ClassCastException {
         return (OneOf1)super.getActualInstance();
     }

--- a/samples/client/others/java/okhttp-gson-oneOf/src/main/java/org/openapitools/client/model/MyExamplePostRequest.java
+++ b/samples/client/others/java/okhttp-gson-oneOf/src/main/java/org/openapitools/client/model/MyExamplePostRequest.java
@@ -174,6 +174,7 @@ public class MyExamplePostRequest extends AbstractOpenApiSchema {
      * @return The actual instance of `String`
      * @throws ClassCastException if the instance is not `String`
      */
+    @SuppressWarnings("unchecked")
     public String getString() throws ClassCastException {
         return (String)super.getActualInstance();
     }

--- a/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/model/SimpleOneOf.java
+++ b/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/model/SimpleOneOf.java
@@ -202,6 +202,7 @@ public class SimpleOneOf extends AbstractOpenApiSchema implements Serializable {
      * @return The actual instance of `String`
      * @throws ClassCastException if the instance is not `String`
      */
+    @SuppressWarnings("unchecked")
     public String getString() throws ClassCastException {
         return (String)super.getActualInstance();
     }
@@ -213,6 +214,7 @@ public class SimpleOneOf extends AbstractOpenApiSchema implements Serializable {
      * @return The actual instance of `Integer`
      * @throws ClassCastException if the instance is not `Integer`
      */
+    @SuppressWarnings("unchecked")
     public Integer getInteger() throws ClassCastException {
         return (Integer)super.getActualInstance();
     }

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/OneOfStringOrInt.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/OneOfStringOrInt.java
@@ -201,6 +201,7 @@ public class OneOfStringOrInt extends AbstractOpenApiSchema {
      * @return The actual instance of `String`
      * @throws ClassCastException if the instance is not `String`
      */
+    @SuppressWarnings("unchecked")
     public String getString() throws ClassCastException {
         return (String)super.getActualInstance();
     }
@@ -212,6 +213,7 @@ public class OneOfStringOrInt extends AbstractOpenApiSchema {
      * @return The actual instance of `Integer`
      * @throws ClassCastException if the instance is not `Integer`
      */
+    @SuppressWarnings("unchecked")
     public Integer getInteger() throws ClassCastException {
         return (Integer)super.getActualInstance();
     }

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/RefRefToPathLevelParameterOneofRefToOneofParameter.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/RefRefToPathLevelParameterOneofRefToOneofParameter.java
@@ -201,6 +201,7 @@ public class RefRefToPathLevelParameterOneofRefToOneofParameter extends Abstract
      * @return The actual instance of `String`
      * @throws ClassCastException if the instance is not `String`
      */
+    @SuppressWarnings("unchecked")
     public String getString() throws ClassCastException {
         return (String)super.getActualInstance();
     }
@@ -212,6 +213,7 @@ public class RefRefToPathLevelParameterOneofRefToOneofParameter extends Abstract
      * @return The actual instance of `Integer`
      * @throws ClassCastException if the instance is not `Integer`
      */
+    @SuppressWarnings("unchecked")
     public Integer getInteger() throws ClassCastException {
         return (Integer)super.getActualInstance();
     }

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/RefToRefParameterAnyofRefToAnyofParameter.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/RefToRefParameterAnyofRefToAnyofParameter.java
@@ -174,7 +174,7 @@ public class RefToRefParameterAnyofRefToAnyofParameter extends AbstractOpenApiSc
     /**
      * Set the instance that matches the oneOf child schema, check
      * the instance parameter is valid against the oneOf child schemas:
-     * List<String>, String
+     * List&lt;String&gt;, String
      *
      * It could be an instance of the 'oneOf' schemas.
      */
@@ -198,9 +198,9 @@ public class RefToRefParameterAnyofRefToAnyofParameter extends AbstractOpenApiSc
 
     /**
      * Get the actual instance, which can be the following:
-     * List<String>, String
+     * List&lt;String&gt;, String
      *
-     * @return The actual instance (List<String>, String)
+     * @return The actual instance (List&lt;String&gt;, String)
      */
     @SuppressWarnings("unchecked")
     @Override
@@ -215,17 +215,19 @@ public class RefToRefParameterAnyofRefToAnyofParameter extends AbstractOpenApiSc
      * @return The actual instance of `String`
      * @throws ClassCastException if the instance is not `String`
      */
+    @SuppressWarnings("unchecked")
     public String getString() throws ClassCastException {
         return (String)super.getActualInstance();
     }
 
     /**
-     * Get the actual instance of `List<String>`. If the actual instance is not `List<String>`,
+     * Get the actual instance of `List&lt;String&gt;`. If the actual instance is not `List&lt;String&gt;`,
      * the ClassCastException will be thrown.
      *
-     * @return The actual instance of `List<String>`
-     * @throws ClassCastException if the instance is not `List<String>`
+     * @return The actual instance of `List&lt;String&gt;`
+     * @throws ClassCastException if the instance is not `List&lt;String&gt;`
      */
+    @SuppressWarnings("unchecked")
     public List<String> getListString() throws ClassCastException {
         return (List<String>)super.getActualInstance();
     }

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/SelfReferenceOneOf.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/SelfReferenceOneOf.java
@@ -201,6 +201,7 @@ public class SelfReferenceOneOf extends AbstractOpenApiSchema {
      * @return The actual instance of `String`
      * @throws ClassCastException if the instance is not `String`
      */
+    @SuppressWarnings("unchecked")
     public String getString() throws ClassCastException {
         return (String)super.getActualInstance();
     }
@@ -212,6 +213,7 @@ public class SelfReferenceOneOf extends AbstractOpenApiSchema {
      * @return The actual instance of `Boolean`
      * @throws ClassCastException if the instance is not `Boolean`
      */
+    @SuppressWarnings("unchecked")
     public Boolean getBoolean() throws ClassCastException {
         return (Boolean)super.getActualInstance();
     }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfModelArrayAnyOfAllOfAttributesC.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AllOfModelArrayAnyOfAllOfAttributesC.java
@@ -211,6 +211,7 @@ public class AllOfModelArrayAnyOfAllOfAttributesC extends AbstractOpenApiSchema 
      * @return The actual instance of `Pet`
      * @throws ClassCastException if the instance is not `Pet`
      */
+    @SuppressWarnings("unchecked")
     public Pet getPet() throws ClassCastException {
         return (Pet)super.getActualInstance();
     }
@@ -222,6 +223,7 @@ public class AllOfModelArrayAnyOfAllOfAttributesC extends AbstractOpenApiSchema 
      * @return The actual instance of `Order`
      * @throws ClassCastException if the instance is not `Order`
      */
+    @SuppressWarnings("unchecked")
     public Order getOrder() throws ClassCastException {
         return (Order)super.getActualInstance();
     }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayAnyOf.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayAnyOf.java
@@ -169,7 +169,7 @@ public class ArrayAnyOf extends AbstractOpenApiSchema {
     /**
      * Set the instance that matches the anyOf child schema, check
      * the instance parameter is valid against the anyOf child schemas:
-     * Integer, List<String>
+     * Integer, List&lt;String&gt;
      *
      * It could be an instance of the 'anyOf' schemas.
      */
@@ -193,9 +193,9 @@ public class ArrayAnyOf extends AbstractOpenApiSchema {
 
     /**
      * Get the actual instance, which can be the following:
-     * Integer, List<String>
+     * Integer, List&lt;String&gt;
      *
-     * @return The actual instance (Integer, List<String>)
+     * @return The actual instance (Integer, List&lt;String&gt;)
      */
     @SuppressWarnings("unchecked")
     @Override
@@ -215,11 +215,11 @@ public class ArrayAnyOf extends AbstractOpenApiSchema {
     }
 
     /**
-     * Get the actual instance of `List<String>`. If the actual instance is not `List<String>`,
+     * Get the actual instance of `List&lt;String&gt;`. If the actual instance is not `List&lt;String&gt;`,
      * the ClassCastException will be thrown.
      *
-     * @return The actual instance of `List<String>`
-     * @throws ClassCastException if the instance is not `List<String>`
+     * @return The actual instance of `List&lt;String&gt;`
+     * @throws ClassCastException if the instance is not `List&lt;String&gt;`
      */
     public List<String> getListString() throws ClassCastException {
         return (List<String>)super.getActualInstance();

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOneOf.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOneOf.java
@@ -174,7 +174,7 @@ public class ArrayOneOf extends AbstractOpenApiSchema {
     /**
      * Set the instance that matches the oneOf child schema, check
      * the instance parameter is valid against the oneOf child schemas:
-     * Integer, List<String>
+     * Integer, List&lt;String&gt;
      *
      * It could be an instance of the 'oneOf' schemas.
      */
@@ -198,9 +198,9 @@ public class ArrayOneOf extends AbstractOpenApiSchema {
 
     /**
      * Get the actual instance, which can be the following:
-     * Integer, List<String>
+     * Integer, List&lt;String&gt;
      *
-     * @return The actual instance (Integer, List<String>)
+     * @return The actual instance (Integer, List&lt;String&gt;)
      */
     @SuppressWarnings("unchecked")
     @Override
@@ -215,17 +215,19 @@ public class ArrayOneOf extends AbstractOpenApiSchema {
      * @return The actual instance of `Integer`
      * @throws ClassCastException if the instance is not `Integer`
      */
+    @SuppressWarnings("unchecked")
     public Integer getInteger() throws ClassCastException {
         return (Integer)super.getActualInstance();
     }
 
     /**
-     * Get the actual instance of `List<String>`. If the actual instance is not `List<String>`,
+     * Get the actual instance of `List&lt;String&gt;`. If the actual instance is not `List&lt;String&gt;`,
      * the ClassCastException will be thrown.
      *
-     * @return The actual instance of `List<String>`
-     * @throws ClassCastException if the instance is not `List<String>`
+     * @return The actual instance of `List&lt;String&gt;`
+     * @throws ClassCastException if the instance is not `List&lt;String&gt;`
      */
+    @SuppressWarnings("unchecked")
     public List<String> getListString() throws ClassCastException {
         return (List<String>)super.getActualInstance();
     }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FakeAnyOfWIthSameErasureGet200Response.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FakeAnyOfWIthSameErasureGet200Response.java
@@ -149,7 +149,7 @@ public class FakeAnyOfWIthSameErasureGet200Response extends AbstractOpenApiSchem
     /**
      * Set the instance that matches the anyOf child schema, check
      * the instance parameter is valid against the anyOf child schemas:
-     * List<Integer>, List<String>
+     * List&lt;Integer&gt;, List&lt;String&gt;
      *
      * It could be an instance of the 'anyOf' schemas.
      */
@@ -168,9 +168,9 @@ public class FakeAnyOfWIthSameErasureGet200Response extends AbstractOpenApiSchem
 
     /**
      * Get the actual instance, which can be the following:
-     * List<Integer>, List<String>
+     * List&lt;Integer&gt;, List&lt;String&gt;
      *
-     * @return The actual instance (List<Integer>, List<String>)
+     * @return The actual instance (List&lt;Integer&gt;, List&lt;String&gt;)
      */
     @SuppressWarnings("unchecked")
     @Override
@@ -179,22 +179,22 @@ public class FakeAnyOfWIthSameErasureGet200Response extends AbstractOpenApiSchem
     }
 
     /**
-     * Get the actual instance of `List<String>`. If the actual instance is not `List<String>`,
+     * Get the actual instance of `List&lt;String&gt;`. If the actual instance is not `List&lt;String&gt;`,
      * the ClassCastException will be thrown.
      *
-     * @return The actual instance of `List<String>`
-     * @throws ClassCastException if the instance is not `List<String>`
+     * @return The actual instance of `List&lt;String&gt;`
+     * @throws ClassCastException if the instance is not `List&lt;String&gt;`
      */
     public List<String> getListString() throws ClassCastException {
         return (List<String>)super.getActualInstance();
     }
 
     /**
-     * Get the actual instance of `List<Integer>`. If the actual instance is not `List<Integer>`,
+     * Get the actual instance of `List&lt;Integer&gt;`. If the actual instance is not `List&lt;Integer&gt;`,
      * the ClassCastException will be thrown.
      *
-     * @return The actual instance of `List<Integer>`
-     * @throws ClassCastException if the instance is not `List<Integer>`
+     * @return The actual instance of `List&lt;Integer&gt;`
+     * @throws ClassCastException if the instance is not `List&lt;Integer&gt;`
      */
     public List<Integer> getListInteger() throws ClassCastException {
         return (List<Integer>)super.getActualInstance();

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FakeOneOfWIthSameErasureGet200Response.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FakeOneOfWIthSameErasureGet200Response.java
@@ -155,7 +155,7 @@ public class FakeOneOfWIthSameErasureGet200Response extends AbstractOpenApiSchem
     /**
      * Set the instance that matches the oneOf child schema, check
      * the instance parameter is valid against the oneOf child schemas:
-     * List<Integer>, List<String>
+     * List&lt;Integer&gt;, List&lt;String&gt;
      *
      * It could be an instance of the 'oneOf' schemas.
      */
@@ -174,9 +174,9 @@ public class FakeOneOfWIthSameErasureGet200Response extends AbstractOpenApiSchem
 
     /**
      * Get the actual instance, which can be the following:
-     * List<Integer>, List<String>
+     * List&lt;Integer&gt;, List&lt;String&gt;
      *
-     * @return The actual instance (List<Integer>, List<String>)
+     * @return The actual instance (List&lt;Integer&gt;, List&lt;String&gt;)
      */
     @SuppressWarnings("unchecked")
     @Override
@@ -185,23 +185,25 @@ public class FakeOneOfWIthSameErasureGet200Response extends AbstractOpenApiSchem
     }
 
     /**
-     * Get the actual instance of `List<String>`. If the actual instance is not `List<String>`,
+     * Get the actual instance of `List&lt;String&gt;`. If the actual instance is not `List&lt;String&gt;`,
      * the ClassCastException will be thrown.
      *
-     * @return The actual instance of `List<String>`
-     * @throws ClassCastException if the instance is not `List<String>`
+     * @return The actual instance of `List&lt;String&gt;`
+     * @throws ClassCastException if the instance is not `List&lt;String&gt;`
      */
+    @SuppressWarnings("unchecked")
     public List<String> getListString() throws ClassCastException {
         return (List<String>)super.getActualInstance();
     }
 
     /**
-     * Get the actual instance of `List<Integer>`. If the actual instance is not `List<Integer>`,
+     * Get the actual instance of `List&lt;Integer&gt;`. If the actual instance is not `List&lt;Integer&gt;`,
      * the ClassCastException will be thrown.
      *
-     * @return The actual instance of `List<Integer>`
-     * @throws ClassCastException if the instance is not `List<Integer>`
+     * @return The actual instance of `List&lt;Integer&gt;`
+     * @throws ClassCastException if the instance is not `List&lt;Integer&gt;`
      */
+    @SuppressWarnings("unchecked")
     public List<Integer> getListInteger() throws ClassCastException {
         return (List<Integer>)super.getActualInstance();
     }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FakeRefParameterPetIdParameter.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FakeRefParameterPetIdParameter.java
@@ -201,6 +201,7 @@ public class FakeRefParameterPetIdParameter extends AbstractOpenApiSchema {
      * @return The actual instance of `String`
      * @throws ClassCastException if the instance is not `String`
      */
+    @SuppressWarnings("unchecked")
     public String getString() throws ClassCastException {
         return (String)super.getActualInstance();
     }
@@ -212,6 +213,7 @@ public class FakeRefParameterPetIdParameter extends AbstractOpenApiSchema {
      * @return The actual instance of `Integer`
      * @throws ClassCastException if the instance is not `Integer`
      */
+    @SuppressWarnings("unchecked")
     public Integer getInteger() throws ClassCastException {
         return (Integer)super.getActualInstance();
     }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FreeFormObjectTestClassProperties.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FreeFormObjectTestClassProperties.java
@@ -166,7 +166,7 @@ public class FreeFormObjectTestClassProperties extends AbstractOpenApiSchema {
     /**
      * Set the instance that matches the oneOf child schema, check
      * the instance parameter is valid against the oneOf child schemas:
-     * Map<String, Object>, String
+     * Map&lt;String, Object&gt;, String
      *
      * It could be an instance of the 'oneOf' schemas.
      */
@@ -187,9 +187,9 @@ public class FreeFormObjectTestClassProperties extends AbstractOpenApiSchema {
 
     /**
      * Get the actual instance, which can be the following:
-     * Map<String, Object>, String
+     * Map&lt;String, Object&gt;, String
      *
-     * @return The actual instance (Map<String, Object>, String)
+     * @return The actual instance (Map&lt;String, Object&gt;, String)
      */
     @SuppressWarnings("unchecked")
     @Override
@@ -204,17 +204,19 @@ public class FreeFormObjectTestClassProperties extends AbstractOpenApiSchema {
      * @return The actual instance of `String`
      * @throws ClassCastException if the instance is not `String`
      */
+    @SuppressWarnings("unchecked")
     public String getString() throws ClassCastException {
         return (String)super.getActualInstance();
     }
 
     /**
-     * Get the actual instance of `Map<String, Object>`. If the actual instance is not `Map<String, Object>`,
+     * Get the actual instance of `Map&lt;String, Object&gt;`. If the actual instance is not `Map&lt;String, Object&gt;`,
      * the ClassCastException will be thrown.
      *
-     * @return The actual instance of `Map<String, Object>`
-     * @throws ClassCastException if the instance is not `Map<String, Object>`
+     * @return The actual instance of `Map&lt;String, Object&gt;`
+     * @throws ClassCastException if the instance is not `Map&lt;String, Object&gt;`
      */
+    @SuppressWarnings("unchecked")
     public Map<String, Object> getMapStringObject() throws ClassCastException {
         return (Map<String, Object>)super.getActualInstance();
     }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Fruit.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Fruit.java
@@ -207,6 +207,7 @@ public class Fruit extends AbstractOpenApiSchema {
      * @return The actual instance of `Apple`
      * @throws ClassCastException if the instance is not `Apple`
      */
+    @SuppressWarnings("unchecked")
     public Apple getApple() throws ClassCastException {
         return (Apple)super.getActualInstance();
     }
@@ -218,6 +219,7 @@ public class Fruit extends AbstractOpenApiSchema {
      * @return The actual instance of `Banana`
      * @throws ClassCastException if the instance is not `Banana`
      */
+    @SuppressWarnings("unchecked")
     public Banana getBanana() throws ClassCastException {
         return (Banana)super.getActualInstance();
     }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FruitReq.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FruitReq.java
@@ -212,6 +212,7 @@ public class FruitReq extends AbstractOpenApiSchema {
      * @return The actual instance of `AppleReq`
      * @throws ClassCastException if the instance is not `AppleReq`
      */
+    @SuppressWarnings("unchecked")
     public AppleReq getAppleReq() throws ClassCastException {
         return (AppleReq)super.getActualInstance();
     }
@@ -223,6 +224,7 @@ public class FruitReq extends AbstractOpenApiSchema {
      * @return The actual instance of `BananaReq`
      * @throws ClassCastException if the instance is not `BananaReq`
      */
+    @SuppressWarnings("unchecked")
     public BananaReq getBananaReq() throws ClassCastException {
         return (BananaReq)super.getActualInstance();
     }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Mammal.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Mammal.java
@@ -258,6 +258,7 @@ public class Mammal extends AbstractOpenApiSchema {
      * @return The actual instance of `Whale`
      * @throws ClassCastException if the instance is not `Whale`
      */
+    @SuppressWarnings("unchecked")
     public Whale getWhale() throws ClassCastException {
         return (Whale)super.getActualInstance();
     }
@@ -269,6 +270,7 @@ public class Mammal extends AbstractOpenApiSchema {
      * @return The actual instance of `Zebra`
      * @throws ClassCastException if the instance is not `Zebra`
      */
+    @SuppressWarnings("unchecked")
     public Zebra getZebra() throws ClassCastException {
         return (Zebra)super.getActualInstance();
     }
@@ -280,6 +282,7 @@ public class Mammal extends AbstractOpenApiSchema {
      * @return The actual instance of `Pig`
      * @throws ClassCastException if the instance is not `Pig`
      */
+    @SuppressWarnings("unchecked")
     public Pig getPig() throws ClassCastException {
         return (Pig)super.getActualInstance();
     }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NullableShape.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NullableShape.java
@@ -233,6 +233,7 @@ public class NullableShape extends AbstractOpenApiSchema {
      * @return The actual instance of `Triangle`
      * @throws ClassCastException if the instance is not `Triangle`
      */
+    @SuppressWarnings("unchecked")
     public Triangle getTriangle() throws ClassCastException {
         return (Triangle)super.getActualInstance();
     }
@@ -244,6 +245,7 @@ public class NullableShape extends AbstractOpenApiSchema {
      * @return The actual instance of `Quadrilateral`
      * @throws ClassCastException if the instance is not `Quadrilateral`
      */
+    @SuppressWarnings("unchecked")
     public Quadrilateral getQuadrilateral() throws ClassCastException {
         return (Quadrilateral)super.getActualInstance();
     }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Pig.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Pig.java
@@ -228,6 +228,7 @@ public class Pig extends AbstractOpenApiSchema {
      * @return The actual instance of `BasquePig`
      * @throws ClassCastException if the instance is not `BasquePig`
      */
+    @SuppressWarnings("unchecked")
     public BasquePig getBasquePig() throws ClassCastException {
         return (BasquePig)super.getActualInstance();
     }
@@ -239,6 +240,7 @@ public class Pig extends AbstractOpenApiSchema {
      * @return The actual instance of `DanishPig`
      * @throws ClassCastException if the instance is not `DanishPig`
      */
+    @SuppressWarnings("unchecked")
     public DanishPig getDanishPig() throws ClassCastException {
         return (DanishPig)super.getActualInstance();
     }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Quadrilateral.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Quadrilateral.java
@@ -228,6 +228,7 @@ public class Quadrilateral extends AbstractOpenApiSchema {
      * @return The actual instance of `SimpleQuadrilateral`
      * @throws ClassCastException if the instance is not `SimpleQuadrilateral`
      */
+    @SuppressWarnings("unchecked")
     public SimpleQuadrilateral getSimpleQuadrilateral() throws ClassCastException {
         return (SimpleQuadrilateral)super.getActualInstance();
     }
@@ -239,6 +240,7 @@ public class Quadrilateral extends AbstractOpenApiSchema {
      * @return The actual instance of `ComplexQuadrilateral`
      * @throws ClassCastException if the instance is not `ComplexQuadrilateral`
      */
+    @SuppressWarnings("unchecked")
     public ComplexQuadrilateral getComplexQuadrilateral() throws ClassCastException {
         return (ComplexQuadrilateral)super.getActualInstance();
     }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Scalar.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Scalar.java
@@ -255,6 +255,7 @@ public class Scalar extends AbstractOpenApiSchema {
      * @return The actual instance of `UUID`
      * @throws ClassCastException if the instance is not `UUID`
      */
+    @SuppressWarnings("unchecked")
     public UUID getUUID() throws ClassCastException {
         return (UUID)super.getActualInstance();
     }
@@ -266,6 +267,7 @@ public class Scalar extends AbstractOpenApiSchema {
      * @return The actual instance of `String`
      * @throws ClassCastException if the instance is not `String`
      */
+    @SuppressWarnings("unchecked")
     public String getString() throws ClassCastException {
         return (String)super.getActualInstance();
     }
@@ -277,6 +279,7 @@ public class Scalar extends AbstractOpenApiSchema {
      * @return The actual instance of `BigDecimal`
      * @throws ClassCastException if the instance is not `BigDecimal`
      */
+    @SuppressWarnings("unchecked")
     public BigDecimal getBigDecimal() throws ClassCastException {
         return (BigDecimal)super.getActualInstance();
     }
@@ -288,6 +291,7 @@ public class Scalar extends AbstractOpenApiSchema {
      * @return The actual instance of `Boolean`
      * @throws ClassCastException if the instance is not `Boolean`
      */
+    @SuppressWarnings("unchecked")
     public Boolean getBoolean() throws ClassCastException {
         return (Boolean)super.getActualInstance();
     }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Shape.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Shape.java
@@ -228,6 +228,7 @@ public class Shape extends AbstractOpenApiSchema {
      * @return The actual instance of `Triangle`
      * @throws ClassCastException if the instance is not `Triangle`
      */
+    @SuppressWarnings("unchecked")
     public Triangle getTriangle() throws ClassCastException {
         return (Triangle)super.getActualInstance();
     }
@@ -239,6 +240,7 @@ public class Shape extends AbstractOpenApiSchema {
      * @return The actual instance of `Quadrilateral`
      * @throws ClassCastException if the instance is not `Quadrilateral`
      */
+    @SuppressWarnings("unchecked")
     public Quadrilateral getQuadrilateral() throws ClassCastException {
         return (Quadrilateral)super.getActualInstance();
     }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ShapeOrNull.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ShapeOrNull.java
@@ -233,6 +233,7 @@ public class ShapeOrNull extends AbstractOpenApiSchema {
      * @return The actual instance of `Triangle`
      * @throws ClassCastException if the instance is not `Triangle`
      */
+    @SuppressWarnings("unchecked")
     public Triangle getTriangle() throws ClassCastException {
         return (Triangle)super.getActualInstance();
     }
@@ -244,6 +245,7 @@ public class ShapeOrNull extends AbstractOpenApiSchema {
      * @return The actual instance of `Quadrilateral`
      * @throws ClassCastException if the instance is not `Quadrilateral`
      */
+    @SuppressWarnings("unchecked")
     public Quadrilateral getQuadrilateral() throws ClassCastException {
         return (Quadrilateral)super.getActualInstance();
     }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Triangle.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Triangle.java
@@ -258,6 +258,7 @@ public class Triangle extends AbstractOpenApiSchema {
      * @return The actual instance of `EquilateralTriangle`
      * @throws ClassCastException if the instance is not `EquilateralTriangle`
      */
+    @SuppressWarnings("unchecked")
     public EquilateralTriangle getEquilateralTriangle() throws ClassCastException {
         return (EquilateralTriangle)super.getActualInstance();
     }
@@ -269,6 +270,7 @@ public class Triangle extends AbstractOpenApiSchema {
      * @return The actual instance of `IsoscelesTriangle`
      * @throws ClassCastException if the instance is not `IsoscelesTriangle`
      */
+    @SuppressWarnings("unchecked")
     public IsoscelesTriangle getIsoscelesTriangle() throws ClassCastException {
         return (IsoscelesTriangle)super.getActualInstance();
     }
@@ -280,6 +282,7 @@ public class Triangle extends AbstractOpenApiSchema {
      * @return The actual instance of `ScaleneTriangle`
      * @throws ClassCastException if the instance is not `ScaleneTriangle`
      */
+    @SuppressWarnings("unchecked")
     public ScaleneTriangle getScaleneTriangle() throws ClassCastException {
         return (ScaleneTriangle)super.getActualInstance();
     }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Value.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Value.java
@@ -174,7 +174,7 @@ public class Value extends AbstractOpenApiSchema {
     /**
      * Set the instance that matches the oneOf child schema, check
      * the instance parameter is valid against the oneOf child schemas:
-     * List<Scalar>, Scalar
+     * List&lt;Scalar&gt;, Scalar
      *
      * It could be an instance of the 'oneOf' schemas.
      */
@@ -198,9 +198,9 @@ public class Value extends AbstractOpenApiSchema {
 
     /**
      * Get the actual instance, which can be the following:
-     * List<Scalar>, Scalar
+     * List&lt;Scalar&gt;, Scalar
      *
-     * @return The actual instance (List<Scalar>, Scalar)
+     * @return The actual instance (List&lt;Scalar&gt;, Scalar)
      */
     @SuppressWarnings("unchecked")
     @Override
@@ -215,17 +215,19 @@ public class Value extends AbstractOpenApiSchema {
      * @return The actual instance of `Scalar`
      * @throws ClassCastException if the instance is not `Scalar`
      */
+    @SuppressWarnings("unchecked")
     public Scalar getScalar() throws ClassCastException {
         return (Scalar)super.getActualInstance();
     }
 
     /**
-     * Get the actual instance of `List<Scalar>`. If the actual instance is not `List<Scalar>`,
+     * Get the actual instance of `List&lt;Scalar&gt;`. If the actual instance is not `List&lt;Scalar&gt;`,
      * the ClassCastException will be thrown.
      *
-     * @return The actual instance of `List<Scalar>`
-     * @throws ClassCastException if the instance is not `List<Scalar>`
+     * @return The actual instance of `List&lt;Scalar&gt;`
+     * @throws ClassCastException if the instance is not `List&lt;Scalar&gt;`
      */
+    @SuppressWarnings("unchecked")
     public List<Scalar> getListScalar() throws ClassCastException {
         return (List<Scalar>)super.getActualInstance();
     }


### PR DESCRIPTION
cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Javadoc warnings in the Java `okhttp-gson` client by escaping generics and cleaning up `oneOf`/`anyOf` docs. Added missing `@SuppressWarnings("unchecked")` on getters; no runtime behavior changes.

- **Bug Fixes**
  - Escape angle brackets in generated Javadoc (switch `{{{...}}}` to `{{...}}`; render `&lt;...&gt;` for generics).
  - Update `anyof_model.mustache` and `oneof_model.mustache` to use `{{dataType}}` and correct return/throws text.
  - Add `@SuppressWarnings("unchecked")` to typed getters and regenerate samples.

<sup>Written for commit c7e14cf8b60e6d9933b91db5b8239f43284c6adf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

