### PR TITLE
[dart-dio] Fix `json_serializable` serialize template to support `hasFormParams`

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/api/serialize.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/api/serialize.mustache
@@ -1,1 +1,19 @@
-{{#bodyParam}}_bodyData=jsonEncode({{{paramName}}});{{/bodyParam}}
+      {{#hasFormParams}}
+      {{#isMultipart}}
+      _bodyData = FormData.fromMap(<String, dynamic>{
+        {{#formParams}}
+        {{^required}}{{^isNullable}}if ({{{paramName}}} != null) {{/isNullable}}{{/required}}r'{{{baseName}}}': {{#isFile}}{{{paramName}}}{{#isArray}}.toList(){{/isArray}}{{/isFile}}{{^isFile}}{{{paramName}}}{{/isFile}},
+        {{/formParams}}
+      });
+      {{/isMultipart}}
+      {{^isMultipart}}
+      _bodyData = <String, dynamic>{
+        {{#formParams}}
+        {{^required}}{{^isNullable}}if ({{{paramName}}} != null) {{/isNullable}}{{/required}}r'{{{baseName}}}': {{{paramName}}},
+        {{/formParams}}
+      };
+      {{/isMultipart}}
+      {{/hasFormParams}}
+      {{#bodyParam}}
+      _bodyData = jsonEncode({{{paramName}}});
+      {{/bodyParam}}

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/another_fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/another_fake_api.dart
@@ -57,7 +57,8 @@ class AnotherFakeApi {
     dynamic _bodyData;
 
     try {
-_bodyData=jsonEncode(modelClient);
+      _bodyData = jsonEncode(modelClient);
+
     } catch(error, stackTrace) {
       throw DioException(
          requestOptions: _options.compose(

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/fake_api.dart
@@ -293,7 +293,8 @@ _responseData = rawData == null ? null : deserialize<HealthCheckResult, HealthCh
     dynamic _bodyData;
 
     try {
-_bodyData=jsonEncode(pet);
+      _bodyData = jsonEncode(pet);
+
     } catch(error, stackTrace) {
       throw DioException(
          requestOptions: _options.compose(
@@ -360,7 +361,8 @@ _bodyData=jsonEncode(pet);
     dynamic _bodyData;
 
     try {
-_bodyData=jsonEncode(body);
+      _bodyData = jsonEncode(body);
+
     } catch(error, stackTrace) {
       throw DioException(
          requestOptions: _options.compose(
@@ -450,7 +452,8 @@ _responseData = rawData == null ? null : deserialize<bool, bool>(rawData, 'bool'
     dynamic _bodyData;
 
     try {
-_bodyData=jsonEncode(outerComposite);
+      _bodyData = jsonEncode(outerComposite);
+
     } catch(error, stackTrace) {
       throw DioException(
          requestOptions: _options.compose(
@@ -540,7 +543,8 @@ _responseData = rawData == null ? null : deserialize<OuterComposite, OuterCompos
     dynamic _bodyData;
 
     try {
-_bodyData=jsonEncode(body);
+      _bodyData = jsonEncode(body);
+
     } catch(error, stackTrace) {
       throw DioException(
          requestOptions: _options.compose(
@@ -630,7 +634,8 @@ _responseData = rawData == null ? null : deserialize<num, num>(rawData, 'num', g
     dynamic _bodyData;
 
     try {
-_bodyData=jsonEncode(body);
+      _bodyData = jsonEncode(body);
+
     } catch(error, stackTrace) {
       throw DioException(
          requestOptions: _options.compose(
@@ -720,7 +725,8 @@ _responseData = rawData == null ? null : deserialize<String, String>(rawData, 'S
     dynamic _bodyData;
 
     try {
-_bodyData=jsonEncode(outerObjectWithEnumProperty);
+      _bodyData = jsonEncode(outerObjectWithEnumProperty);
+
     } catch(error, stackTrace) {
       throw DioException(
          requestOptions: _options.compose(
@@ -810,7 +816,8 @@ _responseData = rawData == null ? null : deserialize<OuterObjectWithEnumProperty
     dynamic _bodyData;
 
     try {
-_bodyData=jsonEncode(requestBody);
+      _bodyData = jsonEncode(requestBody);
+
     } catch(error, stackTrace) {
       throw DioException(
          requestOptions: _options.compose(
@@ -875,7 +882,8 @@ _bodyData=jsonEncode(requestBody);
     dynamic _bodyData;
 
     try {
-_bodyData=jsonEncode(body);
+      _bodyData = jsonEncode(body);
+
     } catch(error, stackTrace) {
       throw DioException(
          requestOptions: _options.compose(
@@ -940,7 +948,8 @@ _bodyData=jsonEncode(body);
     dynamic _bodyData;
 
     try {
-_bodyData=jsonEncode(fileSchemaTestClass);
+      _bodyData = jsonEncode(fileSchemaTestClass);
+
     } catch(error, stackTrace) {
       throw DioException(
          requestOptions: _options.compose(
@@ -1011,7 +1020,8 @@ _bodyData=jsonEncode(fileSchemaTestClass);
     dynamic _bodyData;
 
     try {
-_bodyData=jsonEncode(user);
+      _bodyData = jsonEncode(user);
+
     } catch(error, stackTrace) {
       throw DioException(
          requestOptions: _options.compose(
@@ -1078,7 +1088,8 @@ _bodyData=jsonEncode(user);
     dynamic _bodyData;
 
     try {
-_bodyData=jsonEncode(modelClient);
+      _bodyData = jsonEncode(modelClient);
+
     } catch(error, stackTrace) {
       throw DioException(
          requestOptions: _options.compose(
@@ -1200,6 +1211,22 @@ _responseData = rawData == null ? null : deserialize<ModelClient, ModelClient>(r
     dynamic _bodyData;
 
     try {
+      _bodyData = <String, dynamic>{
+        if (integer != null) r'integer': integer,
+        if (int32 != null) r'int32': int32,
+        if (int64 != null) r'int64': int64,
+        r'number': number,
+        if (float != null) r'float': float,
+        r'double': double_,
+        if (string != null) r'string': string,
+        r'pattern_without_delimiter': patternWithoutDelimiter,
+        r'byte': byte,
+        if (binary != null) r'binary': binary,
+        if (date != null) r'date': date,
+        if (dateTime != null) r'dateTime': dateTime,
+        if (password != null) r'password': password,
+        if (callback != null) r'callback': callback,
+      };
 
     } catch(error, stackTrace) {
       throw DioException(
@@ -1291,6 +1318,10 @@ _responseData = rawData == null ? null : deserialize<ModelClient, ModelClient>(r
     dynamic _bodyData;
 
     try {
+      _bodyData = <String, dynamic>{
+        if (enumFormStringArray != null) r'enum_form_string_array': enumFormStringArray,
+        if (enumFormString != null) r'enum_form_string': enumFormString,
+      };
 
     } catch(error, stackTrace) {
       throw DioException(
@@ -1431,7 +1462,8 @@ _responseData = rawData == null ? null : deserialize<ModelClient, ModelClient>(r
     dynamic _bodyData;
 
     try {
-_bodyData=jsonEncode(requestBody);
+      _bodyData = jsonEncode(requestBody);
+
     } catch(error, stackTrace) {
       throw DioException(
          requestOptions: _options.compose(
@@ -1496,7 +1528,8 @@ _bodyData=jsonEncode(requestBody);
     dynamic _bodyData;
 
     try {
-_bodyData=jsonEncode(testInlineFreeformAdditionalPropertiesRequest);
+      _bodyData = jsonEncode(testInlineFreeformAdditionalPropertiesRequest);
+
     } catch(error, stackTrace) {
       throw DioException(
          requestOptions: _options.compose(
@@ -1563,6 +1596,10 @@ _bodyData=jsonEncode(testInlineFreeformAdditionalPropertiesRequest);
     dynamic _bodyData;
 
     try {
+      _bodyData = <String, dynamic>{
+        r'param': param,
+        r'param2': param2,
+      };
 
     } catch(error, stackTrace) {
       throw DioException(
@@ -1628,7 +1665,8 @@ _bodyData=jsonEncode(testInlineFreeformAdditionalPropertiesRequest);
     dynamic _bodyData;
 
     try {
-_bodyData=jsonEncode(childWithNullable);
+      _bodyData = jsonEncode(childWithNullable);
+
     } catch(error, stackTrace) {
       throw DioException(
          requestOptions: _options.compose(
@@ -1763,7 +1801,8 @@ _bodyData=jsonEncode(childWithNullable);
     dynamic _bodyData;
 
     try {
-_bodyData=jsonEncode(requestBody);
+      _bodyData = jsonEncode(requestBody);
+
     } catch(error, stackTrace) {
       throw DioException(
          requestOptions: _options.compose(

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/fake_classname_tags123_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/fake_classname_tags123_api.dart
@@ -64,7 +64,8 @@ class FakeClassnameTags123Api {
     dynamic _bodyData;
 
     try {
-_bodyData=jsonEncode(modelClient);
+      _bodyData = jsonEncode(modelClient);
+
     } catch(error, stackTrace) {
       throw DioException(
          requestOptions: _options.compose(

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/pet_api.dart
@@ -63,7 +63,8 @@ class PetApi {
     dynamic _bodyData;
 
     try {
-_bodyData=jsonEncode(pet);
+      _bodyData = jsonEncode(pet);
+
     } catch(error, stackTrace) {
       throw DioException(
          requestOptions: _options.compose(
@@ -432,7 +433,8 @@ _responseData = rawData == null ? null : deserialize<Pet, Pet>(rawData, 'Pet', g
     dynamic _bodyData;
 
     try {
-_bodyData=jsonEncode(pet);
+      _bodyData = jsonEncode(pet);
+
     } catch(error, stackTrace) {
       throw DioException(
          requestOptions: _options.compose(
@@ -506,6 +508,10 @@ _bodyData=jsonEncode(pet);
     dynamic _bodyData;
 
     try {
+      _bodyData = <String, dynamic>{
+        if (name != null) r'name': name,
+        if (status != null) r'status': status,
+      };
 
     } catch(error, stackTrace) {
       throw DioException(
@@ -580,6 +586,10 @@ _bodyData=jsonEncode(pet);
     dynamic _bodyData;
 
     try {
+      _bodyData = FormData.fromMap(<String, dynamic>{
+        if (additionalMetadata != null) r'additionalMetadata': additionalMetadata,
+        if (file != null) r'file': file,
+      });
 
     } catch(error, stackTrace) {
       throw DioException(
@@ -679,6 +689,10 @@ _responseData = rawData == null ? null : deserialize<ApiResponse, ApiResponse>(r
     dynamic _bodyData;
 
     try {
+      _bodyData = FormData.fromMap(<String, dynamic>{
+        if (additionalMetadata != null) r'additionalMetadata': additionalMetadata,
+        r'requiredFile': requiredFile,
+      });
 
     } catch(error, stackTrace) {
       throw DioException(

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/store_api.dart
@@ -253,7 +253,8 @@ _responseData = rawData == null ? null : deserialize<Order, Order>(rawData, 'Ord
     dynamic _bodyData;
 
     try {
-_bodyData=jsonEncode(order);
+      _bodyData = jsonEncode(order);
+
     } catch(error, stackTrace) {
       throw DioException(
          requestOptions: _options.compose(

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/user_api.dart
@@ -57,7 +57,8 @@ class UserApi {
     dynamic _bodyData;
 
     try {
-_bodyData=jsonEncode(user);
+      _bodyData = jsonEncode(user);
+
     } catch(error, stackTrace) {
       throw DioException(
          requestOptions: _options.compose(
@@ -122,7 +123,8 @@ _bodyData=jsonEncode(user);
     dynamic _bodyData;
 
     try {
-_bodyData=jsonEncode(user);
+      _bodyData = jsonEncode(user);
+
     } catch(error, stackTrace) {
       throw DioException(
          requestOptions: _options.compose(
@@ -187,7 +189,8 @@ _bodyData=jsonEncode(user);
     dynamic _bodyData;
 
     try {
-_bodyData=jsonEncode(user);
+      _bodyData = jsonEncode(user);
+
     } catch(error, stackTrace) {
       throw DioException(
          requestOptions: _options.compose(
@@ -498,7 +501,8 @@ _responseData = rawData == null ? null : deserialize<String, String>(rawData, 'S
     dynamic _bodyData;
 
     try {
-_bodyData=jsonEncode(user);
+      _bodyData = jsonEncode(user);
+
     } catch(error, stackTrace) {
       throw DioException(
          requestOptions: _options.compose(


### PR DESCRIPTION
## Summary

The `json_serializable` `dart-dio` serialize template only handled `{{#bodyParam}}`, so any operation whose request body was `application/x-www-form-urlencoded` or `multipart/form-data` produced an **empty** `try {}` block: `_bodyData` was declared but never assigned, and the form fields were silently dropped. Only the `built_value` serialization library was correctly handling form params.

This PR adds the missing `{{#hasFormParams}}` handling to `serialization/json_serializable/api/serialize.mustache`, mirroring the pattern from the `built_value` counterpart but without `built_value`-specific `encodeFormParameter` / `_serializers` calls (consistent with how `json_serializable`'s `query_param.mustache` already just outputs `{{{paramName}}}`).

Similar to #20314, but for the dart-dio generator.

### Before

```dart
// updatePetWithForm — application/x-www-form-urlencoded
dynamic _bodyData;

try {
  // empty — form fields lost
} catch (error, stackTrace) { ... }

final _response = await _dio.request<Object>(
  _path,
  data: _bodyData, // always null
  ...
);
```

### After

```dart
dynamic _bodyData;

try {
  _bodyData = <String, dynamic>{
    if (name != null) r'name': name,
    if (status != null) r'status': status,
  };
} catch (error, stackTrace) { ... }
```

For `multipart/form-data` (`uploadFile`), the map is wrapped in `FormData.fromMap(...)` from the `dio` package, and `MultipartFile` values are passed through directly (`{{#isFile}}`).

## Reproduction

Minimal spec with an `application/x-www-form-urlencoded` body (e.g. `updatePetWithForm` from the petstore fake spec) generated with:

```
-g dart-dio --additional-properties=serializationLibrary=json_serializable
```

Before this PR, the generated `_bodyData` is always `null`. After, it is a populated `Map<String, dynamic>` (or `FormData`).

## Changes

- `modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/api/serialize.mustache`: add `hasFormParams` handling for both `isMultipart` and non-multipart cases; preserve the existing `bodyParam` branch (with proper indentation so the generated code is consistent with `built_value`).
- Regenerate `samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/**` via `./bin/generate-samples.sh bin/configs/dart-dio*`. Previously broken operations (`updatePetWithForm`, `uploadFile`, `uploadFileWithRequiredFile`, `testEndpointParameters`, `testEnumParameters`, `testQueryParameterCollectionFormat`) now serialize the form body correctly.
- `built_value` samples, docs, and other generators are **unaffected**.

## PR checklist

- [x] Read the contribution guidelines.
- [x] PR title clearly describes the work.
- [x] `./mvnw clean package -DskipTests -Dmaven.javadoc.skip=true` (built via `-pl modules/openapi-generator-cli -am`).
- [x] `./bin/generate-samples.sh bin/configs/dart-dio*`
- [x] `./bin/utils/export_docs_generators.sh` (no diff).
- [x] All changed files committed.
- [x] Targets `master`.

cc @kuhnroyal @josh-burton @amondnet @ahmednfwela (dart-dio technical committee)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes form parameter serialization in `dart-dio` with `json_serializable`, so `application/x-www-form-urlencoded` and `multipart/form-data` requests set `_bodyData` correctly instead of sending null.

- **Bug Fixes**
  - Add `{{#hasFormParams}}` handling in `serialization/json_serializable/api/serialize.mustache`: build `<String, dynamic>{...}` for urlencoded, `FormData.fromMap(...)` for multipart; pass `MultipartFile` values (and arrays) through; include optional params only when non-null.
  - Preserve the existing `{{#bodyParam}}` branch and align indentation.
  - Regenerate `petstore_client_lib_fake-json_serializable` samples; operations like `updatePetWithForm`, `uploadFile`, `testEndpointParameters`, and `testEnumParameters` now serialize form bodies correctly.

<sup>Written for commit 23b1b94d5fa6e7b2c9e30311418b0332216b5a54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



