### PR TITLE
[Java-Spring] Enable bean validation for `spring-http-interface` when configured

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -430,8 +430,6 @@ public class SpringCodegen extends AbstractJavaCodegen
             documentationProvider = DocumentationProvider.NONE;
             annotationLibrary = AnnotationLibrary.NONE;
             useJakartaEe = true;
-            useBeanValidation = false;
-            performBeanValidation = false;
 
             additionalProperties.put(USE_JAKARTA_EE, useJakartaEe);
             additionalProperties.put(USE_BEANVALIDATION, useBeanValidation);
@@ -443,7 +441,7 @@ public class SpringCodegen extends AbstractJavaCodegen
 
             applyJakartaPackage();
 
-            LOGGER.warn("For Spring HTTP Interface following options are disabled: documentProvider, annotationLibrary, useBeanValidation, performBeanValidation. "
+            LOGGER.warn("For Spring HTTP Interface following options are disabled: documentProvider, annotationLibrary. "
                     + "useJakartaEe defaulted to 'true'");
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -430,25 +430,14 @@ public class SpringCodegen extends AbstractJavaCodegen
             documentationProvider = DocumentationProvider.NONE;
             annotationLibrary = AnnotationLibrary.NONE;
             useJakartaEe = true;
-            if (!additionalProperties.containsKey(USE_BEANVALIDATION)) {
-                useBeanValidation = false;
-            } else {
-                Object beanValidationValue = additionalProperties.get(USE_BEANVALIDATION);
-                if (beanValidationValue instanceof Boolean) {
-                    useBeanValidation = (Boolean) beanValidationValue;
-                } else if (beanValidationValue instanceof String) {
-                    useBeanValidation = Boolean.parseBoolean((String) beanValidationValue);
-                }
+
+            if (configOptions.stream().noneMatch(opt -> USE_BEANVALIDATION.equals(opt.getLeft()))) {
+                Object val = additionalProperties.get(USE_BEANVALIDATION);
+                useBeanValidation = val instanceof Boolean ? (Boolean) val : Boolean.parseBoolean(val.toString());
             }
-            if (!additionalProperties.containsKey(PERFORM_BEANVALIDATION)) {
-                performBeanValidation = false;
-            } else {
-                Object performBeanValidationValue = additionalProperties.get(PERFORM_BEANVALIDATION);
-                if (performBeanValidationValue instanceof Boolean) {
-                    performBeanValidation = (Boolean) performBeanValidationValue;
-                } else if (performBeanValidationValue instanceof String) {
-                    performBeanValidation = Boolean.parseBoolean((String) performBeanValidationValue);
-                }
+            if (configOptions.stream().noneMatch(opt -> PERFORM_BEANVALIDATION.equals(opt.getLeft()))) {
+                Object val = additionalProperties.get(PERFORM_BEANVALIDATION);
+                performBeanValidation = val instanceof Boolean ? (Boolean) val : Boolean.parseBoolean(val.toString());
             }
 
             additionalProperties.put(USE_JAKARTA_EE, useJakartaEe);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -639,7 +639,6 @@ public class SpringCodegen extends AbstractJavaCodegen
 
                 supportingFiles.add(new SupportingFile(httpInterfacesAbstractConfiguratorFile,
                         (sourceFolder + File.separator + configPackage).replace(".", java.io.File.separator), "HttpInterfacesAbstractConfigurator.java"));
-                writePropertyBack(USE_BEANVALIDATION, false);
 
                 writePropertyBack(HTTP_INTERFACES_CONFIGURATOR_DEPENDENCY,
                     useHttpServiceProxyFactoryInterfacesConfigurator ?

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -430,6 +430,26 @@ public class SpringCodegen extends AbstractJavaCodegen
             documentationProvider = DocumentationProvider.NONE;
             annotationLibrary = AnnotationLibrary.NONE;
             useJakartaEe = true;
+            if (!additionalProperties.containsKey(USE_BEANVALIDATION)) {
+                useBeanValidation = false;
+            } else {
+                Object beanValidationValue = additionalProperties.get(USE_BEANVALIDATION);
+                if (beanValidationValue instanceof Boolean) {
+                    useBeanValidation = (Boolean) beanValidationValue;
+                } else if (beanValidationValue instanceof String) {
+                    useBeanValidation = Boolean.parseBoolean((String) beanValidationValue);
+                }
+            }
+            if (!additionalProperties.containsKey(PERFORM_BEANVALIDATION)) {
+                performBeanValidation = false;
+            } else {
+                Object performBeanValidationValue = additionalProperties.get(PERFORM_BEANVALIDATION);
+                if (performBeanValidationValue instanceof Boolean) {
+                    performBeanValidation = (Boolean) performBeanValidationValue;
+                } else if (performBeanValidationValue instanceof String) {
+                    performBeanValidation = Boolean.parseBoolean((String) performBeanValidationValue);
+                }
+            }
 
             additionalProperties.put(USE_JAKARTA_EE, useJakartaEe);
             additionalProperties.put(USE_BEANVALIDATION, useBeanValidation);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -6664,4 +6664,42 @@ public class SpringCodegenTest {
         JavaFileAssert.assertThat(files.get("model/package-info.java"))
                 .fileContains("@org.jspecify.annotations.NullMarked");
     }
+
+        @Test
+        public void useBeanValidationTrueWithSpringHttpInterface() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/petstore.yaml", null, new ParseOptions())
+                .getOpenAPI();
+
+        SpringCodegen codegen = new SpringCodegen();
+        codegen.setLibrary(SPRING_HTTP_INTERFACE);
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.setUseBeanValidation(true);
+        codegen.setPerformBeanValidation(true);
+        codegen.setUseSpringBoot3(true);
+
+        ClientOptInput input = new ClientOptInput();
+        input.openAPI(openAPI);
+        input.config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.setGenerateMetadata(false);
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+
+        generator.opts(input).generate();
+
+        Path pet = Paths.get(
+                output.getAbsolutePath(),
+                "src/main/java/org/openapitools/model/Pet.java"
+        );
+
+        String content = Files.readString(pet);
+
+        assertThat(content).contains("@NotNull");
+        }
 }

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/api/UserApi.java
@@ -55,7 +55,7 @@ public interface UserApi {
         contentType = "application/json"
     )
     void createUsersWithArrayInput(
-         @RequestBody List<UserDto> userDto
+         @RequestBody List<@Valid UserDto> userDto
     );
 
 
@@ -74,7 +74,7 @@ public interface UserApi {
         contentType = "application/json"
     )
     void createUsersWithListInput(
-         @RequestBody List<UserDto> userDto
+         @RequestBody List<@Valid UserDto> userDto
     );
 
 

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ArrayTestDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ArrayTestDto.java
@@ -33,7 +33,7 @@ public class ArrayTestDto {
   private List<List<Long>> arrayArrayOfInteger = new ArrayList<>();
 
   
-  private List<List<ReadOnlyFirstDto>> arrayArrayOfModel = new ArrayList<>();
+  private List<List<@Valid ReadOnlyFirstDto>> arrayArrayOfModel = new ArrayList<>();
 
   public ArrayTestDto arrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
@@ -91,12 +91,12 @@ public class ArrayTestDto {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
-  public ArrayTestDto arrayArrayOfModel(List<List<ReadOnlyFirstDto>> arrayArrayOfModel) {
+  public ArrayTestDto arrayArrayOfModel(List<List<@Valid ReadOnlyFirstDto>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
 
-  public ArrayTestDto addArrayArrayOfModelItem(List<ReadOnlyFirstDto> arrayArrayOfModelItem) {
+  public ArrayTestDto addArrayArrayOfModelItem(List<@Valid ReadOnlyFirstDto> arrayArrayOfModelItem) {
     if (this.arrayArrayOfModel == null) {
       this.arrayArrayOfModel = new ArrayList<>();
     }
@@ -110,12 +110,12 @@ public class ArrayTestDto {
    */
   
   @JsonProperty("array_array_of_model")
-  public List<List<ReadOnlyFirstDto>> getArrayArrayOfModel() {
+  public List<List<@Valid ReadOnlyFirstDto>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
 
   @JsonProperty("array_array_of_model")
-  public void setArrayArrayOfModel(List<List<ReadOnlyFirstDto>> arrayArrayOfModel) {
+  public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirstDto>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }
 

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/FileSchemaTestClassDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/FileSchemaTestClassDto.java
@@ -29,7 +29,7 @@ public class FileSchemaTestClassDto {
   private @Nullable FileDto file;
 
   
-  private List<FileDto> files = new ArrayList<>();
+  private List<@Valid FileDto> files = new ArrayList<>();
 
   public FileSchemaTestClassDto file(@Nullable FileDto file) {
     this.file = file;
@@ -51,7 +51,7 @@ public class FileSchemaTestClassDto {
     this.file = file;
   }
 
-  public FileSchemaTestClassDto files(List<FileDto> files) {
+  public FileSchemaTestClassDto files(List<@Valid FileDto> files) {
     this.files = files;
     return this;
   }
@@ -70,12 +70,12 @@ public class FileSchemaTestClassDto {
    */
   
   @JsonProperty("files")
-  public List<FileDto> getFiles() {
+  public List<@Valid FileDto> getFiles() {
     return files;
   }
 
   @JsonProperty("files")
-  public void setFiles(List<FileDto> files) {
+  public void setFiles(List<@Valid FileDto> files) {
     this.files = files;
   }
 

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/PetDto.java
@@ -41,7 +41,7 @@ public class PetDto {
   private Set<String> photoUrls = new LinkedHashSet<>();
 
   
-  private List<TagDto> tags = new ArrayList<>();
+  private List<@Valid TagDto> tags = new ArrayList<>();
 
   /**
    * pet status in the store
@@ -176,7 +176,7 @@ public class PetDto {
     this.photoUrls = photoUrls;
   }
 
-  public PetDto tags(List<TagDto> tags) {
+  public PetDto tags(List<@Valid TagDto> tags) {
     this.tags = tags;
     return this;
   }
@@ -195,12 +195,12 @@ public class PetDto {
    */
   
   @JsonProperty("tags")
-  public List<TagDto> getTags() {
+  public List<@Valid TagDto> getTags() {
     return tags;
   }
 
   @JsonProperty("tags")
-  public void setTags(List<TagDto> tags) {
+  public void setTags(List<@Valid TagDto> tags) {
     this.tags = tags;
   }
 

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ArrayTest.java
@@ -31,7 +31,7 @@ public class ArrayTest {
   private List<List<Long>> arrayArrayOfInteger = new ArrayList<>();
 
   
-  private List<List<ReadOnlyFirst>> arrayArrayOfModel = new ArrayList<>();
+  private List<List<@Valid ReadOnlyFirst>> arrayArrayOfModel = new ArrayList<>();
 
   public ArrayTest arrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
@@ -89,12 +89,12 @@ public class ArrayTest {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
-  public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+  public ArrayTest arrayArrayOfModel(List<List<@Valid ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
 
-  public ArrayTest addArrayArrayOfModelItem(List<ReadOnlyFirst> arrayArrayOfModelItem) {
+  public ArrayTest addArrayArrayOfModelItem(List<@Valid ReadOnlyFirst> arrayArrayOfModelItem) {
     if (this.arrayArrayOfModel == null) {
       this.arrayArrayOfModel = new ArrayList<>();
     }
@@ -108,12 +108,12 @@ public class ArrayTest {
    */
   
   @JsonProperty("array_array_of_model")
-  public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
+  public List<List<@Valid ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
 
   @JsonProperty("array_array_of_model")
-  public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+  public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }
 

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -27,7 +27,7 @@ public class FileSchemaTestClass {
   private @Nullable File file;
 
   
-  private List<File> files = new ArrayList<>();
+  private List<@Valid File> files = new ArrayList<>();
 
   public FileSchemaTestClass file(@Nullable File file) {
     this.file = file;
@@ -49,7 +49,7 @@ public class FileSchemaTestClass {
     this.file = file;
   }
 
-  public FileSchemaTestClass files(List<File> files) {
+  public FileSchemaTestClass files(List<@Valid File> files) {
     this.files = files;
     return this;
   }
@@ -68,12 +68,12 @@ public class FileSchemaTestClass {
    */
   
   @JsonProperty("files")
-  public List<File> getFiles() {
+  public List<@Valid File> getFiles() {
     return files;
   }
 
   @JsonProperty("files")
-  public void setFiles(List<File> files) {
+  public void setFiles(List<@Valid File> files) {
     this.files = files;
   }
 

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/Pet.java
@@ -39,7 +39,7 @@ public class Pet {
   private Set<String> photoUrls = new LinkedHashSet<>();
 
   
-  private List<Tag> tags = new ArrayList<>();
+  private List<@Valid Tag> tags = new ArrayList<>();
 
   /**
    * pet status in the store
@@ -182,7 +182,7 @@ public class Pet {
     this.photoUrls = photoUrls;
   }
 
-  public Pet tags(List<Tag> tags) {
+  public Pet tags(List<@Valid Tag> tags) {
     this.tags = tags;
     return this;
   }
@@ -201,12 +201,12 @@ public class Pet {
    */
   
   @JsonProperty("tags")
-  public List<Tag> getTags() {
+  public List<@Valid Tag> getTags() {
     return tags;
   }
 
   @JsonProperty("tags")
-  public void setTags(List<Tag> tags) {
+  public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
 

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ArrayTest.java
@@ -31,7 +31,7 @@ public class ArrayTest {
   private List<List<Long>> arrayArrayOfInteger = new ArrayList<>();
 
   
-  private List<List<ReadOnlyFirst>> arrayArrayOfModel = new ArrayList<>();
+  private List<List<@Valid ReadOnlyFirst>> arrayArrayOfModel = new ArrayList<>();
 
   public ArrayTest arrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
@@ -89,12 +89,12 @@ public class ArrayTest {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
-  public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+  public ArrayTest arrayArrayOfModel(List<List<@Valid ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
 
-  public ArrayTest addArrayArrayOfModelItem(List<ReadOnlyFirst> arrayArrayOfModelItem) {
+  public ArrayTest addArrayArrayOfModelItem(List<@Valid ReadOnlyFirst> arrayArrayOfModelItem) {
     if (this.arrayArrayOfModel == null) {
       this.arrayArrayOfModel = new ArrayList<>();
     }
@@ -108,12 +108,12 @@ public class ArrayTest {
    */
   
   @JsonProperty("array_array_of_model")
-  public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
+  public List<List<@Valid ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
 
   @JsonProperty("array_array_of_model")
-  public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+  public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }
 

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -27,7 +27,7 @@ public class FileSchemaTestClass {
   private @Nullable File file;
 
   
-  private List<File> files = new ArrayList<>();
+  private List<@Valid File> files = new ArrayList<>();
 
   public FileSchemaTestClass file(@Nullable File file) {
     this.file = file;
@@ -49,7 +49,7 @@ public class FileSchemaTestClass {
     this.file = file;
   }
 
-  public FileSchemaTestClass files(List<File> files) {
+  public FileSchemaTestClass files(List<@Valid File> files) {
     this.files = files;
     return this;
   }
@@ -68,12 +68,12 @@ public class FileSchemaTestClass {
    */
   
   @JsonProperty("files")
-  public List<File> getFiles() {
+  public List<@Valid File> getFiles() {
     return files;
   }
 
   @JsonProperty("files")
-  public void setFiles(List<File> files) {
+  public void setFiles(List<@Valid File> files) {
     this.files = files;
   }
 

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/Pet.java
@@ -39,7 +39,7 @@ public class Pet {
   private Set<String> photoUrls = new LinkedHashSet<>();
 
   
-  private List<Tag> tags = new ArrayList<>();
+  private List<@Valid Tag> tags = new ArrayList<>();
 
   /**
    * pet status in the store
@@ -182,7 +182,7 @@ public class Pet {
     this.photoUrls = photoUrls;
   }
 
-  public Pet tags(List<Tag> tags) {
+  public Pet tags(List<@Valid Tag> tags) {
     this.tags = tags;
     return this;
   }
@@ -201,12 +201,12 @@ public class Pet {
    */
   
   @JsonProperty("tags")
-  public List<Tag> getTags() {
+  public List<@Valid Tag> getTags() {
     return tags;
   }
 
   @JsonProperty("tags")
-  public void setTags(List<Tag> tags) {
+  public void setTags(List<@Valid Tag> tags) {
     this.tags = tags;
   }
 

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/api/UserApi.java
@@ -53,7 +53,7 @@ public interface UserApi {
         contentType = "application/json"
     )
     ResponseEntity<Void> createUsersWithArrayInput(
-         @RequestBody List<UserDto> userDto
+         @RequestBody List<@Valid UserDto> userDto
     );
 
 
@@ -71,7 +71,7 @@ public interface UserApi {
         contentType = "application/json"
     )
     ResponseEntity<Void> createUsersWithListInput(
-         @RequestBody List<UserDto> userDto
+         @RequestBody List<@Valid UserDto> userDto
     );
 
 

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ArrayTestDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/ArrayTestDto.java
@@ -32,7 +32,7 @@ public class ArrayTestDto {
   private List<List<Long>> arrayArrayOfInteger = new ArrayList<>();
 
   
-  private List<List<ReadOnlyFirstDto>> arrayArrayOfModel = new ArrayList<>();
+  private List<List<@Valid ReadOnlyFirstDto>> arrayArrayOfModel = new ArrayList<>();
 
   public ArrayTestDto arrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
@@ -90,12 +90,12 @@ public class ArrayTestDto {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
-  public ArrayTestDto arrayArrayOfModel(List<List<ReadOnlyFirstDto>> arrayArrayOfModel) {
+  public ArrayTestDto arrayArrayOfModel(List<List<@Valid ReadOnlyFirstDto>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
 
-  public ArrayTestDto addArrayArrayOfModelItem(List<ReadOnlyFirstDto> arrayArrayOfModelItem) {
+  public ArrayTestDto addArrayArrayOfModelItem(List<@Valid ReadOnlyFirstDto> arrayArrayOfModelItem) {
     if (this.arrayArrayOfModel == null) {
       this.arrayArrayOfModel = new ArrayList<>();
     }
@@ -109,12 +109,12 @@ public class ArrayTestDto {
    */
   
   @JsonProperty("array_array_of_model")
-  public List<List<ReadOnlyFirstDto>> getArrayArrayOfModel() {
+  public List<List<@Valid ReadOnlyFirstDto>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
 
   @JsonProperty("array_array_of_model")
-  public void setArrayArrayOfModel(List<List<ReadOnlyFirstDto>> arrayArrayOfModel) {
+  public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirstDto>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }
 

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/FileSchemaTestClassDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/FileSchemaTestClassDto.java
@@ -28,7 +28,7 @@ public class FileSchemaTestClassDto {
   private @Nullable FileDto file;
 
   
-  private List<FileDto> files = new ArrayList<>();
+  private List<@Valid FileDto> files = new ArrayList<>();
 
   public FileSchemaTestClassDto file(@Nullable FileDto file) {
     this.file = file;
@@ -50,7 +50,7 @@ public class FileSchemaTestClassDto {
     this.file = file;
   }
 
-  public FileSchemaTestClassDto files(List<FileDto> files) {
+  public FileSchemaTestClassDto files(List<@Valid FileDto> files) {
     this.files = files;
     return this;
   }
@@ -69,12 +69,12 @@ public class FileSchemaTestClassDto {
    */
   
   @JsonProperty("files")
-  public List<FileDto> getFiles() {
+  public List<@Valid FileDto> getFiles() {
     return files;
   }
 
   @JsonProperty("files")
-  public void setFiles(List<FileDto> files) {
+  public void setFiles(List<@Valid FileDto> files) {
     this.files = files;
   }
 

--- a/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface-springboot-4/src/main/java/org/openapitools/model/PetDto.java
@@ -40,7 +40,7 @@ public class PetDto {
   private Set<String> photoUrls = new LinkedHashSet<>();
 
   
-  private List<TagDto> tags = new ArrayList<>();
+  private List<@Valid TagDto> tags = new ArrayList<>();
 
   /**
    * pet status in the store
@@ -175,7 +175,7 @@ public class PetDto {
     this.photoUrls = photoUrls;
   }
 
-  public PetDto tags(List<TagDto> tags) {
+  public PetDto tags(List<@Valid TagDto> tags) {
     this.tags = tags;
     return this;
   }
@@ -194,12 +194,12 @@ public class PetDto {
    */
   
   @JsonProperty("tags")
-  public List<TagDto> getTags() {
+  public List<@Valid TagDto> getTags() {
     return tags;
   }
 
   @JsonProperty("tags")
-  public void setTags(List<TagDto> tags) {
+  public void setTags(List<@Valid TagDto> tags) {
     this.tags = tags;
   }
 

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/api/UserApi.java
@@ -53,7 +53,7 @@ public interface UserApi {
         contentType = "application/json"
     )
     ResponseEntity<Void> createUsersWithArrayInput(
-         @RequestBody List<UserDto> userDto
+         @RequestBody List<@Valid UserDto> userDto
     );
 
 
@@ -71,7 +71,7 @@ public interface UserApi {
         contentType = "application/json"
     )
     ResponseEntity<Void> createUsersWithListInput(
-         @RequestBody List<UserDto> userDto
+         @RequestBody List<@Valid UserDto> userDto
     );
 
 

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ArrayTestDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ArrayTestDto.java
@@ -33,7 +33,7 @@ public class ArrayTestDto {
   private List<List<Long>> arrayArrayOfInteger = new ArrayList<>();
 
   
-  private List<List<ReadOnlyFirstDto>> arrayArrayOfModel = new ArrayList<>();
+  private List<List<@Valid ReadOnlyFirstDto>> arrayArrayOfModel = new ArrayList<>();
 
   public ArrayTestDto arrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
@@ -91,12 +91,12 @@ public class ArrayTestDto {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
-  public ArrayTestDto arrayArrayOfModel(List<List<ReadOnlyFirstDto>> arrayArrayOfModel) {
+  public ArrayTestDto arrayArrayOfModel(List<List<@Valid ReadOnlyFirstDto>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
 
-  public ArrayTestDto addArrayArrayOfModelItem(List<ReadOnlyFirstDto> arrayArrayOfModelItem) {
+  public ArrayTestDto addArrayArrayOfModelItem(List<@Valid ReadOnlyFirstDto> arrayArrayOfModelItem) {
     if (this.arrayArrayOfModel == null) {
       this.arrayArrayOfModel = new ArrayList<>();
     }
@@ -110,12 +110,12 @@ public class ArrayTestDto {
    */
   
   @JsonProperty("array_array_of_model")
-  public List<List<ReadOnlyFirstDto>> getArrayArrayOfModel() {
+  public List<List<@Valid ReadOnlyFirstDto>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
 
   @JsonProperty("array_array_of_model")
-  public void setArrayArrayOfModel(List<List<ReadOnlyFirstDto>> arrayArrayOfModel) {
+  public void setArrayArrayOfModel(List<List<@Valid ReadOnlyFirstDto>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }
 

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/FileSchemaTestClassDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/FileSchemaTestClassDto.java
@@ -29,7 +29,7 @@ public class FileSchemaTestClassDto {
   private @Nullable FileDto file;
 
   
-  private List<FileDto> files = new ArrayList<>();
+  private List<@Valid FileDto> files = new ArrayList<>();
 
   public FileSchemaTestClassDto file(@Nullable FileDto file) {
     this.file = file;
@@ -51,7 +51,7 @@ public class FileSchemaTestClassDto {
     this.file = file;
   }
 
-  public FileSchemaTestClassDto files(List<FileDto> files) {
+  public FileSchemaTestClassDto files(List<@Valid FileDto> files) {
     this.files = files;
     return this;
   }
@@ -70,12 +70,12 @@ public class FileSchemaTestClassDto {
    */
   
   @JsonProperty("files")
-  public List<FileDto> getFiles() {
+  public List<@Valid FileDto> getFiles() {
     return files;
   }
 
   @JsonProperty("files")
-  public void setFiles(List<FileDto> files) {
+  public void setFiles(List<@Valid FileDto> files) {
     this.files = files;
   }
 

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/PetDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/PetDto.java
@@ -41,7 +41,7 @@ public class PetDto {
   private Set<String> photoUrls = new LinkedHashSet<>();
 
   
-  private List<TagDto> tags = new ArrayList<>();
+  private List<@Valid TagDto> tags = new ArrayList<>();
 
   /**
    * pet status in the store
@@ -176,7 +176,7 @@ public class PetDto {
     this.photoUrls = photoUrls;
   }
 
-  public PetDto tags(List<TagDto> tags) {
+  public PetDto tags(List<@Valid TagDto> tags) {
     this.tags = tags;
     return this;
   }
@@ -195,12 +195,12 @@ public class PetDto {
    */
   
   @JsonProperty("tags")
-  public List<TagDto> getTags() {
+  public List<@Valid TagDto> getTags() {
     return tags;
   }
 
   @JsonProperty("tags")
-  public void setTags(List<TagDto> tags) {
+  public void setTags(List<@Valid TagDto> tags) {
     this.tags = tags;
   }
 


### PR DESCRIPTION
## Description

The current logic for spring-http-interface always sets `useBeanValidation` and `performBeanValidation` to false, which serves problematic when fields are expected to not be nullable. This ensures that if they are set to true, the generated classes contain the `@NotNull` generation alongside those variables. 

This MR will fix #23585 

## Changes

 - `modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java` I removed the logic which always sets them to false and follows through with setting them based on their expected value. 
 - `modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java` tests to ensure the file is generated as expected

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable bean validation in `spring-http-interface` when `useBeanValidation` and `performBeanValidation` are enabled. Generates `@NotNull` for required fields and applies `@Valid` to collection elements and request body lists. Fixes #23585.

- **Bug Fixes**
  - Respect `useBeanValidation`/`performBeanValidation` instead of forcing `false`; parse boolean or string values and default to `false` when unset; removed forced `writePropertyBack(USE_BEANVALIDATION, false)`.
  - Update the warning to only disable `documentationProvider` and `annotationLibrary`; keep `useJakartaEe` defaulted to `true`.
  - Add a unit test verifying `@NotNull` generation when both flags are true; regenerate samples to add `List<@Valid ...>` and nested collection `@Valid` across variants.

<sup>Written for commit 4888232751218b5eb04042a68cc7649a5c1310a5. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23609?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

