### PR TITLE
[CORE] : BUGFIX - prevent Stream closed on concurrent JAR access in TemplateManager

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/TemplateManager.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/TemplateManager.java
@@ -12,6 +12,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
+import java.net.URL;
+import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -146,22 +148,28 @@ public class TemplateManager implements TemplatingExecutor, TemplateProcessor {
         try {
             InputStream is = getInputStream(name);
             return new InputStreamReader(is, StandardCharsets.UTF_8);
-        } catch (FileNotFoundException e) {
+        } catch (IOException e) {
             LOGGER.error(e.getMessage());
             throw new RuntimeException("can't load template " + name);
         }
     }
 
-    private InputStream getInputStream(String name) throws FileNotFoundException {
-        InputStream is;
-        is = this.getClass().getClassLoader().getResourceAsStream(getCPResourcePath(name));
-        if (is == null) {
-            if (name == null || name.contains("..")) {
-                throw new IllegalArgumentException("Template location must be constrained to template directory.");
-            }
-            is = new FileInputStream(name); // May throw but never return a null value
+    private InputStream getInputStream(String name) throws IOException {
+        if (name == null || name.contains("..")) {
+            throw new IllegalArgumentException("Template location must be constrained to template directory.");
         }
-        return is;
+        String cpResourcePath = getCPResourcePath(name);
+        URL resource = this.getClass().getClassLoader().getResource(cpResourcePath);
+        if (resource != null) {
+            // Open a fresh, non-cached connection each time.
+            // setUseCaches(false) prevents sharing the underlying JarFile across classloaders,
+            // which avoids "Stream closed" errors when concurrent Gradle workers use isolated
+            // classloaders that happen to point to the same JAR URL.
+            URLConnection conn = resource.openConnection();
+            conn.setUseCaches(false);
+            return conn.getInputStream();
+        }
+        return new FileInputStream(name); // May throw but never return a null value
     }
 
     /**
@@ -180,15 +188,22 @@ public class TemplateManager implements TemplatingExecutor, TemplateProcessor {
             return writeToFile(target.getPath(), templateContent);
         } else {
             // Do a straight copy of the file if not listed as supported by the template engine.
-            InputStream is;
+            String fullTemplatePath = null;
             try {
                 // look up the file using the same template resolution logic the adapters would use.
-                String fullTemplatePath = getFullTemplateFile(template);
-                is = getInputStream(fullTemplatePath);
+                fullTemplatePath = getFullTemplateFile(template);
             } catch (TemplateNotFoundException ex) {
-                is = new FileInputStream(Paths.get(template).toFile());
+                // not found on classpath; fall through to direct file read below
             }
-            return writeToFile(target.getAbsolutePath(), IOUtils.toByteArray(is));
+            if (fullTemplatePath != null) {
+                try (InputStream is = getInputStream(fullTemplatePath)) {
+                    return writeToFile(target.getAbsolutePath(), IOUtils.toByteArray(is));
+                }
+            } else {
+                try (InputStream is = new FileInputStream(Paths.get(template).toFile())) {
+                    return writeToFile(target.getAbsolutePath(), IOUtils.toByteArray(is));
+                }
+            }
         }
     }
 


### PR DESCRIPTION
When two Gradle tasks run concurrently in isolated classloaders that both point to the same generator JAR, the JVM's `JarFileFactory` shares a single `JarFile` between both classloaders. If one classloader is closed/GC'd while the other is still copying a non-template resource (e.g. README.md), the shared `JarFile` is closed and the other worker's `InflaterInputStream` throws 'Stream closed'.

Two fixes in `TemplateManager`:

1. `getInputStream()` now opens a fresh `URLConnection` with `setUseCaches(false)` for classpath resources, preventing the underlying `JarFile` from being shared across classloaders.

2. `write()` now wraps the `InputStream` in `try-with-resources`, fixing the pre-existing resource leak where the stream was never closed after the binary file copy.

This bug was introduced by **me** as a part of the generator speedup in commit **c07f3a0ec1f**:
**Before modernization:** `GenerateTask.generate()` called `DefaultGenerator(...).generate()` directly on the Gradle worker thread — same classloader, no isolation, no concurrency issues.

**After modernization:** the task was refactored to use `workerExecutor.classLoaderIsolation()`. This runs each task in a separate isolated ClassLoader pointing to the same generator JAR. The JVM's `JarURLConnection` shares a single underlying `JarFile` per JAR URL across classloaders (via `JarFileFactory`). When two tasks run concurrently and one worker's classloader is torn down, it closes the shared `JarFile`, causing `InflaterInputStream: Stream closed` in the other worker.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. - tagging @wing328 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents "Stream closed" errors when Gradle tasks access the same generator JAR concurrently by using non-cached URL connections for classpath resources and properly closing streams during file copy. Improves stability for isolated classloaders and stops flaky builds.

- **Bug Fixes**
  - Open a fresh `URLConnection` with `setUseCaches(false)` for classpath resources to avoid shared `JarFile` across classloaders.
  - Wrap file copy streams in try-with-resources in `write()` to close them reliably and fix the leak.

<sup>Written for commit c30b9a34cab9ebff565c113577b44652d86410ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

