### PR TITLE
[swift6] fix map nullable values (#17996)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift6ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift6ClientCodegen.java
@@ -754,9 +754,15 @@ public class Swift6ClientCodegen extends DefaultCodegen implements CodegenConfig
             return ModelUtils.isSet(p) ? "Set<" + getTypeDeclaration(inner) + ">" : "[" + getTypeDeclaration(inner) + "]";
         } else if (ModelUtils.isMapSchema(p)) {
             Schema inner = ModelUtils.getAdditionalProperties(p);
-            return "[String: " + getTypeDeclaration(inner) + "]";
+            return "[String: " + getItemsTypeDeclaration(inner) + "]";
         }
         return super.getTypeDeclaration(p);
+    }
+
+    private String getItemsTypeDeclaration(Schema items) {
+        String itemsTypeDeclaration = getTypeDeclaration(items);
+        String nullable = items.getNullable() != null && items.getNullable() && !itemsTypeDeclaration.endsWith("?") ? "?" : "";
+        return itemsTypeDeclaration + nullable;
     }
 
     @Override

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift6/Swift6ClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift6/Swift6ClientCodegenTest.java
@@ -19,6 +19,7 @@ package org.openapitools.codegen.swift6;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.Schema;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.config.CodegenConfigurator;
 import org.openapitools.codegen.languages.Swift6ClientCodegen;
@@ -400,5 +401,21 @@ public class Swift6ClientCodegenTest {
         } finally {
             output.deleteOnExit();
         }
+    }
+
+    @Test(description = "Issue #17996")
+    public void testNullableMap() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/swift6/issue17996-nullable-map.yaml");
+
+        Schema test1 = openAPI.getComponents().getSchemas().get("NullMapNotNullMap");
+        CodegenModel cm1 = swiftCodegen.fromModel("NullMapNotNullMap", test1);
+
+        // Assert the dataType properly generated
+        CodegenProperty nullableMap = cm1.vars.get(0);
+        CodegenProperty notNullableMap = cm1.vars.get(1);
+        CodegenProperty defaultMap = cm1.vars.get(2);
+        Assert.assertEquals(nullableMap.getDataType(), "[String: String?]");
+        Assert.assertEquals(notNullableMap.getDataType(), "[String: String]");
+        Assert.assertEquals(defaultMap.getDataType(), "[String: String]");
     }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/swift6/issue17996-nullable-map.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/swift6/issue17996-nullable-map.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.0
+info:
+  title: 'Issue 17996 Nullable map'
+  version: latest
+components:
+  schemas:
+    NullMapNotNullMap:
+      properties:
+        nullableMap:
+          type: object
+          additionalProperties:
+            type: string
+            nullable: true
+        notNullableMap:
+          type: object
+          additionalProperties:
+            type: string
+            nullable: false
+        defaultMap:
+          type: object
+          additionalProperties:
+            type: string


### PR DESCRIPTION
The Swift 6 client generator ignores `nullable: true` on `additionalProperties` values, producing `[String: String]` instead of `[String: String?]`. This causes `DecodingError` at runtime when the JSON payload contains null values inside dictionaries.

This is the same bug as #16501 (fixed for kotlin-spring in #23074), now applied to the Swift 6 generator.

**Example:**

Given this OpenAPI spec:
```yaml
properties:
  hashedIds:
    type: object
    additionalProperties:
      type: string
      nullable: true
```

Before this fix:
```swift
public var hashedIds: [String: String]?  // Decoding fails on {"key": null}
```

After this fix:
```swift
public var hashedIds: [String: String?]?  // Decoding succeeds
```

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/swift6* || exit
  ```
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks)
- [x] Fixes #17996 (for the Swift 6 generator)
- [x] cc @4brunu (Swift 6 technical committee)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Swift 6 generator to honor `nullable: true` for dictionary values, generating `[String: String?]` instead of `[String: String]`. Prevents DecodingError when JSON maps contain nulls.

- **Bug Fixes**
  - Generate `[String: T?]` for `additionalProperties` when `nullable: true`; default and `nullable: false` stay non-optional.
  - Added `getItemsTypeDeclaration` and updated map handling in `getTypeDeclaration` to append `?` only when needed.
  - Added tests and a sample OpenAPI spec to verify `[String: String?]` vs `[String: String]` behavior.

<sup>Written for commit bb3aecfbe47dfb77cb59dfc52abde3566774a6d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

