### PR TITLE
Fix wrong import statements in dart-dio when using import-mappings

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -570,6 +570,20 @@ public class DefaultGenerator implements Generator {
                     allModels.add(modelTemplate);
                 }
 
+                // Don't generate model files for types that were explicitly type-mapped
+                // AND whose mapped name has a corresponding import mapping.
+                // This indicates the user wants to replace the schema type with an
+                // external type (e.g. --type-mappings Address=CustomAddress
+                // --import-mappings CustomAddress=package:custom/address.dart).
+                // The model metadata is still kept in allModels for use by supporting file templates.
+                if (config.typeMapping().containsKey(modelName)) {
+                    String mappedTypeName = config.typeMapping().get(modelName);
+                    if (config.importMapping().containsKey(mappedTypeName)) {
+                        LOGGER.info("Model {} (type-mapped to {}) not generated due to import mapping", modelName, mappedTypeName);
+                        continue;
+                    }
+                }
+
                 // to generate model files
                 generateModel(files, models, modelName);
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
@@ -617,6 +617,18 @@ public class DartDioClientCodegen extends AbstractDartCodegen {
                 CodegenModel cm = mo.getModel();
                 cm.imports = rewriteImports(cm.imports, true);
                 cm.vendorExtensions.put("x-has-vars", !cm.vars.isEmpty());
+
+                // Check if this model's classname has an import mapping.
+                // If so, mark it so that supporting file templates (serializers, barrel)
+                // can use the mapped import path instead of the default model/ path.
+                if (importMapping().containsKey(cm.classname)) {
+                    cm.vendorExtensions.put("x-is-import-mapped", true);
+                    cm.vendorExtensions.put("x-import-path", importMapping().get(cm.classname));
+                } else {
+                    cm.vendorExtensions.put("x-is-import-mapped", false);
+                    cm.vendorExtensions.put("x-import-path",
+                            "package:" + pubName + "/" + sourceFolder + "/" + modelPackage() + "/" + cm.classFilename + ".dart");
+                }
             }
         }
 

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/lib.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/lib.mustache
@@ -9,5 +9,5 @@ export 'package:{{pubName}}/{{sourceFolder}}/auth/oauth.dart';
 
 {{#apiInfo}}{{#apis}}export 'package:{{pubName}}/{{sourceFolder}}/{{apiPackage}}/{{classFilename}}.dart';
 {{/apis}}{{/apiInfo}}
-{{#models}}{{#model}}export 'package:{{pubName}}/{{sourceFolder}}/{{modelPackage}}/{{classFilename}}.dart';
+{{#models}}{{#model}}export '{{{vendorExtensions.x-import-path}}}';
 {{/model}}{{/models}}

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/serializers.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/serializers.mustache
@@ -12,7 +12,7 @@ import 'package:{{pubName}}/{{sourceFolder}}/date_serializer.dart';
 import 'package:{{pubName}}/{{sourceFolder}}/{{modelPackage}}/date.dart';{{/useDateLibCore}}
 {{#useDateLibTimeMachine}}import 'package:time_machine/time_machine.dart';
 import 'package:{{pubName}}/{{sourceFolder}}/offset_date_serializer.dart';{{/useDateLibTimeMachine}}
-{{#models}}{{#model}}import 'package:{{pubName}}/{{sourceFolder}}/{{modelPackage}}/{{classFilename}}.dart';
+{{#models}}{{#model}}import '{{{vendorExtensions.x-import-path}}}';
 {{/model}}{{/models}}{{#builtValueSerializerImports}}import '{{{.}}}';
 {{/builtValueSerializerImports}}
 

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/deserialize.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/deserialize.mustache
@@ -1,7 +1,7 @@
 {{#models}}
   {{#model}}
   {{^isEnum}}
-import 'package:{{pubName}}/{{sourceFolder}}/{{modelPackage}}/{{classFilename}}.dart';
+import '{{{vendorExtensions.x-import-path}}}';
 {{/isEnum}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/dio/DartDioClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/dio/DartDioClientCodegenTest.java
@@ -25,6 +25,7 @@ import org.testng.annotations.Test;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -91,6 +92,54 @@ public class DartDioClientCodegenTest {
             // reserved words are stored in lowercase
             Assert.assertTrue(codegen.reservedWords().contains(keyword.toLowerCase(Locale.ROOT)), String.format(Locale.ROOT, "%s, part of %s, was not found in %s", keyword, reservedWordsList, codegen.reservedWords().toString()));
         }
+    }
+
+    @Test
+    public void testImportMappingsInSerializersAndBarrelFile() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final String pubName = "my_api";
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("dart-dio")
+                .setGitUserId("my-user")
+                .setGitRepoId("my-repo")
+                .setInputSpec("src/test/resources/3_0/dart-dio/import_mapping.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        configurator.addAdditionalProperty("pubName", pubName);
+        configurator.addTypeMapping("Address", "CustomAddress");
+        configurator.addImportMapping("CustomAddress", "package:my_api/src/custom_models/custom_address.dart");
+
+        ClientOptInput opts = configurator.toClientOptInput();
+
+        Generator generator = new DefaultGenerator().opts(opts);
+        List<File> files = generator.generate();
+        files.forEach(File::deleteOnExit);
+
+        // The model file for the mapped type should NOT be generated
+        TestUtils.assertFileNotExists(output.toPath().resolve("lib/src/model/custom_address.dart"));
+
+        // order_out.dart should use the custom import path (this already works per the issue report)
+        Path orderOutPath = output.toPath().resolve("lib/src/model/order_out.dart");
+        TestUtils.assertFileContains(orderOutPath,
+                "package:my_api/src/custom_models/custom_address.dart");
+        TestUtils.assertFileNotContains(orderOutPath,
+                "package:my_api/src/model/custom_address.dart");
+
+        // serializers.dart should use the custom import path, not the hardcoded model/ path
+        Path serializersPath = output.toPath().resolve("lib/src/serializers.dart");
+        TestUtils.assertFileContains(serializersPath,
+                "package:my_api/src/custom_models/custom_address.dart");
+        TestUtils.assertFileNotContains(serializersPath,
+                "package:my_api/src/model/custom_address.dart");
+
+        // The barrel file should use the custom export path, not the hardcoded model/ path
+        Path barrelPath = output.toPath().resolve("lib/my_api.dart");
+        TestUtils.assertFileContains(barrelPath,
+                "package:my_api/src/custom_models/custom_address.dart");
+        TestUtils.assertFileNotContains(barrelPath,
+                "package:my_api/src/model/custom_address.dart");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/resources/3_0/dart-dio/import_mapping.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/dart-dio/import_mapping.yaml
@@ -1,0 +1,33 @@
+openapi: "3.1.0"
+info:
+  title: Example
+  version: "1.0.0"
+paths:
+  /orders:
+    get:
+      operationId: getOrders
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OrderOut"
+components:
+  schemas:
+    Address:
+      type: object
+      required: [street, city]
+      properties:
+        street:
+          type: string
+        city:
+          type: string
+    OrderOut:
+      type: object
+      required: [id, shippingAddress]
+      properties:
+        id:
+          type: integer
+        shippingAddress:
+          $ref: "#/components/schemas/Address"


### PR DESCRIPTION
Fixes #23558 

@jaumard @josh-burton @amondnet @sbu-WBT @kuhnroyal @agilob @ahmednfwela 
--




<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes wrong imports in `dart-dio` when using `--type-mappings` with `--import-mappings`. Generated code now imports/exports the mapped package path and skips generating duplicate model files.

- **Bug Fixes**
  - Use `vendorExtensions.x-import-path` for model imports/exports in the barrel file and serializers (built_value and json_serializable).
  - Detect models that are both type-mapped and import-mapped and do not generate their model files.
  - Add tests and a sample spec to verify custom paths are used in models, serializers, and the barrel file.

<sup>Written for commit 56a2062faed7f383244de670e1e0f3609d1cdc35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

