### PR TITLE
fix(java-restclient): Spring 7 wrong serializers setup

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/ApiClient.mustache
@@ -239,9 +239,9 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
 
         {{#useJackson3}}
         Consumer<HttpMessageConverters.ClientBuilder> messageConverters = builder -> {
-            builder.withJsonConverter(new JacksonJsonHttpMessageConverter(mapper));
+            builder.addCustomConverter(new JacksonJsonHttpMessageConverter(mapper));
             {{#withXml}}
-            builder.withXmlConverter(new JacksonXmlHttpMessageConverter(xmlMapper));
+            builder.addCustomConverter(new JacksonXmlHttpMessageConverter(xmlMapper));
             {{/withXml}}
         };
 

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/src/main/java/org/openapitools/client/ApiClient.java
@@ -148,7 +148,7 @@ public class ApiClient extends JavaTimeFormatter {
     public static RestClient.Builder buildRestClientBuilder(JsonMapper mapper) {
 
         Consumer<HttpMessageConverters.ClientBuilder> messageConverters = builder -> {
-            builder.withJsonConverter(new JacksonJsonHttpMessageConverter(mapper));
+            builder.addCustomConverter(new JacksonJsonHttpMessageConverter(mapper));
         };
 
         return RestClient.builder().configureMessageConverters(messageConverters);

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3/src/main/java/org/openapitools/client/ApiClient.java
@@ -150,7 +150,7 @@ public class ApiClient extends JavaTimeFormatter {
     public static RestClient.Builder buildRestClientBuilder(JsonMapper mapper) {
 
         Consumer<HttpMessageConverters.ClientBuilder> messageConverters = builder -> {
-            builder.withJsonConverter(new JacksonJsonHttpMessageConverter(mapper));
+            builder.addCustomConverter(new JacksonJsonHttpMessageConverter(mapper));
         };
 
         return RestClient.builder().configureMessageConverters(messageConverters);


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

For `spring-boot:4`/`spring:7` the appropriate way of adding the message converters in our context seems to be via [addCustomConverter](https://docs.spring.io/spring-boot/4.0-SNAPSHOT/reference/web/servlet.html#web.servlet.spring-mvc.message-converters) as those are always added.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
  - @cachescrubber 
  - @welshm 
  - @MelleD 
  - @atextor 
  - @manedev79 
  - @javisst 
  - @borsch 
  - @banlevente 
  - @Zomzog 
  - @martin-mfg 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes serialization in Spring Boot 4 `RestClient` clients by adding Jackson JSON/XML message converters via `addCustomConverter` instead of `withJsonConverter`/`withXmlConverter`. Ensures converters are always registered under Spring 7 / Boot 4, restoring correct request/response handling.

<sup>Written for commit 1c9e21b6114a1ac8e8bafafe6fdcd635c50eff2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

