### PR TITLE
[Kotlin][jvm-spring-restclient] make nullableReturnType type bound conditional in ApiClient

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-restclient/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-restclient/infrastructure/ApiClient.kt.mustache
@@ -10,13 +10,13 @@ import org.springframework.util.LinkedMultiValueMap
 
 {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}open class ApiClient(protected val client: RestClient) {
 
-    protected inline fun <reified I : Any?, reified T: Any?> request(requestConfig: RequestConfig<I>): ResponseEntity<T> {
+    protected inline fun <reified I : Any, reified T: Any{{#nullableReturnType}}?{{/nullableReturnType}}> request(requestConfig: RequestConfig<I>): ResponseEntity<T> {
         return prepare(defaults(requestConfig))
             .retrieve()
             .toEntity(object : ParameterizedTypeReference<T>() {})
     }
 
-    protected fun <I : Any?> prepare(requestConfig: RequestConfig<I>) =
+    protected fun <I : Any> prepare(requestConfig: RequestConfig<I>) =
         client.method(requestConfig)
             .uri(requestConfig)
             .headers(requestConfig)
@@ -45,7 +45,7 @@ import org.springframework.util.LinkedMultiValueMap
     private fun <I> RestClient.RequestBodySpec.headers(requestConfig: RequestConfig<I>) =
         apply { requestConfig.headers.forEach { (name, value) -> header(name, value) } }
 
-    private fun <I : Any?> RestClient.RequestBodySpec.nullableBody(requestConfig: RequestConfig<I>): RestClient.RequestBodySpec {
+    private fun <I : Any> RestClient.RequestBodySpec.nullableBody(requestConfig: RequestConfig<I>): RestClient.RequestBodySpec {
         when {
             requestConfig.headers[HttpHeaders.CONTENT_TYPE] == MediaType.MULTIPART_FORM_DATA_VALUE -> {
                 val parts = LinkedMultiValueMap<String, Any>()
@@ -59,7 +59,7 @@ import org.springframework.util.LinkedMultiValueMap
             }
 
             else -> {
-                return apply { if (requestConfig.body != null) body(requestConfig.body as Any) }
+                return apply { if (requestConfig.body != null) body(requestConfig.body) }
             }
         }
     }

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -10,13 +10,13 @@ import org.springframework.util.LinkedMultiValueMap
 
 open class ApiClient(protected val client: RestClient) {
 
-    protected inline fun <reified I : Any?, reified T: Any?> request(requestConfig: RequestConfig<I>): ResponseEntity<T> {
+    protected inline fun <reified I : Any, reified T: Any> request(requestConfig: RequestConfig<I>): ResponseEntity<T> {
         return prepare(defaults(requestConfig))
             .retrieve()
             .toEntity(object : ParameterizedTypeReference<T>() {})
     }
 
-    protected fun <I : Any?> prepare(requestConfig: RequestConfig<I>) =
+    protected fun <I : Any> prepare(requestConfig: RequestConfig<I>) =
         client.method(requestConfig)
             .uri(requestConfig)
             .headers(requestConfig)
@@ -45,7 +45,7 @@ open class ApiClient(protected val client: RestClient) {
     private fun <I> RestClient.RequestBodySpec.headers(requestConfig: RequestConfig<I>) =
         apply { requestConfig.headers.forEach { (name, value) -> header(name, value) } }
 
-    private fun <I : Any?> RestClient.RequestBodySpec.nullableBody(requestConfig: RequestConfig<I>): RestClient.RequestBodySpec {
+    private fun <I : Any> RestClient.RequestBodySpec.nullableBody(requestConfig: RequestConfig<I>): RestClient.RequestBodySpec {
         when {
             requestConfig.headers[HttpHeaders.CONTENT_TYPE] == MediaType.MULTIPART_FORM_DATA_VALUE -> {
                 val parts = LinkedMultiValueMap<String, Any>()
@@ -59,7 +59,7 @@ open class ApiClient(protected val client: RestClient) {
             }
 
             else -> {
-                return apply { if (requestConfig.body != null) body(requestConfig.body as Any) }
+                return apply { if (requestConfig.body != null) body(requestConfig.body) }
             }
         }
     }

--- a/samples/client/others/kotlin-jvm-spring-3-restclient-nullable-return/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/others/kotlin-jvm-spring-3-restclient-nullable-return/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -10,13 +10,13 @@ import org.springframework.util.LinkedMultiValueMap
 
 open class ApiClient(protected val client: RestClient) {
 
-    protected inline fun <reified I : Any?, reified T: Any?> request(requestConfig: RequestConfig<I>): ResponseEntity<T> {
+    protected inline fun <reified I : Any, reified T: Any?> request(requestConfig: RequestConfig<I>): ResponseEntity<T> {
         return prepare(defaults(requestConfig))
             .retrieve()
             .toEntity(object : ParameterizedTypeReference<T>() {})
     }
 
-    protected fun <I : Any?> prepare(requestConfig: RequestConfig<I>) =
+    protected fun <I : Any> prepare(requestConfig: RequestConfig<I>) =
         client.method(requestConfig)
             .uri(requestConfig)
             .headers(requestConfig)
@@ -45,7 +45,7 @@ open class ApiClient(protected val client: RestClient) {
     private fun <I> RestClient.RequestBodySpec.headers(requestConfig: RequestConfig<I>) =
         apply { requestConfig.headers.forEach { (name, value) -> header(name, value) } }
 
-    private fun <I : Any?> RestClient.RequestBodySpec.nullableBody(requestConfig: RequestConfig<I>): RestClient.RequestBodySpec {
+    private fun <I : Any> RestClient.RequestBodySpec.nullableBody(requestConfig: RequestConfig<I>): RestClient.RequestBodySpec {
         when {
             requestConfig.headers[HttpHeaders.CONTENT_TYPE] == MediaType.MULTIPART_FORM_DATA_VALUE -> {
                 val parts = LinkedMultiValueMap<String, Any>()
@@ -59,7 +59,7 @@ open class ApiClient(protected val client: RestClient) {
             }
 
             else -> {
-                return apply { if (requestConfig.body != null) body(requestConfig.body as Any) }
+                return apply { if (requestConfig.body != null) body(requestConfig.body) }
             }
         }
     }

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -10,13 +10,13 @@ import org.springframework.util.LinkedMultiValueMap
 
 open class ApiClient(protected val client: RestClient) {
 
-    protected inline fun <reified I : Any?, reified T: Any?> request(requestConfig: RequestConfig<I>): ResponseEntity<T> {
+    protected inline fun <reified I : Any, reified T: Any> request(requestConfig: RequestConfig<I>): ResponseEntity<T> {
         return prepare(defaults(requestConfig))
             .retrieve()
             .toEntity(object : ParameterizedTypeReference<T>() {})
     }
 
-    protected fun <I : Any?> prepare(requestConfig: RequestConfig<I>) =
+    protected fun <I : Any> prepare(requestConfig: RequestConfig<I>) =
         client.method(requestConfig)
             .uri(requestConfig)
             .headers(requestConfig)
@@ -45,7 +45,7 @@ open class ApiClient(protected val client: RestClient) {
     private fun <I> RestClient.RequestBodySpec.headers(requestConfig: RequestConfig<I>) =
         apply { requestConfig.headers.forEach { (name, value) -> header(name, value) } }
 
-    private fun <I : Any?> RestClient.RequestBodySpec.nullableBody(requestConfig: RequestConfig<I>): RestClient.RequestBodySpec {
+    private fun <I : Any> RestClient.RequestBodySpec.nullableBody(requestConfig: RequestConfig<I>): RestClient.RequestBodySpec {
         when {
             requestConfig.headers[HttpHeaders.CONTENT_TYPE] == MediaType.MULTIPART_FORM_DATA_VALUE -> {
                 val parts = LinkedMultiValueMap<String, Any>()
@@ -59,7 +59,7 @@ open class ApiClient(protected val client: RestClient) {
             }
 
             else -> {
-                return apply { if (requestConfig.body != null) body(requestConfig.body as Any) }
+                return apply { if (requestConfig.body != null) body(requestConfig.body) }
             }
         }
     }


### PR DESCRIPTION
Fixes #23654

PR #23613 unconditionally relaxed the type bound from `T : Any` to `T : Any?` in `ApiClient.kt.mustache` for `jvm-spring-restclient`. This breaks compilation with Spring Boot 4 / Spring Framework 7, where stricter nullability handling rejects nullable bounds on `RestClient.ResponseSpec.toEntity()`.

Make the relaxation conditional on the `nullableReturnType` option:

| Config | `T` bound | Notes |
|--------|-----------|-------|
| Default (`nullableReturnType=false`) | `T : Any` | Identical to pre-#23613 |
| `nullableReturnType=true` | `T : Any?` | Preserves the #23613 NPE fix |

Also restores `I` bound to `Any` everywhere (request bodies are never nullable) and removes the unnecessary `as Any` cast in `nullableBody`.

**Verification:**
- Reproduced the failure on master with Spring Boot 4.0.6 + Kotlin 2.3.21
- Confirmed this fix resolves the compilation error
- Original NPE fix from #23613 remains intact (regression test in nullable-return sample passes)
- `./bin/generate-samples.sh bin/configs/kotlin-*.yaml` — 112 generators, zero drift
- `./bin/utils/export_docs_generators.sh` — no doc changes

> **Note:** `nullableReturnType=true` combined with Spring Boot 4 still has a separate compatibility issue with Spring Framework 7's `toEntity()` bounds. That requires a different architectural approach and is being considered as a follow-up; out of scope for this regression fix.

cc @wing328 @stefankoppier @karismann @Zomzog @andrewemery @4brunu @yutaka0m @e5l @dennisameling

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  - `./bin/generate-samples.sh bin/configs/kotlin-*.yaml` — 112 generators, zero drift
  - `./bin/utils/export_docs_generators.sh` — no doc changes
  - All three restclient samples build successfully; nullable-return regression tests pass
- [x] File the PR against the correct branch: `master`
- [x] PR references issue using GitHub's linking syntax (fixes #23654)
- [x] @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Conditionally relax the response type bound in `jvm-spring-restclient` `ApiClient.kt.mustache` based on `nullableReturnType`. Restores Spring Boot 4 / Spring Framework 7 compatibility while keeping the nullable-return NPE fix.

- **Bug Fixes**
  - Default (`nullableReturnType=false`): `T : Any`; when `true`: `T : Any?`, avoiding `RestClient.ResponseSpec.toEntity()` bound errors.
  - Restore request body bound to non-null (`I : Any`) and remove the unnecessary `as Any` cast.
  - Verified: samples build with Spring Boot 4 + Kotlin 2.3.21; nullable-return regression passes; no doc or sample drift.

<sup>Written for commit c79ab9b71a7e0ec4e8f0b72fbc8d5b32c98d1cfd. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23657?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

