### PR TITLE
[crystal] Fix empty auth_settings Hash literal

### DIFF
--- a/modules/openapi-generator/src/main/resources/crystal/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/crystal/configuration.mustache
@@ -209,6 +209,7 @@ module {{moduleName}}
 
     # Returns Auth Settings hash for api client.
     def auth_settings
+{{#authMethods.0}}
       Hash{
 {{#authMethods}}
 {{#isApiKey}}
@@ -250,6 +251,10 @@ module {{moduleName}}
 {{/isOAuth}}
 {{/authMethods}}
       }
+{{/authMethods.0}}
+{{^authMethods}}
+      {} of String => Hash(Symbol, String)
+{{/authMethods}}
     end
 
     # Returns an array of Server setting

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/crystal/CrystalClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/crystal/CrystalClientCodegenTest.java
@@ -134,6 +134,77 @@ public class CrystalClientCodegenTest {
     }
 
     @Test
+    public void testAuthSettingsWithNoAuthMethodsEmitsValidCrystal() throws Exception {
+        // Regression test: when an OpenAPI spec has no recognized auth methods,
+        // the generated configuration.cr's auth_settings method must not emit
+        // a bare `Hash{}` literal, which is invalid Crystal. Crystal requires
+        // `{} of K => V` for empty hash literals.
+        final File output = Files.createTempDirectory("test").toFile();
+        output.mkdirs();
+        output.deleteOnExit();
+
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/pathWithHtmlEntity.yaml");
+        CodegenConfig codegenConfig = new CrystalClientCodegen();
+        codegenConfig.setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = new ClientOptInput().openAPI(openAPI).config(codegenConfig);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(clientOptInput).generate();
+        boolean configFileGenerated = false;
+        for (File file : files) {
+            if (file.getName().equals("configuration.cr")) {
+                configFileGenerated = true;
+                String content = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
+                // Bug: the previous template emitted `Hash{\n      }` for empty
+                // auth methods, which Crystal rejects with:
+                //   Error: for empty hashes use '{} of KeyType => ValueType'
+                Assert.assertFalse(content.contains("Hash{\n      }"),
+                        "configuration.cr must not contain an empty `Hash{}` literal");
+                Assert.assertFalse(content.contains("Hash{}"),
+                        "configuration.cr must not contain an empty `Hash{}` literal");
+                // Fix: emit a typed empty hash literal that compiles in Crystal.
+                assertTrue(content.contains("{} of String => Hash(Symbol, String)"),
+                        "configuration.cr must emit a typed empty hash literal in auth_settings");
+            }
+        }
+        if (!configFileGenerated) {
+            fail("configuration.cr file is not generated!");
+        }
+    }
+
+    @Test
+    public void testAuthSettingsWithAuthMethodsStillEmitsHashLiteral() throws Exception {
+        // Ensure the empty-auth fix did not regress the populated case.
+        final File output = Files.createTempDirectory("test").toFile();
+        output.mkdirs();
+        output.deleteOnExit();
+
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/crystal/petstore.yaml");
+        CodegenConfig codegenConfig = new CrystalClientCodegen();
+        codegenConfig.setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = new ClientOptInput().openAPI(openAPI).config(codegenConfig);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(clientOptInput).generate();
+        boolean configFileGenerated = false;
+        for (File file : files) {
+            if (file.getName().equals("configuration.cr")) {
+                configFileGenerated = true;
+                String content = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
+                assertTrue(content.contains("Hash{"),
+                        "configuration.cr should still emit `Hash{` for populated auth methods");
+                Assert.assertFalse(content.contains("{} of String => Hash(Symbol, String)"),
+                        "configuration.cr should not emit empty hash literal when auth methods exist");
+            }
+        }
+        if (!configFileGenerated) {
+            fail("configuration.cr file is not generated!");
+        }
+    }
+
+    @Test
     public void testSanitizeModelName() throws Exception {
         final CrystalClientCodegen codegen = new CrystalClientCodegen();
         codegen.setHideGenerationTimestamp(false);


### PR DESCRIPTION
## Bug

The Crystal client codegen template at `modules/openapi-generator/src/main/resources/crystal/configuration.mustache` emits this for the `auth_settings` method:

```mustache
def auth_settings
  Hash{
{{#authMethods}}
{{#isApiKey}} ... {{/isApiKey}}
{{#isBasic}} ... {{/isBasic}}
{{#isOAuth}} ... {{/isOAuth}}
{{/authMethods}}
  }
end
```

When the OpenAPI spec has no `authMethods` recognized by the template (for example, a security scheme using only a non-standard OAuth2 flow URN such as `urn:ietf:params:oauth:grant-type:device_code`), the inner loop emits nothing and the result is a bare `Hash{ }` -- which is invalid Crystal:

```
Error: for empty hashes use '{} of KeyType => ValueType'
```

The Crystal compiler refuses to compile generated clients in this case, so the entire generated client is unusable.

## Fix

Wrap the populated branch in `{{#authMethods.0}}...{{/authMethods.0}}` (truthy when the list has at least one element -- the same idiom used elsewhere in this codebase, e.g. `scala-sttp4/methodParameters.mustache`) and add an inverse `{{^authMethods}}` branch that emits a typed empty hash literal `{} of String => Hash(Symbol, String)`.

Output before, no auth methods:

```crystal
def auth_settings
  Hash{
  }
end
```

Output after, no auth methods:

```crystal
def auth_settings
  {} of String => Hash(Symbol, String)
end
```

The populated case is unchanged.

## Tests

Adds two regression tests in `CrystalClientCodegenTest`:

- `testAuthSettingsWithNoAuthMethodsEmitsValidCrystal` -- generates Crystal from `2_0/pathWithHtmlEntity.yaml` (no auth methods) and asserts the output does not contain `Hash{}` and does contain `{} of String => Hash(Symbol, String)`.
- `testAuthSettingsWithAuthMethodsStillEmitsHashLiteral` -- generates Crystal from `3_0/crystal/petstore.yaml` (with OAuth2 + API key auth) and asserts the output still contains `Hash{` (no regression of the populated branch).

All 8 `CrystalClientCodegenTest` tests pass locally:

```
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

The petstore Crystal sample (`samples/client/petstore/crystal/`) regenerates byte-identical, since it has populated auth methods.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Crystal client codegen to emit a valid empty hash in `auth_settings` when no recognized auth methods are present, so generated clients compile. Adds a typed empty hash fallback while preserving behavior for populated auth settings.

- **Bug Fixes**
  - In Crystal `configuration.mustache`, guard populated output with `{{#authMethods.0}}` and add `{{^authMethods}}` fallback emitting `{} of String => Hash(Symbol, String)`.
  - Prevents Crystal error: "for empty hashes use '{} of KeyType => ValueType'".
  - Adds regression tests for both no-auth and with-auth cases.
  - Petstore Crystal sample regenerates unchanged.

<sup>Written for commit 3dee09a3ecc77293251aac3090b92a947b69000c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

