### PR TITLE
[GRADLE-WRAPPER] feat: add configurable worker isolation and max heap size for code generation

### DIFF
--- a/modules/openapi-generator-gradle-plugin/README.adoc
+++ b/modules/openapi-generator-gradle-plugin/README.adoc
@@ -446,15 +446,15 @@ file states is output.
 |`process`
 a|Controls how the code-generation work action is isolated from the Gradle daemon.
 
-`process` (default):: Runs generation in a separate forked JVM. Generator classes are fully unloaded when the worker
+`classloader` (default):: Runs generation inside the Gradle daemon JVM using a separate `ClassLoader`. Avoids the per-task JVM
+startup overhead, but generator classes accumulate in the daemon's Metaspace across tasks and builds. Suitable for
+single-module projects or local developer loops where Metaspace pressure is not a concern.
+
+`process`:: Runs generation in a separate forked JVM. Generator classes are fully unloaded when the worker
 exits, preventing Metaspace accumulation in the Gradle daemon. A small per-task JVM startup cost is incurred (~1–2 s
 amortized across parallel builds). Recommended for CI/CD and multi-project builds to avoid the
 https://docs.gradle.org/current/userguide/build_environment.html#sec:configuring_jvm_memory[metaspace exhaustion
 warning].
-
-`classloader`:: Runs generation inside the Gradle daemon JVM using a separate `ClassLoader`. Avoids the per-task JVM
-startup overhead, but generator classes accumulate in the daemon's Metaspace across tasks and builds. Suitable for
-single-module projects or local developer loops where Metaspace pressure is not a concern.
 
 |maxWorkerHeapSize
 |String / Provider<String>

--- a/modules/openapi-generator-gradle-plugin/README.adoc
+++ b/modules/openapi-generator-gradle-plugin/README.adoc
@@ -440,6 +440,27 @@ apply plugin: 'org.openapi.generator'
 |false
 |Defines whether the generator should run in dry-run mode. In dry-run mode no files are written and a summary about
 file states is output.
+
+|workerIsolation
+|String / Provider<String>
+|`process`
+a|Controls how the code-generation work action is isolated from the Gradle daemon.
+
+`process` (default):: Runs generation in a separate forked JVM. Generator classes are fully unloaded when the worker
+exits, preventing Metaspace accumulation in the Gradle daemon. A small per-task JVM startup cost is incurred (~1–2 s
+amortized across parallel builds). Recommended for CI/CD and multi-project builds to avoid the
+https://docs.gradle.org/current/userguide/build_environment.html#sec:configuring_jvm_memory[metaspace exhaustion
+warning].
+
+`classloader`:: Runs generation inside the Gradle daemon JVM using a separate `ClassLoader`. Avoids the per-task JVM
+startup overhead, but generator classes accumulate in the daemon's Metaspace across tasks and builds. Suitable for
+single-module projects or local developer loops where Metaspace pressure is not a concern.
+
+|maxWorkerHeapSize
+|String / Provider<String>
+|Gradle default (~512 MiB)
+|Maximum heap size for the forked worker JVM when `workerIsolation` is `process` (e.g. `"512m"`, `"1g"`).
+Has no effect when `workerIsolation` is `classloader`.
 |===
 
 [NOTE]

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
@@ -157,6 +157,8 @@ class OpenApiGeneratorPlugin : Plugin<Project> {
                     engine.set(generate.engine)
                     cleanupOutput.set(generate.cleanupOutput)
                     dryRun.set(generate.dryRun)
+                    workerIsolation.set(generate.workerIsolation)
+                    maxWorkerHeapSize.set(generate.maxWorkerHeapSize)
                 }
             }
         }

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
@@ -412,14 +412,14 @@ open class OpenApiGeneratorGenerateExtension(private val project: Project) {
     /**
      * Controls how the code generation worker is isolated from the Gradle daemon.
      *
-     * - "process" (default): runs in a separate JVM. Metaspace is isolated from the daemon and freed
+     * - "classloader" (default): runs inside the Gradle daemon JVM with a separate ClassLoader. No process
+     *   startup overhead, but generator classes accumulate in daemon Metaspace. Suitable for projects
+     *   with very few generation tasks.
+     *
+     * - "process": runs in a separate JVM. Metaspace is isolated from the daemon and freed
      *   when the worker exits. Gradle reuses the worker process across tasks that share the same
      *   classpath, so the JVM startup cost is typically paid only once per parallel slot.
      *   Best for projects with many generation tasks.
-     *
-     * - "classloader": runs inside the Gradle daemon JVM with a separate ClassLoader. No process
-     *   startup overhead, but generator classes accumulate in daemon Metaspace. Suitable for projects
-     *   with very few generation tasks.
      */
     val workerIsolation = project.objects.property<String>()
 

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
@@ -409,6 +409,28 @@ open class OpenApiGeneratorGenerateExtension(private val project: Project) {
      */
     val dryRun = project.objects.property<Boolean>()
 
+    /**
+     * Controls how the code generation worker is isolated from the Gradle daemon.
+     *
+     * - "process" (default): runs in a separate JVM. Metaspace is isolated from the daemon and freed
+     *   when the worker exits. Gradle reuses the worker process across tasks that share the same
+     *   classpath, so the JVM startup cost is typically paid only once per parallel slot.
+     *   Best for projects with many generation tasks.
+     *
+     * - "classloader": runs inside the Gradle daemon JVM with a separate ClassLoader. No process
+     *   startup overhead, but generator classes accumulate in daemon Metaspace. Suitable for projects
+     *   with very few generation tasks.
+     */
+    val workerIsolation = project.objects.property<String>()
+
+    /**
+     * Maximum heap size for the worker process when [workerIsolation] is "process" (e.g. "512m", "1g").
+     * Has no effect when [workerIsolation] is "classloader".
+     * When not set, the JVM uses ergonomic defaults (typically based on available system memory).
+     * Only set this if you hit OutOfMemoryError during generation of unusually large specs.
+     */
+    val maxWorkerHeapSize = project.objects.property<String>()
+
     init {
         applyDefaults()
     }

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
@@ -891,23 +891,14 @@ abstract class GenerateTask : DefaultTask() {
         }
 
 // Submit generation work using the configured isolation mode.
-// "process" (default): worker runs in a separate JVM; Metaspace is freed after each worker daemon
+// "classloader" (default): worker runs inside the Gradle daemon JVM with a separate ClassLoader; no startup
+//   overhead but generator classes accumulate in daemon Metaspace across all tasks.
+// "process": worker runs in a separate JVM; Metaspace is freed after each worker daemon
 //   exits, and Gradle reuses the same worker daemon across tasks that share the same classpath,
 //   so startup cost is amortized — typically paid only once per parallel slot.
-// "classloader": worker runs inside the Gradle daemon JVM with a separate ClassLoader; no startup
-//   overhead but generator classes accumulate in daemon Metaspace across all tasks.
-        val isolation = workerIsolation.getOrElse("process").lowercase()
+        val isolation = workerIsolation.getOrElse("classloader").lowercase()
         val workQueue = when (isolation) {
-            "classloader" -> {
-                logger.lifecycle(
-                    "[openApiGenerate] Worker isolation: classloader " +
-                            "(fast startup, but generator classes accumulate in Gradle daemon Metaspace - " +
-                            "consider workerIsolation = \"process\" if you hit metaspace pressure)"
-                )
-                workerExecutor.classLoaderIsolation()
-            }
-
-            else -> {
+            "process" -> {
                 val heapMsg = maxWorkerHeapSize.orNull?.let { " (maxHeapSize=$it)" } ?: ""
                 logger.lifecycle(
                     "[openApiGenerate] Worker isolation: process$heapMsg " +
@@ -918,6 +909,17 @@ abstract class GenerateTask : DefaultTask() {
                     maxWorkerHeapSize.orNull?.let { forkOptions.maxHeapSize = it }
                 }
             }
+
+            "classloader" -> {
+                logger.lifecycle(
+                    "[openApiGenerate] Worker isolation: classloader " +
+                            "(fast startup, but generator classes accumulate in Gradle daemon Metaspace - " +
+                            "consider workerIsolation = \"process\" if you hit metaspace pressure)"
+                )
+                workerExecutor.classLoaderIsolation()
+            }
+
+            else -> throw GradleException("Invalid workerIsolation mode: $isolation. Supported values are 'process' and 'classloader'.")
         }
 
         workQueue.submit(OpenApiWorkAction::class.java, object : Action<OpenApiWorkParameters> {

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
@@ -283,6 +283,33 @@ abstract class GenerateTask : DefaultTask() {
     abstract val layout: ProjectLayout
 
     /**
+     * Controls how the code generation worker is isolated from the Gradle daemon.
+     *
+     * - "process" (default): runs in a separate JVM process. Metaspace is fully isolated from the
+     *   daemon and freed after the process exits. Gradle reuses the worker process across tasks that
+     *   share the same classpath, so the JVM startup cost is paid at most once per parallel slot —
+     *   not once per task. Best for projects with many generation tasks.
+     *
+     * - "classloader": runs inside the Gradle daemon JVM using a separate ClassLoader. No process
+     *   startup overhead, but each task loads generator classes into the daemon's Metaspace. With
+     *   many tasks this can exhaust Metaspace. Suitable for projects with very few tasks where the
+     *   daemon memory budget is not a concern.
+     */
+    @get:Optional
+    @get:Input
+    abstract val workerIsolation: Property<String>
+
+    /**
+     * Maximum heap size for the worker process when [workerIsolation] is "process" (e.g. "512m", "1g").
+     * Has no effect when [workerIsolation] is "classloader".
+     * When not set, the JVM uses ergonomic defaults (typically based on available system memory).
+     * Only set this if you hit OutOfMemoryError during generation of unusually large specs.
+     */
+    @get:Optional
+    @get:Input
+    abstract val maxWorkerHeapSize: Property<String>
+
+    /**
      * The verbosity of generation
      */
     @get:Optional
@@ -863,8 +890,35 @@ abstract class GenerateTask : DefaultTask() {
             }
         }
 
-// Submit generation logic to the isolated Worker API Queue
-        val workQueue = workerExecutor.classLoaderIsolation()
+// Submit generation work using the configured isolation mode.
+// "process" (default): worker runs in a separate JVM; Metaspace is freed after each worker daemon
+//   exits, and Gradle reuses the same worker daemon across tasks that share the same classpath,
+//   so startup cost is amortized — typically paid only once per parallel slot.
+// "classloader": worker runs inside the Gradle daemon JVM with a separate ClassLoader; no startup
+//   overhead but generator classes accumulate in daemon Metaspace across all tasks.
+        val isolation = workerIsolation.getOrElse("process").lowercase()
+        val workQueue = when (isolation) {
+            "classloader" -> {
+                logger.lifecycle(
+                    "[openApiGenerate] Worker isolation: classloader " +
+                            "(fast startup, but generator classes accumulate in Gradle daemon Metaspace - " +
+                            "consider workerIsolation = \"process\" if you hit metaspace pressure)"
+                )
+                workerExecutor.classLoaderIsolation()
+            }
+
+            else -> {
+                val heapMsg = maxWorkerHeapSize.orNull?.let { " (maxHeapSize=$it)" } ?: ""
+                logger.lifecycle(
+                    "[openApiGenerate] Worker isolation: process$heapMsg " +
+                            "(isolated JVM per task, no Metaspace leak - " +
+                            "use workerIsolation = \"classloader\" to skip per-task JVM startup cost at the cost of increased Metaspace usage)"
+                )
+                workerExecutor.processIsolation {
+                    maxWorkerHeapSize.orNull?.let { forkOptions.maxHeapSize = it }
+                }
+            }
+        }
 
         workQueue.submit(OpenApiWorkAction::class.java, object : Action<OpenApiWorkParameters> {
             override fun execute(parameters: OpenApiWorkParameters) {


### PR DESCRIPTION
In my spring boot project I have about 20 generation tasks in my gradle build. So during building in memory-constrained environments, I run out of metaspace very quickly. This feature allows one to manually decide between possible latency introduced by spinning up separate jvm for each generation task vs reusing one process with separated class loaders (with increased pressure on metaspace requirements)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable worker isolation and optional max heap for Gradle code generation tasks. Default stays `classloader`; switch to `process` to avoid Gradle daemon Metaspace pressure.

- **New Features**
  - `workerIsolation`: `classloader` (default) or `process`.
  - `maxWorkerHeapSize`: sets heap for the forked worker JVM when using `process` (e.g. `"1g"`).
  - Updated task wiring, README, and logs to explain trade-offs.

- **Migration**
  - No changes required.
  - For CI or many generation tasks, set `workerIsolation = "process"` and optionally `maxWorkerHeapSize`.

<sup>Written for commit e21f51fcdd56d3f9a8dd51698778fbce44b985ef. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23648?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



