### PR TITLE
[POWERSHELL] fix: single-quote DTO property names to prevent $-variable interpolation (fixes #23535)

### DIFF
--- a/modules/openapi-generator/src/main/resources/powershell/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/model_simple.mustache
@@ -122,7 +122,7 @@ function Initialize-{{{apiNamePrefix}}}{{{classname}}} {
         $PSO = [PSCustomObject]@{
             {{=<< >>=}}
             <<#allVars>>
-            "<<baseName>>" = ${<<name>>}
+            '<<baseName>>' = ${<<name>>}
             <</allVars>>
             <<={{ }}=>>
         }
@@ -184,7 +184,7 @@ function Initialize-{{{apiNamePrefix}}}{{{classname}}} {
             {{=<< >>=}}
             <<#allVars>>
             <<^isReadOnly>>
-            "<<baseName>>" = ${<<name>>}
+            '<<baseName>>' = ${<<name>>}
             <</isReadOnly>>
             <</allVars>>
             <<={{ }}=>>
@@ -228,7 +228,7 @@ function ConvertFrom-{{{apiNamePrefix}}}JsonTo{{{classname}}} {
         {{/isAdditionalPropertiesTrue}}
 
         # check if Json contains properties not defined in {{{apiNamePrefix}}}{{{classname}}}
-        $AllProperties = ({{#allVars}}"{{{baseName}}}"{{^-last}}, {{/-last}}{{/allVars}})
+        $AllProperties = ({{#allVars}}'{{{baseName}}}'{{^-last}}, {{/-last}}{{/allVars}})
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             {{^isAdditionalPropertiesTrue}}
             if (!($AllProperties.Contains($name))) {
@@ -250,29 +250,29 @@ function ConvertFrom-{{{apiNamePrefix}}}JsonTo{{{classname}}} {
         }
 
         {{/-first}}
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "{{{baseName}}}"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match '{{{baseName}}}'))) {
             throw "Error! JSON cannot be serialized due to the required property '{{{baseName}}}' missing."
         } else {
-            ${{name}} = $JsonParameters.PSobject.Properties["{{{baseName}}}"].value
+            ${{name}} = $JsonParameters.PSobject.Properties['{{{baseName}}}'].value
         }
 
         {{/requiredVars}}
         {{#optionalVars}}
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "{{{baseName}}}"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match '{{{baseName}}}'))) { #optional property not found
             ${{name}} = $null
         } else {
-            ${{name}} = $JsonParameters.PSobject.Properties["{{{baseName}}}"].value
+            ${{name}} = $JsonParameters.PSobject.Properties['{{{baseName}}}'].value
         }
 
         {{/optionalVars}}
         $PSO = [PSCustomObject]@{
             {{=<< >>=}}
             <<#allVars>>
-            "<<baseName>>" = ${<<name>>}
+            '<<baseName>>' = ${<<name>>}
             <</allVars>>
             <<={{ }}=>>
             {{#isAdditionalPropertiesTrue}}
-            "AdditionalProperties" = ${{{apiNamePrefix}}}{{{classname}}}AdditionalProperties
+            'AdditionalProperties' = ${{{apiNamePrefix}}}{{{classname}}}AdditionalProperties
             {{/isAdditionalPropertiesTrue}}
         }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/powershell/PowerShellClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/powershell/PowerShellClientCodegenTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ * Copyright 2018 SmartBear Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.powershell;
+
+import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import org.openapitools.codegen.ClientOptInput;
+import org.openapitools.codegen.CodegenConstants;
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.languages.PowerShellClientCodegen;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.openapitools.codegen.TestUtils.assertFileContains;
+import static org.openapitools.codegen.TestUtils.assertFileNotContains;
+
+public class PowerShellClientCodegenTest {
+
+    /**
+     * Regression test for <a href="https://github.com/OpenAPITools/openapi-generator/issues/23535">#23535</a>.
+     *
+     * PowerShell treats {@code $} inside double-quoted strings as the sigil for
+     * variable interpolation, so hash-table keys emitted as {@code "$foo"} get
+     * rewritten at runtime to the value of {@code $foo} (usually empty). This
+     * produces invalid DTO commandlets whenever an OpenAPI property name starts
+     * with (or contains) {@code $}. The {@code model_simple.mustache} template
+     * now emits single-quoted keys so the literal baseName is preserved.
+     */
+    @Test
+    public void dollarSignPropertyNamesAreSingleQuoted() throws IOException {
+        File output = Files.createTempDirectory("test-powershell-23535").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/dollar-in-names-pull14359.yaml", null, new ParseOptions())
+                .getOpenAPI();
+
+        PowerShellClientCodegen codegen = new PowerShellClientCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput input = new ClientOptInput();
+        input.openAPI(openAPI);
+        input.config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.SUPPORTING_FILES, "false");
+        generator.opts(input).generate();
+
+        // The PowerShell codegen sanitises "$DollarModel$" to "DollarModel",
+        // so the emitted model lives at src/<package>/Model/DollarModel.ps1.
+        java.nio.file.Path dollarModelPs1 = Paths.get(outputPath + "/src/PSOpenAPITools/Model/DollarModel.ps1");
+
+        // Property names containing `$` must be single-quoted so PowerShell does
+        // not attempt variable interpolation.
+        assertFileContains(dollarModelPs1, "'$dollarValue$'");
+
+        // The previous double-quoted emission must no longer appear anywhere in
+        // the generated model file.
+        assertFileNotContains(dollarModelPs1, "\"$dollarValue$\" = ");
+    }
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/powershell/PowerShellClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/powershell/PowerShellClientCodegenTest.java
@@ -75,12 +75,26 @@ public class PowerShellClientCodegenTest {
         // so the emitted model lives at src/<package>/Model/DollarModel.ps1.
         java.nio.file.Path dollarModelPs1 = Paths.get(outputPath + "/src/PSOpenAPITools/Model/DollarModel.ps1");
 
-        // Property names containing `$` must be single-quoted so PowerShell does
-        // not attempt variable interpolation.
-        assertFileContains(dollarModelPs1, "'$dollarValue$'");
+        // Every site where model_simple.mustache emits a user-supplied baseName
+        // must use single-quoted PowerShell strings so `$` is treated literally:
+        //
+        //   1. The `Initialize-…` hash literal: `'$dollarValue$' = ${DollarValue}`
+        //   2. The JSON round-trip hash literal in `ConvertFrom-…JsonTo…`
+        //   3. The property-allowlist array: `$AllProperties = ('$dollarValue$')`
+        //   4. The property-indexer lookup: `$JsonParameters.PSobject.Properties['$dollarValue$'].value`
+        //   5. The presence-check regex: `-match '$dollarValue$'`
+        assertFileContains(dollarModelPs1,
+                "'$dollarValue$' = ${DollarValue}",
+                "$AllProperties = ('$dollarValue$')",
+                "$JsonParameters.PSobject.Properties['$dollarValue$'].value",
+                "-match '$dollarValue$'");
 
-        // The previous double-quoted emission must no longer appear anywhere in
+        // The previous double-quoted emissions must no longer appear anywhere in
         // the generated model file.
-        assertFileNotContains(dollarModelPs1, "\"$dollarValue$\" = ");
+        assertFileNotContains(dollarModelPs1,
+                "\"$dollarValue$\" = ",
+                "$AllProperties = (\"$dollarValue$\")",
+                "$JsonParameters.PSobject.Properties[\"$dollarValue$\"]",
+                "-match \"$dollarValue$\"");
     }
 }


### PR DESCRIPTION
### Description

Fix for #23535.

PowerShell treats `$` inside double-quoted strings as the sigil for variable interpolation, so a generated hash literal like

```powershell
$PSO = [PSCustomObject]@{
    "$type" = ${Type}
}
```

is rewritten at runtime to `<value-of-$type> = <value-of-Type>`, producing an invalid key. The same interpolation happens in `$AllProperties = (...)`, in `-match "<baseName>"`, and in `.Properties["<baseName>"]` — every site where `model_simple.mustache` emits a user-supplied property name inside a double-quoted PowerShell string literal.

This is not theoretical: `$type` is the default discriminator property C# produces for polymorphic serialization, and `$ref` / `$schema` appear routinely in JSON Schema payloads. A full reproduction repository is linked from the issue.

**Change summary:** swap all eight `"{{{baseName}}}"` / `"<<baseName>>"` emissions in `model_simple.mustache` to single-quoted literals. Single-quoted strings in PowerShell are verbatim, so baseNames containing `$` (or any other interpolation meta-character) are preserved. For names without meta-characters the behaviour is identical — there is no functional change for the existing test suite.

Maintainer sign-off from @wing328 on 2026-04-16 explicitly asked for a PR with this exact fix.

A new `PowerShellClientCodegenTest` exercises the regression using the existing shared `3_0/dollar-in-names-pull14359.yaml` fixture (already used by the Python, PHP, and protobuf codegen tests).

**Note on sample regeneration.** I was not able to run `./bin/generate-samples.sh bin/configs/powershell.yaml` on my host (no JDK/Maven available locally). The committed template change is minimal and deterministic — every affected sample file will differ only in that its double-quoted property-name literals flip to single-quoted. Happy to regenerate once I have JDK access, or if a maintainer prefers to run the sample refresh directly I will rebase on top.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples — **deferred** (no local JDK available; see note above).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`.
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (`fixes #23535`).
- [x] If your PR is targeting a particular programming language, @mention the technical committee members — cc @wing328 (PowerShell tech committee).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Single-quote emitted PowerShell DTO property names to prevent $-variable interpolation, fixing invalid keys and regex checks for names like $type, $ref, and $schema. Fixes #23535.

- **Bug Fixes**
  - Switch all property-name emissions in `model_simple.mustache` to single-quoted literals: PSCustomObject keys (incl. ConvertFrom hash), `$AllProperties` array, `-match` checks, and `.Properties[...]` indexers.
  - Extend regression test `PowerShellClientCodegenTest` to assert single quotes at every emission site (Initialize hash, ConvertFrom hash, `$AllProperties`, `.Properties['…']`, and `-match`) and ensure no double-quoted emissions remain.

<sup>Written for commit 4eba061980356f669dfc84ea05e5f68c39f55c99. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

