### PR TITLE
[POWERSHELL] fix: single-quote DTO property names to prevent $-variable interpolation

### DIFF
--- a/modules/openapi-generator/src/main/resources/powershell/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/model_simple.mustache
@@ -122,7 +122,7 @@ function Initialize-{{{apiNamePrefix}}}{{{classname}}} {
         $PSO = [PSCustomObject]@{
             {{=<< >>=}}
             <<#allVars>>
-            "<<baseName>>" = ${<<name>>}
+            '<<baseName>>' = ${<<name>>}
             <</allVars>>
             <<={{ }}=>>
         }
@@ -184,7 +184,7 @@ function Initialize-{{{apiNamePrefix}}}{{{classname}}} {
             {{=<< >>=}}
             <<#allVars>>
             <<^isReadOnly>>
-            "<<baseName>>" = ${<<name>>}
+            '<<baseName>>' = ${<<name>>}
             <</isReadOnly>>
             <</allVars>>
             <<={{ }}=>>
@@ -228,7 +228,7 @@ function ConvertFrom-{{{apiNamePrefix}}}JsonTo{{{classname}}} {
         {{/isAdditionalPropertiesTrue}}
 
         # check if Json contains properties not defined in {{{apiNamePrefix}}}{{{classname}}}
-        $AllProperties = ({{#allVars}}"{{{baseName}}}"{{^-last}}, {{/-last}}{{/allVars}})
+        $AllProperties = ({{#allVars}}'{{{baseName}}}'{{^-last}}, {{/-last}}{{/allVars}})
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             {{^isAdditionalPropertiesTrue}}
             if (!($AllProperties.Contains($name))) {
@@ -250,29 +250,29 @@ function ConvertFrom-{{{apiNamePrefix}}}JsonTo{{{classname}}} {
         }
 
         {{/-first}}
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "{{{baseName}}}"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match '{{{baseName}}}'))) {
             throw "Error! JSON cannot be serialized due to the required property '{{{baseName}}}' missing."
         } else {
-            ${{name}} = $JsonParameters.PSobject.Properties["{{{baseName}}}"].value
+            ${{name}} = $JsonParameters.PSobject.Properties['{{{baseName}}}'].value
         }
 
         {{/requiredVars}}
         {{#optionalVars}}
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "{{{baseName}}}"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match '{{{baseName}}}'))) { #optional property not found
             ${{name}} = $null
         } else {
-            ${{name}} = $JsonParameters.PSobject.Properties["{{{baseName}}}"].value
+            ${{name}} = $JsonParameters.PSobject.Properties['{{{baseName}}}'].value
         }
 
         {{/optionalVars}}
         $PSO = [PSCustomObject]@{
             {{=<< >>=}}
             <<#allVars>>
-            "<<baseName>>" = ${<<name>>}
+            '<<baseName>>' = ${<<name>>}
             <</allVars>>
             <<={{ }}=>>
             {{#isAdditionalPropertiesTrue}}
-            "AdditionalProperties" = ${{{apiNamePrefix}}}{{{classname}}}AdditionalProperties
+            'AdditionalProperties' = ${{{apiNamePrefix}}}{{{classname}}}AdditionalProperties
             {{/isAdditionalPropertiesTrue}}
         }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/powershell/PowerShellClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/powershell/PowerShellClientCodegenTest.java
@@ -1,6 +1,5 @@
 /*
  * Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
- * Copyright 2018 SmartBear Software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/powershell/PowerShellClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/powershell/PowerShellClientCodegenTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ * Copyright 2018 SmartBear Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.powershell;
+
+import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import org.openapitools.codegen.ClientOptInput;
+import org.openapitools.codegen.CodegenConstants;
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.languages.PowerShellClientCodegen;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.openapitools.codegen.TestUtils.assertFileContains;
+import static org.openapitools.codegen.TestUtils.assertFileNotContains;
+
+public class PowerShellClientCodegenTest {
+
+    /**
+     * Regression test for <a href="https://github.com/OpenAPITools/openapi-generator/issues/23535">#23535</a>.
+     *
+     * PowerShell treats {@code $} inside double-quoted strings as the sigil for
+     * variable interpolation, so hash-table keys emitted as {@code "$foo"} get
+     * rewritten at runtime to the value of {@code $foo} (usually empty). This
+     * produces invalid DTO commandlets whenever an OpenAPI property name starts
+     * with (or contains) {@code $}. The {@code model_simple.mustache} template
+     * now emits single-quoted keys so the literal baseName is preserved.
+     */
+    @Test
+    public void dollarSignPropertyNamesAreSingleQuoted() throws IOException {
+        File output = Files.createTempDirectory("test-powershell-23535").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/dollar-in-names-pull14359.yaml", null, new ParseOptions())
+                .getOpenAPI();
+
+        PowerShellClientCodegen codegen = new PowerShellClientCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput input = new ClientOptInput();
+        input.openAPI(openAPI);
+        input.config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.SUPPORTING_FILES, "false");
+        generator.opts(input).generate();
+
+        // The PowerShell codegen sanitises "$DollarModel$" to "DollarModel",
+        // so the emitted model lives at src/<package>/Model/DollarModel.ps1.
+        java.nio.file.Path dollarModelPs1 = Paths.get(outputPath + "/src/PSOpenAPITools/Model/DollarModel.ps1");
+
+        // Property names containing `$` must be single-quoted so PowerShell does
+        // not attempt variable interpolation.
+        assertFileContains(dollarModelPs1, "'$dollarValue$'");
+
+        // The previous double-quoted emission must no longer appear anywhere in
+        // the generated model file.
+        assertFileNotContains(dollarModelPs1, "\"$dollarValue$\" = ");
+    }
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/powershell/PowerShellClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/powershell/PowerShellClientCodegenTest.java
@@ -75,12 +75,26 @@ public class PowerShellClientCodegenTest {
         // so the emitted model lives at src/<package>/Model/DollarModel.ps1.
         java.nio.file.Path dollarModelPs1 = Paths.get(outputPath + "/src/PSOpenAPITools/Model/DollarModel.ps1");
 
-        // Property names containing `$` must be single-quoted so PowerShell does
-        // not attempt variable interpolation.
-        assertFileContains(dollarModelPs1, "'$dollarValue$'");
+        // Every site where model_simple.mustache emits a user-supplied baseName
+        // must use single-quoted PowerShell strings so `$` is treated literally:
+        //
+        //   1. The `Initialize-…` hash literal: `'$dollarValue$' = ${DollarValue}`
+        //   2. The JSON round-trip hash literal in `ConvertFrom-…JsonTo…`
+        //   3. The property-allowlist array: `$AllProperties = ('$dollarValue$')`
+        //   4. The property-indexer lookup: `$JsonParameters.PSobject.Properties['$dollarValue$'].value`
+        //   5. The presence-check regex: `-match '$dollarValue$'`
+        assertFileContains(dollarModelPs1,
+                "'$dollarValue$' = ${DollarValue}",
+                "$AllProperties = ('$dollarValue$')",
+                "$JsonParameters.PSobject.Properties['$dollarValue$'].value",
+                "-match '$dollarValue$'");
 
-        // The previous double-quoted emission must no longer appear anywhere in
+        // The previous double-quoted emissions must no longer appear anywhere in
         // the generated model file.
-        assertFileNotContains(dollarModelPs1, "\"$dollarValue$\" = ");
+        assertFileNotContains(dollarModelPs1,
+                "\"$dollarValue$\" = ",
+                "$AllProperties = (\"$dollarValue$\")",
+                "$JsonParameters.PSobject.Properties[\"$dollarValue$\"]",
+                "-match \"$dollarValue$\"");
     }
 }

--- a/samples/client/echo_api/powershell/src/PSOpenAPITools/Model/Bird.ps1
+++ b/samples/client/echo_api/powershell/src/PSOpenAPITools/Model/Bird.ps1
@@ -41,8 +41,8 @@ function Initialize-Bird {
 
 
         $PSO = [PSCustomObject]@{
-            "size" = ${Size}
-            "color" = ${Color}
+            'size' = ${Size}
+            'color' = ${Color}
         }
 
 
@@ -80,28 +80,28 @@ function ConvertFrom-JsonToBird {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in Bird
-        $AllProperties = ("size", "color")
+        $AllProperties = ('size', 'color')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "size"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'size'))) { #optional property not found
             $Size = $null
         } else {
-            $Size = $JsonParameters.PSobject.Properties["size"].value
+            $Size = $JsonParameters.PSobject.Properties['size'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "color"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'color'))) { #optional property not found
             $Color = $null
         } else {
-            $Color = $JsonParameters.PSobject.Properties["color"].value
+            $Color = $JsonParameters.PSobject.Properties['color'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "size" = ${Size}
-            "color" = ${Color}
+            'size' = ${Size}
+            'color' = ${Color}
         }
 
         return $PSO

--- a/samples/client/echo_api/powershell/src/PSOpenAPITools/Model/Category.ps1
+++ b/samples/client/echo_api/powershell/src/PSOpenAPITools/Model/Category.ps1
@@ -41,8 +41,8 @@ function Initialize-Category {
 
 
         $PSO = [PSCustomObject]@{
-            "id" = ${Id}
-            "name" = ${Name}
+            'id' = ${Id}
+            'name' = ${Name}
         }
 
 
@@ -80,28 +80,28 @@ function ConvertFrom-JsonToCategory {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in Category
-        $AllProperties = ("id", "name")
+        $AllProperties = ('id', 'name')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "id"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'id'))) { #optional property not found
             $Id = $null
         } else {
-            $Id = $JsonParameters.PSobject.Properties["id"].value
+            $Id = $JsonParameters.PSobject.Properties['id'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "name"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'name'))) { #optional property not found
             $Name = $null
         } else {
-            $Name = $JsonParameters.PSobject.Properties["name"].value
+            $Name = $JsonParameters.PSobject.Properties['name'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "id" = ${Id}
-            "name" = ${Name}
+            'id' = ${Id}
+            'name' = ${Name}
         }
 
         return $PSO

--- a/samples/client/echo_api/powershell/src/PSOpenAPITools/Model/DataQuery.ps1
+++ b/samples/client/echo_api/powershell/src/PSOpenAPITools/Model/DataQuery.ps1
@@ -57,11 +57,11 @@ function Initialize-DataQuery {
 
 
         $PSO = [PSCustomObject]@{
-            "id" = ${Id}
-            "outcomes" = ${Outcomes}
-            "suffix" = ${Suffix}
-            "text" = ${Text}
-            "date" = ${Date}
+            'id' = ${Id}
+            'outcomes' = ${Outcomes}
+            'suffix' = ${Suffix}
+            'text' = ${Text}
+            'date' = ${Date}
         }
 
 
@@ -99,49 +99,49 @@ function ConvertFrom-JsonToDataQuery {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in DataQuery
-        $AllProperties = ("id", "outcomes", "suffix", "text", "date")
+        $AllProperties = ('id', 'outcomes', 'suffix', 'text', 'date')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "id"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'id'))) { #optional property not found
             $Id = $null
         } else {
-            $Id = $JsonParameters.PSobject.Properties["id"].value
+            $Id = $JsonParameters.PSobject.Properties['id'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "outcomes"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'outcomes'))) { #optional property not found
             $Outcomes = $null
         } else {
-            $Outcomes = $JsonParameters.PSobject.Properties["outcomes"].value
+            $Outcomes = $JsonParameters.PSobject.Properties['outcomes'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "suffix"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'suffix'))) { #optional property not found
             $Suffix = $null
         } else {
-            $Suffix = $JsonParameters.PSobject.Properties["suffix"].value
+            $Suffix = $JsonParameters.PSobject.Properties['suffix'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "text"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'text'))) { #optional property not found
             $Text = $null
         } else {
-            $Text = $JsonParameters.PSobject.Properties["text"].value
+            $Text = $JsonParameters.PSobject.Properties['text'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "date"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'date'))) { #optional property not found
             $Date = $null
         } else {
-            $Date = $JsonParameters.PSobject.Properties["date"].value
+            $Date = $JsonParameters.PSobject.Properties['date'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "id" = ${Id}
-            "outcomes" = ${Outcomes}
-            "suffix" = ${Suffix}
-            "text" = ${Text}
-            "date" = ${Date}
+            'id' = ${Id}
+            'outcomes' = ${Outcomes}
+            'suffix' = ${Suffix}
+            'text' = ${Text}
+            'date' = ${Date}
         }
 
         return $PSO

--- a/samples/client/echo_api/powershell/src/PSOpenAPITools/Model/DefaultValue.ps1
+++ b/samples/client/echo_api/powershell/src/PSOpenAPITools/Model/DefaultValue.ps1
@@ -72,14 +72,14 @@ function Initialize-DefaultValue {
 
 
         $PSO = [PSCustomObject]@{
-            "array_string_enum_ref_default" = ${ArrayStringEnumRefDefault}
-            "array_string_enum_default" = ${ArrayStringEnumDefault}
-            "array_string_default" = ${ArrayStringDefault}
-            "array_integer_default" = ${ArrayIntegerDefault}
-            "array_string" = ${ArrayString}
-            "array_string_nullable" = ${ArrayStringNullable}
-            "array_string_extension_nullable" = ${ArrayStringExtensionNullable}
-            "string_nullable" = ${StringNullable}
+            'array_string_enum_ref_default' = ${ArrayStringEnumRefDefault}
+            'array_string_enum_default' = ${ArrayStringEnumDefault}
+            'array_string_default' = ${ArrayStringDefault}
+            'array_integer_default' = ${ArrayIntegerDefault}
+            'array_string' = ${ArrayString}
+            'array_string_nullable' = ${ArrayStringNullable}
+            'array_string_extension_nullable' = ${ArrayStringExtensionNullable}
+            'string_nullable' = ${StringNullable}
         }
 
 
@@ -117,70 +117,70 @@ function ConvertFrom-JsonToDefaultValue {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in DefaultValue
-        $AllProperties = ("array_string_enum_ref_default", "array_string_enum_default", "array_string_default", "array_integer_default", "array_string", "array_string_nullable", "array_string_extension_nullable", "string_nullable")
+        $AllProperties = ('array_string_enum_ref_default', 'array_string_enum_default', 'array_string_default', 'array_integer_default', 'array_string', 'array_string_nullable', 'array_string_extension_nullable', 'string_nullable')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "array_string_enum_ref_default"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'array_string_enum_ref_default'))) { #optional property not found
             $ArrayStringEnumRefDefault = $null
         } else {
-            $ArrayStringEnumRefDefault = $JsonParameters.PSobject.Properties["array_string_enum_ref_default"].value
+            $ArrayStringEnumRefDefault = $JsonParameters.PSobject.Properties['array_string_enum_ref_default'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "array_string_enum_default"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'array_string_enum_default'))) { #optional property not found
             $ArrayStringEnumDefault = $null
         } else {
-            $ArrayStringEnumDefault = $JsonParameters.PSobject.Properties["array_string_enum_default"].value
+            $ArrayStringEnumDefault = $JsonParameters.PSobject.Properties['array_string_enum_default'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "array_string_default"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'array_string_default'))) { #optional property not found
             $ArrayStringDefault = $null
         } else {
-            $ArrayStringDefault = $JsonParameters.PSobject.Properties["array_string_default"].value
+            $ArrayStringDefault = $JsonParameters.PSobject.Properties['array_string_default'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "array_integer_default"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'array_integer_default'))) { #optional property not found
             $ArrayIntegerDefault = $null
         } else {
-            $ArrayIntegerDefault = $JsonParameters.PSobject.Properties["array_integer_default"].value
+            $ArrayIntegerDefault = $JsonParameters.PSobject.Properties['array_integer_default'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "array_string"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'array_string'))) { #optional property not found
             $ArrayString = $null
         } else {
-            $ArrayString = $JsonParameters.PSobject.Properties["array_string"].value
+            $ArrayString = $JsonParameters.PSobject.Properties['array_string'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "array_string_nullable"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'array_string_nullable'))) { #optional property not found
             $ArrayStringNullable = $null
         } else {
-            $ArrayStringNullable = $JsonParameters.PSobject.Properties["array_string_nullable"].value
+            $ArrayStringNullable = $JsonParameters.PSobject.Properties['array_string_nullable'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "array_string_extension_nullable"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'array_string_extension_nullable'))) { #optional property not found
             $ArrayStringExtensionNullable = $null
         } else {
-            $ArrayStringExtensionNullable = $JsonParameters.PSobject.Properties["array_string_extension_nullable"].value
+            $ArrayStringExtensionNullable = $JsonParameters.PSobject.Properties['array_string_extension_nullable'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "string_nullable"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'string_nullable'))) { #optional property not found
             $StringNullable = $null
         } else {
-            $StringNullable = $JsonParameters.PSobject.Properties["string_nullable"].value
+            $StringNullable = $JsonParameters.PSobject.Properties['string_nullable'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "array_string_enum_ref_default" = ${ArrayStringEnumRefDefault}
-            "array_string_enum_default" = ${ArrayStringEnumDefault}
-            "array_string_default" = ${ArrayStringDefault}
-            "array_integer_default" = ${ArrayIntegerDefault}
-            "array_string" = ${ArrayString}
-            "array_string_nullable" = ${ArrayStringNullable}
-            "array_string_extension_nullable" = ${ArrayStringExtensionNullable}
-            "string_nullable" = ${StringNullable}
+            'array_string_enum_ref_default' = ${ArrayStringEnumRefDefault}
+            'array_string_enum_default' = ${ArrayStringEnumDefault}
+            'array_string_default' = ${ArrayStringDefault}
+            'array_integer_default' = ${ArrayIntegerDefault}
+            'array_string' = ${ArrayString}
+            'array_string_nullable' = ${ArrayStringNullable}
+            'array_string_extension_nullable' = ${ArrayStringExtensionNullable}
+            'string_nullable' = ${StringNullable}
         }
 
         return $PSO

--- a/samples/client/echo_api/powershell/src/PSOpenAPITools/Model/NumberPropertiesOnly.ps1
+++ b/samples/client/echo_api/powershell/src/PSOpenAPITools/Model/NumberPropertiesOnly.ps1
@@ -54,9 +54,9 @@ function Initialize-NumberPropertiesOnly {
 
 
         $PSO = [PSCustomObject]@{
-            "number" = ${Number}
-            "float" = ${Float}
-            "double" = ${Double}
+            'number' = ${Number}
+            'float' = ${Float}
+            'double' = ${Double}
         }
 
 
@@ -94,35 +94,35 @@ function ConvertFrom-JsonToNumberPropertiesOnly {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in NumberPropertiesOnly
-        $AllProperties = ("number", "float", "double")
+        $AllProperties = ('number', 'float', 'double')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "number"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'number'))) { #optional property not found
             $Number = $null
         } else {
-            $Number = $JsonParameters.PSobject.Properties["number"].value
+            $Number = $JsonParameters.PSobject.Properties['number'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "float"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'float'))) { #optional property not found
             $Float = $null
         } else {
-            $Float = $JsonParameters.PSobject.Properties["float"].value
+            $Float = $JsonParameters.PSobject.Properties['float'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "double"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'double'))) { #optional property not found
             $Double = $null
         } else {
-            $Double = $JsonParameters.PSobject.Properties["double"].value
+            $Double = $JsonParameters.PSobject.Properties['double'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "number" = ${Number}
-            "float" = ${Float}
-            "double" = ${Double}
+            'number' = ${Number}
+            'float' = ${Float}
+            'double' = ${Double}
         }
 
         return $PSO

--- a/samples/client/echo_api/powershell/src/PSOpenAPITools/Model/Pet.ps1
+++ b/samples/client/echo_api/powershell/src/PSOpenAPITools/Model/Pet.ps1
@@ -70,12 +70,12 @@ function Initialize-Pet {
 
 
         $PSO = [PSCustomObject]@{
-            "id" = ${Id}
-            "name" = ${Name}
-            "category" = ${Category}
-            "photoUrls" = ${PhotoUrls}
-            "tags" = ${Tags}
-            "status" = ${Status}
+            'id' = ${Id}
+            'name' = ${Name}
+            'category' = ${Category}
+            'photoUrls' = ${PhotoUrls}
+            'tags' = ${Tags}
+            'status' = ${Status}
         }
 
 
@@ -113,7 +113,7 @@ function ConvertFrom-JsonToPet {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in Pet
-        $AllProperties = ("id", "name", "category", "photoUrls", "tags", "status")
+        $AllProperties = ('id', 'name', 'category', 'photoUrls', 'tags', 'status')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -124,49 +124,49 @@ function ConvertFrom-JsonToPet {
             throw "Error! Empty JSON cannot be serialized due to the required property 'name' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "name"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'name'))) {
             throw "Error! JSON cannot be serialized due to the required property 'name' missing."
         } else {
-            $Name = $JsonParameters.PSobject.Properties["name"].value
+            $Name = $JsonParameters.PSobject.Properties['name'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "photoUrls"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'photoUrls'))) {
             throw "Error! JSON cannot be serialized due to the required property 'photoUrls' missing."
         } else {
-            $PhotoUrls = $JsonParameters.PSobject.Properties["photoUrls"].value
+            $PhotoUrls = $JsonParameters.PSobject.Properties['photoUrls'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "id"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'id'))) { #optional property not found
             $Id = $null
         } else {
-            $Id = $JsonParameters.PSobject.Properties["id"].value
+            $Id = $JsonParameters.PSobject.Properties['id'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "category"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'category'))) { #optional property not found
             $Category = $null
         } else {
-            $Category = $JsonParameters.PSobject.Properties["category"].value
+            $Category = $JsonParameters.PSobject.Properties['category'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "tags"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'tags'))) { #optional property not found
             $Tags = $null
         } else {
-            $Tags = $JsonParameters.PSobject.Properties["tags"].value
+            $Tags = $JsonParameters.PSobject.Properties['tags'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "status"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'status'))) { #optional property not found
             $Status = $null
         } else {
-            $Status = $JsonParameters.PSobject.Properties["status"].value
+            $Status = $JsonParameters.PSobject.Properties['status'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "id" = ${Id}
-            "name" = ${Name}
-            "category" = ${Category}
-            "photoUrls" = ${PhotoUrls}
-            "tags" = ${Tags}
-            "status" = ${Status}
+            'id' = ${Id}
+            'name' = ${Name}
+            'category' = ${Category}
+            'photoUrls' = ${PhotoUrls}
+            'tags' = ${Tags}
+            'status' = ${Status}
         }
 
         return $PSO

--- a/samples/client/echo_api/powershell/src/PSOpenAPITools/Model/Query.ps1
+++ b/samples/client/echo_api/powershell/src/PSOpenAPITools/Model/Query.ps1
@@ -42,8 +42,8 @@ function Initialize-Query {
 
 
         $PSO = [PSCustomObject]@{
-            "id" = ${Id}
-            "outcomes" = ${Outcomes}
+            'id' = ${Id}
+            'outcomes' = ${Outcomes}
         }
 
 
@@ -81,28 +81,28 @@ function ConvertFrom-JsonToQuery {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in Query
-        $AllProperties = ("id", "outcomes")
+        $AllProperties = ('id', 'outcomes')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "id"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'id'))) { #optional property not found
             $Id = $null
         } else {
-            $Id = $JsonParameters.PSobject.Properties["id"].value
+            $Id = $JsonParameters.PSobject.Properties['id'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "outcomes"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'outcomes'))) { #optional property not found
             $Outcomes = $null
         } else {
-            $Outcomes = $JsonParameters.PSobject.Properties["outcomes"].value
+            $Outcomes = $JsonParameters.PSobject.Properties['outcomes'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "id" = ${Id}
-            "outcomes" = ${Outcomes}
+            'id' = ${Id}
+            'outcomes' = ${Outcomes}
         }
 
         return $PSO

--- a/samples/client/echo_api/powershell/src/PSOpenAPITools/Model/Tag.ps1
+++ b/samples/client/echo_api/powershell/src/PSOpenAPITools/Model/Tag.ps1
@@ -41,8 +41,8 @@ function Initialize-Tag {
 
 
         $PSO = [PSCustomObject]@{
-            "id" = ${Id}
-            "name" = ${Name}
+            'id' = ${Id}
+            'name' = ${Name}
         }
 
 
@@ -80,28 +80,28 @@ function ConvertFrom-JsonToTag {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in Tag
-        $AllProperties = ("id", "name")
+        $AllProperties = ('id', 'name')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "id"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'id'))) { #optional property not found
             $Id = $null
         } else {
-            $Id = $JsonParameters.PSobject.Properties["id"].value
+            $Id = $JsonParameters.PSobject.Properties['id'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "name"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'name'))) { #optional property not found
             $Name = $null
         } else {
-            $Name = $JsonParameters.PSobject.Properties["name"].value
+            $Name = $JsonParameters.PSobject.Properties['name'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "id" = ${Id}
-            "name" = ${Name}
+            'id' = ${Id}
+            'name' = ${Name}
         }
 
         return $PSO

--- a/samples/client/echo_api/powershell/src/PSOpenAPITools/Model/TestFormObjectMultipartRequestMarker.ps1
+++ b/samples/client/echo_api/powershell/src/PSOpenAPITools/Model/TestFormObjectMultipartRequestMarker.ps1
@@ -36,7 +36,7 @@ function Initialize-TestFormObjectMultipartRequestMarker {
 
 
         $PSO = [PSCustomObject]@{
-            "name" = ${Name}
+            'name' = ${Name}
         }
 
 
@@ -74,21 +74,21 @@ function ConvertFrom-JsonToTestFormObjectMultipartRequestMarker {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in TestFormObjectMultipartRequestMarker
-        $AllProperties = ("name")
+        $AllProperties = ('name')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "name"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'name'))) { #optional property not found
             $Name = $null
         } else {
-            $Name = $JsonParameters.PSobject.Properties["name"].value
+            $Name = $JsonParameters.PSobject.Properties['name'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "name" = ${Name}
+            'name' = ${Name}
         }
 
         return $PSO

--- a/samples/client/echo_api/powershell/src/PSOpenAPITools/Model/TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter.ps1
+++ b/samples/client/echo_api/powershell/src/PSOpenAPITools/Model/TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter.ps1
@@ -51,10 +51,10 @@ function Initialize-TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectPar
 
 
         $PSO = [PSCustomObject]@{
-            "size" = ${Size}
-            "color" = ${Color}
-            "id" = ${Id}
-            "name" = ${Name}
+            'size' = ${Size}
+            'color' = ${Color}
+            'id' = ${Id}
+            'name' = ${Name}
         }
 
 
@@ -92,42 +92,42 @@ function ConvertFrom-JsonToTestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryOb
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter
-        $AllProperties = ("size", "color", "id", "name")
+        $AllProperties = ('size', 'color', 'id', 'name')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "size"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'size'))) { #optional property not found
             $Size = $null
         } else {
-            $Size = $JsonParameters.PSobject.Properties["size"].value
+            $Size = $JsonParameters.PSobject.Properties['size'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "color"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'color'))) { #optional property not found
             $Color = $null
         } else {
-            $Color = $JsonParameters.PSobject.Properties["color"].value
+            $Color = $JsonParameters.PSobject.Properties['color'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "id"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'id'))) { #optional property not found
             $Id = $null
         } else {
-            $Id = $JsonParameters.PSobject.Properties["id"].value
+            $Id = $JsonParameters.PSobject.Properties['id'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "name"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'name'))) { #optional property not found
             $Name = $null
         } else {
-            $Name = $JsonParameters.PSobject.Properties["name"].value
+            $Name = $JsonParameters.PSobject.Properties['name'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "size" = ${Size}
-            "color" = ${Color}
-            "id" = ${Id}
-            "name" = ${Name}
+            'size' = ${Size}
+            'color' = ${Color}
+            'id' = ${Id}
+            'name' = ${Name}
         }
 
         return $PSO

--- a/samples/client/echo_api/powershell/src/PSOpenAPITools/Model/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.ps1
+++ b/samples/client/echo_api/powershell/src/PSOpenAPITools/Model/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.ps1
@@ -36,7 +36,7 @@ function Initialize-TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter
 
 
         $PSO = [PSCustomObject]@{
-            "values" = ${Values}
+            'values' = ${Values}
         }
 
 
@@ -74,21 +74,21 @@ function ConvertFrom-JsonToTestQueryStyleFormExplodeTrueArrayStringQueryObjectPa
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter
-        $AllProperties = ("values")
+        $AllProperties = ('values')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "values"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'values'))) { #optional property not found
             $Values = $null
         } else {
-            $Values = $JsonParameters.PSobject.Properties["values"].value
+            $Values = $JsonParameters.PSobject.Properties['values'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "values" = ${Values}
+            'values' = ${Values}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/AdditionalPropertiesClass.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/AdditionalPropertiesClass.ps1
@@ -70,14 +70,14 @@ function Initialize-PSAdditionalPropertiesClass {
 
 
         $PSO = [PSCustomObject]@{
-            "map_property" = ${MapProperty}
-            "map_of_map_property" = ${MapOfMapProperty}
-            "anytype_1" = ${Anytype1}
-            "map_with_undeclared_properties_anytype_1" = ${MapWithUndeclaredPropertiesAnytype1}
-            "map_with_undeclared_properties_anytype_2" = ${MapWithUndeclaredPropertiesAnytype2}
-            "map_with_undeclared_properties_anytype_3" = ${MapWithUndeclaredPropertiesAnytype3}
-            "empty_map" = ${EmptyMap}
-            "map_with_undeclared_properties_string" = ${MapWithUndeclaredPropertiesString}
+            'map_property' = ${MapProperty}
+            'map_of_map_property' = ${MapOfMapProperty}
+            'anytype_1' = ${Anytype1}
+            'map_with_undeclared_properties_anytype_1' = ${MapWithUndeclaredPropertiesAnytype1}
+            'map_with_undeclared_properties_anytype_2' = ${MapWithUndeclaredPropertiesAnytype2}
+            'map_with_undeclared_properties_anytype_3' = ${MapWithUndeclaredPropertiesAnytype3}
+            'empty_map' = ${EmptyMap}
+            'map_with_undeclared_properties_string' = ${MapWithUndeclaredPropertiesString}
         }
 
 
@@ -115,70 +115,70 @@ function ConvertFrom-PSJsonToAdditionalPropertiesClass {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSAdditionalPropertiesClass
-        $AllProperties = ("map_property", "map_of_map_property", "anytype_1", "map_with_undeclared_properties_anytype_1", "map_with_undeclared_properties_anytype_2", "map_with_undeclared_properties_anytype_3", "empty_map", "map_with_undeclared_properties_string")
+        $AllProperties = ('map_property', 'map_of_map_property', 'anytype_1', 'map_with_undeclared_properties_anytype_1', 'map_with_undeclared_properties_anytype_2', 'map_with_undeclared_properties_anytype_3', 'empty_map', 'map_with_undeclared_properties_string')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "map_property"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'map_property'))) { #optional property not found
             $MapProperty = $null
         } else {
-            $MapProperty = $JsonParameters.PSobject.Properties["map_property"].value
+            $MapProperty = $JsonParameters.PSobject.Properties['map_property'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "map_of_map_property"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'map_of_map_property'))) { #optional property not found
             $MapOfMapProperty = $null
         } else {
-            $MapOfMapProperty = $JsonParameters.PSobject.Properties["map_of_map_property"].value
+            $MapOfMapProperty = $JsonParameters.PSobject.Properties['map_of_map_property'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "anytype_1"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'anytype_1'))) { #optional property not found
             $Anytype1 = $null
         } else {
-            $Anytype1 = $JsonParameters.PSobject.Properties["anytype_1"].value
+            $Anytype1 = $JsonParameters.PSobject.Properties['anytype_1'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "map_with_undeclared_properties_anytype_1"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'map_with_undeclared_properties_anytype_1'))) { #optional property not found
             $MapWithUndeclaredPropertiesAnytype1 = $null
         } else {
-            $MapWithUndeclaredPropertiesAnytype1 = $JsonParameters.PSobject.Properties["map_with_undeclared_properties_anytype_1"].value
+            $MapWithUndeclaredPropertiesAnytype1 = $JsonParameters.PSobject.Properties['map_with_undeclared_properties_anytype_1'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "map_with_undeclared_properties_anytype_2"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'map_with_undeclared_properties_anytype_2'))) { #optional property not found
             $MapWithUndeclaredPropertiesAnytype2 = $null
         } else {
-            $MapWithUndeclaredPropertiesAnytype2 = $JsonParameters.PSobject.Properties["map_with_undeclared_properties_anytype_2"].value
+            $MapWithUndeclaredPropertiesAnytype2 = $JsonParameters.PSobject.Properties['map_with_undeclared_properties_anytype_2'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "map_with_undeclared_properties_anytype_3"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'map_with_undeclared_properties_anytype_3'))) { #optional property not found
             $MapWithUndeclaredPropertiesAnytype3 = $null
         } else {
-            $MapWithUndeclaredPropertiesAnytype3 = $JsonParameters.PSobject.Properties["map_with_undeclared_properties_anytype_3"].value
+            $MapWithUndeclaredPropertiesAnytype3 = $JsonParameters.PSobject.Properties['map_with_undeclared_properties_anytype_3'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "empty_map"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'empty_map'))) { #optional property not found
             $EmptyMap = $null
         } else {
-            $EmptyMap = $JsonParameters.PSobject.Properties["empty_map"].value
+            $EmptyMap = $JsonParameters.PSobject.Properties['empty_map'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "map_with_undeclared_properties_string"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'map_with_undeclared_properties_string'))) { #optional property not found
             $MapWithUndeclaredPropertiesString = $null
         } else {
-            $MapWithUndeclaredPropertiesString = $JsonParameters.PSobject.Properties["map_with_undeclared_properties_string"].value
+            $MapWithUndeclaredPropertiesString = $JsonParameters.PSobject.Properties['map_with_undeclared_properties_string'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "map_property" = ${MapProperty}
-            "map_of_map_property" = ${MapOfMapProperty}
-            "anytype_1" = ${Anytype1}
-            "map_with_undeclared_properties_anytype_1" = ${MapWithUndeclaredPropertiesAnytype1}
-            "map_with_undeclared_properties_anytype_2" = ${MapWithUndeclaredPropertiesAnytype2}
-            "map_with_undeclared_properties_anytype_3" = ${MapWithUndeclaredPropertiesAnytype3}
-            "empty_map" = ${EmptyMap}
-            "map_with_undeclared_properties_string" = ${MapWithUndeclaredPropertiesString}
+            'map_property' = ${MapProperty}
+            'map_of_map_property' = ${MapOfMapProperty}
+            'anytype_1' = ${Anytype1}
+            'map_with_undeclared_properties_anytype_1' = ${MapWithUndeclaredPropertiesAnytype1}
+            'map_with_undeclared_properties_anytype_2' = ${MapWithUndeclaredPropertiesAnytype2}
+            'map_with_undeclared_properties_anytype_3' = ${MapWithUndeclaredPropertiesAnytype3}
+            'empty_map' = ${EmptyMap}
+            'map_with_undeclared_properties_string' = ${MapWithUndeclaredPropertiesString}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/Animal.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/Animal.ps1
@@ -44,8 +44,8 @@ function Initialize-PSAnimal {
 
 
         $PSO = [PSCustomObject]@{
-            "className" = ${ClassName}
-            "color" = ${Color}
+            'className' = ${ClassName}
+            'color' = ${Color}
         }
 
 
@@ -83,7 +83,7 @@ function ConvertFrom-PSJsonToAnimal {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSAnimal
-        $AllProperties = ("className", "color")
+        $AllProperties = ('className', 'color')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -94,21 +94,21 @@ function ConvertFrom-PSJsonToAnimal {
             throw "Error! Empty JSON cannot be serialized due to the required property 'className' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "className"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'className'))) {
             throw "Error! JSON cannot be serialized due to the required property 'className' missing."
         } else {
-            $ClassName = $JsonParameters.PSobject.Properties["className"].value
+            $ClassName = $JsonParameters.PSobject.Properties['className'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "color"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'color'))) { #optional property not found
             $Color = $null
         } else {
-            $Color = $JsonParameters.PSobject.Properties["color"].value
+            $Color = $JsonParameters.PSobject.Properties['color'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "className" = ${ClassName}
-            "color" = ${Color}
+            'className' = ${ClassName}
+            'color' = ${Color}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/ApiResponse.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/ApiResponse.ps1
@@ -45,9 +45,9 @@ function Initialize-PSApiResponse {
 
 
         $PSO = [PSCustomObject]@{
-            "code" = ${Code}
-            "type" = ${Type}
-            "message" = ${Message}
+            'code' = ${Code}
+            'type' = ${Type}
+            'message' = ${Message}
         }
 
 
@@ -85,35 +85,35 @@ function ConvertFrom-PSJsonToApiResponse {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSApiResponse
-        $AllProperties = ("code", "type", "message")
+        $AllProperties = ('code', 'type', 'message')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "code"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'code'))) { #optional property not found
             $Code = $null
         } else {
-            $Code = $JsonParameters.PSobject.Properties["code"].value
+            $Code = $JsonParameters.PSobject.Properties['code'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "type"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'type'))) { #optional property not found
             $Type = $null
         } else {
-            $Type = $JsonParameters.PSobject.Properties["type"].value
+            $Type = $JsonParameters.PSobject.Properties['type'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "message"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'message'))) { #optional property not found
             $Message = $null
         } else {
-            $Message = $JsonParameters.PSobject.Properties["message"].value
+            $Message = $JsonParameters.PSobject.Properties['message'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "code" = ${Code}
-            "type" = ${Type}
-            "message" = ${Message}
+            'code' = ${Code}
+            'type' = ${Type}
+            'message' = ${Message}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/Apple.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/Apple.ps1
@@ -42,8 +42,8 @@ function Initialize-PSApple {
 
 
         $PSO = [PSCustomObject]@{
-            "cultivar" = ${Cultivar}
-            "origin" = ${Origin}
+            'cultivar' = ${Cultivar}
+            'origin' = ${Origin}
         }
 
 
@@ -81,28 +81,28 @@ function ConvertFrom-PSJsonToApple {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSApple
-        $AllProperties = ("cultivar", "origin")
+        $AllProperties = ('cultivar', 'origin')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "cultivar"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'cultivar'))) { #optional property not found
             $Cultivar = $null
         } else {
-            $Cultivar = $JsonParameters.PSobject.Properties["cultivar"].value
+            $Cultivar = $JsonParameters.PSobject.Properties['cultivar'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "origin"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'origin'))) { #optional property not found
             $Origin = $null
         } else {
-            $Origin = $JsonParameters.PSobject.Properties["origin"].value
+            $Origin = $JsonParameters.PSobject.Properties['origin'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "cultivar" = ${Cultivar}
-            "origin" = ${Origin}
+            'cultivar' = ${Cultivar}
+            'origin' = ${Origin}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/AppleReq.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/AppleReq.ps1
@@ -44,8 +44,8 @@ function Initialize-PSAppleReq {
 
 
         $PSO = [PSCustomObject]@{
-            "cultivar" = ${Cultivar}
-            "mealy" = ${Mealy}
+            'cultivar' = ${Cultivar}
+            'mealy' = ${Mealy}
         }
 
 
@@ -83,7 +83,7 @@ function ConvertFrom-PSJsonToAppleReq {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSAppleReq
-        $AllProperties = ("cultivar", "mealy")
+        $AllProperties = ('cultivar', 'mealy')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -94,21 +94,21 @@ function ConvertFrom-PSJsonToAppleReq {
             throw "Error! Empty JSON cannot be serialized due to the required property 'cultivar' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "cultivar"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'cultivar'))) {
             throw "Error! JSON cannot be serialized due to the required property 'cultivar' missing."
         } else {
-            $Cultivar = $JsonParameters.PSobject.Properties["cultivar"].value
+            $Cultivar = $JsonParameters.PSobject.Properties['cultivar'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "mealy"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'mealy'))) { #optional property not found
             $Mealy = $null
         } else {
-            $Mealy = $JsonParameters.PSobject.Properties["mealy"].value
+            $Mealy = $JsonParameters.PSobject.Properties['mealy'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "cultivar" = ${Cultivar}
-            "mealy" = ${Mealy}
+            'cultivar' = ${Cultivar}
+            'mealy' = ${Mealy}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/ArrayOfArrayOfNumberOnly.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/ArrayOfArrayOfNumberOnly.ps1
@@ -35,7 +35,7 @@ function Initialize-PSArrayOfArrayOfNumberOnly {
 
 
         $PSO = [PSCustomObject]@{
-            "ArrayArrayNumber" = ${ArrayArrayNumber}
+            'ArrayArrayNumber' = ${ArrayArrayNumber}
         }
 
 
@@ -73,21 +73,21 @@ function ConvertFrom-PSJsonToArrayOfArrayOfNumberOnly {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSArrayOfArrayOfNumberOnly
-        $AllProperties = ("ArrayArrayNumber")
+        $AllProperties = ('ArrayArrayNumber')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "ArrayArrayNumber"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'ArrayArrayNumber'))) { #optional property not found
             $ArrayArrayNumber = $null
         } else {
-            $ArrayArrayNumber = $JsonParameters.PSobject.Properties["ArrayArrayNumber"].value
+            $ArrayArrayNumber = $JsonParameters.PSobject.Properties['ArrayArrayNumber'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "ArrayArrayNumber" = ${ArrayArrayNumber}
+            'ArrayArrayNumber' = ${ArrayArrayNumber}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/ArrayOfNumberOnly.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/ArrayOfNumberOnly.ps1
@@ -35,7 +35,7 @@ function Initialize-PSArrayOfNumberOnly {
 
 
         $PSO = [PSCustomObject]@{
-            "ArrayNumber" = ${ArrayNumber}
+            'ArrayNumber' = ${ArrayNumber}
         }
 
 
@@ -73,21 +73,21 @@ function ConvertFrom-PSJsonToArrayOfNumberOnly {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSArrayOfNumberOnly
-        $AllProperties = ("ArrayNumber")
+        $AllProperties = ('ArrayNumber')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "ArrayNumber"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'ArrayNumber'))) { #optional property not found
             $ArrayNumber = $null
         } else {
-            $ArrayNumber = $JsonParameters.PSobject.Properties["ArrayNumber"].value
+            $ArrayNumber = $JsonParameters.PSobject.Properties['ArrayNumber'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "ArrayNumber" = ${ArrayNumber}
+            'ArrayNumber' = ${ArrayNumber}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/ArrayTest.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/ArrayTest.ps1
@@ -45,9 +45,9 @@ function Initialize-PSArrayTest {
 
 
         $PSO = [PSCustomObject]@{
-            "array_of_string" = ${ArrayOfString}
-            "array_array_of_integer" = ${ArrayArrayOfInteger}
-            "array_array_of_model" = ${ArrayArrayOfModel}
+            'array_of_string' = ${ArrayOfString}
+            'array_array_of_integer' = ${ArrayArrayOfInteger}
+            'array_array_of_model' = ${ArrayArrayOfModel}
         }
 
 
@@ -85,35 +85,35 @@ function ConvertFrom-PSJsonToArrayTest {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSArrayTest
-        $AllProperties = ("array_of_string", "array_array_of_integer", "array_array_of_model")
+        $AllProperties = ('array_of_string', 'array_array_of_integer', 'array_array_of_model')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "array_of_string"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'array_of_string'))) { #optional property not found
             $ArrayOfString = $null
         } else {
-            $ArrayOfString = $JsonParameters.PSobject.Properties["array_of_string"].value
+            $ArrayOfString = $JsonParameters.PSobject.Properties['array_of_string'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "array_array_of_integer"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'array_array_of_integer'))) { #optional property not found
             $ArrayArrayOfInteger = $null
         } else {
-            $ArrayArrayOfInteger = $JsonParameters.PSobject.Properties["array_array_of_integer"].value
+            $ArrayArrayOfInteger = $JsonParameters.PSobject.Properties['array_array_of_integer'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "array_array_of_model"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'array_array_of_model'))) { #optional property not found
             $ArrayArrayOfModel = $null
         } else {
-            $ArrayArrayOfModel = $JsonParameters.PSobject.Properties["array_array_of_model"].value
+            $ArrayArrayOfModel = $JsonParameters.PSobject.Properties['array_array_of_model'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "array_of_string" = ${ArrayOfString}
-            "array_array_of_integer" = ${ArrayArrayOfInteger}
-            "array_array_of_model" = ${ArrayArrayOfModel}
+            'array_of_string' = ${ArrayOfString}
+            'array_array_of_integer' = ${ArrayArrayOfInteger}
+            'array_array_of_model' = ${ArrayArrayOfModel}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/Banana.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/Banana.ps1
@@ -35,7 +35,7 @@ function Initialize-PSBanana {
 
 
         $PSO = [PSCustomObject]@{
-            "lengthCm" = ${LengthCm}
+            'lengthCm' = ${LengthCm}
         }
 
 
@@ -73,21 +73,21 @@ function ConvertFrom-PSJsonToBanana {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSBanana
-        $AllProperties = ("lengthCm")
+        $AllProperties = ('lengthCm')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "lengthCm"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'lengthCm'))) { #optional property not found
             $LengthCm = $null
         } else {
-            $LengthCm = $JsonParameters.PSobject.Properties["lengthCm"].value
+            $LengthCm = $JsonParameters.PSobject.Properties['lengthCm'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "lengthCm" = ${LengthCm}
+            'lengthCm' = ${LengthCm}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/BananaReq.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/BananaReq.ps1
@@ -44,8 +44,8 @@ function Initialize-PSBananaReq {
 
 
         $PSO = [PSCustomObject]@{
-            "lengthCm" = ${LengthCm}
-            "sweet" = ${Sweet}
+            'lengthCm' = ${LengthCm}
+            'sweet' = ${Sweet}
         }
 
 
@@ -83,7 +83,7 @@ function ConvertFrom-PSJsonToBananaReq {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSBananaReq
-        $AllProperties = ("lengthCm", "sweet")
+        $AllProperties = ('lengthCm', 'sweet')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -94,21 +94,21 @@ function ConvertFrom-PSJsonToBananaReq {
             throw "Error! Empty JSON cannot be serialized due to the required property 'lengthCm' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "lengthCm"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'lengthCm'))) {
             throw "Error! JSON cannot be serialized due to the required property 'lengthCm' missing."
         } else {
-            $LengthCm = $JsonParameters.PSobject.Properties["lengthCm"].value
+            $LengthCm = $JsonParameters.PSobject.Properties['lengthCm'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "sweet"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'sweet'))) { #optional property not found
             $Sweet = $null
         } else {
-            $Sweet = $JsonParameters.PSobject.Properties["sweet"].value
+            $Sweet = $JsonParameters.PSobject.Properties['sweet'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "lengthCm" = ${LengthCm}
-            "sweet" = ${Sweet}
+            'lengthCm' = ${LengthCm}
+            'sweet' = ${Sweet}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/BasquePig.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/BasquePig.ps1
@@ -39,7 +39,7 @@ function Initialize-PSBasquePig {
 
 
         $PSO = [PSCustomObject]@{
-            "className" = ${ClassName}
+            'className' = ${ClassName}
         }
 
 
@@ -77,7 +77,7 @@ function ConvertFrom-PSJsonToBasquePig {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSBasquePig
-        $AllProperties = ("className")
+        $AllProperties = ('className')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -88,14 +88,14 @@ function ConvertFrom-PSJsonToBasquePig {
             throw "Error! Empty JSON cannot be serialized due to the required property 'className' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "className"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'className'))) {
             throw "Error! JSON cannot be serialized due to the required property 'className' missing."
         } else {
-            $ClassName = $JsonParameters.PSobject.Properties["className"].value
+            $ClassName = $JsonParameters.PSobject.Properties['className'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "className" = ${ClassName}
+            'className' = ${ClassName}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/Capitalization.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/Capitalization.ps1
@@ -60,12 +60,12 @@ function Initialize-PSCapitalization {
 
 
         $PSO = [PSCustomObject]@{
-            "smallCamel" = ${SmallCamel}
-            "CapitalCamel" = ${CapitalCamel}
-            "small_Snake" = ${SmallSnake}
-            "Capital_Snake" = ${CapitalSnake}
-            "SCA_ETH_Flow_Points" = ${SCAETHFlowPoints}
-            "ATT_NAME" = ${ATTNAME}
+            'smallCamel' = ${SmallCamel}
+            'CapitalCamel' = ${CapitalCamel}
+            'small_Snake' = ${SmallSnake}
+            'Capital_Snake' = ${CapitalSnake}
+            'SCA_ETH_Flow_Points' = ${SCAETHFlowPoints}
+            'ATT_NAME' = ${ATTNAME}
         }
 
 
@@ -103,56 +103,56 @@ function ConvertFrom-PSJsonToCapitalization {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSCapitalization
-        $AllProperties = ("smallCamel", "CapitalCamel", "small_Snake", "Capital_Snake", "SCA_ETH_Flow_Points", "ATT_NAME")
+        $AllProperties = ('smallCamel', 'CapitalCamel', 'small_Snake', 'Capital_Snake', 'SCA_ETH_Flow_Points', 'ATT_NAME')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "smallCamel"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'smallCamel'))) { #optional property not found
             $SmallCamel = $null
         } else {
-            $SmallCamel = $JsonParameters.PSobject.Properties["smallCamel"].value
+            $SmallCamel = $JsonParameters.PSobject.Properties['smallCamel'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "CapitalCamel"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'CapitalCamel'))) { #optional property not found
             $CapitalCamel = $null
         } else {
-            $CapitalCamel = $JsonParameters.PSobject.Properties["CapitalCamel"].value
+            $CapitalCamel = $JsonParameters.PSobject.Properties['CapitalCamel'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "small_Snake"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'small_Snake'))) { #optional property not found
             $SmallSnake = $null
         } else {
-            $SmallSnake = $JsonParameters.PSobject.Properties["small_Snake"].value
+            $SmallSnake = $JsonParameters.PSobject.Properties['small_Snake'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "Capital_Snake"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'Capital_Snake'))) { #optional property not found
             $CapitalSnake = $null
         } else {
-            $CapitalSnake = $JsonParameters.PSobject.Properties["Capital_Snake"].value
+            $CapitalSnake = $JsonParameters.PSobject.Properties['Capital_Snake'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "SCA_ETH_Flow_Points"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'SCA_ETH_Flow_Points'))) { #optional property not found
             $SCAETHFlowPoints = $null
         } else {
-            $SCAETHFlowPoints = $JsonParameters.PSobject.Properties["SCA_ETH_Flow_Points"].value
+            $SCAETHFlowPoints = $JsonParameters.PSobject.Properties['SCA_ETH_Flow_Points'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "ATT_NAME"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'ATT_NAME'))) { #optional property not found
             $ATTNAME = $null
         } else {
-            $ATTNAME = $JsonParameters.PSobject.Properties["ATT_NAME"].value
+            $ATTNAME = $JsonParameters.PSobject.Properties['ATT_NAME'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "smallCamel" = ${SmallCamel}
-            "CapitalCamel" = ${CapitalCamel}
-            "small_Snake" = ${SmallSnake}
-            "Capital_Snake" = ${CapitalSnake}
-            "SCA_ETH_Flow_Points" = ${SCAETHFlowPoints}
-            "ATT_NAME" = ${ATTNAME}
+            'smallCamel' = ${SmallCamel}
+            'CapitalCamel' = ${CapitalCamel}
+            'small_Snake' = ${SmallSnake}
+            'Capital_Snake' = ${CapitalSnake}
+            'SCA_ETH_Flow_Points' = ${SCAETHFlowPoints}
+            'ATT_NAME' = ${ATTNAME}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/Cat.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/Cat.ps1
@@ -49,9 +49,9 @@ function Initialize-PSCat {
 
 
         $PSO = [PSCustomObject]@{
-            "className" = ${ClassName}
-            "color" = ${Color}
-            "declawed" = ${Declawed}
+            'className' = ${ClassName}
+            'color' = ${Color}
+            'declawed' = ${Declawed}
         }
 
 
@@ -89,7 +89,7 @@ function ConvertFrom-PSJsonToCat {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSCat
-        $AllProperties = ("className", "color", "declawed")
+        $AllProperties = ('className', 'color', 'declawed')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -100,28 +100,28 @@ function ConvertFrom-PSJsonToCat {
             throw "Error! Empty JSON cannot be serialized due to the required property 'className' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "className"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'className'))) {
             throw "Error! JSON cannot be serialized due to the required property 'className' missing."
         } else {
-            $ClassName = $JsonParameters.PSobject.Properties["className"].value
+            $ClassName = $JsonParameters.PSobject.Properties['className'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "color"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'color'))) { #optional property not found
             $Color = $null
         } else {
-            $Color = $JsonParameters.PSobject.Properties["color"].value
+            $Color = $JsonParameters.PSobject.Properties['color'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "declawed"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'declawed'))) { #optional property not found
             $Declawed = $null
         } else {
-            $Declawed = $JsonParameters.PSobject.Properties["declawed"].value
+            $Declawed = $JsonParameters.PSobject.Properties['declawed'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "className" = ${ClassName}
-            "color" = ${Color}
-            "declawed" = ${Declawed}
+            'className' = ${ClassName}
+            'color' = ${Color}
+            'declawed' = ${Declawed}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/Category.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/Category.ps1
@@ -44,8 +44,8 @@ function Initialize-PSCategory {
 
 
         $PSO = [PSCustomObject]@{
-            "id" = ${Id}
-            "name" = ${Name}
+            'id' = ${Id}
+            'name' = ${Name}
         }
 
 
@@ -83,7 +83,7 @@ function ConvertFrom-PSJsonToCategory {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSCategory
-        $AllProperties = ("id", "name")
+        $AllProperties = ('id', 'name')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -94,21 +94,21 @@ function ConvertFrom-PSJsonToCategory {
             throw "Error! Empty JSON cannot be serialized due to the required property 'name' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "name"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'name'))) {
             throw "Error! JSON cannot be serialized due to the required property 'name' missing."
         } else {
-            $Name = $JsonParameters.PSobject.Properties["name"].value
+            $Name = $JsonParameters.PSobject.Properties['name'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "id"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'id'))) { #optional property not found
             $Id = $null
         } else {
-            $Id = $JsonParameters.PSobject.Properties["id"].value
+            $Id = $JsonParameters.PSobject.Properties['id'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "id" = ${Id}
-            "name" = ${Name}
+            'id' = ${Id}
+            'name' = ${Name}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/ClassModel.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/ClassModel.ps1
@@ -35,7 +35,7 @@ function Initialize-PSClassModel {
 
 
         $PSO = [PSCustomObject]@{
-            "_class" = ${Class}
+            '_class' = ${Class}
         }
 
 
@@ -73,21 +73,21 @@ function ConvertFrom-PSJsonToClassModel {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSClassModel
-        $AllProperties = ("_class")
+        $AllProperties = ('_class')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "_class"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match '_class'))) { #optional property not found
             $Class = $null
         } else {
-            $Class = $JsonParameters.PSobject.Properties["_class"].value
+            $Class = $JsonParameters.PSobject.Properties['_class'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "_class" = ${Class}
+            '_class' = ${Class}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/Client.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/Client.ps1
@@ -35,7 +35,7 @@ function Initialize-PSClient {
 
 
         $PSO = [PSCustomObject]@{
-            "client" = ${Client}
+            'client' = ${Client}
         }
 
 
@@ -73,21 +73,21 @@ function ConvertFrom-PSJsonToClient {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSClient
-        $AllProperties = ("client")
+        $AllProperties = ('client')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "client"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'client'))) { #optional property not found
             $Client = $null
         } else {
-            $Client = $JsonParameters.PSobject.Properties["client"].value
+            $Client = $JsonParameters.PSobject.Properties['client'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "client" = ${Client}
+            'client' = ${Client}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/ComplexQuadrilateral.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/ComplexQuadrilateral.ps1
@@ -48,8 +48,8 @@ function Initialize-PSComplexQuadrilateral {
 
 
         $PSO = [PSCustomObject]@{
-            "shapeType" = ${ShapeType}
-            "quadrilateralType" = ${QuadrilateralType}
+            'shapeType' = ${ShapeType}
+            'quadrilateralType' = ${QuadrilateralType}
         }
 
 
@@ -87,7 +87,7 @@ function ConvertFrom-PSJsonToComplexQuadrilateral {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSComplexQuadrilateral
-        $AllProperties = ("shapeType", "quadrilateralType")
+        $AllProperties = ('shapeType', 'quadrilateralType')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -98,21 +98,21 @@ function ConvertFrom-PSJsonToComplexQuadrilateral {
             throw "Error! Empty JSON cannot be serialized due to the required property 'shapeType' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "shapeType"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'shapeType'))) {
             throw "Error! JSON cannot be serialized due to the required property 'shapeType' missing."
         } else {
-            $ShapeType = $JsonParameters.PSobject.Properties["shapeType"].value
+            $ShapeType = $JsonParameters.PSobject.Properties['shapeType'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "quadrilateralType"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'quadrilateralType'))) {
             throw "Error! JSON cannot be serialized due to the required property 'quadrilateralType' missing."
         } else {
-            $QuadrilateralType = $JsonParameters.PSobject.Properties["quadrilateralType"].value
+            $QuadrilateralType = $JsonParameters.PSobject.Properties['quadrilateralType'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "shapeType" = ${ShapeType}
-            "quadrilateralType" = ${QuadrilateralType}
+            'shapeType' = ${ShapeType}
+            'quadrilateralType' = ${QuadrilateralType}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/DanishPig.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/DanishPig.ps1
@@ -39,7 +39,7 @@ function Initialize-PSDanishPig {
 
 
         $PSO = [PSCustomObject]@{
-            "className" = ${ClassName}
+            'className' = ${ClassName}
         }
 
 
@@ -77,7 +77,7 @@ function ConvertFrom-PSJsonToDanishPig {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSDanishPig
-        $AllProperties = ("className")
+        $AllProperties = ('className')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -88,14 +88,14 @@ function ConvertFrom-PSJsonToDanishPig {
             throw "Error! Empty JSON cannot be serialized due to the required property 'className' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "className"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'className'))) {
             throw "Error! JSON cannot be serialized due to the required property 'className' missing."
         } else {
-            $ClassName = $JsonParameters.PSobject.Properties["className"].value
+            $ClassName = $JsonParameters.PSobject.Properties['className'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "className" = ${ClassName}
+            'className' = ${ClassName}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/DeprecatedObject.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/DeprecatedObject.ps1
@@ -35,7 +35,7 @@ function Initialize-PSDeprecatedObject {
 
 
         $PSO = [PSCustomObject]@{
-            "name" = ${Name}
+            'name' = ${Name}
         }
 
 
@@ -73,21 +73,21 @@ function ConvertFrom-PSJsonToDeprecatedObject {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSDeprecatedObject
-        $AllProperties = ("name")
+        $AllProperties = ('name')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "name"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'name'))) { #optional property not found
             $Name = $null
         } else {
-            $Name = $JsonParameters.PSobject.Properties["name"].value
+            $Name = $JsonParameters.PSobject.Properties['name'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "name" = ${Name}
+            'name' = ${Name}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/Dog.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/Dog.ps1
@@ -49,9 +49,9 @@ function Initialize-PSDog {
 
 
         $PSO = [PSCustomObject]@{
-            "className" = ${ClassName}
-            "color" = ${Color}
-            "breed" = ${Breed}
+            'className' = ${ClassName}
+            'color' = ${Color}
+            'breed' = ${Breed}
         }
 
 
@@ -89,7 +89,7 @@ function ConvertFrom-PSJsonToDog {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSDog
-        $AllProperties = ("className", "color", "breed")
+        $AllProperties = ('className', 'color', 'breed')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -100,28 +100,28 @@ function ConvertFrom-PSJsonToDog {
             throw "Error! Empty JSON cannot be serialized due to the required property 'className' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "className"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'className'))) {
             throw "Error! JSON cannot be serialized due to the required property 'className' missing."
         } else {
-            $ClassName = $JsonParameters.PSobject.Properties["className"].value
+            $ClassName = $JsonParameters.PSobject.Properties['className'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "color"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'color'))) { #optional property not found
             $Color = $null
         } else {
-            $Color = $JsonParameters.PSobject.Properties["color"].value
+            $Color = $JsonParameters.PSobject.Properties['color'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "breed"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'breed'))) { #optional property not found
             $Breed = $null
         } else {
-            $Breed = $JsonParameters.PSobject.Properties["breed"].value
+            $Breed = $JsonParameters.PSobject.Properties['breed'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "className" = ${ClassName}
-            "color" = ${Color}
-            "breed" = ${Breed}
+            'className' = ${ClassName}
+            'color' = ${Color}
+            'breed' = ${Breed}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/Drawing.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/Drawing.ps1
@@ -50,10 +50,10 @@ function Initialize-PSDrawing {
 
 
         $PSO = [PSCustomObject]@{
-            "mainShape" = ${MainShape}
-            "shapeOrNull" = ${ShapeOrNull}
-            "nullableShape" = ${NullableShape}
-            "shapes" = ${Shapes}
+            'mainShape' = ${MainShape}
+            'shapeOrNull' = ${ShapeOrNull}
+            'nullableShape' = ${NullableShape}
+            'shapes' = ${Shapes}
         }
 
 
@@ -92,7 +92,7 @@ function ConvertFrom-PSJsonToDrawing {
         $PSDrawingAdditionalProperties = @{}
 
         # check if Json contains properties not defined in PSDrawing
-        $AllProperties = ("mainShape", "shapeOrNull", "nullableShape", "shapes")
+        $AllProperties = ('mainShape', 'shapeOrNull', 'nullableShape', 'shapes')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             # store undefined properties in additionalProperties
             if (!($AllProperties.Contains($name))) {
@@ -100,36 +100,36 @@ function ConvertFrom-PSJsonToDrawing {
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "mainShape"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'mainShape'))) { #optional property not found
             $MainShape = $null
         } else {
-            $MainShape = $JsonParameters.PSobject.Properties["mainShape"].value
+            $MainShape = $JsonParameters.PSobject.Properties['mainShape'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "shapeOrNull"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'shapeOrNull'))) { #optional property not found
             $ShapeOrNull = $null
         } else {
-            $ShapeOrNull = $JsonParameters.PSobject.Properties["shapeOrNull"].value
+            $ShapeOrNull = $JsonParameters.PSobject.Properties['shapeOrNull'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "nullableShape"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'nullableShape'))) { #optional property not found
             $NullableShape = $null
         } else {
-            $NullableShape = $JsonParameters.PSobject.Properties["nullableShape"].value
+            $NullableShape = $JsonParameters.PSobject.Properties['nullableShape'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "shapes"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'shapes'))) { #optional property not found
             $Shapes = $null
         } else {
-            $Shapes = $JsonParameters.PSobject.Properties["shapes"].value
+            $Shapes = $JsonParameters.PSobject.Properties['shapes'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "mainShape" = ${MainShape}
-            "shapeOrNull" = ${ShapeOrNull}
-            "nullableShape" = ${NullableShape}
-            "shapes" = ${Shapes}
-            "AdditionalProperties" = $PSDrawingAdditionalProperties
+            'mainShape' = ${MainShape}
+            'shapeOrNull' = ${ShapeOrNull}
+            'nullableShape' = ${NullableShape}
+            'shapes' = ${Shapes}
+            'AdditionalProperties' = $PSDrawingAdditionalProperties
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/EnumArrays.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/EnumArrays.ps1
@@ -42,8 +42,8 @@ function Initialize-PSEnumArrays {
 
 
         $PSO = [PSCustomObject]@{
-            "just_symbol" = ${JustSymbol}
-            "array_enum" = ${ArrayEnum}
+            'just_symbol' = ${JustSymbol}
+            'array_enum' = ${ArrayEnum}
         }
 
 
@@ -81,28 +81,28 @@ function ConvertFrom-PSJsonToEnumArrays {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSEnumArrays
-        $AllProperties = ("just_symbol", "array_enum")
+        $AllProperties = ('just_symbol', 'array_enum')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "just_symbol"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'just_symbol'))) { #optional property not found
             $JustSymbol = $null
         } else {
-            $JustSymbol = $JsonParameters.PSobject.Properties["just_symbol"].value
+            $JustSymbol = $JsonParameters.PSobject.Properties['just_symbol'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "array_enum"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'array_enum'))) { #optional property not found
             $ArrayEnum = $null
         } else {
-            $ArrayEnum = $JsonParameters.PSobject.Properties["array_enum"].value
+            $ArrayEnum = $JsonParameters.PSobject.Properties['array_enum'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "just_symbol" = ${JustSymbol}
-            "array_enum" = ${ArrayEnum}
+            'just_symbol' = ${JustSymbol}
+            'array_enum' = ${ArrayEnum}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/EnumTest.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/EnumTest.ps1
@@ -70,12 +70,12 @@ function Initialize-PSEnumTest {
 
 
         $PSO = [PSCustomObject]@{
-            "enum_string" = ${EnumString}
-            "enum_string_required" = ${EnumStringRequired}
-            "enum_integer" = ${EnumInteger}
-            "enum_integer_only" = ${EnumIntegerOnly}
-            "enum_number" = ${EnumNumber}
-            "outerEnum" = ${OuterEnum}
+            'enum_string' = ${EnumString}
+            'enum_string_required' = ${EnumStringRequired}
+            'enum_integer' = ${EnumInteger}
+            'enum_integer_only' = ${EnumIntegerOnly}
+            'enum_number' = ${EnumNumber}
+            'outerEnum' = ${OuterEnum}
         }
 
 
@@ -113,7 +113,7 @@ function ConvertFrom-PSJsonToEnumTest {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSEnumTest
-        $AllProperties = ("enum_string", "enum_string_required", "enum_integer", "enum_integer_only", "enum_number", "outerEnum")
+        $AllProperties = ('enum_string', 'enum_string_required', 'enum_integer', 'enum_integer_only', 'enum_number', 'outerEnum')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -124,49 +124,49 @@ function ConvertFrom-PSJsonToEnumTest {
             throw "Error! Empty JSON cannot be serialized due to the required property 'enum_string_required' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "enum_string_required"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'enum_string_required'))) {
             throw "Error! JSON cannot be serialized due to the required property 'enum_string_required' missing."
         } else {
-            $EnumStringRequired = $JsonParameters.PSobject.Properties["enum_string_required"].value
+            $EnumStringRequired = $JsonParameters.PSobject.Properties['enum_string_required'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "enum_string"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'enum_string'))) { #optional property not found
             $EnumString = $null
         } else {
-            $EnumString = $JsonParameters.PSobject.Properties["enum_string"].value
+            $EnumString = $JsonParameters.PSobject.Properties['enum_string'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "enum_integer"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'enum_integer'))) { #optional property not found
             $EnumInteger = $null
         } else {
-            $EnumInteger = $JsonParameters.PSobject.Properties["enum_integer"].value
+            $EnumInteger = $JsonParameters.PSobject.Properties['enum_integer'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "enum_integer_only"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'enum_integer_only'))) { #optional property not found
             $EnumIntegerOnly = $null
         } else {
-            $EnumIntegerOnly = $JsonParameters.PSobject.Properties["enum_integer_only"].value
+            $EnumIntegerOnly = $JsonParameters.PSobject.Properties['enum_integer_only'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "enum_number"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'enum_number'))) { #optional property not found
             $EnumNumber = $null
         } else {
-            $EnumNumber = $JsonParameters.PSobject.Properties["enum_number"].value
+            $EnumNumber = $JsonParameters.PSobject.Properties['enum_number'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "outerEnum"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'outerEnum'))) { #optional property not found
             $OuterEnum = $null
         } else {
-            $OuterEnum = $JsonParameters.PSobject.Properties["outerEnum"].value
+            $OuterEnum = $JsonParameters.PSobject.Properties['outerEnum'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "enum_string" = ${EnumString}
-            "enum_string_required" = ${EnumStringRequired}
-            "enum_integer" = ${EnumInteger}
-            "enum_integer_only" = ${EnumIntegerOnly}
-            "enum_number" = ${EnumNumber}
-            "outerEnum" = ${OuterEnum}
+            'enum_string' = ${EnumString}
+            'enum_string_required' = ${EnumStringRequired}
+            'enum_integer' = ${EnumInteger}
+            'enum_integer_only' = ${EnumIntegerOnly}
+            'enum_number' = ${EnumNumber}
+            'outerEnum' = ${OuterEnum}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/EquilateralTriangle.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/EquilateralTriangle.ps1
@@ -48,8 +48,8 @@ function Initialize-PSEquilateralTriangle {
 
 
         $PSO = [PSCustomObject]@{
-            "shapeType" = ${ShapeType}
-            "triangleType" = ${TriangleType}
+            'shapeType' = ${ShapeType}
+            'triangleType' = ${TriangleType}
         }
 
 
@@ -87,7 +87,7 @@ function ConvertFrom-PSJsonToEquilateralTriangle {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSEquilateralTriangle
-        $AllProperties = ("shapeType", "triangleType")
+        $AllProperties = ('shapeType', 'triangleType')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -98,21 +98,21 @@ function ConvertFrom-PSJsonToEquilateralTriangle {
             throw "Error! Empty JSON cannot be serialized due to the required property 'shapeType' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "shapeType"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'shapeType'))) {
             throw "Error! JSON cannot be serialized due to the required property 'shapeType' missing."
         } else {
-            $ShapeType = $JsonParameters.PSobject.Properties["shapeType"].value
+            $ShapeType = $JsonParameters.PSobject.Properties['shapeType'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "triangleType"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'triangleType'))) {
             throw "Error! JSON cannot be serialized due to the required property 'triangleType' missing."
         } else {
-            $TriangleType = $JsonParameters.PSobject.Properties["triangleType"].value
+            $TriangleType = $JsonParameters.PSobject.Properties['triangleType'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "shapeType" = ${ShapeType}
-            "triangleType" = ${TriangleType}
+            'shapeType' = ${ShapeType}
+            'triangleType' = ${TriangleType}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/File.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/File.ps1
@@ -35,7 +35,7 @@ function Initialize-PSFile {
 
 
         $PSO = [PSCustomObject]@{
-            "sourceURI" = ${SourceURI}
+            'sourceURI' = ${SourceURI}
         }
 
 
@@ -73,21 +73,21 @@ function ConvertFrom-PSJsonToFile {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSFile
-        $AllProperties = ("sourceURI")
+        $AllProperties = ('sourceURI')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "sourceURI"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'sourceURI'))) { #optional property not found
             $SourceURI = $null
         } else {
-            $SourceURI = $JsonParameters.PSobject.Properties["sourceURI"].value
+            $SourceURI = $JsonParameters.PSobject.Properties['sourceURI'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "sourceURI" = ${SourceURI}
+            'sourceURI' = ${SourceURI}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/FileSchemaTestClass.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/FileSchemaTestClass.ps1
@@ -40,8 +40,8 @@ function Initialize-PSFileSchemaTestClass {
 
 
         $PSO = [PSCustomObject]@{
-            "file" = ${File}
-            "files" = ${Files}
+            'file' = ${File}
+            'files' = ${Files}
         }
 
 
@@ -79,28 +79,28 @@ function ConvertFrom-PSJsonToFileSchemaTestClass {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSFileSchemaTestClass
-        $AllProperties = ("file", "files")
+        $AllProperties = ('file', 'files')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "file"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'file'))) { #optional property not found
             $File = $null
         } else {
-            $File = $JsonParameters.PSobject.Properties["file"].value
+            $File = $JsonParameters.PSobject.Properties['file'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "files"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'files'))) { #optional property not found
             $Files = $null
         } else {
-            $Files = $JsonParameters.PSobject.Properties["files"].value
+            $Files = $JsonParameters.PSobject.Properties['files'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "file" = ${File}
-            "files" = ${Files}
+            'file' = ${File}
+            'files' = ${Files}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/Foo.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/Foo.ps1
@@ -35,7 +35,7 @@ function Initialize-PSFoo {
 
 
         $PSO = [PSCustomObject]@{
-            "bar" = ${Bar}
+            'bar' = ${Bar}
         }
 
 
@@ -73,21 +73,21 @@ function ConvertFrom-PSJsonToFoo {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSFoo
-        $AllProperties = ("bar")
+        $AllProperties = ('bar')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "bar"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'bar'))) { #optional property not found
             $Bar = $null
         } else {
-            $Bar = $JsonParameters.PSobject.Properties["bar"].value
+            $Bar = $JsonParameters.PSobject.Properties['bar'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "bar" = ${Bar}
+            'bar' = ${Bar}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/FooGetDefaultResponse.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/FooGetDefaultResponse.ps1
@@ -35,7 +35,7 @@ function Initialize-PSFooGetDefaultResponse {
 
 
         $PSO = [PSCustomObject]@{
-            "string" = ${String}
+            'string' = ${String}
         }
 
 
@@ -73,21 +73,21 @@ function ConvertFrom-PSJsonToFooGetDefaultResponse {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSFooGetDefaultResponse
-        $AllProperties = ("string")
+        $AllProperties = ('string')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "string"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'string'))) { #optional property not found
             $String = $null
         } else {
-            $String = $JsonParameters.PSobject.Properties["string"].value
+            $String = $JsonParameters.PSobject.Properties['string'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "string" = ${String}
+            'string' = ${String}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/FormatTest.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/FormatTest.ps1
@@ -177,22 +177,22 @@ function Initialize-PSFormatTest {
 
 
         $PSO = [PSCustomObject]@{
-            "integer" = ${Integer}
-            "int32" = ${Int32}
-            "int64" = ${Int64}
-            "number" = ${Number}
-            "float" = ${Float}
-            "double" = ${Double}
-            "decimal" = ${Decimal}
-            "string" = ${String}
-            "byte" = ${Byte}
-            "binary" = ${Binary}
-            "date" = ${Date}
-            "dateTime" = ${DateTime}
-            "uuid" = ${Uuid}
-            "password" = ${Password}
-            "pattern_with_digits" = ${PatternWithDigits}
-            "pattern_with_digits_and_delimiter" = ${PatternWithDigitsAndDelimiter}
+            'integer' = ${Integer}
+            'int32' = ${Int32}
+            'int64' = ${Int64}
+            'number' = ${Number}
+            'float' = ${Float}
+            'double' = ${Double}
+            'decimal' = ${Decimal}
+            'string' = ${String}
+            'byte' = ${Byte}
+            'binary' = ${Binary}
+            'date' = ${Date}
+            'dateTime' = ${DateTime}
+            'uuid' = ${Uuid}
+            'password' = ${Password}
+            'pattern_with_digits' = ${PatternWithDigits}
+            'pattern_with_digits_and_delimiter' = ${PatternWithDigitsAndDelimiter}
         }
 
 
@@ -230,7 +230,7 @@ function ConvertFrom-PSJsonToFormatTest {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSFormatTest
-        $AllProperties = ("integer", "int32", "int64", "number", "float", "double", "decimal", "string", "byte", "binary", "date", "dateTime", "uuid", "password", "pattern_with_digits", "pattern_with_digits_and_delimiter")
+        $AllProperties = ('integer', 'int32', 'int64', 'number', 'float', 'double', 'decimal', 'string', 'byte', 'binary', 'date', 'dateTime', 'uuid', 'password', 'pattern_with_digits', 'pattern_with_digits_and_delimiter')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -241,119 +241,119 @@ function ConvertFrom-PSJsonToFormatTest {
             throw "Error! Empty JSON cannot be serialized due to the required property 'number' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "number"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'number'))) {
             throw "Error! JSON cannot be serialized due to the required property 'number' missing."
         } else {
-            $Number = $JsonParameters.PSobject.Properties["number"].value
+            $Number = $JsonParameters.PSobject.Properties['number'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "byte"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'byte'))) {
             throw "Error! JSON cannot be serialized due to the required property 'byte' missing."
         } else {
-            $Byte = $JsonParameters.PSobject.Properties["byte"].value
+            $Byte = $JsonParameters.PSobject.Properties['byte'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "date"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'date'))) {
             throw "Error! JSON cannot be serialized due to the required property 'date' missing."
         } else {
-            $Date = $JsonParameters.PSobject.Properties["date"].value
+            $Date = $JsonParameters.PSobject.Properties['date'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "password"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'password'))) {
             throw "Error! JSON cannot be serialized due to the required property 'password' missing."
         } else {
-            $Password = $JsonParameters.PSobject.Properties["password"].value
+            $Password = $JsonParameters.PSobject.Properties['password'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "integer"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'integer'))) { #optional property not found
             $Integer = $null
         } else {
-            $Integer = $JsonParameters.PSobject.Properties["integer"].value
+            $Integer = $JsonParameters.PSobject.Properties['integer'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "int32"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'int32'))) { #optional property not found
             $Int32 = $null
         } else {
-            $Int32 = $JsonParameters.PSobject.Properties["int32"].value
+            $Int32 = $JsonParameters.PSobject.Properties['int32'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "int64"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'int64'))) { #optional property not found
             $Int64 = $null
         } else {
-            $Int64 = $JsonParameters.PSobject.Properties["int64"].value
+            $Int64 = $JsonParameters.PSobject.Properties['int64'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "float"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'float'))) { #optional property not found
             $Float = $null
         } else {
-            $Float = $JsonParameters.PSobject.Properties["float"].value
+            $Float = $JsonParameters.PSobject.Properties['float'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "double"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'double'))) { #optional property not found
             $Double = $null
         } else {
-            $Double = $JsonParameters.PSobject.Properties["double"].value
+            $Double = $JsonParameters.PSobject.Properties['double'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "decimal"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'decimal'))) { #optional property not found
             $Decimal = $null
         } else {
-            $Decimal = $JsonParameters.PSobject.Properties["decimal"].value
+            $Decimal = $JsonParameters.PSobject.Properties['decimal'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "string"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'string'))) { #optional property not found
             $String = $null
         } else {
-            $String = $JsonParameters.PSobject.Properties["string"].value
+            $String = $JsonParameters.PSobject.Properties['string'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "binary"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'binary'))) { #optional property not found
             $Binary = $null
         } else {
-            $Binary = $JsonParameters.PSobject.Properties["binary"].value
+            $Binary = $JsonParameters.PSobject.Properties['binary'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "dateTime"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'dateTime'))) { #optional property not found
             $DateTime = $null
         } else {
-            $DateTime = $JsonParameters.PSobject.Properties["dateTime"].value
+            $DateTime = $JsonParameters.PSobject.Properties['dateTime'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "uuid"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'uuid'))) { #optional property not found
             $Uuid = $null
         } else {
-            $Uuid = $JsonParameters.PSobject.Properties["uuid"].value
+            $Uuid = $JsonParameters.PSobject.Properties['uuid'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "pattern_with_digits"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'pattern_with_digits'))) { #optional property not found
             $PatternWithDigits = $null
         } else {
-            $PatternWithDigits = $JsonParameters.PSobject.Properties["pattern_with_digits"].value
+            $PatternWithDigits = $JsonParameters.PSobject.Properties['pattern_with_digits'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "pattern_with_digits_and_delimiter"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'pattern_with_digits_and_delimiter'))) { #optional property not found
             $PatternWithDigitsAndDelimiter = $null
         } else {
-            $PatternWithDigitsAndDelimiter = $JsonParameters.PSobject.Properties["pattern_with_digits_and_delimiter"].value
+            $PatternWithDigitsAndDelimiter = $JsonParameters.PSobject.Properties['pattern_with_digits_and_delimiter'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "integer" = ${Integer}
-            "int32" = ${Int32}
-            "int64" = ${Int64}
-            "number" = ${Number}
-            "float" = ${Float}
-            "double" = ${Double}
-            "decimal" = ${Decimal}
-            "string" = ${String}
-            "byte" = ${Byte}
-            "binary" = ${Binary}
-            "date" = ${Date}
-            "dateTime" = ${DateTime}
-            "uuid" = ${Uuid}
-            "password" = ${Password}
-            "pattern_with_digits" = ${PatternWithDigits}
-            "pattern_with_digits_and_delimiter" = ${PatternWithDigitsAndDelimiter}
+            'integer' = ${Integer}
+            'int32' = ${Int32}
+            'int64' = ${Int64}
+            'number' = ${Number}
+            'float' = ${Float}
+            'double' = ${Double}
+            'decimal' = ${Decimal}
+            'string' = ${String}
+            'byte' = ${Byte}
+            'binary' = ${Binary}
+            'date' = ${Date}
+            'dateTime' = ${DateTime}
+            'uuid' = ${Uuid}
+            'password' = ${Password}
+            'pattern_with_digits' = ${PatternWithDigits}
+            'pattern_with_digits_and_delimiter' = ${PatternWithDigitsAndDelimiter}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/GrandparentAnimal.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/GrandparentAnimal.ps1
@@ -39,7 +39,7 @@ function Initialize-PSGrandparentAnimal {
 
 
         $PSO = [PSCustomObject]@{
-            "pet_type" = ${PetType}
+            'pet_type' = ${PetType}
         }
 
 
@@ -77,7 +77,7 @@ function ConvertFrom-PSJsonToGrandparentAnimal {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSGrandparentAnimal
-        $AllProperties = ("pet_type")
+        $AllProperties = ('pet_type')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -88,14 +88,14 @@ function ConvertFrom-PSJsonToGrandparentAnimal {
             throw "Error! Empty JSON cannot be serialized due to the required property 'pet_type' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "pet_type"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'pet_type'))) {
             throw "Error! JSON cannot be serialized due to the required property 'pet_type' missing."
         } else {
-            $PetType = $JsonParameters.PSobject.Properties["pet_type"].value
+            $PetType = $JsonParameters.PSobject.Properties['pet_type'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "pet_type" = ${PetType}
+            'pet_type' = ${PetType}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/HasOnlyReadOnly.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/HasOnlyReadOnly.ps1
@@ -40,8 +40,8 @@ function Initialize-PSHasOnlyReadOnly {
 
 
         $PSO = [PSCustomObject]@{
-            "bar" = ${Bar}
-            "foo" = ${Foo}
+            'bar' = ${Bar}
+            'foo' = ${Foo}
         }
 
 
@@ -79,28 +79,28 @@ function ConvertFrom-PSJsonToHasOnlyReadOnly {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSHasOnlyReadOnly
-        $AllProperties = ("bar", "foo")
+        $AllProperties = ('bar', 'foo')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "bar"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'bar'))) { #optional property not found
             $Bar = $null
         } else {
-            $Bar = $JsonParameters.PSobject.Properties["bar"].value
+            $Bar = $JsonParameters.PSobject.Properties['bar'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "foo"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'foo'))) { #optional property not found
             $Foo = $null
         } else {
-            $Foo = $JsonParameters.PSobject.Properties["foo"].value
+            $Foo = $JsonParameters.PSobject.Properties['foo'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "bar" = ${Bar}
-            "foo" = ${Foo}
+            'bar' = ${Bar}
+            'foo' = ${Foo}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/HealthCheckResult.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/HealthCheckResult.ps1
@@ -35,7 +35,7 @@ function Initialize-PSHealthCheckResult {
 
 
         $PSO = [PSCustomObject]@{
-            "NullableMessage" = ${NullableMessage}
+            'NullableMessage' = ${NullableMessage}
         }
 
 
@@ -73,21 +73,21 @@ function ConvertFrom-PSJsonToHealthCheckResult {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSHealthCheckResult
-        $AllProperties = ("NullableMessage")
+        $AllProperties = ('NullableMessage')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "NullableMessage"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'NullableMessage'))) { #optional property not found
             $NullableMessage = $null
         } else {
-            $NullableMessage = $JsonParameters.PSobject.Properties["NullableMessage"].value
+            $NullableMessage = $JsonParameters.PSobject.Properties['NullableMessage'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "NullableMessage" = ${NullableMessage}
+            'NullableMessage' = ${NullableMessage}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/IsoscelesTriangle.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/IsoscelesTriangle.ps1
@@ -48,8 +48,8 @@ function Initialize-PSIsoscelesTriangle {
 
 
         $PSO = [PSCustomObject]@{
-            "shapeType" = ${ShapeType}
-            "triangleType" = ${TriangleType}
+            'shapeType' = ${ShapeType}
+            'triangleType' = ${TriangleType}
         }
 
 
@@ -87,7 +87,7 @@ function ConvertFrom-PSJsonToIsoscelesTriangle {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSIsoscelesTriangle
-        $AllProperties = ("shapeType", "triangleType")
+        $AllProperties = ('shapeType', 'triangleType')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -98,21 +98,21 @@ function ConvertFrom-PSJsonToIsoscelesTriangle {
             throw "Error! Empty JSON cannot be serialized due to the required property 'shapeType' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "shapeType"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'shapeType'))) {
             throw "Error! JSON cannot be serialized due to the required property 'shapeType' missing."
         } else {
-            $ShapeType = $JsonParameters.PSobject.Properties["shapeType"].value
+            $ShapeType = $JsonParameters.PSobject.Properties['shapeType'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "triangleType"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'triangleType'))) {
             throw "Error! JSON cannot be serialized due to the required property 'triangleType' missing."
         } else {
-            $TriangleType = $JsonParameters.PSobject.Properties["triangleType"].value
+            $TriangleType = $JsonParameters.PSobject.Properties['triangleType'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "shapeType" = ${ShapeType}
-            "triangleType" = ${TriangleType}
+            'shapeType' = ${ShapeType}
+            'triangleType' = ${TriangleType}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/List.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/List.ps1
@@ -35,7 +35,7 @@ function Initialize-PSList {
 
 
         $PSO = [PSCustomObject]@{
-            "123-list" = ${Var123List}
+            '123-list' = ${Var123List}
         }
 
 
@@ -73,21 +73,21 @@ function ConvertFrom-PSJsonToList {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSList
-        $AllProperties = ("123-list")
+        $AllProperties = ('123-list')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "123-list"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match '123-list'))) { #optional property not found
             $Var123List = $null
         } else {
-            $Var123List = $JsonParameters.PSobject.Properties["123-list"].value
+            $Var123List = $JsonParameters.PSobject.Properties['123-list'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "123-list" = ${Var123List}
+            '123-list' = ${Var123List}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/MapTest.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/MapTest.ps1
@@ -51,10 +51,10 @@ function Initialize-PSMapTest {
 
 
         $PSO = [PSCustomObject]@{
-            "map_map_of_string" = ${MapMapOfString}
-            "map_of_enum_string" = ${MapOfEnumString}
-            "direct_map" = ${DirectMap}
-            "indirect_map" = ${IndirectMap}
+            'map_map_of_string' = ${MapMapOfString}
+            'map_of_enum_string' = ${MapOfEnumString}
+            'direct_map' = ${DirectMap}
+            'indirect_map' = ${IndirectMap}
         }
 
 
@@ -92,42 +92,42 @@ function ConvertFrom-PSJsonToMapTest {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSMapTest
-        $AllProperties = ("map_map_of_string", "map_of_enum_string", "direct_map", "indirect_map")
+        $AllProperties = ('map_map_of_string', 'map_of_enum_string', 'direct_map', 'indirect_map')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "map_map_of_string"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'map_map_of_string'))) { #optional property not found
             $MapMapOfString = $null
         } else {
-            $MapMapOfString = $JsonParameters.PSobject.Properties["map_map_of_string"].value
+            $MapMapOfString = $JsonParameters.PSobject.Properties['map_map_of_string'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "map_of_enum_string"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'map_of_enum_string'))) { #optional property not found
             $MapOfEnumString = $null
         } else {
-            $MapOfEnumString = $JsonParameters.PSobject.Properties["map_of_enum_string"].value
+            $MapOfEnumString = $JsonParameters.PSobject.Properties['map_of_enum_string'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "direct_map"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'direct_map'))) { #optional property not found
             $DirectMap = $null
         } else {
-            $DirectMap = $JsonParameters.PSobject.Properties["direct_map"].value
+            $DirectMap = $JsonParameters.PSobject.Properties['direct_map'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "indirect_map"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'indirect_map'))) { #optional property not found
             $IndirectMap = $null
         } else {
-            $IndirectMap = $JsonParameters.PSobject.Properties["indirect_map"].value
+            $IndirectMap = $JsonParameters.PSobject.Properties['indirect_map'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "map_map_of_string" = ${MapMapOfString}
-            "map_of_enum_string" = ${MapOfEnumString}
-            "direct_map" = ${DirectMap}
-            "indirect_map" = ${IndirectMap}
+            'map_map_of_string' = ${MapMapOfString}
+            'map_of_enum_string' = ${MapOfEnumString}
+            'direct_map' = ${DirectMap}
+            'indirect_map' = ${IndirectMap}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/MixedPropertiesAndAdditionalPropertiesClass.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/MixedPropertiesAndAdditionalPropertiesClass.ps1
@@ -45,9 +45,9 @@ function Initialize-PSMixedPropertiesAndAdditionalPropertiesClass {
 
 
         $PSO = [PSCustomObject]@{
-            "uuid" = ${Uuid}
-            "dateTime" = ${DateTime}
-            "map" = ${Map}
+            'uuid' = ${Uuid}
+            'dateTime' = ${DateTime}
+            'map' = ${Map}
         }
 
 
@@ -85,35 +85,35 @@ function ConvertFrom-PSJsonToMixedPropertiesAndAdditionalPropertiesClass {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSMixedPropertiesAndAdditionalPropertiesClass
-        $AllProperties = ("uuid", "dateTime", "map")
+        $AllProperties = ('uuid', 'dateTime', 'map')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "uuid"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'uuid'))) { #optional property not found
             $Uuid = $null
         } else {
-            $Uuid = $JsonParameters.PSobject.Properties["uuid"].value
+            $Uuid = $JsonParameters.PSobject.Properties['uuid'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "dateTime"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'dateTime'))) { #optional property not found
             $DateTime = $null
         } else {
-            $DateTime = $JsonParameters.PSobject.Properties["dateTime"].value
+            $DateTime = $JsonParameters.PSobject.Properties['dateTime'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "map"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'map'))) { #optional property not found
             $Map = $null
         } else {
-            $Map = $JsonParameters.PSobject.Properties["map"].value
+            $Map = $JsonParameters.PSobject.Properties['map'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "uuid" = ${Uuid}
-            "dateTime" = ${DateTime}
-            "map" = ${Map}
+            'uuid' = ${Uuid}
+            'dateTime' = ${DateTime}
+            'map' = ${Map}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/Model200Response.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/Model200Response.ps1
@@ -40,8 +40,8 @@ function Initialize-PSModel200Response {
 
 
         $PSO = [PSCustomObject]@{
-            "name" = ${Name}
-            "class" = ${Class}
+            'name' = ${Name}
+            'class' = ${Class}
         }
 
 
@@ -79,28 +79,28 @@ function ConvertFrom-PSJsonToModel200Response {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSModel200Response
-        $AllProperties = ("name", "class")
+        $AllProperties = ('name', 'class')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "name"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'name'))) { #optional property not found
             $Name = $null
         } else {
-            $Name = $JsonParameters.PSobject.Properties["name"].value
+            $Name = $JsonParameters.PSobject.Properties['name'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "class"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'class'))) { #optional property not found
             $Class = $null
         } else {
-            $Class = $JsonParameters.PSobject.Properties["class"].value
+            $Class = $JsonParameters.PSobject.Properties['class'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "name" = ${Name}
-            "class" = ${Class}
+            'name' = ${Name}
+            'class' = ${Class}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/ModelReturn.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/ModelReturn.ps1
@@ -35,7 +35,7 @@ function Initialize-PSModelReturn {
 
 
         $PSO = [PSCustomObject]@{
-            "return" = ${VarReturn}
+            'return' = ${VarReturn}
         }
 
 
@@ -73,21 +73,21 @@ function ConvertFrom-PSJsonToModelReturn {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSModelReturn
-        $AllProperties = ("return")
+        $AllProperties = ('return')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "return"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'return'))) { #optional property not found
             $VarReturn = $null
         } else {
-            $VarReturn = $JsonParameters.PSobject.Properties["return"].value
+            $VarReturn = $JsonParameters.PSobject.Properties['return'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "return" = ${VarReturn}
+            'return' = ${VarReturn}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/Name.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/Name.ps1
@@ -54,10 +54,10 @@ function Initialize-PSName {
 
 
         $PSO = [PSCustomObject]@{
-            "name" = ${Name}
-            "snake_case" = ${SnakeCase}
-            "property" = ${Property}
-            "123Number" = ${Var123Number}
+            'name' = ${Name}
+            'snake_case' = ${SnakeCase}
+            'property' = ${Property}
+            '123Number' = ${Var123Number}
         }
 
 
@@ -95,7 +95,7 @@ function ConvertFrom-PSJsonToName {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSName
-        $AllProperties = ("name", "snake_case", "property", "123Number")
+        $AllProperties = ('name', 'snake_case', 'property', '123Number')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -106,35 +106,35 @@ function ConvertFrom-PSJsonToName {
             throw "Error! Empty JSON cannot be serialized due to the required property 'name' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "name"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'name'))) {
             throw "Error! JSON cannot be serialized due to the required property 'name' missing."
         } else {
-            $Name = $JsonParameters.PSobject.Properties["name"].value
+            $Name = $JsonParameters.PSobject.Properties['name'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "snake_case"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'snake_case'))) { #optional property not found
             $SnakeCase = $null
         } else {
-            $SnakeCase = $JsonParameters.PSobject.Properties["snake_case"].value
+            $SnakeCase = $JsonParameters.PSobject.Properties['snake_case'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "property"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'property'))) { #optional property not found
             $Property = $null
         } else {
-            $Property = $JsonParameters.PSobject.Properties["property"].value
+            $Property = $JsonParameters.PSobject.Properties['property'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "123Number"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match '123Number'))) { #optional property not found
             $Var123Number = $null
         } else {
-            $Var123Number = $JsonParameters.PSobject.Properties["123Number"].value
+            $Var123Number = $JsonParameters.PSobject.Properties['123Number'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "name" = ${Name}
-            "snake_case" = ${SnakeCase}
-            "property" = ${Property}
-            "123Number" = ${Var123Number}
+            'name' = ${Name}
+            'snake_case' = ${SnakeCase}
+            'property' = ${Property}
+            '123Number' = ${Var123Number}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/NewModel.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/NewModel.ps1
@@ -35,7 +35,7 @@ function Initialize-PSNewModel {
 
 
         $PSO = [PSCustomObject]@{
-            "name" = ${Name}
+            'name' = ${Name}
         }
 
 
@@ -73,21 +73,21 @@ function ConvertFrom-PSJsonToNewModel {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSNewModel
-        $AllProperties = ("name")
+        $AllProperties = ('name')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "name"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'name'))) { #optional property not found
             $Name = $null
         } else {
-            $Name = $JsonParameters.PSobject.Properties["name"].value
+            $Name = $JsonParameters.PSobject.Properties['name'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "name" = ${Name}
+            'name' = ${Name}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/NullableClass.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/NullableClass.ps1
@@ -90,18 +90,18 @@ function Initialize-PSNullableClass {
 
 
         $PSO = [PSCustomObject]@{
-            "integer_prop" = ${IntegerProp}
-            "number_prop" = ${NumberProp}
-            "boolean_prop" = ${BooleanProp}
-            "string_prop" = ${StringProp}
-            "date_prop" = ${DateProp}
-            "datetime_prop" = ${DatetimeProp}
-            "array_nullable_prop" = ${ArrayNullableProp}
-            "array_and_items_nullable_prop" = ${ArrayAndItemsNullableProp}
-            "array_items_nullable" = ${ArrayItemsNullable}
-            "object_nullable_prop" = ${ObjectNullableProp}
-            "object_and_items_nullable_prop" = ${ObjectAndItemsNullableProp}
-            "object_items_nullable" = ${ObjectItemsNullable}
+            'integer_prop' = ${IntegerProp}
+            'number_prop' = ${NumberProp}
+            'boolean_prop' = ${BooleanProp}
+            'string_prop' = ${StringProp}
+            'date_prop' = ${DateProp}
+            'datetime_prop' = ${DatetimeProp}
+            'array_nullable_prop' = ${ArrayNullableProp}
+            'array_and_items_nullable_prop' = ${ArrayAndItemsNullableProp}
+            'array_items_nullable' = ${ArrayItemsNullable}
+            'object_nullable_prop' = ${ObjectNullableProp}
+            'object_and_items_nullable_prop' = ${ObjectAndItemsNullableProp}
+            'object_items_nullable' = ${ObjectItemsNullable}
         }
 
 
@@ -140,7 +140,7 @@ function ConvertFrom-PSJsonToNullableClass {
         $PSNullableClassAdditionalProperties = @{}
 
         # check if Json contains properties not defined in PSNullableClass
-        $AllProperties = ("integer_prop", "number_prop", "boolean_prop", "string_prop", "date_prop", "datetime_prop", "array_nullable_prop", "array_and_items_nullable_prop", "array_items_nullable", "object_nullable_prop", "object_and_items_nullable_prop", "object_items_nullable")
+        $AllProperties = ('integer_prop', 'number_prop', 'boolean_prop', 'string_prop', 'date_prop', 'datetime_prop', 'array_nullable_prop', 'array_and_items_nullable_prop', 'array_items_nullable', 'object_nullable_prop', 'object_and_items_nullable_prop', 'object_items_nullable')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             # store undefined properties in additionalProperties
             if (!($AllProperties.Contains($name))) {
@@ -148,92 +148,92 @@ function ConvertFrom-PSJsonToNullableClass {
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "integer_prop"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'integer_prop'))) { #optional property not found
             $IntegerProp = $null
         } else {
-            $IntegerProp = $JsonParameters.PSobject.Properties["integer_prop"].value
+            $IntegerProp = $JsonParameters.PSobject.Properties['integer_prop'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "number_prop"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'number_prop'))) { #optional property not found
             $NumberProp = $null
         } else {
-            $NumberProp = $JsonParameters.PSobject.Properties["number_prop"].value
+            $NumberProp = $JsonParameters.PSobject.Properties['number_prop'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "boolean_prop"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'boolean_prop'))) { #optional property not found
             $BooleanProp = $null
         } else {
-            $BooleanProp = $JsonParameters.PSobject.Properties["boolean_prop"].value
+            $BooleanProp = $JsonParameters.PSobject.Properties['boolean_prop'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "string_prop"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'string_prop'))) { #optional property not found
             $StringProp = $null
         } else {
-            $StringProp = $JsonParameters.PSobject.Properties["string_prop"].value
+            $StringProp = $JsonParameters.PSobject.Properties['string_prop'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "date_prop"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'date_prop'))) { #optional property not found
             $DateProp = $null
         } else {
-            $DateProp = $JsonParameters.PSobject.Properties["date_prop"].value
+            $DateProp = $JsonParameters.PSobject.Properties['date_prop'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "datetime_prop"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'datetime_prop'))) { #optional property not found
             $DatetimeProp = $null
         } else {
-            $DatetimeProp = $JsonParameters.PSobject.Properties["datetime_prop"].value
+            $DatetimeProp = $JsonParameters.PSobject.Properties['datetime_prop'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "array_nullable_prop"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'array_nullable_prop'))) { #optional property not found
             $ArrayNullableProp = $null
         } else {
-            $ArrayNullableProp = $JsonParameters.PSobject.Properties["array_nullable_prop"].value
+            $ArrayNullableProp = $JsonParameters.PSobject.Properties['array_nullable_prop'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "array_and_items_nullable_prop"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'array_and_items_nullable_prop'))) { #optional property not found
             $ArrayAndItemsNullableProp = $null
         } else {
-            $ArrayAndItemsNullableProp = $JsonParameters.PSobject.Properties["array_and_items_nullable_prop"].value
+            $ArrayAndItemsNullableProp = $JsonParameters.PSobject.Properties['array_and_items_nullable_prop'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "array_items_nullable"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'array_items_nullable'))) { #optional property not found
             $ArrayItemsNullable = $null
         } else {
-            $ArrayItemsNullable = $JsonParameters.PSobject.Properties["array_items_nullable"].value
+            $ArrayItemsNullable = $JsonParameters.PSobject.Properties['array_items_nullable'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "object_nullable_prop"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'object_nullable_prop'))) { #optional property not found
             $ObjectNullableProp = $null
         } else {
-            $ObjectNullableProp = $JsonParameters.PSobject.Properties["object_nullable_prop"].value
+            $ObjectNullableProp = $JsonParameters.PSobject.Properties['object_nullable_prop'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "object_and_items_nullable_prop"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'object_and_items_nullable_prop'))) { #optional property not found
             $ObjectAndItemsNullableProp = $null
         } else {
-            $ObjectAndItemsNullableProp = $JsonParameters.PSobject.Properties["object_and_items_nullable_prop"].value
+            $ObjectAndItemsNullableProp = $JsonParameters.PSobject.Properties['object_and_items_nullable_prop'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "object_items_nullable"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'object_items_nullable'))) { #optional property not found
             $ObjectItemsNullable = $null
         } else {
-            $ObjectItemsNullable = $JsonParameters.PSobject.Properties["object_items_nullable"].value
+            $ObjectItemsNullable = $JsonParameters.PSobject.Properties['object_items_nullable'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "integer_prop" = ${IntegerProp}
-            "number_prop" = ${NumberProp}
-            "boolean_prop" = ${BooleanProp}
-            "string_prop" = ${StringProp}
-            "date_prop" = ${DateProp}
-            "datetime_prop" = ${DatetimeProp}
-            "array_nullable_prop" = ${ArrayNullableProp}
-            "array_and_items_nullable_prop" = ${ArrayAndItemsNullableProp}
-            "array_items_nullable" = ${ArrayItemsNullable}
-            "object_nullable_prop" = ${ObjectNullableProp}
-            "object_and_items_nullable_prop" = ${ObjectAndItemsNullableProp}
-            "object_items_nullable" = ${ObjectItemsNullable}
-            "AdditionalProperties" = $PSNullableClassAdditionalProperties
+            'integer_prop' = ${IntegerProp}
+            'number_prop' = ${NumberProp}
+            'boolean_prop' = ${BooleanProp}
+            'string_prop' = ${StringProp}
+            'date_prop' = ${DateProp}
+            'datetime_prop' = ${DatetimeProp}
+            'array_nullable_prop' = ${ArrayNullableProp}
+            'array_and_items_nullable_prop' = ${ArrayAndItemsNullableProp}
+            'array_items_nullable' = ${ArrayItemsNullable}
+            'object_nullable_prop' = ${ObjectNullableProp}
+            'object_and_items_nullable_prop' = ${ObjectAndItemsNullableProp}
+            'object_items_nullable' = ${ObjectItemsNullable}
+            'AdditionalProperties' = $PSNullableClassAdditionalProperties
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/NumberOnly.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/NumberOnly.ps1
@@ -35,7 +35,7 @@ function Initialize-PSNumberOnly {
 
 
         $PSO = [PSCustomObject]@{
-            "JustNumber" = ${JustNumber}
+            'JustNumber' = ${JustNumber}
         }
 
 
@@ -73,21 +73,21 @@ function ConvertFrom-PSJsonToNumberOnly {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSNumberOnly
-        $AllProperties = ("JustNumber")
+        $AllProperties = ('JustNumber')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "JustNumber"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'JustNumber'))) { #optional property not found
             $JustNumber = $null
         } else {
-            $JustNumber = $JsonParameters.PSobject.Properties["JustNumber"].value
+            $JustNumber = $JsonParameters.PSobject.Properties['JustNumber'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "JustNumber" = ${JustNumber}
+            'JustNumber' = ${JustNumber}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/ObjectWithDeprecatedFields.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/ObjectWithDeprecatedFields.ps1
@@ -55,11 +55,11 @@ function Initialize-PSObjectWithDeprecatedFields {
 
 
         $PSO = [PSCustomObject]@{
-            "uuid" = ${Uuid}
-            "id" = ${Id}
-            "deprecatedRef" = ${DeprecatedRef}
-            "bars" = ${Bars}
-            "name_mapping" = ${SomethingElse}
+            'uuid' = ${Uuid}
+            'id' = ${Id}
+            'deprecatedRef' = ${DeprecatedRef}
+            'bars' = ${Bars}
+            'name_mapping' = ${SomethingElse}
         }
 
 
@@ -97,49 +97,49 @@ function ConvertFrom-PSJsonToObjectWithDeprecatedFields {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSObjectWithDeprecatedFields
-        $AllProperties = ("uuid", "id", "deprecatedRef", "bars", "name_mapping")
+        $AllProperties = ('uuid', 'id', 'deprecatedRef', 'bars', 'name_mapping')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "uuid"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'uuid'))) { #optional property not found
             $Uuid = $null
         } else {
-            $Uuid = $JsonParameters.PSobject.Properties["uuid"].value
+            $Uuid = $JsonParameters.PSobject.Properties['uuid'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "id"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'id'))) { #optional property not found
             $Id = $null
         } else {
-            $Id = $JsonParameters.PSobject.Properties["id"].value
+            $Id = $JsonParameters.PSobject.Properties['id'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "deprecatedRef"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'deprecatedRef'))) { #optional property not found
             $DeprecatedRef = $null
         } else {
-            $DeprecatedRef = $JsonParameters.PSobject.Properties["deprecatedRef"].value
+            $DeprecatedRef = $JsonParameters.PSobject.Properties['deprecatedRef'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "bars"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'bars'))) { #optional property not found
             $Bars = $null
         } else {
-            $Bars = $JsonParameters.PSobject.Properties["bars"].value
+            $Bars = $JsonParameters.PSobject.Properties['bars'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "name_mapping"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'name_mapping'))) { #optional property not found
             $SomethingElse = $null
         } else {
-            $SomethingElse = $JsonParameters.PSobject.Properties["name_mapping"].value
+            $SomethingElse = $JsonParameters.PSobject.Properties['name_mapping'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "uuid" = ${Uuid}
-            "id" = ${Id}
-            "deprecatedRef" = ${DeprecatedRef}
-            "bars" = ${Bars}
-            "name_mapping" = ${SomethingElse}
+            'uuid' = ${Uuid}
+            'id' = ${Id}
+            'deprecatedRef' = ${DeprecatedRef}
+            'bars' = ${Bars}
+            'name_mapping' = ${SomethingElse}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/Order.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/Order.ps1
@@ -61,12 +61,12 @@ function Initialize-PSOrder {
 
 
         $PSO = [PSCustomObject]@{
-            "id" = ${Id}
-            "petId" = ${PetId}
-            "quantity" = ${Quantity}
-            "shipDate" = ${ShipDate}
-            "status" = ${Status}
-            "complete" = ${Complete}
+            'id' = ${Id}
+            'petId' = ${PetId}
+            'quantity' = ${Quantity}
+            'shipDate' = ${ShipDate}
+            'status' = ${Status}
+            'complete' = ${Complete}
         }
 
 
@@ -104,56 +104,56 @@ function ConvertFrom-PSJsonToOrder {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSOrder
-        $AllProperties = ("id", "petId", "quantity", "shipDate", "status", "complete")
+        $AllProperties = ('id', 'petId', 'quantity', 'shipDate', 'status', 'complete')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "id"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'id'))) { #optional property not found
             $Id = $null
         } else {
-            $Id = $JsonParameters.PSobject.Properties["id"].value
+            $Id = $JsonParameters.PSobject.Properties['id'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "petId"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'petId'))) { #optional property not found
             $PetId = $null
         } else {
-            $PetId = $JsonParameters.PSobject.Properties["petId"].value
+            $PetId = $JsonParameters.PSobject.Properties['petId'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "quantity"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'quantity'))) { #optional property not found
             $Quantity = $null
         } else {
-            $Quantity = $JsonParameters.PSobject.Properties["quantity"].value
+            $Quantity = $JsonParameters.PSobject.Properties['quantity'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "shipDate"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'shipDate'))) { #optional property not found
             $ShipDate = $null
         } else {
-            $ShipDate = $JsonParameters.PSobject.Properties["shipDate"].value
+            $ShipDate = $JsonParameters.PSobject.Properties['shipDate'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "status"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'status'))) { #optional property not found
             $Status = $null
         } else {
-            $Status = $JsonParameters.PSobject.Properties["status"].value
+            $Status = $JsonParameters.PSobject.Properties['status'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "complete"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'complete'))) { #optional property not found
             $Complete = $null
         } else {
-            $Complete = $JsonParameters.PSobject.Properties["complete"].value
+            $Complete = $JsonParameters.PSobject.Properties['complete'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "id" = ${Id}
-            "petId" = ${PetId}
-            "quantity" = ${Quantity}
-            "shipDate" = ${ShipDate}
-            "status" = ${Status}
-            "complete" = ${Complete}
+            'id' = ${Id}
+            'petId' = ${PetId}
+            'quantity' = ${Quantity}
+            'shipDate' = ${ShipDate}
+            'status' = ${Status}
+            'complete' = ${Complete}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/OuterComposite.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/OuterComposite.ps1
@@ -45,9 +45,9 @@ function Initialize-PSOuterComposite {
 
 
         $PSO = [PSCustomObject]@{
-            "my_number" = ${MyNumber}
-            "my_string" = ${MyString}
-            "my_boolean" = ${MyBoolean}
+            'my_number' = ${MyNumber}
+            'my_string' = ${MyString}
+            'my_boolean' = ${MyBoolean}
         }
 
 
@@ -85,35 +85,35 @@ function ConvertFrom-PSJsonToOuterComposite {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSOuterComposite
-        $AllProperties = ("my_number", "my_string", "my_boolean")
+        $AllProperties = ('my_number', 'my_string', 'my_boolean')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "my_number"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'my_number'))) { #optional property not found
             $MyNumber = $null
         } else {
-            $MyNumber = $JsonParameters.PSobject.Properties["my_number"].value
+            $MyNumber = $JsonParameters.PSobject.Properties['my_number'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "my_string"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'my_string'))) { #optional property not found
             $MyString = $null
         } else {
-            $MyString = $JsonParameters.PSobject.Properties["my_string"].value
+            $MyString = $JsonParameters.PSobject.Properties['my_string'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "my_boolean"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'my_boolean'))) { #optional property not found
             $MyBoolean = $null
         } else {
-            $MyBoolean = $JsonParameters.PSobject.Properties["my_boolean"].value
+            $MyBoolean = $JsonParameters.PSobject.Properties['my_boolean'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "my_number" = ${MyNumber}
-            "my_string" = ${MyString}
-            "my_boolean" = ${MyBoolean}
+            'my_number' = ${MyNumber}
+            'my_string' = ${MyString}
+            'my_boolean' = ${MyBoolean}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/ParentPet.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/ParentPet.ps1
@@ -39,7 +39,7 @@ function Initialize-PSParentPet {
 
 
         $PSO = [PSCustomObject]@{
-            "pet_type" = ${PetType}
+            'pet_type' = ${PetType}
         }
 
 
@@ -77,7 +77,7 @@ function ConvertFrom-PSJsonToParentPet {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSParentPet
-        $AllProperties = ("pet_type")
+        $AllProperties = ('pet_type')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -88,14 +88,14 @@ function ConvertFrom-PSJsonToParentPet {
             throw "Error! Empty JSON cannot be serialized due to the required property 'pet_type' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "pet_type"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'pet_type'))) {
             throw "Error! JSON cannot be serialized due to the required property 'pet_type' missing."
         } else {
-            $PetType = $JsonParameters.PSobject.Properties["pet_type"].value
+            $PetType = $JsonParameters.PSobject.Properties['pet_type'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "pet_type" = ${PetType}
+            'pet_type' = ${PetType}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/Pet.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/Pet.ps1
@@ -69,12 +69,12 @@ function Initialize-PSPet {
 
 
         $PSO = [PSCustomObject]@{
-            "id" = ${Id}
-            "category" = ${Category}
-            "name" = ${Name}
-            "photoUrls" = ${PhotoUrls}
-            "tags" = ${Tags}
-            "status" = ${Status}
+            'id' = ${Id}
+            'category' = ${Category}
+            'name' = ${Name}
+            'photoUrls' = ${PhotoUrls}
+            'tags' = ${Tags}
+            'status' = ${Status}
         }
 
 
@@ -112,7 +112,7 @@ function ConvertFrom-PSJsonToPet {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSPet
-        $AllProperties = ("id", "category", "name", "photoUrls", "tags", "status")
+        $AllProperties = ('id', 'category', 'name', 'photoUrls', 'tags', 'status')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -123,49 +123,49 @@ function ConvertFrom-PSJsonToPet {
             throw "Error! Empty JSON cannot be serialized due to the required property 'name' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "name"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'name'))) {
             throw "Error! JSON cannot be serialized due to the required property 'name' missing."
         } else {
-            $Name = $JsonParameters.PSobject.Properties["name"].value
+            $Name = $JsonParameters.PSobject.Properties['name'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "photoUrls"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'photoUrls'))) {
             throw "Error! JSON cannot be serialized due to the required property 'photoUrls' missing."
         } else {
-            $PhotoUrls = $JsonParameters.PSobject.Properties["photoUrls"].value
+            $PhotoUrls = $JsonParameters.PSobject.Properties['photoUrls'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "id"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'id'))) { #optional property not found
             $Id = $null
         } else {
-            $Id = $JsonParameters.PSobject.Properties["id"].value
+            $Id = $JsonParameters.PSobject.Properties['id'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "category"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'category'))) { #optional property not found
             $Category = $null
         } else {
-            $Category = $JsonParameters.PSobject.Properties["category"].value
+            $Category = $JsonParameters.PSobject.Properties['category'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "tags"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'tags'))) { #optional property not found
             $Tags = $null
         } else {
-            $Tags = $JsonParameters.PSobject.Properties["tags"].value
+            $Tags = $JsonParameters.PSobject.Properties['tags'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "status"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'status'))) { #optional property not found
             $Status = $null
         } else {
-            $Status = $JsonParameters.PSobject.Properties["status"].value
+            $Status = $JsonParameters.PSobject.Properties['status'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "id" = ${Id}
-            "category" = ${Category}
-            "name" = ${Name}
-            "photoUrls" = ${PhotoUrls}
-            "tags" = ${Tags}
-            "status" = ${Status}
+            'id' = ${Id}
+            'category' = ${Category}
+            'name' = ${Name}
+            'photoUrls' = ${PhotoUrls}
+            'tags' = ${Tags}
+            'status' = ${Status}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/PetWithRequiredTags.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/PetWithRequiredTags.ps1
@@ -73,12 +73,12 @@ function Initialize-PSPetWithRequiredTags {
 
 
         $PSO = [PSCustomObject]@{
-            "id" = ${Id}
-            "category" = ${Category}
-            "name" = ${Name}
-            "photoUrls" = ${PhotoUrls}
-            "tags" = ${Tags}
-            "status" = ${Status}
+            'id' = ${Id}
+            'category' = ${Category}
+            'name' = ${Name}
+            'photoUrls' = ${PhotoUrls}
+            'tags' = ${Tags}
+            'status' = ${Status}
         }
 
 
@@ -116,7 +116,7 @@ function ConvertFrom-PSJsonToPetWithRequiredTags {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSPetWithRequiredTags
-        $AllProperties = ("id", "category", "name", "photoUrls", "tags", "status")
+        $AllProperties = ('id', 'category', 'name', 'photoUrls', 'tags', 'status')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -127,49 +127,49 @@ function ConvertFrom-PSJsonToPetWithRequiredTags {
             throw "Error! Empty JSON cannot be serialized due to the required property 'name' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "name"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'name'))) {
             throw "Error! JSON cannot be serialized due to the required property 'name' missing."
         } else {
-            $Name = $JsonParameters.PSobject.Properties["name"].value
+            $Name = $JsonParameters.PSobject.Properties['name'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "photoUrls"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'photoUrls'))) {
             throw "Error! JSON cannot be serialized due to the required property 'photoUrls' missing."
         } else {
-            $PhotoUrls = $JsonParameters.PSobject.Properties["photoUrls"].value
+            $PhotoUrls = $JsonParameters.PSobject.Properties['photoUrls'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "tags"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'tags'))) {
             throw "Error! JSON cannot be serialized due to the required property 'tags' missing."
         } else {
-            $Tags = $JsonParameters.PSobject.Properties["tags"].value
+            $Tags = $JsonParameters.PSobject.Properties['tags'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "id"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'id'))) { #optional property not found
             $Id = $null
         } else {
-            $Id = $JsonParameters.PSobject.Properties["id"].value
+            $Id = $JsonParameters.PSobject.Properties['id'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "category"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'category'))) { #optional property not found
             $Category = $null
         } else {
-            $Category = $JsonParameters.PSobject.Properties["category"].value
+            $Category = $JsonParameters.PSobject.Properties['category'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "status"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'status'))) { #optional property not found
             $Status = $null
         } else {
-            $Status = $JsonParameters.PSobject.Properties["status"].value
+            $Status = $JsonParameters.PSobject.Properties['status'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "id" = ${Id}
-            "category" = ${Category}
-            "name" = ${Name}
-            "photoUrls" = ${PhotoUrls}
-            "tags" = ${Tags}
-            "status" = ${Status}
+            'id' = ${Id}
+            'category' = ${Category}
+            'name' = ${Name}
+            'photoUrls' = ${PhotoUrls}
+            'tags' = ${Tags}
+            'status' = ${Status}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/QuadrilateralInterface.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/QuadrilateralInterface.ps1
@@ -39,7 +39,7 @@ function Initialize-PSQuadrilateralInterface {
 
 
         $PSO = [PSCustomObject]@{
-            "quadrilateralType" = ${QuadrilateralType}
+            'quadrilateralType' = ${QuadrilateralType}
         }
 
 
@@ -77,7 +77,7 @@ function ConvertFrom-PSJsonToQuadrilateralInterface {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSQuadrilateralInterface
-        $AllProperties = ("quadrilateralType")
+        $AllProperties = ('quadrilateralType')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -88,14 +88,14 @@ function ConvertFrom-PSJsonToQuadrilateralInterface {
             throw "Error! Empty JSON cannot be serialized due to the required property 'quadrilateralType' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "quadrilateralType"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'quadrilateralType'))) {
             throw "Error! JSON cannot be serialized due to the required property 'quadrilateralType' missing."
         } else {
-            $QuadrilateralType = $JsonParameters.PSobject.Properties["quadrilateralType"].value
+            $QuadrilateralType = $JsonParameters.PSobject.Properties['quadrilateralType'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "quadrilateralType" = ${QuadrilateralType}
+            'quadrilateralType' = ${QuadrilateralType}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/ReadOnlyFirst.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/ReadOnlyFirst.ps1
@@ -40,8 +40,8 @@ function Initialize-PSReadOnlyFirst {
 
 
         $PSO = [PSCustomObject]@{
-            "bar" = ${Bar}
-            "baz" = ${Baz}
+            'bar' = ${Bar}
+            'baz' = ${Baz}
         }
 
 
@@ -79,28 +79,28 @@ function ConvertFrom-PSJsonToReadOnlyFirst {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSReadOnlyFirst
-        $AllProperties = ("bar", "baz")
+        $AllProperties = ('bar', 'baz')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "bar"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'bar'))) { #optional property not found
             $Bar = $null
         } else {
-            $Bar = $JsonParameters.PSobject.Properties["bar"].value
+            $Bar = $JsonParameters.PSobject.Properties['bar'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "baz"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'baz'))) { #optional property not found
             $Baz = $null
         } else {
-            $Baz = $JsonParameters.PSobject.Properties["baz"].value
+            $Baz = $JsonParameters.PSobject.Properties['baz'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "bar" = ${Bar}
-            "baz" = ${Baz}
+            'bar' = ${Bar}
+            'baz' = ${Baz}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/ScaleneTriangle.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/ScaleneTriangle.ps1
@@ -48,8 +48,8 @@ function Initialize-PSScaleneTriangle {
 
 
         $PSO = [PSCustomObject]@{
-            "shapeType" = ${ShapeType}
-            "triangleType" = ${TriangleType}
+            'shapeType' = ${ShapeType}
+            'triangleType' = ${TriangleType}
         }
 
 
@@ -87,7 +87,7 @@ function ConvertFrom-PSJsonToScaleneTriangle {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSScaleneTriangle
-        $AllProperties = ("shapeType", "triangleType")
+        $AllProperties = ('shapeType', 'triangleType')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -98,21 +98,21 @@ function ConvertFrom-PSJsonToScaleneTriangle {
             throw "Error! Empty JSON cannot be serialized due to the required property 'shapeType' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "shapeType"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'shapeType'))) {
             throw "Error! JSON cannot be serialized due to the required property 'shapeType' missing."
         } else {
-            $ShapeType = $JsonParameters.PSobject.Properties["shapeType"].value
+            $ShapeType = $JsonParameters.PSobject.Properties['shapeType'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "triangleType"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'triangleType'))) {
             throw "Error! JSON cannot be serialized due to the required property 'triangleType' missing."
         } else {
-            $TriangleType = $JsonParameters.PSobject.Properties["triangleType"].value
+            $TriangleType = $JsonParameters.PSobject.Properties['triangleType'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "shapeType" = ${ShapeType}
-            "triangleType" = ${TriangleType}
+            'shapeType' = ${ShapeType}
+            'triangleType' = ${TriangleType}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/ShapeInterface.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/ShapeInterface.ps1
@@ -39,7 +39,7 @@ function Initialize-PSShapeInterface {
 
 
         $PSO = [PSCustomObject]@{
-            "shapeType" = ${ShapeType}
+            'shapeType' = ${ShapeType}
         }
 
 
@@ -77,7 +77,7 @@ function ConvertFrom-PSJsonToShapeInterface {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSShapeInterface
-        $AllProperties = ("shapeType")
+        $AllProperties = ('shapeType')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -88,14 +88,14 @@ function ConvertFrom-PSJsonToShapeInterface {
             throw "Error! Empty JSON cannot be serialized due to the required property 'shapeType' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "shapeType"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'shapeType'))) {
             throw "Error! JSON cannot be serialized due to the required property 'shapeType' missing."
         } else {
-            $ShapeType = $JsonParameters.PSobject.Properties["shapeType"].value
+            $ShapeType = $JsonParameters.PSobject.Properties['shapeType'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "shapeType" = ${ShapeType}
+            'shapeType' = ${ShapeType}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/SimpleQuadrilateral.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/SimpleQuadrilateral.ps1
@@ -48,8 +48,8 @@ function Initialize-PSSimpleQuadrilateral {
 
 
         $PSO = [PSCustomObject]@{
-            "shapeType" = ${ShapeType}
-            "quadrilateralType" = ${QuadrilateralType}
+            'shapeType' = ${ShapeType}
+            'quadrilateralType' = ${QuadrilateralType}
         }
 
 
@@ -87,7 +87,7 @@ function ConvertFrom-PSJsonToSimpleQuadrilateral {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSSimpleQuadrilateral
-        $AllProperties = ("shapeType", "quadrilateralType")
+        $AllProperties = ('shapeType', 'quadrilateralType')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -98,21 +98,21 @@ function ConvertFrom-PSJsonToSimpleQuadrilateral {
             throw "Error! Empty JSON cannot be serialized due to the required property 'shapeType' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "shapeType"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'shapeType'))) {
             throw "Error! JSON cannot be serialized due to the required property 'shapeType' missing."
         } else {
-            $ShapeType = $JsonParameters.PSobject.Properties["shapeType"].value
+            $ShapeType = $JsonParameters.PSobject.Properties['shapeType'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "quadrilateralType"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'quadrilateralType'))) {
             throw "Error! JSON cannot be serialized due to the required property 'quadrilateralType' missing."
         } else {
-            $QuadrilateralType = $JsonParameters.PSobject.Properties["quadrilateralType"].value
+            $QuadrilateralType = $JsonParameters.PSobject.Properties['quadrilateralType'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "shapeType" = ${ShapeType}
-            "quadrilateralType" = ${QuadrilateralType}
+            'shapeType' = ${ShapeType}
+            'quadrilateralType' = ${QuadrilateralType}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/SpecialModelName.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/SpecialModelName.ps1
@@ -40,8 +40,8 @@ function Initialize-PSSpecialModelName {
 
 
         $PSO = [PSCustomObject]@{
-            "$special[property.name]" = ${SpecialPropertyName}
-            "_special_model.name_" = ${SpecialModelName}
+            '$special[property.name]' = ${SpecialPropertyName}
+            '_special_model.name_' = ${SpecialModelName}
         }
 
 
@@ -79,28 +79,28 @@ function ConvertFrom-PSJsonToSpecialModelName {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSSpecialModelName
-        $AllProperties = ("$special[property.name]", "_special_model.name_")
+        $AllProperties = ('$special[property.name]', '_special_model.name_')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "$special[property.name]"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match '$special[property.name]'))) { #optional property not found
             $SpecialPropertyName = $null
         } else {
-            $SpecialPropertyName = $JsonParameters.PSobject.Properties["$special[property.name]"].value
+            $SpecialPropertyName = $JsonParameters.PSobject.Properties['$special[property.name]'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "_special_model.name_"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match '_special_model.name_'))) { #optional property not found
             $SpecialModelName = $null
         } else {
-            $SpecialModelName = $JsonParameters.PSobject.Properties["_special_model.name_"].value
+            $SpecialModelName = $JsonParameters.PSobject.Properties['_special_model.name_'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "$special[property.name]" = ${SpecialPropertyName}
-            "_special_model.name_" = ${SpecialModelName}
+            '$special[property.name]' = ${SpecialPropertyName}
+            '_special_model.name_' = ${SpecialModelName}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/Tag.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/Tag.ps1
@@ -40,8 +40,8 @@ function Initialize-PSTag {
 
 
         $PSO = [PSCustomObject]@{
-            "id" = ${Id}
-            "name" = ${Name}
+            'id' = ${Id}
+            'name' = ${Name}
         }
 
 
@@ -79,28 +79,28 @@ function ConvertFrom-PSJsonToTag {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSTag
-        $AllProperties = ("id", "name")
+        $AllProperties = ('id', 'name')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "id"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'id'))) { #optional property not found
             $Id = $null
         } else {
-            $Id = $JsonParameters.PSobject.Properties["id"].value
+            $Id = $JsonParameters.PSobject.Properties['id'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "name"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'name'))) { #optional property not found
             $Name = $null
         } else {
-            $Name = $JsonParameters.PSobject.Properties["name"].value
+            $Name = $JsonParameters.PSobject.Properties['name'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "id" = ${Id}
-            "name" = ${Name}
+            'id' = ${Id}
+            'name' = ${Name}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/TestInlineFreeformAdditionalPropertiesRequest.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/TestInlineFreeformAdditionalPropertiesRequest.ps1
@@ -35,7 +35,7 @@ function Initialize-PSTestInlineFreeformAdditionalPropertiesRequest {
 
 
         $PSO = [PSCustomObject]@{
-            "someProperty" = ${SomeProperty}
+            'someProperty' = ${SomeProperty}
         }
 
 
@@ -74,7 +74,7 @@ function ConvertFrom-PSJsonToTestInlineFreeformAdditionalPropertiesRequest {
         $PSTestInlineFreeformAdditionalPropertiesRequestAdditionalProperties = @{}
 
         # check if Json contains properties not defined in PSTestInlineFreeformAdditionalPropertiesRequest
-        $AllProperties = ("someProperty")
+        $AllProperties = ('someProperty')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             # store undefined properties in additionalProperties
             if (!($AllProperties.Contains($name))) {
@@ -82,15 +82,15 @@ function ConvertFrom-PSJsonToTestInlineFreeformAdditionalPropertiesRequest {
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "someProperty"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'someProperty'))) { #optional property not found
             $SomeProperty = $null
         } else {
-            $SomeProperty = $JsonParameters.PSobject.Properties["someProperty"].value
+            $SomeProperty = $JsonParameters.PSobject.Properties['someProperty'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "someProperty" = ${SomeProperty}
-            "AdditionalProperties" = $PSTestInlineFreeformAdditionalPropertiesRequestAdditionalProperties
+            'someProperty' = ${SomeProperty}
+            'AdditionalProperties' = $PSTestInlineFreeformAdditionalPropertiesRequestAdditionalProperties
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/TriangleInterface.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/TriangleInterface.ps1
@@ -39,7 +39,7 @@ function Initialize-PSTriangleInterface {
 
 
         $PSO = [PSCustomObject]@{
-            "triangleType" = ${TriangleType}
+            'triangleType' = ${TriangleType}
         }
 
 
@@ -77,7 +77,7 @@ function ConvertFrom-PSJsonToTriangleInterface {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSTriangleInterface
-        $AllProperties = ("triangleType")
+        $AllProperties = ('triangleType')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -88,14 +88,14 @@ function ConvertFrom-PSJsonToTriangleInterface {
             throw "Error! Empty JSON cannot be serialized due to the required property 'triangleType' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "triangleType"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'triangleType'))) {
             throw "Error! JSON cannot be serialized due to the required property 'triangleType' missing."
         } else {
-            $TriangleType = $JsonParameters.PSobject.Properties["triangleType"].value
+            $TriangleType = $JsonParameters.PSobject.Properties['triangleType'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "triangleType" = ${TriangleType}
+            'triangleType' = ${TriangleType}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/User.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/User.ps1
@@ -90,18 +90,18 @@ function Initialize-PSUser {
 
 
         $PSO = [PSCustomObject]@{
-            "id" = ${Id}
-            "username" = ${Username}
-            "firstName" = ${FirstName}
-            "lastName" = ${LastName}
-            "email" = ${Email}
-            "password" = ${Password}
-            "phone" = ${Phone}
-            "userStatus" = ${UserStatus}
-            "objectWithNoDeclaredProps" = ${ObjectWithNoDeclaredProps}
-            "objectWithNoDeclaredPropsNullable" = ${ObjectWithNoDeclaredPropsNullable}
-            "anyTypeProp" = ${AnyTypeProp}
-            "anyTypePropNullable" = ${AnyTypePropNullable}
+            'id' = ${Id}
+            'username' = ${Username}
+            'firstName' = ${FirstName}
+            'lastName' = ${LastName}
+            'email' = ${Email}
+            'password' = ${Password}
+            'phone' = ${Phone}
+            'userStatus' = ${UserStatus}
+            'objectWithNoDeclaredProps' = ${ObjectWithNoDeclaredProps}
+            'objectWithNoDeclaredPropsNullable' = ${ObjectWithNoDeclaredPropsNullable}
+            'anyTypeProp' = ${AnyTypeProp}
+            'anyTypePropNullable' = ${AnyTypePropNullable}
         }
 
 
@@ -139,98 +139,98 @@ function ConvertFrom-PSJsonToUser {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSUser
-        $AllProperties = ("id", "username", "firstName", "lastName", "email", "password", "phone", "userStatus", "objectWithNoDeclaredProps", "objectWithNoDeclaredPropsNullable", "anyTypeProp", "anyTypePropNullable")
+        $AllProperties = ('id', 'username', 'firstName', 'lastName', 'email', 'password', 'phone', 'userStatus', 'objectWithNoDeclaredProps', 'objectWithNoDeclaredPropsNullable', 'anyTypeProp', 'anyTypePropNullable')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "id"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'id'))) { #optional property not found
             $Id = $null
         } else {
-            $Id = $JsonParameters.PSobject.Properties["id"].value
+            $Id = $JsonParameters.PSobject.Properties['id'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "username"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'username'))) { #optional property not found
             $Username = $null
         } else {
-            $Username = $JsonParameters.PSobject.Properties["username"].value
+            $Username = $JsonParameters.PSobject.Properties['username'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "firstName"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'firstName'))) { #optional property not found
             $FirstName = $null
         } else {
-            $FirstName = $JsonParameters.PSobject.Properties["firstName"].value
+            $FirstName = $JsonParameters.PSobject.Properties['firstName'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "lastName"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'lastName'))) { #optional property not found
             $LastName = $null
         } else {
-            $LastName = $JsonParameters.PSobject.Properties["lastName"].value
+            $LastName = $JsonParameters.PSobject.Properties['lastName'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "email"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'email'))) { #optional property not found
             $Email = $null
         } else {
-            $Email = $JsonParameters.PSobject.Properties["email"].value
+            $Email = $JsonParameters.PSobject.Properties['email'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "password"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'password'))) { #optional property not found
             $Password = $null
         } else {
-            $Password = $JsonParameters.PSobject.Properties["password"].value
+            $Password = $JsonParameters.PSobject.Properties['password'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "phone"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'phone'))) { #optional property not found
             $Phone = $null
         } else {
-            $Phone = $JsonParameters.PSobject.Properties["phone"].value
+            $Phone = $JsonParameters.PSobject.Properties['phone'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "userStatus"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'userStatus'))) { #optional property not found
             $UserStatus = $null
         } else {
-            $UserStatus = $JsonParameters.PSobject.Properties["userStatus"].value
+            $UserStatus = $JsonParameters.PSobject.Properties['userStatus'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "objectWithNoDeclaredProps"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'objectWithNoDeclaredProps'))) { #optional property not found
             $ObjectWithNoDeclaredProps = $null
         } else {
-            $ObjectWithNoDeclaredProps = $JsonParameters.PSobject.Properties["objectWithNoDeclaredProps"].value
+            $ObjectWithNoDeclaredProps = $JsonParameters.PSobject.Properties['objectWithNoDeclaredProps'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "objectWithNoDeclaredPropsNullable"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'objectWithNoDeclaredPropsNullable'))) { #optional property not found
             $ObjectWithNoDeclaredPropsNullable = $null
         } else {
-            $ObjectWithNoDeclaredPropsNullable = $JsonParameters.PSobject.Properties["objectWithNoDeclaredPropsNullable"].value
+            $ObjectWithNoDeclaredPropsNullable = $JsonParameters.PSobject.Properties['objectWithNoDeclaredPropsNullable'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "anyTypeProp"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'anyTypeProp'))) { #optional property not found
             $AnyTypeProp = $null
         } else {
-            $AnyTypeProp = $JsonParameters.PSobject.Properties["anyTypeProp"].value
+            $AnyTypeProp = $JsonParameters.PSobject.Properties['anyTypeProp'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "anyTypePropNullable"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'anyTypePropNullable'))) { #optional property not found
             $AnyTypePropNullable = $null
         } else {
-            $AnyTypePropNullable = $JsonParameters.PSobject.Properties["anyTypePropNullable"].value
+            $AnyTypePropNullable = $JsonParameters.PSobject.Properties['anyTypePropNullable'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "id" = ${Id}
-            "username" = ${Username}
-            "firstName" = ${FirstName}
-            "lastName" = ${LastName}
-            "email" = ${Email}
-            "password" = ${Password}
-            "phone" = ${Phone}
-            "userStatus" = ${UserStatus}
-            "objectWithNoDeclaredProps" = ${ObjectWithNoDeclaredProps}
-            "objectWithNoDeclaredPropsNullable" = ${ObjectWithNoDeclaredPropsNullable}
-            "anyTypeProp" = ${AnyTypeProp}
-            "anyTypePropNullable" = ${AnyTypePropNullable}
+            'id' = ${Id}
+            'username' = ${Username}
+            'firstName' = ${FirstName}
+            'lastName' = ${LastName}
+            'email' = ${Email}
+            'password' = ${Password}
+            'phone' = ${Phone}
+            'userStatus' = ${UserStatus}
+            'objectWithNoDeclaredProps' = ${ObjectWithNoDeclaredProps}
+            'objectWithNoDeclaredPropsNullable' = ${ObjectWithNoDeclaredPropsNullable}
+            'anyTypeProp' = ${AnyTypeProp}
+            'anyTypePropNullable' = ${AnyTypePropNullable}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/Whale.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/Whale.ps1
@@ -49,9 +49,9 @@ function Initialize-PSWhale {
 
 
         $PSO = [PSCustomObject]@{
-            "hasBaleen" = ${HasBaleen}
-            "hasTeeth" = ${HasTeeth}
-            "className" = ${ClassName}
+            'hasBaleen' = ${HasBaleen}
+            'hasTeeth' = ${HasTeeth}
+            'className' = ${ClassName}
         }
 
 
@@ -89,7 +89,7 @@ function ConvertFrom-PSJsonToWhale {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in PSWhale
-        $AllProperties = ("hasBaleen", "hasTeeth", "className")
+        $AllProperties = ('hasBaleen', 'hasTeeth', 'className')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
@@ -100,28 +100,28 @@ function ConvertFrom-PSJsonToWhale {
             throw "Error! Empty JSON cannot be serialized due to the required property 'className' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "className"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'className'))) {
             throw "Error! JSON cannot be serialized due to the required property 'className' missing."
         } else {
-            $ClassName = $JsonParameters.PSobject.Properties["className"].value
+            $ClassName = $JsonParameters.PSobject.Properties['className'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "hasBaleen"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'hasBaleen'))) { #optional property not found
             $HasBaleen = $null
         } else {
-            $HasBaleen = $JsonParameters.PSobject.Properties["hasBaleen"].value
+            $HasBaleen = $JsonParameters.PSobject.Properties['hasBaleen'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "hasTeeth"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'hasTeeth'))) { #optional property not found
             $HasTeeth = $null
         } else {
-            $HasTeeth = $JsonParameters.PSobject.Properties["hasTeeth"].value
+            $HasTeeth = $JsonParameters.PSobject.Properties['hasTeeth'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "hasBaleen" = ${HasBaleen}
-            "hasTeeth" = ${HasTeeth}
-            "className" = ${ClassName}
+            'hasBaleen' = ${HasBaleen}
+            'hasTeeth' = ${HasTeeth}
+            'className' = ${ClassName}
         }
 
         return $PSO

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/Zebra.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/Zebra.ps1
@@ -45,8 +45,8 @@ function Initialize-PSZebra {
 
 
         $PSO = [PSCustomObject]@{
-            "type" = ${Type}
-            "className" = ${ClassName}
+            'type' = ${Type}
+            'className' = ${ClassName}
         }
 
 
@@ -85,7 +85,7 @@ function ConvertFrom-PSJsonToZebra {
         $PSZebraAdditionalProperties = @{}
 
         # check if Json contains properties not defined in PSZebra
-        $AllProperties = ("type", "className")
+        $AllProperties = ('type', 'className')
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             # store undefined properties in additionalProperties
             if (!($AllProperties.Contains($name))) {
@@ -97,22 +97,22 @@ function ConvertFrom-PSJsonToZebra {
             throw "Error! Empty JSON cannot be serialized due to the required property 'className' missing."
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "className"))) {
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'className'))) {
             throw "Error! JSON cannot be serialized due to the required property 'className' missing."
         } else {
-            $ClassName = $JsonParameters.PSobject.Properties["className"].value
+            $ClassName = $JsonParameters.PSobject.Properties['className'].value
         }
 
-        if (!([bool]($JsonParameters.PSobject.Properties.name -match "type"))) { #optional property not found
+        if (!([bool]($JsonParameters.PSobject.Properties.name -match 'type'))) { #optional property not found
             $Type = $null
         } else {
-            $Type = $JsonParameters.PSobject.Properties["type"].value
+            $Type = $JsonParameters.PSobject.Properties['type'].value
         }
 
         $PSO = [PSCustomObject]@{
-            "type" = ${Type}
-            "className" = ${ClassName}
-            "AdditionalProperties" = $PSZebraAdditionalProperties
+            'type' = ${Type}
+            'className' = ${ClassName}
+            'AdditionalProperties' = $PSZebraAdditionalProperties
         }
 
         return $PSO


### PR DESCRIPTION
based on https://github.com/OpenAPITools/openapi-generator/pull/23622

fixes #23535

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quote all generated PowerShell model property names with single quotes to prevent $-variable interpolation, fixing DTO (de)serialization for names like $ref, $schema, and $type. Adds a regression test and updates samples; fixes #23535.

- **Bug Fixes**
  - In `powershell/model_simple.mustache`, emit user property names as single-quoted literals in PSCustomObject keys, the `$AllProperties` allow-list, `.Properties['...']` indexers, and `-match '...'` presence checks.
  - Added `PowerShellClientCodegenTest` to assert single-quoted emission at all sites; regenerated samples to reflect the change.

<sup>Written for commit cf4a55246a696f8f741436838399060e33d1731c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

