### PR TITLE
[KOTLIN-SPRING;JAVA-SPRING] chore: upgrade spring boot 3 to 3.3.13 version

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom-sb3.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom-sb3.mustache
@@ -58,7 +58,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.0</version>
+                <version>2023.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom-sb3.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom-sb3.mustache
@@ -58,7 +58,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.9</version>
+                <version>2023.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/buildGradle-sb3-Kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/buildGradle-sb3-Kts.mustache
@@ -25,7 +25,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
     id("org.springframework.boot") version "3.3.13"
-    id("io.spring.dependency-management") version "1.0.14.RELEASE"
+    id("io.spring.dependency-management") version "1.1.7"
 }
 
 dependencies {

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/buildGradle-sb3-Kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/buildGradle-sb3-Kts.mustache
@@ -24,7 +24,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
-    id("org.springframework.boot") version "3.0.2"
+    id("org.springframework.boot") version "3.3.13"
     id("io.spring.dependency-management") version "1.0.14.RELEASE"
 }
 

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/pom-sb3.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/pom-sb3.mustache
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.3</version>
+        <version>3.3.13</version>
     </parent>
     <repositories>
         <repository>

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradle-sb3-Kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradle-sb3-Kts.mustache
@@ -18,7 +18,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
-    id("org.springframework.boot") version "3.0.2"
+    id("org.springframework.boot") version "3.3.13"
     id("io.spring.dependency-management") version "1.0.14.RELEASE"
 }
 

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradle-sb3-Kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradle-sb3-Kts.mustache
@@ -32,7 +32,7 @@ tasks.getByName("jar") {
 
 dependencyManagement {
     imports {
-        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2021.0.5")
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2023.0.9")
     }
 }
 

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradle-sb3-Kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradle-sb3-Kts.mustache
@@ -19,7 +19,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
     id("org.springframework.boot") version "3.3.13"
-    id("io.spring.dependency-management") version "1.0.14.RELEASE"
+    id("io.spring.dependency-management") version "1.1.7"
 }
 
 tasks.getByName("bootJar") {

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradle-sb3-Kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradle-sb3-Kts.mustache
@@ -32,7 +32,7 @@ tasks.getByName("jar") {
 
 dependencyManagement {
     imports {
-        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2023.0.9")
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2023.0.6")
     }
 }
 

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradle-sb3-Kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradle-sb3-Kts.mustache
@@ -58,7 +58,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     implementation("org.springframework.cloud:spring-cloud-starter-openfeign"){{#hasAuthMethods}}
-        implementation("org.springframework.cloud:spring-cloud-starter-oauth2:2.2.5.RELEASE"){{/hasAuthMethods}}
+        implementation("org.springframework.boot:spring-boot-starter-oauth2-client"){{/hasAuthMethods}}
 
 {{#useBeanValidation}}
     implementation("jakarta.validation:jakarta.validation-api"){{/useBeanValidation}}

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradleKts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradleKts.mustache
@@ -65,7 +65,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     implementation("org.springframework.cloud:spring-cloud-starter-openfeign"){{#hasAuthMethods}}
-    implementation("org.springframework.boot:spring-boot-starter-oauth2-client"){{/hasAuthMethods}}
+    implementation("org.springframework.cloud:spring-cloud-starter-oauth2:2.2.5.RELEASE"){{/hasAuthMethods}}
 
 {{#useBeanValidation}}
     implementation("javax.validation:validation-api"){{/useBeanValidation}}

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradleKts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradleKts.mustache
@@ -65,7 +65,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     implementation("org.springframework.cloud:spring-cloud-starter-openfeign"){{#hasAuthMethods}}
-    implementation("org.springframework.cloud:spring-cloud-starter-oauth2:2.2.5.RELEASE"){{/hasAuthMethods}}
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client"){{/hasAuthMethods}}
 
 {{#useBeanValidation}}
     implementation("javax.validation:validation-api"){{/useBeanValidation}}

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/clientConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/clientConfiguration.mustache
@@ -8,20 +8,14 @@ import feign.auth.BasicAuthRequestInterceptor
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 {{/-first}}
-{{^useSpringBoot4}}
-{{#isOAuth}}
-import org.springframework.boot.context.properties.ConfigurationProperties
-{{/isOAuth}}
-{{/useSpringBoot4}}
+{{^useSpringBoot4}}{{^useSpringBoot3}}{{#isOAuth}}import org.springframework.boot.context.properties.ConfigurationProperties{{/isOAuth}}{{/useSpringBoot3}}{{/useSpringBoot4}}
 {{/authMethods}}
-{{^useSpringBoot4}}
-import org.springframework.boot.context.properties.EnableConfigurationProperties
-{{/useSpringBoot4}}
+{{^useSpringBoot4}}{{^useSpringBoot3}}import org.springframework.boot.context.properties.EnableConfigurationProperties{{/useSpringBoot3}}{{/useSpringBoot4}}
 {{#hasAuthMethods}}
 import org.springframework.context.annotation.Bean
 {{/hasAuthMethods}}
 import org.springframework.context.annotation.Configuration
-{{^useSpringBoot4}}
+{{^useSpringBoot4}}{{^useSpringBoot3}}
 {{#authMethods}}
 {{#isOAuth}}
 import org.springframework.cloud.openfeign.security.OAuth2FeignRequestInterceptor
@@ -41,7 +35,24 @@ import org.springframework.security.oauth2.client.token.grant.password.ResourceO
 {{/isPassword}}
 {{/isOAuth}}
 {{/authMethods}}
-{{/useSpringBoot4}}
+{{/useSpringBoot3}}{{/useSpringBoot4}}
+{{#useSpringBoot3}}
+{{#hasOAuthMethods}}
+import org.springframework.security.authentication.AnonymousAuthenticationToken
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException
+import org.springframework.security.oauth2.core.OAuth2AccessToken
+import org.springframework.security.core.authority.AuthorityUtils
+import org.springframework.http.HttpHeaders
+
+import feign.RequestInterceptor
+import feign.RequestTemplate
+{{/hasOAuthMethods}}
+{{/useSpringBoot3}}
 {{#useSpringBoot4}}
 {{#hasOAuthMethods}}
 import org.springframework.security.authentication.AnonymousAuthenticationToken
@@ -60,10 +71,8 @@ import feign.RequestTemplate
 {{/hasOAuthMethods}}
 {{/useSpringBoot4}}
 
-@Configuration
-{{^useSpringBoot4}}
-@EnableConfigurationProperties
-{{/useSpringBoot4}}
+@Configuration{{^useSpringBoot4}}{{^useSpringBoot3}}
+@EnableConfigurationProperties{{/useSpringBoot3}}{{/useSpringBoot4}}
 class ClientConfiguration {
 
     {{#authMethods}}
@@ -93,7 +102,7 @@ class ClientConfiguration {
 
     {{/isApiKey}}
     {{#isOAuth}}
-{{^useSpringBoot4}}
+{{^useSpringBoot4}}{{^useSpringBoot3}}
     @Bean
     @ConditionalOnProperty("{{#lambda.lowercase}}{{{title}}}{{/lambda.lowercase}}.security.{{{name}}}.client-id")
     fun {{#lambda.camelcase}}{{{name}}}{{/lambda.camelcase}}RequestInterceptor(oAuth2ClientContext: OAuth2ClientContext): OAuth2FeignRequestInterceptor {
@@ -151,7 +160,29 @@ class ClientConfiguration {
     }
 
     {{/isImplicit}}
-{{/useSpringBoot4}}
+{{/useSpringBoot3}}{{/useSpringBoot4}}
+{{#useSpringBoot3}}
+    @Bean
+    @ConditionalOnProperty(prefix = "spring.security.oauth2.client.registration.{{{name}}}{{#lambda.pascalcase}}{{{flow}}}{{/lambda.pascalcase}}", name = ["enabled"], havingValue = "true")
+    fun {{{flow}}}OAuth2RequestInterceptor({{{flow}}}AuthorizedClientManager: OAuth2AuthorizedClientManager): OAuth2RequestInterceptor {
+        return OAuth2RequestInterceptor(
+            OAuth2AuthorizeRequest.withClientRegistrationId("{{{name}}}{{#lambda.pascalcase}}{{{flow}}}{{/lambda.pascalcase}}")
+                .principal(AnonymousAuthenticationToken(CLIENT_PRINCIPAL_{{#lambda.uppercase}}{{{flow}}}{{/lambda.uppercase}}, CLIENT_PRINCIPAL_{{#lambda.uppercase}}{{{flow}}}{{/lambda.uppercase}}, AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
+                .build(),
+            {{{flow}}}AuthorizedClientManager
+        )
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "spring.security.oauth2.client.registration.{{{name}}}{{#lambda.pascalcase}}{{{flow}}}{{/lambda.pascalcase}}", name = ["enabled"], havingValue = "true")
+    fun {{{flow}}}AuthorizedClientManager(
+        clientRegistrationRepository: ClientRegistrationRepository,
+        authorizedClientService: OAuth2AuthorizedClientService
+    ): OAuth2AuthorizedClientManager {
+        return AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService)
+    }
+
+{{/useSpringBoot3}}
 {{#useSpringBoot4}}
     @Bean
     @ConditionalOnProperty(prefix = "spring.security.oauth2.client.registration.{{{name}}}{{#lambda.pascalcase}}{{{flow}}}{{/lambda.pascalcase}}", name = ["enabled"], havingValue = "true")
@@ -176,6 +207,38 @@ class ClientConfiguration {
 {{/useSpringBoot4}}
     {{/isOAuth}}
     {{/authMethods}}
+{{#useSpringBoot3}}
+    {{#hasOAuthMethods}}
+    class OAuth2RequestInterceptor(
+        private val oAuth2AuthorizeRequest: OAuth2AuthorizeRequest,
+        private val oAuth2AuthorizedClientManager: OAuth2AuthorizedClientManager
+    ) : RequestInterceptor {
+
+        override fun apply(template: RequestTemplate) {
+            template.header(HttpHeaders.AUTHORIZATION, getBearerToken())
+        }
+
+        fun getAccessToken(): OAuth2AccessToken {
+            val authorizedClient = oAuth2AuthorizedClientManager.authorize(oAuth2AuthorizeRequest)
+                ?: throw OAuth2AuthenticationException("Client failed to authenticate")
+            return authorizedClient.accessToken
+        }
+
+        fun getBearerToken(): String {
+            val accessToken = getAccessToken()
+            return String.format(java.util.Locale.ROOT, "%s %s", accessToken.tokenType?.value, accessToken.tokenValue)
+        }
+    }
+
+    companion object {
+        {{#authMethods}}
+        {{#isOAuth}}
+        private const val CLIENT_PRINCIPAL_{{#lambda.uppercase}}{{{flow}}}{{/lambda.uppercase}} = "oauth2FeignClient"
+        {{/isOAuth}}
+        {{/authMethods}}
+    }
+    {{/hasOAuthMethods}}
+{{/useSpringBoot3}}
 {{#useSpringBoot4}}
     {{#hasOAuthMethods}}
     class OAuth2RequestInterceptor(

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom-sb3.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom-sb3.mustache
@@ -34,7 +34,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.9</version>
+                <version>2023.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom-sb3.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom-sb3.mustache
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.3</version>
+        <version>3.3.13</version>
     </parent>
     <dependencyManagement>
         <dependencies>

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom-sb3.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom-sb3.mustache
@@ -34,7 +34,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2021.0.5</version>
+                <version>2023.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom-sb3.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom-sb3.mustache
@@ -192,11 +192,8 @@
         </dependency>
         {{#hasAuthMethods}}
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-oauth2</artifactId>
-            {{^parentOverridden}}
-                <version>2.2.5.RELEASE</version>
-            {{/parentOverridden}}
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
         </dependency>
         {{/hasAuthMethods}}
         <dependency>

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom.mustache
@@ -170,11 +170,8 @@
         </dependency>
         {{#hasAuthMethods}}
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-oauth2</artifactId>
-            {{^parentOverridden}}
-                <version>2.2.5.RELEASE</version>
-            {{/parentOverridden}}
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
         </dependency>
         {{/hasAuthMethods}}
         <dependency>

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom.mustache
@@ -170,8 +170,11 @@
         </dependency>
         {{#hasAuthMethods}}
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-oauth2-client</artifactId>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-oauth2</artifactId>
+            {{^parentOverridden}}
+                <version>2.2.5.RELEASE</version>
+            {{/parentOverridden}}
         </dependency>
         {{/hasAuthMethods}}
         <dependency>

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/buildGradle-sb3-Kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/buildGradle-sb3-Kts.mustache
@@ -58,7 +58,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
 {{#hasAuthMethods}}
-    implementation("org.springframework.cloud:spring-cloud-starter-oauth2:2.2.5.RELEASE"){{/hasAuthMethods}}
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client"){{/hasAuthMethods}}
 
 {{#useBeanValidation}}
     implementation("jakarta.validation:jakarta.validation-api"){{/useBeanValidation}}

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/buildGradle-sb3-Kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/buildGradle-sb3-Kts.mustache
@@ -18,7 +18,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
-    id("org.springframework.boot") version "3.0.2"
+    id("org.springframework.boot") version "3.3.13"
     id("io.spring.dependency-management") version "1.0.14.RELEASE"
 }
 

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/buildGradle-sb3-Kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/buildGradle-sb3-Kts.mustache
@@ -32,7 +32,7 @@ tasks.getByName("jar") {
 
 dependencyManagement {
     imports {
-        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2021.0.5")
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2023.0.9")
     }
 }
 

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/buildGradle-sb3-Kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/buildGradle-sb3-Kts.mustache
@@ -19,7 +19,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
     id("org.springframework.boot") version "3.3.13"
-    id("io.spring.dependency-management") version "1.0.14.RELEASE"
+    id("io.spring.dependency-management") version "1.1.7"
 }
 
 tasks.getByName("bootJar") {

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/buildGradle-sb3-Kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/buildGradle-sb3-Kts.mustache
@@ -32,7 +32,7 @@ tasks.getByName("jar") {
 
 dependencyManagement {
     imports {
-        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2023.0.9")
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2023.0.6")
     }
 }
 

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/pom-sb3.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/pom-sb3.mustache
@@ -34,7 +34,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.9</version>
+                <version>2023.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/pom-sb3.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/pom-sb3.mustache
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.3</version>
+        <version>3.3.13</version>
     </parent>
     <dependencyManagement>
         <dependencies>

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/pom-sb3.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/pom-sb3.mustache
@@ -34,7 +34,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2021.0.5</version>
+                <version>2023.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/pom-sb3.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/pom-sb3.mustache
@@ -188,11 +188,8 @@
         </dependency>
         {{#hasAuthMethods}}
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-oauth2</artifactId>
-            {{^parentOverridden}}
-                <version>2.2.5.RELEASE</version>
-            {{/parentOverridden}}
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
         </dependency>
         {{/hasAuthMethods}}
         <dependency>

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
@@ -5042,6 +5042,7 @@ public class KotlinSpringServerCodegenTest {
         String methodPattern = "fun test\\s*\\(.*?\\)";
         Pattern pattern = Pattern.compile(methodPattern);
 
+
         Matcher matcher = pattern.matcher(content);
         Assert.assertTrue(matcher.find(), "Method 'test' should be found in generated file");
 

--- a/samples/client/petstore/spring-cloud-auth/pom.xml
+++ b/samples/client/petstore/spring-cloud-auth/pom.xml
@@ -27,7 +27,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.0</version>
+                <version>2023.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/client/petstore/spring-cloud-auth/pom.xml
+++ b/samples/client/petstore/spring-cloud-auth/pom.xml
@@ -27,7 +27,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.9</version>
+                <version>2023.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/client/petstore/spring-cloud-date-time/pom.xml
+++ b/samples/client/petstore/spring-cloud-date-time/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.0</version>
+                <version>2023.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/client/petstore/spring-cloud-date-time/pom.xml
+++ b/samples/client/petstore/spring-cloud-date-time/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.9</version>
+                <version>2023.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/client/petstore/spring-cloud-deprecated/pom.xml
+++ b/samples/client/petstore/spring-cloud-deprecated/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.0</version>
+                <version>2023.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/client/petstore/spring-cloud-deprecated/pom.xml
+++ b/samples/client/petstore/spring-cloud-deprecated/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.9</version>
+                <version>2023.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/client/petstore/spring-cloud-feign-without-url/pom.xml
+++ b/samples/client/petstore/spring-cloud-feign-without-url/pom.xml
@@ -28,7 +28,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.0</version>
+                <version>2023.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/client/petstore/spring-cloud-feign-without-url/pom.xml
+++ b/samples/client/petstore/spring-cloud-feign-without-url/pom.xml
@@ -28,7 +28,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.9</version>
+                <version>2023.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/client/petstore/spring-cloud-tags/pom.xml
+++ b/samples/client/petstore/spring-cloud-tags/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.0</version>
+                <version>2023.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/client/petstore/spring-cloud-tags/pom.xml
+++ b/samples/client/petstore/spring-cloud-tags/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.9</version>
+                <version>2023.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/client/petstore/spring-cloud/pom.xml
+++ b/samples/client/petstore/spring-cloud/pom.xml
@@ -28,7 +28,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.0</version>
+                <version>2023.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/client/petstore/spring-cloud/pom.xml
+++ b/samples/client/petstore/spring-cloud/pom.xml
@@ -28,7 +28,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.9</version>
+                <version>2023.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/pom.xml
@@ -27,7 +27,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.0</version>
+                <version>2023.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/pom.xml
@@ -27,7 +27,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.9</version>
+                <version>2023.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/openapi3/client/petstore/spring-cloud-3/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-3/pom.xml
@@ -28,7 +28,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.0</version>
+                <version>2023.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/openapi3/client/petstore/spring-cloud-3/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-3/pom.xml
@@ -28,7 +28,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.9</version>
+                <version>2023.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/openapi3/client/petstore/spring-cloud-async/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-async/pom.xml
@@ -28,7 +28,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.0</version>
+                <version>2023.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/openapi3/client/petstore/spring-cloud-async/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-async/pom.xml
@@ -28,7 +28,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.9</version>
+                <version>2023.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/openapi3/client/petstore/spring-cloud-date-time/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-date-time/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.0</version>
+                <version>2023.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/openapi3/client/petstore/spring-cloud-date-time/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-date-time/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.9</version>
+                <version>2023.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/openapi3/client/petstore/spring-cloud-http-basic/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-http-basic/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.0</version>
+                <version>2023.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/openapi3/client/petstore/spring-cloud-http-basic/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-http-basic/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.9</version>
+                <version>2023.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.0</version>
+                <version>2023.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.9</version>
+                <version>2023.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/pom.xml
@@ -28,7 +28,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.0</version>
+                <version>2023.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/pom.xml
@@ -28,7 +28,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.9</version>
+                <version>2023.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/openapi3/client/petstore/spring-cloud/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.0</version>
+                <version>2023.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/openapi3/client/petstore/spring-cloud/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.9</version>
+                <version>2023.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/server/petstore/kotlin-spring-cloud/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-cloud/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
-    implementation("org.springframework.cloud:spring-cloud-starter-oauth2:2.2.5.RELEASE")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 
     implementation("javax.validation:validation-api")
     implementation("javax.annotation:javax.annotation-api:1.3.2")

--- a/samples/server/petstore/kotlin-spring-cloud/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-cloud/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
-    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+    implementation("org.springframework.cloud:spring-cloud-starter-oauth2:2.2.5.RELEASE")
 
     implementation("javax.validation:validation-api")
     implementation("javax.annotation:javax.annotation-api:1.3.2")

--- a/samples/server/petstore/kotlin-spring-cloud/pom.xml
+++ b/samples/server/petstore/kotlin-spring-cloud/pom.xml
@@ -109,9 +109,8 @@
             <artifactId>spring-cloud-starter-openfeign</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-oauth2</artifactId>
-                <version>2.2.5.RELEASE</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/samples/server/petstore/kotlin-spring-cloud/pom.xml
+++ b/samples/server/petstore/kotlin-spring-cloud/pom.xml
@@ -109,8 +109,9 @@
             <artifactId>spring-cloud-starter-openfeign</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-oauth2-client</artifactId>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-oauth2</artifactId>
+                <version>2.2.5.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/configuration/ClientConfiguration.kt
+++ b/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/configuration/ClientConfiguration.kt
@@ -3,17 +3,21 @@ package org.openapitools.configuration
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.ConfigurationProperties
+
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+
 import org.springframework.cloud.openfeign.security.OAuth2FeignRequestInterceptor
 import org.springframework.security.oauth2.client.DefaultOAuth2ClientContext
 import org.springframework.security.oauth2.client.OAuth2ClientContext
 import org.springframework.security.oauth2.client.token.grant.implicit.ImplicitResourceDetails
 
+
 @Configuration
 @EnableConfigurationProperties
 class ClientConfiguration {
+
 
     @Bean
     @ConditionalOnProperty("openapipetstore.security.petstore_auth.client-id")
@@ -35,6 +39,7 @@ class ClientConfiguration {
         details.userAuthorizationUri= "http://petstore.swagger.io/api/oauth/dialog"
         return details
     }
+
 
     @Value("\${openapipetstore.security.api_key.key:}")
     private lateinit var apiKeyKey: String

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
-    id("org.springframework.boot") version "3.0.2"
+    id("org.springframework.boot") version "3.3.13"
     id("io.spring.dependency-management") version "1.0.14.RELEASE"
 }
 

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/build.gradle.kts
@@ -32,7 +32,7 @@ tasks.getByName("jar") {
 
 dependencyManagement {
     imports {
-        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2021.0.5")
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2023.0.9")
     }
 }
 

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
     id("org.springframework.boot") version "3.3.13"
-    id("io.spring.dependency-management") version "1.0.14.RELEASE"
+    id("io.spring.dependency-management") version "1.1.7"
 }
 
 tasks.getByName("bootJar") {

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/build.gradle.kts
@@ -32,7 +32,7 @@ tasks.getByName("jar") {
 
 dependencyManagement {
     imports {
-        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2023.0.9")
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2023.0.6")
     }
 }
 

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/build.gradle.kts
@@ -51,7 +51,7 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
-    implementation("org.springframework.cloud:spring-cloud-starter-oauth2:2.2.5.RELEASE")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 
     implementation("jakarta.validation:jakarta.validation-api")
     implementation("jakarta.annotation:jakarta.annotation-api:2.1.0")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/pom.xml
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/pom.xml
@@ -26,7 +26,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2021.0.5</version>
+                <version>2023.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/pom.xml
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.3</version>
+        <version>3.3.13</version>
     </parent>
     <dependencyManagement>
         <dependencies>

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/pom.xml
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/pom.xml
@@ -26,7 +26,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.9</version>
+                <version>2023.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/pom.xml
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/pom.xml
@@ -137,9 +137,8 @@
             <version>${findbugs-jsr305.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-oauth2</artifactId>
-                <version>2.2.5.RELEASE</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
-    id("org.springframework.boot") version "3.0.2"
+    id("org.springframework.boot") version "3.3.13"
     id("io.spring.dependency-management") version "1.0.14.RELEASE"
 }
 

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/build.gradle.kts
@@ -32,7 +32,7 @@ tasks.getByName("jar") {
 
 dependencyManagement {
     imports {
-        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2021.0.5")
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2023.0.9")
     }
 }
 

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
     id("org.springframework.boot") version "3.3.13"
-    id("io.spring.dependency-management") version "1.0.14.RELEASE"
+    id("io.spring.dependency-management") version "1.1.7"
 }
 
 tasks.getByName("bootJar") {

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/build.gradle.kts
@@ -32,7 +32,7 @@ tasks.getByName("jar") {
 
 dependencyManagement {
     imports {
-        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2023.0.9")
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2023.0.6")
     }
 }
 

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/build.gradle.kts
@@ -51,7 +51,7 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
-    implementation("org.springframework.cloud:spring-cloud-starter-oauth2:2.2.5.RELEASE")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 
     implementation("jakarta.validation:jakarta.validation-api")
     implementation("jakarta.annotation:jakarta.annotation-api:2.1.0")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/pom.xml
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/pom.xml
@@ -26,7 +26,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2021.0.5</version>
+                <version>2023.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/pom.xml
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.3</version>
+        <version>3.3.13</version>
     </parent>
     <dependencyManagement>
         <dependencies>

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/pom.xml
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/pom.xml
@@ -26,7 +26,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.9</version>
+                <version>2023.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/pom.xml
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/pom.xml
@@ -137,9 +137,8 @@
             <version>${findbugs-jsr305.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-oauth2</artifactId>
-                <version>2.2.5.RELEASE</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
-    id("org.springframework.boot") version "3.0.2"
+    id("org.springframework.boot") version "3.3.13"
     id("io.spring.dependency-management") version "1.0.14.RELEASE"
 }
 

--- a/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/build.gradle.kts
@@ -32,7 +32,7 @@ tasks.getByName("jar") {
 
 dependencyManagement {
     imports {
-        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2021.0.5")
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2023.0.9")
     }
 }
 

--- a/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
     id("org.springframework.boot") version "3.3.13"
-    id("io.spring.dependency-management") version "1.0.14.RELEASE"
+    id("io.spring.dependency-management") version "1.1.7"
 }
 
 tasks.getByName("bootJar") {

--- a/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/build.gradle.kts
@@ -32,7 +32,7 @@ tasks.getByName("jar") {
 
 dependencyManagement {
     imports {
-        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2023.0.9")
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2023.0.6")
     }
 }
 

--- a/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
-    implementation("org.springframework.cloud:spring-cloud-starter-oauth2:2.2.5.RELEASE")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 
     implementation("jakarta.validation:jakarta.validation-api")
     implementation("jakarta.annotation:jakarta.annotation-api:2.1.0")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/pom.xml
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/pom.xml
@@ -24,7 +24,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2021.0.5</version>
+                <version>2023.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/pom.xml
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.3</version>
+        <version>3.3.13</version>
     </parent>
     <dependencyManagement>
         <dependencies>

--- a/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/pom.xml
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/pom.xml
@@ -125,9 +125,8 @@
             <version>${findbugs-jsr305.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-oauth2</artifactId>
-                <version>2.2.5.RELEASE</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/pom.xml
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/pom.xml
@@ -24,7 +24,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.9</version>
+                <version>2023.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/server/petstore/kotlin-spring-declarative-interface/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-declarative-interface/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
-    id("org.springframework.boot") version "3.0.2"
+    id("org.springframework.boot") version "3.3.13"
     id("io.spring.dependency-management") version "1.0.14.RELEASE"
 }
 

--- a/samples/server/petstore/kotlin-spring-declarative-interface/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-declarative-interface/build.gradle.kts
@@ -32,7 +32,7 @@ tasks.getByName("jar") {
 
 dependencyManagement {
     imports {
-        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2021.0.5")
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2023.0.9")
     }
 }
 

--- a/samples/server/petstore/kotlin-spring-declarative-interface/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-declarative-interface/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
     id("org.springframework.boot") version "3.3.13"
-    id("io.spring.dependency-management") version "1.0.14.RELEASE"
+    id("io.spring.dependency-management") version "1.1.7"
 }
 
 tasks.getByName("bootJar") {

--- a/samples/server/petstore/kotlin-spring-declarative-interface/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-declarative-interface/build.gradle.kts
@@ -32,7 +32,7 @@ tasks.getByName("jar") {
 
 dependencyManagement {
     imports {
-        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2023.0.9")
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2023.0.6")
     }
 }
 

--- a/samples/server/petstore/kotlin-spring-declarative-interface/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-declarative-interface/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
-    implementation("org.springframework.cloud:spring-cloud-starter-oauth2:2.2.5.RELEASE")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 
     implementation("jakarta.validation:jakarta.validation-api")
     implementation("jakarta.annotation:jakarta.annotation-api:2.1.0")

--- a/samples/server/petstore/kotlin-spring-declarative-interface/pom.xml
+++ b/samples/server/petstore/kotlin-spring-declarative-interface/pom.xml
@@ -24,7 +24,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2021.0.5</version>
+                <version>2023.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/server/petstore/kotlin-spring-declarative-interface/pom.xml
+++ b/samples/server/petstore/kotlin-spring-declarative-interface/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.3</version>
+        <version>3.3.13</version>
     </parent>
     <dependencyManagement>
         <dependencies>

--- a/samples/server/petstore/kotlin-spring-declarative-interface/pom.xml
+++ b/samples/server/petstore/kotlin-spring-declarative-interface/pom.xml
@@ -125,9 +125,8 @@
             <version>${findbugs-jsr305.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-oauth2</artifactId>
-                <version>2.2.5.RELEASE</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/samples/server/petstore/kotlin-spring-declarative-interface/pom.xml
+++ b/samples/server/petstore/kotlin-spring-declarative-interface/pom.xml
@@ -24,7 +24,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-parent</artifactId>
-                <version>2023.0.9</version>
+                <version>2023.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/server/petstore/kotlin-spring-sealed-interfaces/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-sealed-interfaces/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
     id("org.springframework.boot") version "3.3.13"
-    id("io.spring.dependency-management") version "1.0.14.RELEASE"
+    id("io.spring.dependency-management") version "1.1.7"
 }
 
 dependencies {

--- a/samples/server/petstore/kotlin-spring-sealed-interfaces/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-sealed-interfaces/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
-    id("org.springframework.boot") version "3.0.2"
+    id("org.springframework.boot") version "3.3.13"
     id("io.spring.dependency-management") version "1.0.14.RELEASE"
 }
 

--- a/samples/server/petstore/kotlin-spring-sealed-interfaces/pom.xml
+++ b/samples/server/petstore/kotlin-spring-sealed-interfaces/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.3</version>
+        <version>3.3.13</version>
     </parent>
     <repositories>
         <repository>

--- a/samples/server/petstore/kotlin-springboot-3-no-response-entity/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-3-no-response-entity/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
-    id("org.springframework.boot") version "3.0.2"
+    id("org.springframework.boot") version "3.3.13"
     id("io.spring.dependency-management") version "1.0.14.RELEASE"
 }
 

--- a/samples/server/petstore/kotlin-springboot-3-no-response-entity/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-3-no-response-entity/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
     id("org.springframework.boot") version "3.3.13"
-    id("io.spring.dependency-management") version "1.0.14.RELEASE"
+    id("io.spring.dependency-management") version "1.1.7"
 }
 
 dependencies {

--- a/samples/server/petstore/kotlin-springboot-3-no-response-entity/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-3-no-response-entity/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.3</version>
+        <version>3.3.13</version>
     </parent>
     <repositories>
         <repository>

--- a/samples/server/petstore/kotlin-springboot-3/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-3/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
-    id("org.springframework.boot") version "3.0.2"
+    id("org.springframework.boot") version "3.3.13"
     id("io.spring.dependency-management") version "1.0.14.RELEASE"
 }
 

--- a/samples/server/petstore/kotlin-springboot-3/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-3/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
     id("org.springframework.boot") version "3.3.13"
-    id("io.spring.dependency-management") version "1.0.14.RELEASE"
+    id("io.spring.dependency-management") version "1.1.7"
 }
 
 dependencies {

--- a/samples/server/petstore/kotlin-springboot-3/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-3/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.3</version>
+        <version>3.3.13</version>
     </parent>
     <repositories>
         <repository>

--- a/samples/server/petstore/kotlin-springboot-additionalproperties/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-additionalproperties/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
-    id("org.springframework.boot") version "3.0.2"
+    id("org.springframework.boot") version "3.3.13"
     id("io.spring.dependency-management") version "1.0.14.RELEASE"
 }
 

--- a/samples/server/petstore/kotlin-springboot-additionalproperties/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-additionalproperties/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
     id("org.springframework.boot") version "3.3.13"
-    id("io.spring.dependency-management") version "1.0.14.RELEASE"
+    id("io.spring.dependency-management") version "1.1.7"
 }
 
 dependencies {

--- a/samples/server/petstore/kotlin-springboot-additionalproperties/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-additionalproperties/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.3</version>
+        <version>3.3.13</version>
     </parent>
     <repositories>
         <repository>

--- a/samples/server/petstore/kotlin-springboot-delegate-nodefaults/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-delegate-nodefaults/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
-    id("org.springframework.boot") version "3.0.2"
+    id("org.springframework.boot") version "3.3.13"
     id("io.spring.dependency-management") version "1.0.14.RELEASE"
 }
 

--- a/samples/server/petstore/kotlin-springboot-delegate-nodefaults/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-delegate-nodefaults/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
     id("org.springframework.boot") version "3.3.13"
-    id("io.spring.dependency-management") version "1.0.14.RELEASE"
+    id("io.spring.dependency-management") version "1.1.7"
 }
 
 dependencies {

--- a/samples/server/petstore/kotlin-springboot-delegate-nodefaults/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-delegate-nodefaults/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.3</version>
+        <version>3.3.13</version>
     </parent>
     <repositories>
         <repository>

--- a/samples/server/petstore/kotlin-springboot-integer-enum/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-integer-enum/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
     id("org.springframework.boot") version "3.3.13"
-    id("io.spring.dependency-management") version "1.0.14.RELEASE"
+    id("io.spring.dependency-management") version "1.1.7"
 }
 
 dependencies {

--- a/samples/server/petstore/kotlin-springboot-integer-enum/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-integer-enum/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
-    id("org.springframework.boot") version "3.0.2"
+    id("org.springframework.boot") version "3.3.13"
     id("io.spring.dependency-management") version "1.0.14.RELEASE"
 }
 

--- a/samples/server/petstore/kotlin-springboot-integer-enum/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-integer-enum/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.3</version>
+        <version>3.3.13</version>
     </parent>
     <repositories>
         <repository>

--- a/samples/server/petstore/kotlin-springboot-request-cookie/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
     id("org.springframework.boot") version "3.3.13"
-    id("io.spring.dependency-management") version "1.0.14.RELEASE"
+    id("io.spring.dependency-management") version "1.1.7"
 }
 
 dependencies {

--- a/samples/server/petstore/kotlin-springboot-request-cookie/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.jpa") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
-    id("org.springframework.boot") version "3.0.2"
+    id("org.springframework.boot") version "3.3.13"
     id("io.spring.dependency-management") version "1.0.14.RELEASE"
 }
 

--- a/samples/server/petstore/kotlin-springboot-request-cookie/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.3</version>
+        <version>3.3.13</version>
     </parent>
     <repositories>
         <repository>


### PR DESCRIPTION
Upgraded spring boot 3 version to 3.3.13

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. - @cachescrubber (2022/02) @welshm (2022/02) @MelleD (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02) @borsch (2022/02) @banlevente (2022/02) @Zomzog (2022/09) @martin-mfg (2023/08), @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06) @e5l (2024/10) @dennisameling (2026/02)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Kotlin and Java Spring generator templates and petstore samples to Spring Boot 3.3.13 and Spring Cloud 2023.0.6. Modernizes OAuth2 for Spring Boot 3 and aligns Gradle/Maven builds.

- **Dependencies**
  - Spring Boot: Gradle `org.springframework.boot` 3.0.2 -> 3.3.13; Maven `spring-boot-starter-parent` 3.1.3 -> 3.3.13.
  - Spring Cloud: BOM/parent `spring-cloud-dependencies`/`spring-cloud-starter-parent` 2021.0.5/2023.0.0 -> 2023.0.6.
  - Gradle: `io.spring.dependency-management` 1.0.14.RELEASE -> 1.1.7.
  - OAuth: replace `org.springframework.cloud:spring-cloud-starter-oauth2:2.2.5.RELEASE` with `org.springframework.boot:spring-boot-starter-oauth2-client`.

- **Refactors**
  - Add Spring Boot 3 OAuth2 Feign interceptor using `OAuth2AuthorizedClientManager` in `ClientConfiguration`, with per-flow beans toggled by `spring.security.oauth2.client.registration.{name}{Flow}.enabled=true`.

<sup>Written for commit 49a3262ef336ecf2c5b8931a2b7a7be02b029148. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

