### PR TITLE
Document how to use JBang to run openapi-generator-cli

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -143,6 +143,14 @@ export JAVA_HOME=`/usr/libexec/java_home -v 1.11`
 export PATH=${JAVA_HOME}/bin:$PATH
 ```
 
+## JBang
+
+> **Platform(s)**: Linux, macOS, Windows
+
+Use [JBang](https://www.jbang.dev/) to retrieve and run the JAR file using Maven coordinates. 
+
+Run `jbang --java 11 org.openapitools:openapi-generator-cli:LATEST help` to show the usage.
+
 ## Bash Launcher Script
 
 > **Platform(s)**: Linux, macOS, Windows (variable)


### PR DESCRIPTION
Closes #23583 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add JBang instructions to the Installation docs so users can run OpenAPI Generator CLI via Maven coordinates. You can now run the latest `org.openapitools:openapi-generator-cli` with `jbang --java 11 org.openapitools:openapi-generator-cli:LATEST help`, no manual JAR download needed.

<sup>Written for commit 89f2cb4b194403d3c8317af20fcb2de122230476. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

