### PR TITLE
[Fix][scala-sttp] Register JSON value type in importMapping to avoid model-package-prefixed import

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaSttpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaSttpClientCodegen.java
@@ -125,11 +125,6 @@ public class ScalaSttpClientCodegen extends AbstractScalaCodegen implements Code
         additionalProperties.put("fnCamelize", new CamelizeLambda(false));
         additionalProperties.put("fnEnumEntry", new EnumEntryLambda());
 
-//        importMapping.remove("Seq");
-//        importMapping.remove("List");
-//        importMapping.remove("Set");
-//        importMapping.remove("Map");
-
         // TODO: there is no specific sttp mapping. All Scala Type mappings should be in AbstractScala
         typeMapping = new HashMap<>();
         typeMapping.put("array", "Seq");
@@ -171,6 +166,8 @@ public class ScalaSttpClientCodegen extends AbstractScalaCodegen implements Code
 
         String jsonLibrary = JSON_LIBRARY_PROPERTY.getValue(additionalProperties);
         String jsonValueClass = "circe".equals(jsonLibrary) ? "io.circe.Json" : "org.json4s.JValue";
+        importMapping.put(jsonValueClass, jsonValueClass);
+
         typeMapping.put("object", jsonValueClass);
         typeMapping.put("AnyType", jsonValueClass);
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaSttpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaSttpClientCodegen.java
@@ -165,11 +165,12 @@ public class ScalaSttpClientCodegen extends AbstractScalaCodegen implements Code
         modelPackage = PACKAGE_PROPERTY.getModelPackage(additionalProperties);
 
         String jsonLibrary = JSON_LIBRARY_PROPERTY.getValue(additionalProperties);
-        String jsonValueClass = "circe".equals(jsonLibrary) ? "io.circe.Json" : "org.json4s.JValue";
-        importMapping.put(jsonValueClass, jsonValueClass);
+        String jsonValueFqn = "circe".equals(jsonLibrary) ? "io.circe.Json" : "org.json4s.JValue";
+        String jsonValueSimpleName = jsonValueFqn.substring(jsonValueFqn.lastIndexOf('.') + 1);
 
-        typeMapping.put("object", jsonValueClass);
-        typeMapping.put("AnyType", jsonValueClass);
+        typeMapping.put("object", jsonValueSimpleName);
+        typeMapping.put("AnyType", jsonValueSimpleName);
+        importMapping.put(jsonValueSimpleName, jsonValueFqn);
 
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
         supportingFiles.add(new SupportingFile("build.sbt.mustache", "", "build.sbt"));

--- a/modules/openapi-generator/src/test/resources/3_0/scala-sttp-circe/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/scala-sttp-circe/petstore.yaml
@@ -283,6 +283,22 @@ paths:
                   description: file to upload
                   type: string
                   format: binary
+  /store/stats:
+    get:
+      tags:
+        - store
+      summary: Returns store statistics as a free-form JSON object
+      description: Returns arbitrary store metrics whose schema is not fixed
+      operationId: getStoreStats
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+      security:
+        - api_key: []
   /store/inventory:
     get:
       tags:

--- a/samples/client/petstore/scala-sttp-circe/README.md
+++ b/samples/client/petstore/scala-sttp-circe/README.md
@@ -78,6 +78,7 @@ Class | Method | HTTP request | Description
 *StoreApi* | **deleteOrder** | **DELETE** /store/order/${orderId} | Delete purchase order by ID
 *StoreApi* | **getInventory** | **GET** /store/inventory | Returns pet inventories by status
 *StoreApi* | **getOrderById** | **GET** /store/order/${orderId} | Find purchase order by ID
+*StoreApi* | **getStoreStats** | **GET** /store/stats | Returns store statistics as a free-form JSON object
 *StoreApi* | **placeOrder** | **POST** /store/order | Place an order for a pet
 *UserApi* | **createUser** | **POST** /user | Create user
 *UserApi* | **createUsersWithArrayInput** | **POST** /user/createWithArray | Creates list of users with given input array

--- a/samples/client/petstore/scala-sttp-circe/src/main/scala/org/openapitools/client/api/StoreApi.scala
+++ b/samples/client/petstore/scala-sttp-circe/src/main/scala/org/openapitools/client/api/StoreApi.scala
@@ -11,8 +11,8 @@
  */
 package org.openapitools.client.api
 
-import org.openapitools.client.model.Order
 import io.circe.Json
+import org.openapitools.client.model.Order
 import org.openapitools.client.core.JsonSupport._
 import sttp.client3._
 import sttp.model.Method
@@ -77,18 +77,18 @@ class StoreApi(baseUrl: String) {
    * Returns arbitrary store metrics whose schema is not fixed
    * 
    * Expected answers:
-   *   code 200 : io.circe.Json (successful operation)
+   *   code 200 : Json (successful operation)
    * 
    * Available security schemes:
    *   api_key (apiKey)
    */
   def getStoreStats(apiKeyHeader: String)(
-): Request[Either[ResponseException[String, Exception], io.circe.Json], Any] =
+): Request[Either[ResponseException[String, Exception], Json], Any] =
     basicRequest
       .method(Method.GET, uri"$baseUrl/store/stats")
       .contentType("application/json")
       .header("api_key", apiKeyHeader)
-      .response(asJson[io.circe.Json])
+      .response(asJson[Json])
 
   /**
    * 

--- a/samples/client/petstore/scala-sttp-circe/src/main/scala/org/openapitools/client/api/StoreApi.scala
+++ b/samples/client/petstore/scala-sttp-circe/src/main/scala/org/openapitools/client/api/StoreApi.scala
@@ -12,6 +12,7 @@
 package org.openapitools.client.api
 
 import org.openapitools.client.model.Order
+import io.circe.Json
 import org.openapitools.client.core.JsonSupport._
 import sttp.client3._
 import sttp.model.Method
@@ -71,6 +72,23 @@ class StoreApi(baseUrl: String) {
       .method(Method.GET, uri"$baseUrl/store/order/${orderId}")
       .contentType("application/json")
       .response(asJson[Order])
+
+  /**
+   * Returns arbitrary store metrics whose schema is not fixed
+   * 
+   * Expected answers:
+   *   code 200 : io.circe.Json (successful operation)
+   * 
+   * Available security schemes:
+   *   api_key (apiKey)
+   */
+  def getStoreStats(apiKeyHeader: String)(
+): Request[Either[ResponseException[String, Exception], io.circe.Json], Any] =
+    basicRequest
+      .method(Method.GET, uri"$baseUrl/store/stats")
+      .contentType("application/json")
+      .header("api_key", apiKeyHeader)
+      .response(asJson[io.circe.Json])
 
   /**
    * 


### PR DESCRIPTION
## Summary
The `scala-sttp` generator emits a broken import in the generated API file when an endpoint returns a free-form
`type: object` (or `AnyType`) schema:

```scala
// Before
import org.openapitools.client.model.io.circe.Json // <- does not exist; compile fails
```

`processOpts()` registers the fully-qualified `io.circe.Json` (or `org.json4s.JValue`) in `typeMapping` for `object` /`AnyType`, but does not register a corresponding entry in `importMapping`. As a result, DefaultGenerator.getAllImportsMappings()` falls through to `DefaultCodegen.toModelImport()`, which blindly prepends the configured model package to the type name.

## Fix

Register the simple class name in `typeMapping` (so generated code uses `Json` / `JValue` inline) and the fully-qualified name in `importMapping` (so the import resolves correctly to the library, not the model package):

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details
  about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects)
  and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ```
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files.
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master.
  These must match the expectations made by your contribution.
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example
  `./bin/generate-samples.sh bin/configs/java*`.
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written
  tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches):
  `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without
  fallbacks)
- [x] If your PR solves a reported issue, reference it
  using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (
  e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention
  the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee)
  members, so they are more likely to review the pull request.