### PR TITLE
[Fix][scala-sttp][circe] Add Base64OrArrayByteDecoder for `format:byte` and `format:binary` JSON properties

### DIFF
--- a/modules/openapi-generator/src/main/resources/scala-sttp/additionalTypeSerializers.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp/additionalTypeSerializers.mustache
@@ -27,6 +27,7 @@ object AdditionalTypeSerializers {
 {{#circe}}
 import java.io.File
 import java.nio.file.Files
+import java.util.Base64
 
 trait AdditionalTypeSerializers {
   import io.circe._
@@ -79,5 +80,11 @@ trait AdditionalTypeSerializers {
       case "-Infinity" => Right(Double.NegativeInfinity)
       case s => Left(s"Cannot decode '$s' as Double")
   })
+
+  implicit final lazy val Base64OrArrayByteDecoder: Decoder[Array[Byte]] =
+    Decoder.decodeArray[Byte].or(Decoder.decodeString.emap { s =>
+      try Right(Base64.getDecoder.decode(s))
+      catch { case _: IllegalArgumentException => Left(s"Cannot decode '$s' as Base64 Array[Byte]") }
+    })
 }
 {{/circe}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/ScalaSttpCirceCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/ScalaSttpCirceCodegenTest.java
@@ -70,6 +70,7 @@ public class ScalaSttpCirceCodegenTest {
         // BinaryPayload: File and untyped object fields
         Path binaryPath = Paths.get(outputPath + "/src/main/scala/org/openapitools/client/model/BinaryPayload.scala");
         assertFileContains(binaryPath, "data: Option[File]");
+        assertFileContains(binaryPath, "checksum: Option[Array[Byte]]");
         assertFileContains(binaryPath, "implicit val encoderBinaryPayload");
         assertFileContains(binaryPath, "implicit val decoderBinaryPayload");
 
@@ -83,6 +84,8 @@ public class ScalaSttpCirceCodegenTest {
         assertFileContains(serializersPath, "Double.NaN");
         assertFileContains(serializersPath, "Double.PositiveInfinity");
         assertFileContains(serializersPath, "Double.NegativeInfinity");
+        assertFileContains(serializersPath, "Base64OrArrayByteDecoder");
+        assertFileContains(serializersPath, "Base64.getDecoder.decode");
 
         // JsonSupport should NOT use AutoDerivation
         Path jsonSupportPath = Paths.get(outputPath + "/src/main/scala/org/openapitools/client/core/JsonSupport.scala");

--- a/modules/openapi-generator/src/test/resources/3_0/scala/mixed-case-fields.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/scala/mixed-case-fields.yaml
@@ -34,6 +34,9 @@ components:
         data:
           type: string
           format: binary
+        checksum:
+          type: string
+          format: byte
         metadata:
           type: object
     Animal:

--- a/samples/client/petstore/scala-sttp-circe/src/main/scala/org/openapitools/client/core/AdditionalTypeSerializers.scala
+++ b/samples/client/petstore/scala-sttp-circe/src/main/scala/org/openapitools/client/core/AdditionalTypeSerializers.scala
@@ -4,6 +4,7 @@ import java.net.{ URI, URISyntaxException }
 
 import java.io.File
 import java.nio.file.Files
+import java.util.Base64
 
 trait AdditionalTypeSerializers {
   import io.circe._
@@ -56,4 +57,10 @@ trait AdditionalTypeSerializers {
       case "-Infinity" => Right(Double.NegativeInfinity)
       case s => Left(s"Cannot decode '$s' as Double")
   })
+
+  implicit final lazy val FlexibleByteArrayDecoder: Decoder[Array[Byte]] =
+    Decoder.decodeArray[Byte].or(Decoder.decodeString.emap { s =>
+      try Right(Base64.getDecoder.decode(s))
+      catch { case _: IllegalArgumentException => Left(s"Cannot decode '$s' as Base64 Array[Byte]") }
+    })
 }

--- a/samples/client/petstore/scala-sttp-circe/src/main/scala/org/openapitools/client/core/AdditionalTypeSerializers.scala
+++ b/samples/client/petstore/scala-sttp-circe/src/main/scala/org/openapitools/client/core/AdditionalTypeSerializers.scala
@@ -58,7 +58,7 @@ trait AdditionalTypeSerializers {
       case s => Left(s"Cannot decode '$s' as Double")
   })
 
-  implicit final lazy val FlexibleByteArrayDecoder: Decoder[Array[Byte]] =
+  implicit final lazy val Base64OrArrayByteDecoder: Decoder[Array[Byte]] =
     Decoder.decodeArray[Byte].or(Decoder.decodeString.emap { s =>
       try Right(Base64.getDecoder.decode(s))
       catch { case _: IllegalArgumentException => Left(s"Cannot decode '$s' as Base64 Array[Byte]") }


### PR DESCRIPTION
Fixes [#23618](https://github.com/OpenAPITools/openapi-generator/issues/23618).

cc @clasnake (2017/07), @shijinkui (2018/01), @ramzimaalej (2018/03), @chameleon82 (2020/03), @Bouillie (2020/04) @Fish86 (2023/06)

Adds `FlexibleByteArrayDecoder: Decoder[Array[Byte]]` to `additionalTypeSerializers.mustache` for the `scala-sttp` circe generator.

**Problem:** Properties with `format: byte` generate `Option[Array[Byte]]`, but circe's derived `Decoder[Array[Byte]]` expects a JSON number array. Jackson serializes `byte[]` fields as Base64 strings, so decoding always fails at runtime with `DecodingFailure at .field: Array[Byte]`. The existing `FileDecoder` (used for `format: binary` JSON properties) is also broken for the same reason, since it delegates to `Decoder[Array[Byte]]`.

**Fix:** The new decoder tries JSON array first (strict OAS compliance), then falls back to Base64 string decoding

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ```
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #23618. Adds `Base64OrArrayByteDecoder` to the `scala-sttp` `circe` generator so `format: byte` and `format: binary` fields decode from JSON arrays or Base64 strings without runtime failures.

- **Bug Fixes**
  - Implemented `Base64OrArrayByteDecoder: Decoder[Array[Byte]]` (array-first, Base64 fallback).
  - Updated `additionalTypeSerializers.mustache` with the decoder and `java.util.Base64` import.
  - Extended tests and samples to assert decoder emission and map `checksum: byte` to `Option[Array[Byte]]`.

<sup>Written for commit caffe64f05944a4d931ffcd91e7a9266981a3c88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



