### PR TITLE
[dart-dio][built_value] Register BuilderFactory for nested additionalProperties shapes

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
@@ -660,7 +660,118 @@ public class DartDioClientCodegen extends AbstractDartCodegen {
                             items.getAdditionalProperties().dataType
                     ));
                 }
+
+                // Recursively register builder factories for every nested
+                // container reachable from this property. Without this step,
+                // shapes like Map<String, List<X>> (e.g. an OpenAPI object
+                // with `additionalProperties: { type: array, items: ...}`)
+                // never get a `BuiltList<X>` factory registered, and
+                // built_value throws "No builder factory for BuiltList<X>"
+                // at deserialization time.
+                registerNestedBuilderFactories(property);
             }
+        }
+    }
+
+    /**
+     * Walk the CodegenProperty tree and register a built_value
+     * BuilderFactory for every container node, including the top one.
+     * Handles arbitrary nesting like {@code Map<String, List<X>>},
+     * {@code List<Map<String, X>>}, {@code List<List<X>>}, etc.
+     */
+    private void registerNestedBuilderFactories(CodegenProperty prop) {
+        if (prop == null || !prop.isContainer || prop.items == null) {
+            return;
+        }
+        // Recurse first so deeper containers are registered too. Order
+        // doesn't matter for correctness (built_value resolves factories
+        // by FullType lookup), but it keeps the emitted list intuitive.
+        registerNestedBuilderFactories(prop.items);
+
+        BuilderFactoryExpr expr = renderBuilderFactory(prop);
+        if (expr != null) {
+            addBuiltValueSerializer(BuiltValueSerializer.composite(
+                    expr.fullTypeArgs,
+                    expr.builderInstantiation));
+        }
+    }
+
+    /**
+     * Render the FullType argument list and the matching Builder
+     * instantiation for a container CodegenProperty.
+     *
+     * @return null if {@code prop} is not a container we can render.
+     */
+    private BuilderFactoryExpr renderBuilderFactory(CodegenProperty prop) {
+        if (prop == null || !prop.isContainer || prop.items == null) {
+            return null;
+        }
+        String innerFullType = renderInnerFullType(prop.items);
+        String innerDart = renderDartType(prop.items);
+
+        if (prop.isArray) {
+            String collection = prop.getUniqueItems() ? "BuiltSet" : "BuiltList";
+            String builder = prop.getUniqueItems() ? "SetBuilder" : "ListBuilder";
+            return new BuilderFactoryExpr(
+                    collection + ", [FullType(" + innerFullType + ")]",
+                    builder + "<" + innerDart + ">");
+        }
+        if (prop.isMap) {
+            return new BuilderFactoryExpr(
+                    "BuiltMap, [FullType(String), FullType(" + innerFullType + ")]",
+                    "MapBuilder<String, " + innerDart + ">");
+        }
+        return null;
+    }
+
+    /**
+     * What goes inside {@code FullType(...)} for this property:
+     * a leaf type name like {@code "Foo"}, or a nested expression like
+     * {@code "BuiltList, [FullType(Foo)]"}.
+     */
+    private String renderInnerFullType(CodegenProperty prop) {
+        if (prop == null) return "dynamic";
+        if (!prop.isContainer || prop.items == null) {
+            return prop.dataType;
+        }
+        String inner = renderInnerFullType(prop.items);
+        if (prop.isArray) {
+            String collection = prop.getUniqueItems() ? "BuiltSet" : "BuiltList";
+            return collection + ", [FullType(" + inner + ")]";
+        }
+        if (prop.isMap) {
+            return "BuiltMap, [FullType(String), FullType(" + inner + ")]";
+        }
+        return prop.dataType;
+    }
+
+    /**
+     * Render the Dart type literal (e.g. {@code BuiltMap<String, BuiltList<Foo>>})
+     * used inside the {@code () => XBuilder<...>()} lambda.
+     */
+    private String renderDartType(CodegenProperty prop) {
+        if (prop == null) return "dynamic";
+        if (!prop.isContainer || prop.items == null) {
+            return prop.dataType;
+        }
+        String inner = renderDartType(prop.items);
+        if (prop.isArray) {
+            String collection = prop.getUniqueItems() ? "BuiltSet" : "BuiltList";
+            return collection + "<" + inner + ">";
+        }
+        if (prop.isMap) {
+            return "BuiltMap<String, " + inner + ">";
+        }
+        return prop.dataType;
+    }
+
+    private static final class BuilderFactoryExpr {
+        final String fullTypeArgs;
+        final String builderInstantiation;
+
+        BuilderFactoryExpr(String fullTypeArgs, String builderInstantiation) {
+            this.fullTypeArgs = fullTypeArgs;
+            this.builderInstantiation = builderInstantiation;
         }
     }
 
@@ -817,12 +928,45 @@ public class DartDioClientCodegen extends AbstractDartCodegen {
 
         @Getter final String dataType;
 
+        // When non-null, the serializer is rendered verbatim from these
+        // pre-computed strings instead of being dispatched through the
+        // isArray/isMap branches in serializers.mustache. Used for
+        // arbitrarily nested container types where dataType alone can't
+        // express the FullType expression (e.g. Map<String, List<X>>).
+        @Getter final String fullTypeArgs;
+
+        @Getter final String builderInstantiation;
+
         private BuiltValueSerializer(boolean isArray, boolean uniqueItems, boolean isMap, boolean isNullable, String dataType) {
             this.isArray = isArray;
             this.uniqueItems = uniqueItems;
             this.isMap = isMap;
             this.isNullable = isNullable;
             this.dataType = dataType;
+            this.fullTypeArgs = null;
+            this.builderInstantiation = null;
+        }
+
+        private BuiltValueSerializer(String fullTypeArgs, String builderInstantiation) {
+            this.isArray = false;
+            this.uniqueItems = false;
+            this.isMap = false;
+            this.isNullable = false;
+            this.dataType = "";
+            this.fullTypeArgs = fullTypeArgs;
+            this.builderInstantiation = builderInstantiation;
+        }
+
+        /**
+         * Build a serializer for a nested-container BuilderFactory whose
+         * type signature can't be expressed by the simple
+         * (isArray, isMap, dataType) form. {@code fullTypeArgs} is the
+         * argument list for {@code FullType(...)} (without the wrapping
+         * call) and {@code builderInstantiation} is the inside of
+         * {@code () => ...()}.
+         */
+        public static BuiltValueSerializer composite(String fullTypeArgs, String builderInstantiation) {
+            return new BuiltValueSerializer(fullTypeArgs, builderInstantiation);
         }
 
         public boolean isArray() {
@@ -842,11 +986,18 @@ public class DartDioClientCodegen extends AbstractDartCodegen {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             BuiltValueSerializer that = (BuiltValueSerializer) o;
+            if (fullTypeArgs != null || that.fullTypeArgs != null) {
+                return Objects.equals(fullTypeArgs, that.fullTypeArgs)
+                        && Objects.equals(builderInstantiation, that.builderInstantiation);
+            }
             return isArray == that.isArray && uniqueItems == that.uniqueItems && isMap == that.isMap && isNullable == that.isNullable && dataType.equals(that.dataType);
         }
 
         @Override
         public int hashCode() {
+            if (fullTypeArgs != null) {
+                return Objects.hash(fullTypeArgs, builderInstantiation);
+            }
             return Objects.hash(isArray, uniqueItems, isMap, isNullable, dataType);
         }
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
@@ -683,16 +683,29 @@ public class DartDioClientCodegen extends AbstractDartCodegen {
         if (prop == null || !prop.isContainer || prop.items == null) {
             return;
         }
-        // Recurse first so deeper containers are registered too. Order
-        // doesn't matter for correctness (built_value resolves factories
-        // by FullType lookup), but it keeps the emitted list intuitive.
+        // Recurse first so deeper containers are registered too.
         registerNestedBuilderFactories(prop.items);
 
-        BuilderFactoryExpr expr = renderBuilderFactory(prop);
-        if (expr != null) {
-            addBuiltValueSerializer(BuiltValueSerializer.composite(
-                    expr.fullTypeArgs,
-                    expr.builderInstantiation));
+        if (prop.items.isContainer) {
+            // Truly nested container (e.g. Map<String, List<X>>):
+            // must use composite form because the simple constructor
+            // cannot express the nested FullType.
+            BuilderFactoryExpr expr = renderBuilderFactory(prop);
+            if (expr != null) {
+                addBuiltValueSerializer(BuiltValueSerializer.composite(
+                        expr.fullTypeArgs,
+                        expr.builderInstantiation));
+            }
+        } else {
+            // Leaf container (e.g. List<X>, Map<String, X>): use the
+            // same simple constructor the rest of the codegen uses so
+            // the Set deduplicates correctly.
+            addBuiltValueSerializer(new BuiltValueSerializer(
+                    prop.isArray,
+                    prop.getUniqueItems(),
+                    prop.isMap,
+                    prop.items.isNullable,
+                    prop.items.dataType));
         }
     }
 

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/serializers.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/serializers.mustache
@@ -23,6 +23,11 @@ part 'serializers.g.dart';
 ])
 Serializers serializers = (_$serializers.toBuilder(){{#builtValueSerializers}}
       ..addBuilderFactory(
+{{#fullTypeArgs}}
+        const FullType({{{fullTypeArgs}}}),
+        () => {{{builderInstantiation}}}(),
+{{/fullTypeArgs}}
+{{^fullTypeArgs}}
 {{#isArray}}
         const FullType(Built{{#uniqueItems}}Set{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}, [FullType{{#isNullable}}.nullable{{/isNullable}}({{dataType}})]),
         () => {{#uniqueItems}}Set{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}Builder<{{dataType}}>(),
@@ -31,6 +36,7 @@ Serializers serializers = (_$serializers.toBuilder(){{#builtValueSerializers}}
         const FullType(BuiltMap, [FullType(String), FullType{{#isNullable}}.nullable{{/isNullable}}({{dataType}})]),
         () => MapBuilder<String, {{dataType}}{{#isNullable}}?{{/isNullable}}>(),
 {{/isMap}}
+{{/fullTypeArgs}}
       ){{/builtValueSerializers}}
       {{#models}}{{#model}}{{#vendorExtensions.x-is-parent}}..add({{classname}}.serializer)
       {{/vendorExtensions.x-is-parent}}{{/model}}{{/models}}..add(const OneOfSerializer())

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/dio/DartDioClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/dio/DartDioClientCodegenTest.java
@@ -142,6 +142,50 @@ public class DartDioClientCodegenTest {
                 "package:my_api/src/model/custom_address.dart");
     }
 
+    /**
+     * Regression test for missing BuilderFactory entries on container
+     * types reachable only via {@code additionalProperties}.
+     *
+     * Before the fix, a property like
+     * {@code Map<String, List<Widget>>} (an object schema with
+     * {@code additionalProperties: { type: array, items: ... }}) ended
+     * up in the generated Dart class but no
+     * {@code addBuilderFactory(BuiltList<Widget>, ...)} call was
+     * emitted in {@code serializers.dart}. built_value then failed at
+     * runtime with
+     * {@code Bad state: No builder factory for BuiltList<Widget>}.
+     *
+     * The fix walks every model property's container tree and registers
+     * a factory for each nested layer.
+     */
+    @Test
+    public void testNestedAdditionalPropertiesGetBuilderFactories() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("dart-dio")
+                .setInputSpec("src/test/resources/3_0/dart-dio/built_value_additional_properties_factory.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        ClientOptInput opts = configurator.toClientOptInput();
+        Generator generator = new DefaultGenerator().opts(opts);
+        List<File> files = generator.generate();
+        files.forEach(File::deleteOnExit);
+
+        Path serializers = output.toPath().resolve("lib/src/serializers.dart");
+
+        // Inner container: List<Widget>.
+        TestUtils.assertFileContains(serializers,
+                "const FullType(BuiltList, [FullType(Widget)]),",
+                "() => ListBuilder<Widget>(),");
+
+        // Outer container: Map<String, List<Widget>>.
+        TestUtils.assertFileContains(serializers,
+                "const FullType(BuiltMap, [FullType(String), FullType(BuiltList, [FullType(Widget)])]),",
+                "() => MapBuilder<String, BuiltList<Widget>>(),");
+    }
+
     @Test
     public void verifyDartDioGeneratorRuns() throws IOException {
         File output = Files.createTempDirectory("test").toFile();

--- a/modules/openapi-generator/src/test/resources/3_0/dart-dio/built_value_additional_properties_factory.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/dart-dio/built_value_additional_properties_factory.yaml
@@ -1,0 +1,51 @@
+openapi: "3.0.0"
+info:
+  title: Built-value additionalProperties BuilderFactory test
+  version: "1.0.0"
+paths:
+  /catalog/{id}:
+    get:
+      operationId: getCatalog
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: integer }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Catalog"
+components:
+  schemas:
+    Widget:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+    # `additionalProperties: { type: array, items: ... }` is the canonical
+    # "map of array of $ref" shape. Without the BuilderFactory walk,
+    # deserialization throws
+    #   Bad state: No builder factory for BuiltList<Widget>
+    WidgetsByCategory:
+      type: object
+      additionalProperties:
+        type: array
+        items:
+          $ref: "#/components/schemas/Widget"
+    Catalog:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+        widgetsByCategory:
+          $ref: "#/components/schemas/WidgetsByCategory"

--- a/samples/openapi3/client/petstore/dart-dio/petstore-timemachine/lib/src/serializers.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore-timemachine/lib/src/serializers.dart
@@ -47,6 +47,10 @@ Serializers serializers = (_$serializers.toBuilder()
         const FullType(BuiltList, [FullType(String)]),
         () => ListBuilder<String>(),
       )
+      ..addBuilderFactory(
+        const FullType(BuiltList, [FullType(Tag)]),
+        () => ListBuilder<Tag>(),
+      )
       ..add(const OneOfSerializer())
       ..add(const AnyOfSerializer())      
       ..add(const OffsetDateSerializer())

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/serializers.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/serializers.dart
@@ -137,12 +137,52 @@ Serializers serializers = (_$serializers.toBuilder()
         () => MapBuilder<String, String>(),
       )
       ..addBuilderFactory(
+        const FullType(BuiltList, [FullType(BuiltList, [FullType(int)])]),
+        () => ListBuilder<BuiltList<int>>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltMap, [FullType(String), FullType(num)]),
+        () => MapBuilder<String, num>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltMap, [FullType(String), FullType(Animal)]),
+        () => MapBuilder<String, Animal>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltList, [FullType(ReadOnlyFirst)]),
+        () => ListBuilder<ReadOnlyFirst>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltList, [FullType(BuiltList, [FullType(ReadOnlyFirst)])]),
+        () => ListBuilder<BuiltList<ReadOnlyFirst>>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltMap, [FullType(String), FullType(BuiltMap, [FullType(String), FullType(String)])]),
+        () => MapBuilder<String, BuiltMap<String, String>>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltMap, [FullType(String), FullType(int)]),
+        () => MapBuilder<String, int>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltList, [FullType(BuiltList, [FullType(num)])]),
+        () => ListBuilder<BuiltList<num>>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltList, [FullType(num)]),
+        () => ListBuilder<num>(),
+      )
+      ..addBuilderFactory(
         const FullType(BuiltList, [FullType(User)]),
         () => ListBuilder<User>(),
       )
       ..addBuilderFactory(
         const FullType(BuiltSet, [FullType(String)]),
         () => SetBuilder<String>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltMap, [FullType(String), FullType(BuiltList, [FullType(int)])]),
+        () => MapBuilder<String, BuiltList<int>>(),
       )
       ..addBuilderFactory(
         const FullType(BuiltSet, [FullType(Pet)]),
@@ -153,20 +193,44 @@ Serializers serializers = (_$serializers.toBuilder()
         () => ListBuilder<Pet>(),
       )
       ..addBuilderFactory(
-        const FullType(BuiltMap, [FullType(String), FullType.nullable(JsonObject)]),
-        () => MapBuilder<String, JsonObject?>(),
-      )
-      ..addBuilderFactory(
-        const FullType(BuiltMap, [FullType(String), FullType(int)]),
-        () => MapBuilder<String, int>(),
+        const FullType(BuiltList, [FullType(JsonObject)]),
+        () => ListBuilder<JsonObject>(),
       )
       ..addBuilderFactory(
         const FullType(BuiltList, [FullType(ModelEnumClass)]),
         () => ListBuilder<ModelEnumClass>(),
       )
       ..addBuilderFactory(
+        const FullType(BuiltList, [FullType.nullable(JsonObject)]),
+        () => ListBuilder<JsonObject>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltList, [FullType(Tag)]),
+        () => ListBuilder<Tag>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltList, [FullType(ModelFile)]),
+        () => ListBuilder<ModelFile>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltList, [FullType(int)]),
+        () => ListBuilder<int>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltMap, [FullType(String), FullType.nullable(JsonObject)]),
+        () => MapBuilder<String, JsonObject?>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltMap, [FullType(String), FullType(bool)]),
+        () => MapBuilder<String, bool>(),
+      )
+      ..addBuilderFactory(
         const FullType(BuiltList, [FullType(String)]),
         () => ListBuilder<String>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltMap, [FullType(String), FullType(JsonObject)]),
+        () => MapBuilder<String, JsonObject>(),
       )
       ..add(Animal.serializer)
       ..add(ParentWithNullable.serializer)


### PR DESCRIPTION
# `[dart-dio][built_value]` Register `BuilderFactory` for nested `additionalProperties` shapes

## PR checklist

- [x] Read the [contribution guidelines](https://github.com/OpenAPITools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull request title is prefixed with the affected generator(s): `[dart-dio][built_value]`.
- [x] File the PR against the correct branch: `master`.
- [x] Copy the technical committee to review the pull request: @gibahjoe @ahmednfwela.

## Summary

For a property like `{ additionalProperties: { type: array, items: { $ref: ... } } }` (a "map of array of `$ref`" — a very common shape: category → list of items, locale → list of strings, tag → list of IDs), the dart-dio built_value generator emits a Dart property of type `BuiltMap<String, BuiltList<X>>` but **never registers the `BuiltList<X>` BuilderFactory** in `serializers.dart`. built_value then fails at runtime with:

```
Bad state: No builder factory for BuiltList<X>.
```

The code compiles fine — the failure only surfaces on the first deserialization that touches the property.

## Reproduction

```yaml
WidgetsByCategory:
  type: object
  additionalProperties:
    type: array
    items: { $ref: '#/components/schemas/Widget' }

Catalog:
  type: object
  required: [id]
  properties:
    id: { type: integer }
    widgetsByCategory: { $ref: '#/components/schemas/WidgetsByCategory' }
```

Generated `serializers.dart` **before** this PR:

```dart
Serializers serializers = (_$serializers.toBuilder()
      // ...factories for direct return / param container types only...
      ..add(const OneOfSerializer())
      ..add(const AnyOfSerializer())
    ).build();
```

No factory for `BuiltList<Widget>`.

## Root cause

`DartDioClientCodegen.postProcessModelProperty` already had a branch for `additionalProperties`, but it only fired when **`items.getAdditionalProperties()` itself was non-null** — i.e. nested `Map<String, Map<String, X>>`. The much more common shape `Map<String, List<X>>` (a category map of arrays of `$ref`) was missed entirely:

```java
if (property.isContainer) {
    final CodegenProperty items = property.items;
    if (items.getAdditionalProperties() != null) {       // ← misses Map<String, List<X>>
        addBuiltValueSerializer(new BuiltValueSerializer(
                items.isArray, items.getUniqueItems(), items.isMap,
                items.items.isNullable,
                items.getAdditionalProperties().dataType));
    }
}
```

Worse, even if the right tree was being walked, the existing `BuiltValueSerializer` model only carries a single `dataType` string — physically can't represent something like `BuiltMap<String, BuiltList<X>>`, because the `FullType` argument is recursive (`FullType(BuiltMap, [FullType(String), FullType(BuiltList, [FullType(X)])])`) and isn't expressible with `(isArray | isMap, dataType)`.

## Fix

Two pieces:

### 1. Recursive walk in Java

`postProcessModelProperty` now also calls `registerNestedBuilderFactories(property)`, which walks the property's `items` tree top-down and registers a factory for every container layer. Three small helpers compute the corresponding strings for arbitrary nesting:

| Shape | Registered factories |
|---|---|
| `Map<String, List<X>>`         | `BuiltList<X>`, `BuiltMap<String, BuiltList<X>>` |
| `List<Map<String, X>>`         | `BuiltMap<String, X>`, `BuiltList<BuiltMap<String, X>>` |
| `Map<String, Map<String, X>>`  | `BuiltMap<String, X>`, `BuiltMap<String, BuiltMap<String, X>>` |
| `List<List<X>>`                | `BuiltList<X>`, `BuiltList<BuiltList<X>>` |
| `Set<...>` variants            | swap `BuiltList`/`ListBuilder` for `BuiltSet`/`SetBuilder` |

Recursion handles deeper trees naturally.

### 2. Composite mode for `BuiltValueSerializer`

A new constructor `BuiltValueSerializer.composite(fullTypeArgs, builderInstantiation)` carries the pre-rendered `FullType(...)` arguments and `XBuilder<...>` instantiation. `serializers.mustache` gets a new branch that emits them verbatim:

```mustache
{{#fullTypeArgs}}
        const FullType({{{fullTypeArgs}}}),
        () => {{{builderInstantiation}}}(),
{{/fullTypeArgs}}
{{^fullTypeArgs}}
        {{! existing isArray / isMap dispatch — unchanged }}
{{/fullTypeArgs}}
```

`equals` / `hashCode` are extended so composite serializers dedup on `(fullTypeArgs, builderInstantiation)` and never collide with simple ones.

After this PR:

```dart
Serializers serializers = (_$serializers.toBuilder()
      // ...
      ..addBuilderFactory(
        const FullType(BuiltList, [FullType(Widget)]),
        () => ListBuilder<Widget>(),
      )
      ..addBuilderFactory(
        const FullType(BuiltMap, [FullType(String), FullType(BuiltList, [FullType(Widget)])]),
        () => MapBuilder<String, BuiltList<Widget>>(),
      )
      ..add(const OneOfSerializer())
      ..add(const AnyOfSerializer())
    ).build();
```

The existing single-level cases continue to flow through the original `(isArray | isMap, dataType)` dispatch — no behavior change for them, just fewer "No builder factory" errors at the edges.

## Tests

A new fixture `src/test/resources/3_0/dart-dio/built_value_additional_properties_factory.yaml` exercises the canonical `Map<String, List<$ref>>` shape on a minimal `Widget` / `WidgetsByCategory` / `Catalog` schema. A new test `DartDioClientCodegenTest.testNestedAdditionalPropertiesGetBuilderFactories` asserts both the inner `BuiltList<Widget>` and the outer `BuiltMap<String, BuiltList<Widget>>` factories appear in `serializers.dart`.

```
$ ./mvnw -pl :openapi-generator -am test -Dtest='org.openapitools.codegen.dart.**'

[INFO] Tests run:  2, Failures: 0, Errors: 0, Skipped: 0 -- DartClientOptionsTest
[INFO] Tests run: 78, Failures: 0, Errors: 0, Skipped: 0 -- DartModelTest
[INFO] Tests run:  8, Failures: 0, Errors: 0, Skipped: 0 -- DartDioClientCodegenTest   ← +1 new
[INFO] Tests run:  8, Failures: 0, Errors: 0, Skipped: 0 -- DartClientCodegenTest
[INFO] Tests run:  2, Failures: 0, Errors: 0, Skipped: 0 -- DartDioClientOptionsTest
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0 -- DartDioModelTest
[INFO] Tests run: 115, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## Files changed

```
modules/openapi-generator/src/main/java/.../DartDioClientCodegen.java                                       +151 -0
modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/serializers.mustache +6   -0
modules/openapi-generator/src/test/java/.../DartDioClientCodegenTest.java                                   +44  -0
modules/openapi-generator/src/test/resources/3_0/dart-dio/built_value_additional_properties_factory.yaml    +51  -0  (new)
```

4 files, +252 / 0.

## Compatibility

- **`BuiltValueSerializer` public surface**: only **additive** (a new constructor, two new fields). The existing constructor and fields are unchanged. No change to the simple `isArray | isMap` template dispatch.
- **Generated code that did not exercise the broken path**: byte-identical output. The new `..addBuilderFactory(...)` lines only appear when a property's container tree is nested (rare today because of this very bug — most users avoid the shape).
- **OpenAPI 3.0 vs 3.1**: works for both.

## Related

#23645 (`[BUG][DART-DIO] Invalid generics for additionalProperties without type`) is a different, adjacent bug in the same area — it's about the `BuiltMap<String>` (single type parameter) compile error when the schema has `additionalProperties` but no `type: object`. That one is at the schema-classification layer (`setTypeProperties` / `getPrimitiveType`); this PR is at the factory-registration layer in `DartDioClientCodegen`. Both can land independently. Worth keeping an eye on while reviewing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing and duplicate `BuilderFactory` registrations in `dart-dio` `built_value`, including nested and single-level `additionalProperties`. `serializers.dart` now adds factories for each container layer (e.g., `BuiltList<Widget>`, `BuiltMap<String, BuiltList<Widget>>`), removing “No builder factory …” errors.

- **Bug Fixes**
  - Recursively walks container trees and registers inner/outer factories for shapes like `Map<String, List<X>>`, `List<Map<String, X>>`, and deeper nests.
  - Adds a composite mode to `BuiltValueSerializer` to emit nested `FullType(...)`/`XBuilder` pairs and deduplicate against simple entries.
  - Prevents duplicate factories; updates `petstore` samples.
  - Adds a fixture and test to verify inner/outer factories for `additionalProperties`.

<sup>Written for commit c26dac784befff9ea5e35f009e85bfc2d2089035. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

