### PR TITLE
[Fix][scala-sttp][circe] Add NaN-tolerant Decoder[Double] for non-finite values

### DIFF
--- a/modules/openapi-generator/src/main/resources/scala-sttp/additionalTypeSerializers.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp/additionalTypeSerializers.mustache
@@ -71,5 +71,13 @@ trait AdditionalTypeSerializers {
     case s: String => Json.fromString(s)
     case other => Json.fromString(other.toString)
   }
+
+  implicit final lazy val NanTolerantDoubleDecoder: Decoder[Double] =
+    Decoder.decodeDouble.or(Decoder.decodeString.emap {
+      case "NaN" => Right(Double.NaN)
+      case "Infinity" => Right(Double.PositiveInfinity)
+      case "-Infinity" => Right(Double.NegativeInfinity)
+      case s => Left(s"Cannot decode '$s' as Double")
+  })
 }
 {{/circe}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/ScalaSttpCirceCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/ScalaSttpCirceCodegenTest.java
@@ -73,12 +73,16 @@ public class ScalaSttpCirceCodegenTest {
         assertFileContains(binaryPath, "implicit val encoderBinaryPayload");
         assertFileContains(binaryPath, "implicit val decoderBinaryPayload");
 
-        // AdditionalTypeSerializers: File and Any codecs
+        // AdditionalTypeSerializers: File, Any, and NaN-tolerant Double codecs
         Path serializersPath = Paths.get(outputPath + "/src/main/scala/org/openapitools/client/core/AdditionalTypeSerializers.scala");
         assertFileContains(serializersPath, "FileDecoder");
         assertFileContains(serializersPath, "FileEncoder");
         assertFileContains(serializersPath, "AnyDecoder");
         assertFileContains(serializersPath, "AnyEncoder");
+        assertFileContains(serializersPath, "NanTolerantDoubleDecoder");
+        assertFileContains(serializersPath, "Double.NaN");
+        assertFileContains(serializersPath, "Double.PositiveInfinity");
+        assertFileContains(serializersPath, "Double.NegativeInfinity");
 
         // JsonSupport should NOT use AutoDerivation
         Path jsonSupportPath = Paths.get(outputPath + "/src/main/scala/org/openapitools/client/core/JsonSupport.scala");

--- a/samples/client/petstore/scala-sttp-circe/src/main/scala/org/openapitools/client/core/AdditionalTypeSerializers.scala
+++ b/samples/client/petstore/scala-sttp-circe/src/main/scala/org/openapitools/client/core/AdditionalTypeSerializers.scala
@@ -48,4 +48,12 @@ trait AdditionalTypeSerializers {
     case s: String => Json.fromString(s)
     case other => Json.fromString(other.toString)
   }
+
+  implicit final lazy val NanTolerantDoubleDecoder: Decoder[Double] =
+    Decoder.decodeDouble.or(Decoder.decodeString.emap {
+      case "NaN" => Right(Double.NaN)
+      case "Infinity" => Right(Double.PositiveInfinity)
+      case "-Infinity" => Right(Double.NegativeInfinity)
+      case s => Left(s"Cannot decode '$s' as Double")
+  })
 }


### PR DESCRIPTION
Fixes [#23610](https://github.com/OpenAPITools/openapi-generator/issues/23610).

Adds a NaN-tolerant `Decoder[Double]` to the `scala-sttp` + `circe` generator. The default `Decoder.decodeDouble` rejects the JSON strings `"NaN"`, `"Infinity"`, `"-Infinity"` - values many servers emit when Jackson encounters non-finite doubles. Generated clients hit `DecodingFailure` on any response containing such a value.

The new `NanTolerantDoubleDecoder` is added to `AdditionalTypeSerializers` so it applies to every generated model's `Double` fields. Strict numeric parsing stays as the first path; string fallback only handles the three non-finite IEEE 754 values.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ```
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @chameleon82 (Scala sttp)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a NaN-tolerant `Decoder[Double]` to the `scala-sttp` generator with `circe` to accept "NaN", "Infinity", and "-Infinity". Prevents response decoding failures when servers emit these non-finite numbers. Fixes #23610.

- **Bug Fixes**
  - Added `NanTolerantDoubleDecoder` in `AdditionalTypeSerializers`; tries strict numeric first, then string fallback for the three IEEE 754 values.
  - Applies to all generated `Double` fields.
  - Updated tests and the petstore sample to cover the new decoder.

<sup>Written for commit 8641a018b5b92a13297617171f30610c58368181. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

