### PR TITLE
[Fix][openapi-yaml] preserve format:byte examples instead of !!binary

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/serializer/ByteArraySerializer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/serializer/ByteArraySerializer.java
@@ -1,0 +1,31 @@
+package org.openapitools.codegen.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Serializes {@code byte[]} as a UTF-8 string, preserving the original base64 representation
+ * of an OpenAPI {@code format: byte} example. swagger-parser stores {@code format: byte}
+ * examples as the raw bytes of the input base64 string (not the decoded content), so writing
+ * those bytes back as a string round-trips to the user's original value. This prevents
+ * Jackson's default YAML behavior of emitting a {@code !!binary} block with a re-encoded payload.
+ *
+ * <p>Load-bearing assumption: this only round-trips correctly because swagger-parser stores the
+ * raw input bytes. If swagger-parser ever decodes {@code format: byte} examples internally, this
+ * serializer must switch to {@code Base64.getEncoder().encodeToString(value)}.
+ */
+public class ByteArraySerializer extends StdSerializer<byte[]> {
+
+    public ByteArraySerializer() {
+        super(byte[].class);
+    }
+
+    @Override
+    public void serialize(byte[] value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeString(new String(value, StandardCharsets.UTF_8));
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/serializer/SerializerUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/serializer/SerializerUtils.java
@@ -66,6 +66,7 @@ public class SerializerUtils {
     private static SimpleModule createModule() {
         SimpleModule module = new SimpleModule("OpenAPIModule");
         module.addSerializer(OpenAPI.class, new OpenAPISerializer());
+        module.addSerializer(byte[].class, new ByteArraySerializer());
         return module;
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/yaml/YamlGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/yaml/YamlGeneratorTest.java
@@ -18,6 +18,8 @@
 package org.openapitools.codegen.yaml;
 
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.Parameter;
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.DefaultGenerator;
 import org.openapitools.codegen.TestUtils;
@@ -27,6 +29,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -148,5 +151,38 @@ public class YamlGeneratorTest {
 
         Assert.assertEquals(actual.getComponents().getSchemas().get("myresponse").getExample(),
                 expected.getComponents().getSchemas().get("myresponse").getExample());
+    }
+
+    @Test
+    public void testIssue19929() throws Exception {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(OpenAPIYamlGenerator.OUTPUT_NAME, "issue_19929.yaml");
+
+        File output = Files.createTempDirectory("issue_19929").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("openapi-yaml")
+                .setAdditionalProperties(properties)
+                .setInputSpec("src/test/resources/3_0/issue_19929.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.opts(clientOptInput).generate();
+
+        Path generated = Path.of(output.getAbsolutePath(), "issue_19929.yaml");
+        String generatedYaml = new String(Files.readAllBytes(generated), StandardCharsets.UTF_8);
+
+        Assert.assertFalse(generatedYaml.contains("!!binary"),
+                "openapi-yaml output must not emit !!binary for format: byte examples. Output was:\n" + generatedYaml);
+        Assert.assertTrue(generatedYaml.contains("aGVsbG8K"),
+                "openapi-yaml output should preserve the original base64 example. Output was:\n" + generatedYaml);
+
+        OpenAPI roundTripped = TestUtils.parseSpec(generated.toString());
+        Parameter coordinates = roundTripped.getPaths().get("/operationsTest/").getGet().getParameters().get(0);
+        Schema<?> dataSchema = (Schema<?>) coordinates.getContent().get("application/json").getSchema().getProperties().get("data");
+        byte[] exampleBytes = (byte[]) dataSchema.getExample();
+        Assert.assertEquals(new String(exampleBytes, StandardCharsets.UTF_8), "aGVsbG8K");
     }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/issue_19929.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_19929.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.3
+info:
+  title: TestRestService2.v2
+  description: Hello
+  version: 2.2.2
+paths:
+  /operationsTest/:
+    get:
+      responses:
+        '200':
+          description: Empty response.
+      parameters:
+        - in: query
+          name: coordinates
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: string
+                    format: byte
+                    description: 'Base64 encoded JSON with description of audited operation.'
+                    example: 'aGVsbG8K'


### PR DESCRIPTION
Fixes #19929.

## Problem

When the `openapi-yaml` generator processes a spec with a `type: string, format: byte` property carrying an `example` (e.g. `'aGVsbG8K'`), the regenerated YAML emits an invalid, double-encoded payload:

```yaml
example: !!binary |-
  YUdWc2JHOEs=
```

This breaks downstream tools that expect the standard OpenAPI representation (a quoted base64 string), and `YUdWc2JHOEs=` is `base64("aGVsbG8K")` — i.e. the original example has been base64-re-encoded.

## Root cause

`SerializerUtils.toYamlString(...)` uses Jackson's `YAMLMapper`. swagger-parser stores `format: byte` examples as the raw bytes of the input base64 string (not the decoded content). Jackson's default `byte[]` YAML serializer then emits those bytes with a `!!binary` tag and re-base64-encodes them.

## Fix

Register a `ByteArraySerializer` (`StdSerializer<byte[]>`) in the existing `OpenAPIModule` that writes `byte[]` as its UTF-8 string representation. This restores the user's original base64 literal in the regenerated YAML:

```yaml
example: aGVsbG8K
```

The fix is purely at the serializer layer; no template or generator changes are needed.

## Validation

- New regression test `YamlGeneratorTest#testIssue19929` (asserts no `!!binary`, original `aGVsbG8K` preserved, round-trips through `TestUtils.parseSpec`).
- Full module test suite: `Tests run: 3954, Failures: 0, Errors: 0, Skipped: 7`.
- Reproduced the original CLI command from the issue against the new fixture; output `openapi.yaml` contains `example: aGVsbG8K` and no `!!binary`.
- `./bin/generate-samples.sh ./bin/configs/*.yaml` produced **zero** diff in `samples/`, confirming the change is backward-compatible.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ```
  All three completed successfully with no resulting diff in samples or docs.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`.
- [x] If your PR solves a reported issue, reference it (fixes #19929).
- [ ] If your PR is targeting a particular programming language, @mention the technical committee — N/A, this is a fix in the shared YAML serializer used by the `openapi-yaml` generator.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves `format: byte` examples in `openapi-yaml` by serializing `byte[]` as UTF‑8 strings, avoiding `!!binary` and double base64 in YAML. Fixes #19929.

- **Bug Fixes**
  - Adds `ByteArraySerializer` and registers it in `SerializerUtils` to write `byte[]` as the original base64 literal (e.g., `aGVsbG8K`).
  - Ensures YAML emits a string for `format: byte`; never emits `!!binary`.
  - Adds regression test and fixture; verifies round-trip via `TestUtils.parseSpec`; samples unchanged.

<sup>Written for commit a7aaf1ff8fb4aaa94a6cf54748a545113ddaa4d6. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23623?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

