### PR TITLE
[BUG][SWIFT6] unalias additionalProperties before building map type declaration

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift6ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift6ClientCodegen.java
@@ -753,7 +753,7 @@ public class Swift6ClientCodegen extends DefaultCodegen implements CodegenConfig
             Schema inner = ModelUtils.getSchemaItems(p);
             return ModelUtils.isSet(p) ? "Set<" + getTypeDeclaration(inner) + ">" : "[" + getTypeDeclaration(inner) + "]";
         } else if (ModelUtils.isMapSchema(p)) {
-            Schema inner = ModelUtils.getAdditionalProperties(p);
+            Schema inner = unaliasSchema(ModelUtils.getAdditionalProperties(p));
             return "[String: " + getItemsTypeDeclaration(inner) + "]";
         }
         return super.getTypeDeclaration(p);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift6/Swift6ClientCodegenModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift6/Swift6ClientCodegenModelTest.java
@@ -25,8 +25,11 @@ import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.DefaultCodegen;
 import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.languages.Swift6ClientCodegen;
+import org.openapitools.codegen.utils.ModelUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.util.Map;
 
 @SuppressWarnings("static-method")
 public class Swift6ClientCodegenModelTest {
@@ -161,6 +164,28 @@ public class Swift6ClientCodegenModelTest {
         Assert.assertEquals(property7.baseType, "OpenAPIDateWithoutTime");
         Assert.assertFalse(property7.required);
         Assert.assertFalse(property7.isContainer);
+    }
+
+    @Test(description = "nested map via $ref should resolve to [String: [String: String]], not [String: Dictionary]", enabled = true)
+    public void nestedMapRefTypeTest() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/swift6_nested_map.yaml");
+        final Swift6ClientCodegen codegen = new Swift6ClientCodegen();
+        codegen.setOpenAPI(openAPI);
+        codegen.processOpts();
+
+        Map<String, Schema> schemas = ModelUtils.getSchemas(openAPI);
+        Schema emailTemplateSchema = schemas.get("EmailTemplate");
+        Assert.assertNotNull(emailTemplateSchema, "EmailTemplate schema should exist");
+
+        final CodegenModel cm = codegen.fromModel("EmailTemplate", emailTemplateSchema);
+
+        CodegenProperty translationProp = cm.vars.stream()
+                .filter(p -> p.baseName.equals("translationOverridesByLocale"))
+                .findFirst().orElse(null);
+        Assert.assertNotNull(translationProp, "translationOverridesByLocale property should exist");
+        // Must be [String: [String: String]], NOT [String: Dictionary]
+        Assert.assertEquals(translationProp.dataType, "[String: [String: String]]",
+                "Nested map via $ref should resolve to [String: [String: String]]");
     }
 
 }

--- a/modules/openapi-generator/src/test/resources/3_0/swift6_nested_map.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/swift6_nested_map.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.0
+info:
+  title: Nested Map Type Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    StringMap:
+      type: object
+      additionalProperties:
+        type: string
+      description: A map of string to string
+    EmailTemplate:
+      type: object
+      required:
+        - id
+        - ejs
+      properties:
+        id:
+          type: string
+        ejs:
+          type: string
+        translationOverridesByLocale:
+          $ref: '#/components/schemas/NestedStringMap'
+    NestedStringMap:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/StringMap'
+      description: A map of string to map of string to string


### PR DESCRIPTION
Closes #23666.

A nested map property whose `additionalProperties` is a `$ref` to an aliased map schema produced `[String: Dictionary]` (no generic args, doesn't compile in Swift 6) instead of the resolved `[String: [String: String]]`.

```yaml
StringMap:
  type: object
  additionalProperties: { type: string }
EmailTemplate:
  properties:
    translationOverridesByLocale:
      type: object
      additionalProperties:
        $ref: '#/components/schemas/StringMap'
```

### Fix
Wrap `ModelUtils.getAdditionalProperties(p)` with `unaliasSchema(...)` in `Swift6ClientCodegen.getTypeDeclaration` so the alias resolves to the actual schema before recursion.

### Test
New `nestedMapRefTypeTest` in `Swift6ClientCodegenModelTest` against `swift6_nested_map.yaml` asserts the resolved type. Full swift6 suite (39 tests) passes.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/OpenAPITools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to build the project and update samples:
   ```
   ./mvnw clean package
   ```
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.x.x) (patches will be cascaded from `master` to other branches by the maintainers)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @4brunu @yutailang0119