### PR TITLE
[GRADLE-WRAPPER] bug fix - pass maven java_home to gradle correctly

### DIFF
--- a/modules/openapi-generator-gradle-plugin/pom.xml
+++ b/modules/openapi-generator-gradle-plugin/pom.xml
@@ -91,6 +91,10 @@
 
                 <configuration>
                     <gradleVersion>${gradleVersion}</gradleVersion>
+                    <!-- Force the Gradle daemon to use the same JVM Maven is running with.
+                         This prevents Gradle from picking up a system-level JDK (e.g. JDK 25)
+                         when Maven is configured to run on a different JDK (e.g. JDK 21). -->
+                    <javaHome>${java.home}</javaHome>
                     <args>
                         <arg>-P openApiGeneratorVersion=${project.version}</arg>
                         <!--
@@ -99,12 +103,6 @@
                         <arg>-Psigning.secretKeyRingFile=${env.TRAVIS_BUILD_DIR}/sec.gpg</arg>
                         -->
                     </args>
-                    <!-- Force the Gradle daemon to use the same JVM Maven is running with.
-                         This prevents Gradle from picking up a system-level JDK (e.g. JDK 25)
-                         when Maven is configured to run on a different JDK (e.g. JDK 21). -->
-                    <jvmArgs>
-                        <jvmArg>-Dorg.gradle.java.home=${java.home}</jvmArg>
-                    </jvmArgs>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
My previous attempt to pass identical java_home used for maven to the underlying gradle was incorrect. I only noticed on my other machine where the default java_home points to java 25 which is not compatible with the kotlin version used by the gradle maven wrapper.

So this is another attempt to make it work. I tested locally that the correct java_home is propagated now.

**Impact of the current incorrect implementation** - there is no practical impact. _It simply does not work_ (the same way it did not work before my original attempt to link the java_home). And it definitely has no practical impact on the released version as this practically only comes into play when building locally

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @wing328 - tagging you, since there is no dedicated committee for gradle. If there is no need to tag you, let me know and I will stop.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure Gradle uses the same JDK as Maven by passing Maven’s `${java.home}` via the plugin’s `javaHome` setting instead of `-Dorg.gradle.java.home`. Prevents Gradle from picking a different system JDK (e.g., JDK 25 when Maven runs on JDK 21).

<sup>Written for commit a2f6da0b61c65a68ecdc66ed66419c31b7fedfb2. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23646?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

