### PR TITLE
refactor: centralize common schema checks in ModelUtils

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2515,7 +2515,7 @@ public class DefaultCodegen implements CodegenConfig {
             // Note: the value of a free-form object cannot be an arbitrary type. Per OAS specification,
             // it must be a map of string to values.
             return "object";
-        } else if (schema.getProperties() != null && !schema.getProperties().isEmpty()) { // having property implies it's a model
+        } else if (ModelUtils.hasProperties(schema)) { // having property implies it's a model
             return "object";
         } else if (ModelUtils.isAnyType(schema)) {
             return "AnyType";
@@ -2707,8 +2707,8 @@ public class DefaultCodegen implements CodegenConfig {
         List<String> allRequired = new ArrayList<>();
 
         // if schema has properties outside of allOf/oneOf/anyOf also add them to m
-        if (composed.getProperties() != null && !composed.getProperties().isEmpty()) {
-            if (composed.getOneOf() != null && !composed.getOneOf().isEmpty()) {
+        if (ModelUtils.hasProperties(composed)) {
+            if (ModelUtils.hasOneOf(composed)) {
                 LOGGER.warn("'oneOf' is intended to include only the additional optional OAS extension discriminator object. " +
                         "For more details, see https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.9.2.1.3 and the OAS section on 'Composition and Inheritance'.");
             }
@@ -3362,7 +3362,7 @@ public class DefaultCodegen implements CodegenConfig {
                     }
                 }
             }
-            if (composedSchema.getOneOf() != null && composedSchema.getOneOf().size() != 0) {
+            if (ModelUtils.hasOneOf(composedSchema)) {
                 // All oneOf definitions must contain the discriminator
                 CodegenProperty cp = new CodegenProperty();
                 for (Object oneOf : composedSchema.getOneOf()) {
@@ -3388,7 +3388,7 @@ public class DefaultCodegen implements CodegenConfig {
                 }
                 return cp;
             }
-            if (composedSchema.getAnyOf() != null && composedSchema.getAnyOf().size() != 0) {
+            if (ModelUtils.hasAnyOf(composedSchema)) {
                 // All anyOf definitions must contain the discriminator because a min of one must be selected
                 CodegenProperty cp = new CodegenProperty();
                 for (Object anyOf : composedSchema.getAnyOf()) {
@@ -3457,7 +3457,7 @@ public class DefaultCodegen implements CodegenConfig {
                     }
                 }
             }
-            if (composedSchema.getOneOf() != null && composedSchema.getOneOf().size() != 0) {
+            if (ModelUtils.hasOneOf(composedSchema)) {
                 // All oneOf definitions must contain the discriminator
                 Integer hasDiscriminatorCnt = 0;
                 Integer hasNullTypeCnt = 0;
@@ -3792,7 +3792,7 @@ public class DefaultCodegen implements CodegenConfig {
         }
         if (ModelUtils.isComposedSchema(schema)) {
             // fix issue #16797 and #15796, constructor fail by missing parent required params
-            if (schema.getProperties() != null && !schema.getProperties().isEmpty()) {
+            if (ModelUtils.hasProperties(schema)) {
                 properties.putAll(schema.getProperties());
             }
 
@@ -8599,7 +8599,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param name   name of the parent oneOf schema
      */
     public void addOneOfNameExtension(Schema schema, String name) {
-        if (schema.getOneOf() != null && !schema.getOneOf().isEmpty()) {
+        if (ModelUtils.hasOneOf(schema)) {
             schema.addExtension(X_ONE_OF_NAME, name);
         }
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/InlineModelResolver.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/InlineModelResolver.java
@@ -30,7 +30,6 @@ import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.slf4j.Logger;
@@ -236,9 +235,9 @@ public class InlineModelResolver {
         if (resolveInlineEnums && schema.getEnum() != null && schema.getEnum().size() > 0) {
             return true;
         }
-        if (schema.getType() == null || "object".equals(schema.getType())) {
+        if (schema.getType() == null || ModelUtils.isObjectTypeOAS30(schema)) {
             // object or undeclared type with properties
-            if (schema.getProperties() != null && schema.getProperties().size() > 0) {
+            if (ModelUtils.hasProperties(schema)) {
                 return true;
             }
         }
@@ -264,7 +263,7 @@ public class InlineModelResolver {
                 return isModelNeeded((Schema) schema.getAllOf().get(0), visitedSchemas);
             }
 
-            if (schema.getAllOf() != null && !schema.getAllOf().isEmpty()) {
+            if (ModelUtils.hasAllOf(schema)) {
                 // check to ensure at least one of the allOf item is model
                 for (Object inner : schema.getAllOf()) {
                     if (isModelNeeded(ModelUtils.getReferencedSchema(openAPI, (Schema) inner), visitedSchemas)) {
@@ -275,10 +274,10 @@ public class InlineModelResolver {
                 return false;
             }
 
-            if (schema.getAnyOf() != null && !schema.getAnyOf().isEmpty()) {
+            if (ModelUtils.hasAnyOf(schema)) {
                 return true;
             }
-            if (schema.getOneOf() != null && !schema.getOneOf().isEmpty()) {
+            if (ModelUtils.hasOneOf(schema)) {
                 return true;
             }
         }
@@ -297,9 +296,9 @@ public class InlineModelResolver {
         if (schema.get$ref() != null) {
             // if ref already, no inline schemas should be present but check for
             // any to catch OpenAPI violations
-            if (isModelNeeded(schema) || "object".equals(schema.getType()) ||
+            if (isModelNeeded(schema) || ModelUtils.isObjectTypeOAS30(schema) ||
                     schema.getProperties() != null || schema.getAdditionalProperties() != null ||
-                    ModelUtils.isComposedSchema(schema)) {
+                ModelUtils.isComposedSchema(schema)) {
                 LOGGER.error("Illegal schema found with $ref combined with other properties," +
                         " no properties should be defined alongside a $ref:\n " + schema.toString());
             }
@@ -308,7 +307,7 @@ public class InlineModelResolver {
         // Check object models / any type models / composed models for properties,
         // if the schema has a type defined that is not "object" it should not define
         // any properties
-        if (schema.getType() == null || "object".equals(schema.getType())) {
+        if (schema.getType() == null || ModelUtils.isObjectTypeOAS30(schema)) {
             // Check properties and recurse, each property could be its own inline model
             Map<String, Schema> props = schema.getProperties();
             if (props != null) {
@@ -640,10 +639,8 @@ public class InlineModelResolver {
         ListIterator<Schema> listIterator = children.listIterator();
         while (listIterator.hasNext()) {
             Schema component = listIterator.next();
-            if ((component != null) &&
-                    (component.get$ref() == null) &&
-                    ((component.getProperties() != null && !component.getProperties().isEmpty()) ||
-                            (component.getEnum() != null && !component.getEnum().isEmpty()))) {
+            boolean componentDoesNotHaveRef = component != null && component.get$ref() == null;
+            if (componentDoesNotHaveRef && (ModelUtils.hasProperties(component) || ModelUtils.hasEnum(component))) {
                 // If a `title` attribute is defined in the inline schema, codegen uses it to name the
                 // inline schema. Otherwise, we'll use the default naming such as InlineObject1, etc.
                 // We know that this is not the best way to name the model.
@@ -839,7 +836,7 @@ public class InlineModelResolver {
                 Schema inner = ModelUtils.getSchemaItems(property);
                 if (ModelUtils.isObjectSchema(inner)) {
                     Schema op = inner;
-                    if (op.getProperties() != null && op.getProperties().size() > 0) {
+                    if (ModelUtils.hasProperties(op)) {
                         flattenProperties(openAPI, op.getProperties(), path);
                         String modelName = resolveModelName(op.getTitle(), path + "_" + key);
                         Schema innerModel = modelFromProperty(openAPI, op, modelName);
@@ -869,7 +866,7 @@ public class InlineModelResolver {
                 Schema inner = ModelUtils.getAdditionalProperties(property);
                 if (ModelUtils.isObjectSchema(inner)) {
                     Schema op = inner;
-                    if (op.getProperties() != null && op.getProperties().size() > 0) {
+                    if (ModelUtils.hasProperties(op)) {
                         flattenProperties(openAPI, op.getProperties(), path);
                         String modelName = resolveModelName(op.getTitle(), path + "_" + key);
                         Schema innerModel = modelFromProperty(openAPI, op, modelName);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -760,19 +760,19 @@ public class OpenAPINormalizer {
                 schema = normalizeComplexComposedSchema(schema, visitedSchemas);
             }
 
-            if (schema.getAllOf() != null && !schema.getAllOf().isEmpty()) {
+            if (ModelUtils.hasAllOf(schema)) {
                 return normalizeAllOf(schema, visitedSchemas);
             }
 
-            if (schema.getOneOf() != null && !schema.getOneOf().isEmpty()) {
+            if (ModelUtils.hasOneOf(schema)) {
                 return normalizeOneOf(schema, visitedSchemas);
             }
 
-            if (schema.getAnyOf() != null && !schema.getAnyOf().isEmpty()) {
+            if (ModelUtils.hasAnyOf(schema)) {
                 return normalizeAnyOf(schema, visitedSchemas);
             }
 
-            if (schema.getProperties() != null && !schema.getProperties().isEmpty()) {
+            if (ModelUtils.hasProperties(schema)) {
                 normalizeProperties(schema, visitedSchemas);
             }
 
@@ -781,7 +781,7 @@ public class OpenAPINormalizer {
             }
 
             return schema;
-        } else if (schema.getProperties() != null && !schema.getProperties().isEmpty()) {
+        } else if (ModelUtils.hasProperties(schema)) {
             normalizeProperties(schema, visitedSchemas);
         } else if (schema.getAdditionalProperties() instanceof Schema) { // map
             normalizeMapSchema(schema);
@@ -1109,7 +1109,7 @@ public class OpenAPINormalizer {
 
     protected Schema normalizeComplexComposedSchema(Schema schema, Set<Schema> visitedSchemas) {
         // loop through properties, if any
-        if (schema.getProperties() != null && !schema.getProperties().isEmpty()) {
+        if (ModelUtils.hasProperties(schema)) {
             normalizeProperties(schema, visitedSchemas);
         }
 
@@ -1294,10 +1294,9 @@ public class OpenAPINormalizer {
             return;
         }
 
-        if (((schema.getOneOf() != null && !schema.getOneOf().isEmpty())
-                || (schema.getAnyOf() != null && !schema.getAnyOf().isEmpty())) // has anyOf or oneOf
-                && (schema.getProperties() != null && !schema.getProperties().isEmpty()) // has properties
-                && schema.getAllOf() == null) { // not allOf
+        boolean hasAnyOfOrOneOf = ModelUtils.hasOneOf(schema) || ModelUtils.hasAnyOf(schema);
+        boolean notAllOf = schema.getAllOf() == null;
+        if (hasAnyOfOrOneOf && ModelUtils.hasProperties(schema) && notAllOf) {
             // clear oneOf, anyOf
             schema.setOneOf(null);
             schema.setAnyOf(null);
@@ -1374,9 +1373,7 @@ public class OpenAPINormalizer {
         if (schema.getAnyOf() == null || schema.getAnyOf().isEmpty()) {
             return schema;
         }
-        if(schema.getOneOf() != null && !schema.getOneOf().isEmpty() ||
-            schema.getAllOf() != null && !schema.getAllOf().isEmpty() ||
-            schema.getNot() != null) {
+        if(ModelUtils.hasOneOf(schema) || ModelUtils.hasAllOf(schema) || schema.getNot() != null) {
             //only convert to enum if anyOf is the only composition
             return schema;
         }
@@ -1399,9 +1396,7 @@ public class OpenAPINormalizer {
         if (schema.getOneOf() == null || schema.getOneOf().isEmpty()) {
             return schema;
         }
-        if(schema.getAnyOf() != null && !schema.getAnyOf().isEmpty() ||
-                schema.getAllOf() != null && !schema.getAllOf().isEmpty() ||
-                schema.getNot() != null) {
+        if(ModelUtils.hasAnyOf(schema) || ModelUtils.hasAllOf(schema) || schema.getNot() != null) {
             //only convert to enum if oneOf is the only composition
             return schema;
         }
@@ -2109,7 +2104,7 @@ public class OpenAPINormalizer {
             // Check object models / any type models / composed models for properties,
             // if the schema has a type defined that is not "object" it should not define
             // any properties
-            if (schema.getType() != null && !"object".equals(schema.getType())) {
+            if (schema.getType() != null && !ModelUtils.isObjectTypeOAS30(schema)) {
                 schema.setProperties(null);
             }
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1383,7 +1383,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             }
             return toArrayDefaultValue(cp, schema);
         } else if (ModelUtils.isMapSchema(schema) && !(ModelUtils.isComposedSchema(schema))) {
-            if (schema.getProperties() != null && schema.getProperties().size() > 0) {
+            if (ModelUtils.hasProperties(schema)) {
                 // object is complex object with free-form additional properties
                 if (schema.getDefault() != null) {
                     return super.toDefaultValue(schema);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -406,7 +406,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
             openAPIType = "UNKNOWN_OPENAPI_TYPE";
         }
 
-        if ((p.getAnyOf() != null && !p.getAnyOf().isEmpty()) || (p.getOneOf() != null && !p.getOneOf().isEmpty())) {
+        if (ModelUtils.hasAnyOf(p) || ModelUtils.hasOneOf(p)) {
             return openAPIType;
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -512,7 +512,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
 
             // if required and optionals
             List<String> reqs = new ArrayList<>();
-            if (schema.getProperties() != null && !schema.getProperties().isEmpty()) {
+            if (ModelUtils.hasProperties(schema)) {
                 for (Object toAdd : schema.getProperties().keySet()) {
                     reqs.add((String) toAdd);
                 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonPydanticV1Codegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonPydanticV1Codegen.java
@@ -483,7 +483,7 @@ public abstract class AbstractPythonPydanticV1Codegen extends DefaultCodegen imp
 
             // if required and optionals
             List<String> reqs = new ArrayList<>();
-            if (schema.getProperties() != null && !schema.getProperties().isEmpty()) {
+            if (ModelUtils.hasProperties(schema)) {
                 for (Object toAdd : schema.getProperties().keySet()) {
                     reqs.add((String) toAdd);
                 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppHttplibServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppHttplibServerCodegen.java
@@ -980,7 +980,7 @@ public class CppHttplibServerCodegen extends AbstractCppCodegen {
                 // Set title for nested inline schemas
                 if (propSchema.getTitle() == null && propSchema.get$ref() == null) {
                     // For nested objects, create a meaningful name
-                    if ("object".equals(propSchema.getType()) || (propSchema.getType() == null && propSchema.getProperties() != null)) {
+                    if (isNestedObject(propSchema)) {
                         String title = toPascalCase(parentName + "_" + propertyName);
                         propSchema.setTitle(title);
 
@@ -995,7 +995,7 @@ public class CppHttplibServerCodegen extends AbstractCppCodegen {
         if (schema.getItems() != null) {
             Schema itemSchema = schema.getItems();
             if (itemSchema.getTitle() == null && itemSchema.get$ref() == null) {
-                if ("object".equals(itemSchema.getType()) || (itemSchema.getType() == null && itemSchema.getProperties() != null)) {
+                if (isNestedObject(itemSchema)) {
                     String title = toPascalCase(parentName + "_item");
                     itemSchema.setTitle(title);
                     processNestedSchemas(itemSchema, title, depth + 1);
@@ -1007,7 +1007,7 @@ public class CppHttplibServerCodegen extends AbstractCppCodegen {
         if (schema.getAdditionalProperties() instanceof Schema) {
             Schema additionalSchema = (Schema) schema.getAdditionalProperties();
             if (additionalSchema.getTitle() == null && additionalSchema.get$ref() == null) {
-                if ("object".equals(additionalSchema.getType()) || (additionalSchema.getType() == null && additionalSchema.getProperties() != null)) {
+                if (isNestedObject(additionalSchema)) {
                     String title = toPascalCase(parentName + "_additional");
                     additionalSchema.setTitle(title);
                     processNestedSchemas(additionalSchema, title, depth + 1);
@@ -1499,7 +1499,7 @@ public class CppHttplibServerCodegen extends AbstractCppCodegen {
     @Override
     @SuppressWarnings({"rawtypes", "unchecked"})
     public String getTypeDeclaration(Schema p) {
-        if (p.getOneOf() != null && !p.getOneOf().isEmpty()) {
+        if (ModelUtils.hasOneOf(p)) {
             // For oneOf, map to std::variant of possible types
             StringBuilder variant = new StringBuilder("std::variant<");
             List<Schema> schemas = p.getOneOf();
@@ -1509,7 +1509,7 @@ public class CppHttplibServerCodegen extends AbstractCppCodegen {
             }
             variant.append(">");
             return variant.toString();
-        } else if (p.getAnyOf() != null && !p.getAnyOf().isEmpty()) {
+        } else if (ModelUtils.hasAnyOf(p)) {
             // For anyOf, also use std::variant to handle multiple possible types
             StringBuilder variant = new StringBuilder("std::variant<");
             List<Schema> schemas = p.getAnyOf();
@@ -1557,7 +1557,7 @@ public class CppHttplibServerCodegen extends AbstractCppCodegen {
             model.name = toModelName(modelName);
             model.classname = model.name;
 
-            if (schema.getAllOf() != null && !schema.getAllOf().isEmpty() && this.openAPI != null) {
+            if (ModelUtils.hasAllOf(schema) && this.openAPI != null) {
                 int refCount = 0;
                 String parentRef = null;
                 Set<String> parentPropertyNames = new HashSet<>();
@@ -1619,7 +1619,7 @@ public class CppHttplibServerCodegen extends AbstractCppCodegen {
             }
 
             // Handle oneOf/anyOf schemas - generate std::variant type alias instead of class
-            if (schema.getOneOf() != null && !schema.getOneOf().isEmpty()) {
+            if (ModelUtils.hasOneOf(schema)) {
                 model.vendorExtensions.put("isOneOfSchema", true);
                 model.vendorExtensions.put("hasVariant", true);
                 List<String> variantTypes = new ArrayList<>();
@@ -1647,7 +1647,7 @@ public class CppHttplibServerCodegen extends AbstractCppCodegen {
                         model.vendorExtensions.put("discriminatorMapping", mappingList);
                     }
                 }
-            } else if (schema.getAnyOf() != null && !schema.getAnyOf().isEmpty()) {
+            } else if (ModelUtils.hasAnyOf(schema)) {
                 model.vendorExtensions.put("isAnyOfSchema", true);
                 model.vendorExtensions.put("hasVariant", true);
                 List<String> variantTypes = new ArrayList<>();
@@ -2569,5 +2569,9 @@ public class CppHttplibServerCodegen extends AbstractCppCodegen {
             supportingFiles.add(new SupportingFile("AuthenticationManager.mustache", "api", "AuthenticationManager.h"));
         }
         return super.postProcessSupportingFileData(objs);
+    }
+
+    private static boolean isNestedObject(Schema<?> schema) {
+        return ModelUtils.isObjectTypeOAS30(schema) || (schema.getType() == null && schema.getProperties() != null);
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestSdkClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestSdkClientCodegen.java
@@ -293,7 +293,7 @@ public class CppRestSdkClientCodegen extends AbstractCppCodegen {
 
         // Handle additionalProperties for models that have both properties and additionalProperties
         Schema addlProps = ModelUtils.getAdditionalProperties(model);
-        if (addlProps != null && model.getProperties() != null && !model.getProperties().isEmpty()) {
+        if (addlProps != null && ModelUtils.hasProperties(model)) {
             // This model has both defined properties AND additionalProperties
             codegenModel.additionalPropertiesType = getTypeDeclaration(addlProps);
             // Add import for web::json::value which is used to store additional properties

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -410,6 +410,25 @@ public class ModelUtils {
         return ref;
     }
 
+    public static boolean hasProperties(Schema<?> schema) {
+        return schema.getProperties() != null && !schema.getProperties().isEmpty();
+    }
+
+    public static boolean hasEnum(Schema<?> schema) {
+        return schema.getEnum() != null && !schema.getEnum().isEmpty();
+    }
+
+    /**
+     * Return true if the specified schema is type object
+     * Only considers OAS 3.0 {@code type} and not OAS 3.1 {@code types}
+     *
+     * @param schema the OAS schema
+     * @return true if the specified schema is an OAS 3.0 {@code object} schema.
+     */
+    public static boolean isObjectTypeOAS30(Schema<?> schema) {
+        return SchemaTypeUtil.OBJECT_TYPE.equals(schema.getType());
+    }
+
     /**
      * Return true if the specified schema is type object
      * We can't use isObjectSchema because it requires properties to exist which is not required
@@ -453,7 +472,7 @@ public class ModelUtils {
                 // must not be a map
                 (SchemaTypeUtil.OBJECT_TYPE.equals(getType(schema)) && !(ModelUtils.isMapSchema(schema))) ||
                 // must have at least one property
-                (getType(schema) == null && schema.getProperties() != null && !schema.getProperties().isEmpty());
+                (getType(schema) == null && hasProperties(schema));
     }
 
     /**
@@ -502,19 +521,19 @@ public class ModelUtils {
     public static boolean isComplexComposedSchema(Schema schema) {
         int count = 0;
 
-        if (schema.getAllOf() != null && !schema.getAllOf().isEmpty()) {
+        if (hasAllOf(schema)) {
             count++;
         }
 
-        if (schema.getOneOf() != null && !schema.getOneOf().isEmpty()) {
+        if (hasOneOf(schema)) {
             count++;
         }
 
-        if (schema.getAnyOf() != null && !schema.getAnyOf().isEmpty()) {
+        if (hasAnyOf(schema)) {
             count++;
         }
 
-        if (schema.getProperties() != null && !schema.getProperties().isEmpty()) {
+        if (hasProperties(schema)) {
             count++;
         }
 
@@ -884,7 +903,7 @@ public class ModelUtils {
                 return false;
             }
 
-            if (schema.getProperties() != null && !schema.getProperties().isEmpty()) { // has properties
+            if (hasProperties(schema)) {
                 return false;
             }
 
@@ -921,7 +940,7 @@ public class ModelUtils {
                 if (schema.getExtensions() != null && schema.getExtensions().containsKey(freeFormExplicit)) {
                     // User has hard-coded vendor extension to handle free-form evaluation.
                     boolean isFreeFormExplicit = Boolean.parseBoolean(String.valueOf(schema.getExtensions().get(freeFormExplicit)));
-                    if (!isFreeFormExplicit && addlProps != null && addlProps.getProperties() != null && !addlProps.getProperties().isEmpty()) {
+                    if (!isFreeFormExplicit && addlProps != null && hasProperties(addlProps)) {
                         once(LOGGER).error(String.format(Locale.ROOT, "Potentially confusing usage of %s within model which defines additional properties", freeFormExplicit));
                     }
                     return isFreeFormExplicit;
@@ -1334,7 +1353,7 @@ public class ModelUtils {
             }
         } else if (schema.getNot() != null) {
             return hasSelfReference(openAPI, schema.getNot(), visitedSchemaNames);
-        } else if (schema.getProperties() != null && !schema.getProperties().isEmpty()) {
+        } else if (hasProperties(schema)) {
             // go through properties to see if there's any self-reference
             for (Schema property : ((Map<String, Schema>) schema.getProperties()).values()) {
                 if (hasSelfReference(openAPI, property, visitedSchemaNames)) {
@@ -1400,7 +1419,7 @@ public class ModelUtils {
             } else if (isComposedSchema(ref)) {
                 return schema;
             } else if (isMapSchema(ref)) {
-                if (ref.getProperties() != null && !ref.getProperties().isEmpty()) // has at least one property
+                if (hasProperties(ref))
                     return schema; // treat it as model
                 else {
                     if (isGenerateAliasAsModel(ref)) {
@@ -1412,7 +1431,7 @@ public class ModelUtils {
                     }
                 }
             } else if (isObjectSchema(ref)) { // model
-                if (ref.getProperties() != null && !ref.getProperties().isEmpty()) { // has at least one property
+                if (hasProperties(ref)) {
                     // TODO we may need to check `hasSelfReference(openAPI, ref)` as a special/edge case:
                     // TODO we may also need to revise below to return `ref` instead of schema
                     // which is the last reference to the actual model/object
@@ -1530,11 +1549,11 @@ public class ModelUtils {
      * @return a list of schema defined in allOf, anyOf or oneOf
      */
     public static List<Schema> getInterfaces(Schema composed) {
-        if (composed.getAllOf() != null && !composed.getAllOf().isEmpty()) {
+        if (hasAllOf(composed)) {
             return composed.getAllOf();
-        } else if (composed.getAnyOf() != null && !composed.getAnyOf().isEmpty()) {
+        } else if (hasAnyOf(composed)) {
             return composed.getAnyOf();
-        } else if (composed.getOneOf() != null && !composed.getOneOf().isEmpty()) {
+        } else if (hasOneOf(composed)) {
             return composed.getOneOf();
         } else {
             return Collections.emptyList();
@@ -2112,7 +2131,7 @@ public class ModelUtils {
      * @return true if the schema contains allOf but no properties/oneOf/anyOf defined.
      */
     public static boolean isAllOfWithProperties(Schema schema) {
-        return hasAllOf(schema) && (schema.getProperties() != null && !schema.getProperties().isEmpty()) &&
+        return hasAllOf(schema) && (hasProperties(schema)) &&
                 (schema.getOneOf() == null || schema.getOneOf().isEmpty()) &&
                 (schema.getAnyOf() == null || schema.getAnyOf().isEmpty());
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
@@ -67,8 +67,8 @@ class OpenApiSchemaValidations extends GenericValidator<SchemaWrapper> {
             // check for loosely defined oneOf extension requirements.
             // This is a recommendation because the 3.0.x spec is not clear enough on usage of oneOf.
             // see https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.9.2.1.3 and the OAS section on 'Composition and Inheritance'.
-            if (schema.getOneOf() != null && schema.getOneOf().size() > 0) {
-                if (schema.getProperties() != null && schema.getProperties().size() >= 1 && schema.getProperties().get("discriminator") == null) {
+            if (ModelUtils.hasOneOf(schema)) {
+                if (ModelUtils.hasProperties(schema) && schema.getProperties().get("discriminator") == null) {
                     // not necessarily "invalid" here, but we trigger the recommendation which requires the method to return false.
                     result = ValidationRule.Fail.empty();
                 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Adds a `SchemaUtils` class with common schema operations. Improves readability and makes the if-cases easier to read as the method name clearly highlights what is checked.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes schema checks in `ModelUtils` and refactors generators/utilities to use them for consistent, clearer logic. No functional changes intended.

- **Refactors**
  - Added helpers in `org.openapitools.codegen.utils.ModelUtils`: `hasAllOf`, `hasOneOf`, `hasAnyOf`, `hasProperties`, `hasEnum`, `isObjectTypeOAS30`.
  - Replaced inline checks across `DefaultCodegen`, `InlineModelResolver`, `OpenAPINormalizer`, language codegens (`AbstractJavaCodegen`, `AbstractPhpCodegen`, `AbstractPythonCodegen`, `AbstractPythonPydanticV1Codegen`, `CppHttplibServerCodegen`, `CppRestSdkClientCodegen`), and `OpenApiSchemaValidations`.
  - C++ server: added local `isNestedObject` and standardized `oneOf`/`anyOf` handling using `std::variant`.

<sup>Written for commit 79df5f598df7b3e120c5b51a6514fc8ce1d006e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

