### PR TITLE
[BUG][CORE] Use intersection of required fields across anyOf/oneOf members

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2756,6 +2756,13 @@ public class DefaultCodegen implements CodegenConfig {
 
         // interfaces (schemas defined in allOf, anyOf, oneOf)
         List<Schema> interfaces = ModelUtils.getInterfaces(composed);
+
+        // For anyOf/oneOf, required fields should be the intersection across members,
+        // not the union. A field is only guaranteed present if ALL members require it.
+        boolean isAnyOfOrOneOf = (composed.getAnyOf() != null && !composed.getAnyOf().isEmpty())
+                || (composed.getOneOf() != null && !composed.getOneOf().isEmpty());
+        List<Set<String>> perMemberRequiredSets = isAnyOfOrOneOf ? new ArrayList<>() : null;
+
         if (!interfaces.isEmpty()) {
             // m.interfaces is for backward compatibility
             if (m.interfaces == null)
@@ -2816,7 +2823,14 @@ public class DefaultCodegen implements CodegenConfig {
                     } else {
                         // composition
                         Map<String, Schema> newProperties = new LinkedHashMap<>();
-                        addProperties(newProperties, required, refSchema, new HashSet<>());
+                        if (isAnyOfOrOneOf) {
+                            // Collect required fields per-member for later intersection
+                            List<String> memberRequired = new ArrayList<>();
+                            addProperties(newProperties, memberRequired, refSchema, new HashSet<>());
+                            perMemberRequiredSets.add(new HashSet<>(memberRequired));
+                        } else {
+                            addProperties(newProperties, required, refSchema, new HashSet<>());
+                        }
                         mergeProperties(properties, newProperties);
                         addProperties(allProperties, allRequired, refSchema, new HashSet<>());
                     }
@@ -2857,8 +2871,15 @@ public class DefaultCodegen implements CodegenConfig {
         for (Schema component : interfaces) {
             if (component.get$ref() == null) {
                 if (component != null) {
-                    // component is the child schema
-                    addProperties(properties, required, component, new HashSet<>());
+                    if (isAnyOfOrOneOf) {
+                        // Collect required fields per-member for later intersection
+                        List<String> memberRequired = new ArrayList<>();
+                        addProperties(properties, memberRequired, component, new HashSet<>());
+                        perMemberRequiredSets.add(new HashSet<>(memberRequired));
+                    } else {
+                        // component is the child schema
+                        addProperties(properties, required, component, new HashSet<>());
+                    }
 
                     // includes child's properties (all, required) in allProperties, allRequired
                     addProperties(allProperties, allRequired, component, new HashSet<>());
@@ -2866,6 +2887,16 @@ public class DefaultCodegen implements CodegenConfig {
                 // in 7.0.0 release, we comment out below to allow more than 1 child schemas in allOf
                 //break; // at most one child only
             }
+        }
+
+        // For anyOf/oneOf, compute the intersection of required fields across all members.
+        // A field is only required in the merged model if ALL members require it.
+        if (isAnyOfOrOneOf && !perMemberRequiredSets.isEmpty()) {
+            Set<String> intersected = new HashSet<>(perMemberRequiredSets.get(0));
+            for (int i = 1; i < perMemberRequiredSets.size(); i++) {
+                intersected.retainAll(perMemberRequiredSets.get(i));
+            }
+            required.addAll(intersected);
         }
 
         if (composed.getRequired() != null) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2759,8 +2759,7 @@ public class DefaultCodegen implements CodegenConfig {
 
         // For anyOf/oneOf, required fields should be the intersection across members,
         // not the union. A field is only guaranteed present if ALL members require it.
-        boolean isAnyOfOrOneOf = (composed.getAnyOf() != null && !composed.getAnyOf().isEmpty())
-                || (composed.getOneOf() != null && !composed.getOneOf().isEmpty());
+        boolean isAnyOfOrOneOf = ModelUtils.hasAnyOf(composed) || ModelUtils.hasOneOf(composed);
         List<Set<String>> perMemberRequiredSets = isAnyOfOrOneOf ? new ArrayList<>() : null;
 
         if (!interfaces.isEmpty()) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift6/Swift6ClientCodegenModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift6/Swift6ClientCodegenModelTest.java
@@ -25,8 +25,11 @@ import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.DefaultCodegen;
 import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.languages.Swift6ClientCodegen;
+import org.openapitools.codegen.utils.ModelUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.util.Map;
 
 @SuppressWarnings("static-method")
 public class Swift6ClientCodegenModelTest {
@@ -161,6 +164,76 @@ public class Swift6ClientCodegenModelTest {
         Assert.assertEquals(property7.baseType, "OpenAPIDateWithoutTime");
         Assert.assertFalse(property7.required);
         Assert.assertFalse(property7.isContainer);
+    }
+
+    @Test(description = "anyOf with different required fields should use intersection for required", enabled = true)
+    public void anyOfRequiredFieldsIntersectionTest() {
+        // VoteResponse requires: status, voteId
+        // APIError requires: status, reason, code
+        // Intersection: only "status" should be required in the merged model
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/swift6_anyof_required.yaml");
+        final Swift6ClientCodegen codegen = new Swift6ClientCodegen();
+        codegen.setOpenAPI(openAPI);
+        codegen.processOpts();
+
+        // The inline model resolver creates a model for the anyOf response.
+        // Find the composed schema that merges VoteResponse and APIError.
+        Map<String, Schema> schemas = ModelUtils.getSchemas(openAPI);
+        Schema composedSchema = null;
+        String composedName = null;
+        for (Map.Entry<String, Schema> entry : schemas.entrySet()) {
+            Schema s = entry.getValue();
+            if (s.getAnyOf() != null && !s.getAnyOf().isEmpty()) {
+                composedSchema = s;
+                composedName = entry.getKey();
+                break;
+            }
+        }
+        Assert.assertNotNull(composedSchema, "Should find an anyOf composed schema");
+
+        final CodegenModel cm = codegen.fromModel(composedName, composedSchema);
+
+        // "status" is required in BOTH VoteResponse and APIError -> should be required
+        CodegenProperty statusProp = cm.vars.stream()
+                .filter(p -> p.baseName.equals("status"))
+                .findFirst().orElse(null);
+        Assert.assertNotNull(statusProp, "status property should exist");
+        Assert.assertTrue(statusProp.required, "status should be required (present in all anyOf members)");
+
+        // "voteId" is required only in VoteResponse, not in APIError -> should NOT be required
+        CodegenProperty voteIdProp = cm.vars.stream()
+                .filter(p -> p.baseName.equals("voteId"))
+                .findFirst().orElse(null);
+        Assert.assertNotNull(voteIdProp, "voteId property should exist");
+        Assert.assertFalse(voteIdProp.required, "voteId should NOT be required (only in VoteResponse, not APIError)");
+
+        // "reason" is required only in APIError, not in VoteResponse -> should NOT be required
+        CodegenProperty reasonProp = cm.vars.stream()
+                .filter(p -> p.baseName.equals("reason"))
+                .findFirst().orElse(null);
+        Assert.assertNotNull(reasonProp, "reason property should exist");
+        Assert.assertFalse(reasonProp.required, "reason should NOT be required (only in APIError, not VoteResponse)");
+
+        // "code" is required only in APIError, not in VoteResponse -> should NOT be required
+        CodegenProperty codeProp = cm.vars.stream()
+                .filter(p -> p.baseName.equals("code"))
+                .findFirst().orElse(null);
+        Assert.assertNotNull(codeProp, "code property should exist");
+        Assert.assertFalse(codeProp.required, "code should NOT be required (only in APIError, not VoteResponse)");
+
+        // "isVerified" is optional in VoteResponse, not in APIError -> should NOT be required
+        CodegenProperty isVerifiedProp = cm.vars.stream()
+                .filter(p -> p.baseName.equals("isVerified"))
+                .findFirst().orElse(null);
+        Assert.assertNotNull(isVerifiedProp, "isVerified property should exist");
+        Assert.assertFalse(isVerifiedProp.required, "isVerified should NOT be required");
+
+        // "secondaryCode" is optional in APIError -> should NOT be required
+        CodegenProperty secondaryCodeProp = cm.vars.stream()
+                .filter(p -> p.baseName.equals("secondaryCode"))
+                .findFirst().orElse(null);
+        Assert.assertNotNull(secondaryCodeProp, "secondaryCode property should exist");
+        Assert.assertFalse(secondaryCodeProp.required, "secondaryCode should NOT be required");
     }
 
 }

--- a/modules/openapi-generator/src/test/resources/3_0/swift6_anyof_required.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/swift6_anyof_required.yaml
@@ -1,0 +1,51 @@
+openapi: 3.0.0
+info:
+  title: anyOf Required Fields Test
+  version: 1.0.0
+paths:
+  /vote:
+    post:
+      operationId: voteOnItem
+      responses:
+        '200':
+          description: Success or error response
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: '#/components/schemas/VoteResponse'
+                  - $ref: '#/components/schemas/APIError'
+components:
+  schemas:
+    APIStatus:
+      type: string
+      enum:
+        - success
+        - failed
+    VoteResponse:
+      type: object
+      required:
+        - status
+        - voteId
+      properties:
+        status:
+          $ref: '#/components/schemas/APIStatus'
+        voteId:
+          type: string
+        isVerified:
+          type: boolean
+    APIError:
+      type: object
+      required:
+        - status
+        - reason
+        - code
+      properties:
+        status:
+          $ref: '#/components/schemas/APIStatus'
+        reason:
+          type: string
+        code:
+          type: string
+        secondaryCode:
+          type: string

--- a/samples/client/others/go/oneof-anyof-required/docs/Object.md
+++ b/samples/client/others/go/oneof-anyof-required/docs/Object.md
@@ -4,14 +4,14 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Field1** | **string** | Specifies an action name to be used with the Android Intent class. | 
-**Field2** | **string** | Specifies an action name to be used with the Android Intent class. | 
+**Field1** | Pointer to **string** | Specifies an action name to be used with the Android Intent class. | [optional] 
+**Field2** | Pointer to **string** | Specifies an action name to be used with the Android Intent class. | [optional] 
 
 ## Methods
 
 ### NewObject
 
-`func NewObject(field1 string, field2 string, ) *Object`
+`func NewObject() *Object`
 
 NewObject instantiates a new Object object
 This constructor will assign default values to properties that have it defined,
@@ -45,6 +45,11 @@ and a boolean to check if the value has been set.
 
 SetField1 sets Field1 field to given value.
 
+### HasField1
+
+`func (o *Object) HasField1() bool`
+
+HasField1 returns a boolean if a field has been set.
 
 ### GetField2
 
@@ -65,6 +70,11 @@ and a boolean to check if the value has been set.
 
 SetField2 sets Field2 field to given value.
 
+### HasField2
+
+`func (o *Object) HasField2() bool`
+
+HasField2 returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/others/go/oneof-anyof-required/docs/Object2.md
+++ b/samples/client/others/go/oneof-anyof-required/docs/Object2.md
@@ -4,14 +4,14 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Field1** | **string** | Specifies an action name to be used with the Android Intent class. | 
-**Field2** | **string** | Specifies an action name to be used with the Android Intent class. | 
+**Field1** | Pointer to **string** | Specifies an action name to be used with the Android Intent class. | [optional] 
+**Field2** | Pointer to **string** | Specifies an action name to be used with the Android Intent class. | [optional] 
 
 ## Methods
 
 ### NewObject2
 
-`func NewObject2(field1 string, field2 string, ) *Object2`
+`func NewObject2() *Object2`
 
 NewObject2 instantiates a new Object2 object
 This constructor will assign default values to properties that have it defined,
@@ -45,6 +45,11 @@ and a boolean to check if the value has been set.
 
 SetField1 sets Field1 field to given value.
 
+### HasField1
+
+`func (o *Object2) HasField1() bool`
+
+HasField1 returns a boolean if a field has been set.
 
 ### GetField2
 
@@ -65,6 +70,11 @@ and a boolean to check if the value has been set.
 
 SetField2 sets Field2 field to given value.
 
+### HasField2
+
+`func (o *Object2) HasField2() bool`
+
+HasField2 returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/others/go/oneof-discriminator-lookup/docs/Object.md
+++ b/samples/client/others/go/oneof-discriminator-lookup/docs/Object.md
@@ -4,14 +4,14 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Field1** | **string** | Specifies an action name to be used with the Android Intent class. | 
+**Field1** | Pointer to **string** | Specifies an action name to be used with the Android Intent class. | [optional] 
 **Type** | Pointer to **string** |  | [optional] 
 
 ## Methods
 
 ### NewObject
 
-`func NewObject(field1 string, ) *Object`
+`func NewObject() *Object`
 
 NewObject instantiates a new Object object
 This constructor will assign default values to properties that have it defined,
@@ -45,6 +45,11 @@ and a boolean to check if the value has been set.
 
 SetField1 sets Field1 field to given value.
 
+### HasField1
+
+`func (o *Object) HasField1() bool`
+
+HasField1 returns a boolean if a field has been set.
 
 ### GetType
 

--- a/samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization/docs/AnyOfUserOrPet.md
+++ b/samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization/docs/AnyOfUserOrPet.md
@@ -5,8 +5,8 @@
 | Name | Type | Description | Notes |
 | ------------ | ------------- | ------------- | ------------- |
 | **id** | **kotlin.Long** |  |  |
-| **username** | **kotlin.String** |  |  |
-| **name** | **kotlin.String** |  |  |
+| **username** | **kotlin.String** |  |  [optional] |
+| **name** | **kotlin.String** |  |  [optional] |
 
 
 

--- a/samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization/docs/AnyOfUserOrPetOrArrayString.md
+++ b/samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization/docs/AnyOfUserOrPetOrArrayString.md
@@ -4,9 +4,9 @@
 ## Properties
 | Name | Type | Description | Notes |
 | ------------ | ------------- | ------------- | ------------- |
-| **id** | **kotlin.Long** |  |  |
-| **username** | **kotlin.String** |  |  |
-| **name** | **kotlin.String** |  |  |
+| **id** | **kotlin.Long** |  |  [optional] |
+| **username** | **kotlin.String** |  |  [optional] |
+| **name** | **kotlin.String** |  |  [optional] |
 
 
 

--- a/samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization/docs/UserOrPet.md
+++ b/samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization/docs/UserOrPet.md
@@ -5,8 +5,8 @@
 | Name | Type | Description | Notes |
 | ------------ | ------------- | ------------- | ------------- |
 | **id** | **kotlin.Long** |  |  |
-| **username** | **kotlin.String** |  |  |
-| **name** | **kotlin.String** |  |  |
+| **username** | **kotlin.String** |  |  [optional] |
+| **name** | **kotlin.String** |  |  [optional] |
 
 
 

--- a/samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization/docs/UserOrPetOrArrayString.md
+++ b/samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization/docs/UserOrPetOrArrayString.md
@@ -4,9 +4,9 @@
 ## Properties
 | Name | Type | Description | Notes |
 | ------------ | ------------- | ------------- | ------------- |
-| **id** | **kotlin.Long** |  |  |
-| **username** | **kotlin.String** |  |  |
-| **name** | **kotlin.String** |  |  |
+| **id** | **kotlin.Long** |  |  [optional] |
+| **username** | **kotlin.String** |  |  [optional] |
+| **name** | **kotlin.String** |  |  [optional] |
 
 
 

--- a/samples/client/others/terraform/oneof-anyof-required/internal/client/model_object.go
+++ b/samples/client/others/terraform/oneof-anyof-required/internal/client/model_object.go
@@ -4,6 +4,6 @@ package client
 
 // Object - Object struct
 type Object struct {
-	Field1 string `json:"field1"`
-	Field2 string `json:"field2"`
+	Field1 string `json:"field1,omitempty"`
+	Field2 string `json:"field2,omitempty"`
 }

--- a/samples/client/others/terraform/oneof-anyof-required/internal/client/model_object2.go
+++ b/samples/client/others/terraform/oneof-anyof-required/internal/client/model_object2.go
@@ -4,6 +4,6 @@ package client
 
 // Object2 - Object2 struct
 type Object2 struct {
-	Field1 string `json:"field1"`
-	Field2 string `json:"field2"`
+	Field1 string `json:"field1,omitempty"`
+	Field2 string `json:"field2,omitempty"`
 }

--- a/samples/client/others/terraform/oneof-discriminator-lookup/internal/client/model_object.go
+++ b/samples/client/others/terraform/oneof-discriminator-lookup/internal/client/model_object.go
@@ -4,6 +4,6 @@ package client
 
 // Object - Object struct
 type Object struct {
-	Field1 string `json:"field1"`
+	Field1 string `json:"field1,omitempty"`
 	Type string `json:"type,omitempty"`
 }

--- a/samples/client/petstore/R-httr2-wrapper/docs/AnyOfPig.md
+++ b/samples/client/petstore/R-httr2-wrapper/docs/AnyOfPig.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **className** | **character** |  | 
-**color** | **character** |  | 
-**size** | **integer** |  | 
+**color** | **character** |  | [optional] 
+**size** | **integer** |  | [optional] 
 
 

--- a/samples/client/petstore/R-httr2-wrapper/docs/Pig.md
+++ b/samples/client/petstore/R-httr2-wrapper/docs/Pig.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **className** | **character** |  | 
-**color** | **character** |  | 
-**size** | **integer** |  | 
+**color** | **character** |  | [optional] 
+**size** | **integer** |  | [optional] 
 
 

--- a/samples/client/petstore/R-httr2/docs/AnyOfPig.md
+++ b/samples/client/petstore/R-httr2/docs/AnyOfPig.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **className** | **character** |  | 
-**color** | **character** |  | 
-**size** | **integer** |  | 
+**color** | **character** |  | [optional] 
+**size** | **integer** |  | [optional] 
 
 

--- a/samples/client/petstore/R-httr2/docs/Pig.md
+++ b/samples/client/petstore/R-httr2/docs/Pig.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **className** | **character** |  | 
-**color** | **character** |  | 
-**size** | **integer** |  | 
+**color** | **character** |  | [optional] 
+**size** | **integer** |  | [optional] 
 
 

--- a/samples/client/petstore/R/docs/AnyOfPig.md
+++ b/samples/client/petstore/R/docs/AnyOfPig.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **className** | **character** |  | 
-**color** | **character** |  | 
-**size** | **integer** |  | 
+**color** | **character** |  | [optional] 
+**size** | **integer** |  | [optional] 
 
 

--- a/samples/client/petstore/R/docs/Pig.md
+++ b/samples/client/petstore/R/docs/Pig.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **className** | **character** |  | 
-**color** | **character** |  | 
-**size** | **integer** |  | 
+**color** | **character** |  | [optional] 
+**size** | **integer** |  | [optional] 
 
 

--- a/samples/client/petstore/csharp/httpclient/net10/Petstore/docs/FruitReq.md
+++ b/samples/client/petstore/csharp/httpclient/net10/Petstore/docs/FruitReq.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Cultivar** | **string** |  | 
+**Cultivar** | **string** |  | [optional] 
 **Mealy** | **bool** |  | [optional] 
-**LengthCm** | **decimal** |  | 
+**LengthCm** | **decimal** |  | [optional] 
 **Sweet** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/httpclient/net10/Petstore/docs/NullableShape.md
+++ b/samples/client/petstore/csharp/httpclient/net10/Petstore/docs/NullableShape.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. The 'nullable' attribute was intro
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/httpclient/net10/Petstore/docs/Shape.md
+++ b/samples/client/petstore/csharp/httpclient/net10/Petstore/docs/Shape.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/httpclient/net10/Petstore/docs/ShapeOrNull.md
+++ b/samples/client/petstore/csharp/httpclient/net10/Petstore/docs/ShapeOrNull.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. This is introduced in OAS schema >
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/httpclient/net9/Petstore/docs/FruitReq.md
+++ b/samples/client/petstore/csharp/httpclient/net9/Petstore/docs/FruitReq.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Cultivar** | **string** |  | 
+**Cultivar** | **string** |  | [optional] 
 **Mealy** | **bool** |  | [optional] 
-**LengthCm** | **decimal** |  | 
+**LengthCm** | **decimal** |  | [optional] 
 **Sweet** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/httpclient/net9/Petstore/docs/NullableShape.md
+++ b/samples/client/petstore/csharp/httpclient/net9/Petstore/docs/NullableShape.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. The 'nullable' attribute was intro
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/httpclient/net9/Petstore/docs/Shape.md
+++ b/samples/client/petstore/csharp/httpclient/net9/Petstore/docs/Shape.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/httpclient/net9/Petstore/docs/ShapeOrNull.md
+++ b/samples/client/petstore/csharp/httpclient/net9/Petstore/docs/ShapeOrNull.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. This is introduced in OAS schema >
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/docs/FruitReq.md
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/docs/FruitReq.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Cultivar** | **string** |  | 
+**Cultivar** | **string** |  | [optional] 
 **Mealy** | **bool** |  | [optional] 
-**LengthCm** | **decimal** |  | 
+**LengthCm** | **decimal** |  | [optional] 
 **Sweet** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/docs/NullableShape.md
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/docs/NullableShape.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. The 'nullable' attribute was intro
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/docs/Shape.md
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/docs/Shape.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/docs/ShapeOrNull.md
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/docs/ShapeOrNull.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. This is introduced in OAS schema >
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net10/Petstore/docs/FruitReq.md
+++ b/samples/client/petstore/csharp/restsharp/net10/Petstore/docs/FruitReq.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Cultivar** | **string** |  | 
+**Cultivar** | **string** |  | [optional] 
 **Mealy** | **bool** |  | [optional] 
-**LengthCm** | **decimal** |  | 
+**LengthCm** | **decimal** |  | [optional] 
 **Sweet** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/restsharp/net10/Petstore/docs/NullableShape.md
+++ b/samples/client/petstore/csharp/restsharp/net10/Petstore/docs/NullableShape.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. The 'nullable' attribute was intro
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net10/Petstore/docs/Shape.md
+++ b/samples/client/petstore/csharp/restsharp/net10/Petstore/docs/Shape.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net10/Petstore/docs/ShapeOrNull.md
+++ b/samples/client/petstore/csharp/restsharp/net10/Petstore/docs/ShapeOrNull.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. This is introduced in OAS schema >
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/docs/FruitReq.md
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/docs/FruitReq.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Cultivar** | **string** |  | 
+**Cultivar** | **string** |  | [optional] 
 **Mealy** | **bool** |  | [optional] 
-**LengthCm** | **decimal** |  | 
+**LengthCm** | **decimal** |  | [optional] 
 **Sweet** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/docs/NullableShape.md
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/docs/NullableShape.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. The 'nullable' attribute was intro
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/docs/Shape.md
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/docs/Shape.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/docs/ShapeOrNull.md
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/docs/ShapeOrNull.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. This is introduced in OAS schema >
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/docs/FruitReq.md
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/docs/FruitReq.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Cultivar** | **string** |  | 
+**Cultivar** | **string** |  | [optional] 
 **Mealy** | **bool** |  | [optional] 
-**LengthCm** | **decimal** |  | 
+**LengthCm** | **decimal** |  | [optional] 
 **Sweet** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/docs/NullableShape.md
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/docs/NullableShape.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. The 'nullable' attribute was intro
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/docs/Shape.md
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/docs/Shape.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/docs/ShapeOrNull.md
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/docs/ShapeOrNull.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. This is introduced in OAS schema >
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net8/EnumMappings/docs/FruitReq.md
+++ b/samples/client/petstore/csharp/restsharp/net8/EnumMappings/docs/FruitReq.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Cultivar** | **string** |  | 
+**Cultivar** | **string** |  | [optional] 
 **Mealy** | **bool** |  | [optional] 
-**LengthCm** | **decimal** |  | 
+**LengthCm** | **decimal** |  | [optional] 
 **Sweet** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/restsharp/net8/EnumMappings/docs/NullableShape.md
+++ b/samples/client/petstore/csharp/restsharp/net8/EnumMappings/docs/NullableShape.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. The 'nullable' attribute was intro
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net8/EnumMappings/docs/Shape.md
+++ b/samples/client/petstore/csharp/restsharp/net8/EnumMappings/docs/Shape.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net8/EnumMappings/docs/ShapeOrNull.md
+++ b/samples/client/petstore/csharp/restsharp/net8/EnumMappings/docs/ShapeOrNull.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. This is introduced in OAS schema >
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net8/Petstore/docs/FruitReq.md
+++ b/samples/client/petstore/csharp/restsharp/net8/Petstore/docs/FruitReq.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Cultivar** | **string** |  | 
+**Cultivar** | **string** |  | [optional] 
 **Mealy** | **bool** |  | [optional] 
-**LengthCm** | **decimal** |  | 
+**LengthCm** | **decimal** |  | [optional] 
 **Sweet** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/restsharp/net8/Petstore/docs/NullableShape.md
+++ b/samples/client/petstore/csharp/restsharp/net8/Petstore/docs/NullableShape.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. The 'nullable' attribute was intro
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net8/Petstore/docs/Shape.md
+++ b/samples/client/petstore/csharp/restsharp/net8/Petstore/docs/Shape.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net8/Petstore/docs/ShapeOrNull.md
+++ b/samples/client/petstore/csharp/restsharp/net8/Petstore/docs/ShapeOrNull.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. This is introduced in OAS schema >
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net9/EnumMappings/docs/FruitReq.md
+++ b/samples/client/petstore/csharp/restsharp/net9/EnumMappings/docs/FruitReq.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Cultivar** | **string** |  | 
+**Cultivar** | **string** |  | [optional] 
 **Mealy** | **bool** |  | [optional] 
-**LengthCm** | **decimal** |  | 
+**LengthCm** | **decimal** |  | [optional] 
 **Sweet** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/restsharp/net9/EnumMappings/docs/NullableShape.md
+++ b/samples/client/petstore/csharp/restsharp/net9/EnumMappings/docs/NullableShape.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. The 'nullable' attribute was intro
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net9/EnumMappings/docs/Shape.md
+++ b/samples/client/petstore/csharp/restsharp/net9/EnumMappings/docs/Shape.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net9/EnumMappings/docs/ShapeOrNull.md
+++ b/samples/client/petstore/csharp/restsharp/net9/EnumMappings/docs/ShapeOrNull.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. This is introduced in OAS schema >
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/docs/FruitReq.md
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/docs/FruitReq.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Cultivar** | **string** |  | 
+**Cultivar** | **string** |  | [optional] 
 **Mealy** | **bool** |  | [optional] 
-**LengthCm** | **decimal** |  | 
+**LengthCm** | **decimal** |  | [optional] 
 **Sweet** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/docs/NullableShape.md
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/docs/NullableShape.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. The 'nullable' attribute was intro
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/docs/Shape.md
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/docs/Shape.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/docs/ShapeOrNull.md
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/docs/ShapeOrNull.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. This is introduced in OAS schema >
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/docs/FruitReq.md
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/docs/FruitReq.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Cultivar** | **string** |  | 
+**Cultivar** | **string** |  | [optional] 
 **Mealy** | **bool** |  | [optional] 
-**LengthCm** | **decimal** |  | 
+**LengthCm** | **decimal** |  | [optional] 
 **Sweet** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/docs/NullableShape.md
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/docs/NullableShape.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. The 'nullable' attribute was intro
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/docs/Shape.md
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/docs/Shape.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/docs/ShapeOrNull.md
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/docs/ShapeOrNull.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. This is introduced in OAS schema >
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/unityWebRequest/net10/Petstore/docs/FruitReq.md
+++ b/samples/client/petstore/csharp/unityWebRequest/net10/Petstore/docs/FruitReq.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Cultivar** | **string** |  | 
+**Cultivar** | **string** |  | [optional] 
 **Mealy** | **bool** |  | [optional] 
-**LengthCm** | **decimal** |  | 
+**LengthCm** | **decimal** |  | [optional] 
 **Sweet** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/unityWebRequest/net10/Petstore/docs/NullableShape.md
+++ b/samples/client/petstore/csharp/unityWebRequest/net10/Petstore/docs/NullableShape.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. The 'nullable' attribute was intro
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/unityWebRequest/net10/Petstore/docs/Shape.md
+++ b/samples/client/petstore/csharp/unityWebRequest/net10/Petstore/docs/Shape.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/unityWebRequest/net10/Petstore/docs/ShapeOrNull.md
+++ b/samples/client/petstore/csharp/unityWebRequest/net10/Petstore/docs/ShapeOrNull.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. This is introduced in OAS schema >
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/docs/FruitReq.md
+++ b/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/docs/FruitReq.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Cultivar** | **string** |  | 
+**Cultivar** | **string** |  | [optional] 
 **Mealy** | **bool** |  | [optional] 
-**LengthCm** | **decimal** |  | 
+**LengthCm** | **decimal** |  | [optional] 
 **Sweet** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/docs/NullableShape.md
+++ b/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/docs/NullableShape.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. The 'nullable' attribute was intro
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/docs/Shape.md
+++ b/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/docs/Shape.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/docs/ShapeOrNull.md
+++ b/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/docs/ShapeOrNull.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. This is introduced in OAS schema >
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/docs/FruitReq.md
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/docs/FruitReq.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Cultivar** | **string** |  | 
+**Cultivar** | **string** |  | [optional] 
 **Mealy** | **bool** |  | [optional] 
-**LengthCm** | **decimal** |  | 
+**LengthCm** | **decimal** |  | [optional] 
 **Sweet** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/docs/NullableShape.md
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/docs/NullableShape.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. The 'nullable' attribute was intro
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/docs/Shape.md
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/docs/Shape.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/docs/ShapeOrNull.md
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/docs/ShapeOrNull.md
@@ -6,8 +6,8 @@ The value may be a shape or the 'null' value. This is introduced in OAS schema >
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **string** |  | 
-**TriangleType** | **string** |  | 
-**QuadrilateralType** | **string** |  | 
+**TriangleType** | **string** |  | [optional] 
+**QuadrilateralType** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/java/okhttp-gson/docs/AllOfModelArrayAnyOfAllOfAttributesC.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/AllOfModelArrayAnyOfAllOfAttributesC.md
@@ -9,8 +9,8 @@
 |------------ | ------------- | ------------- | -------------|
 |**id** | **Long** |  |  [optional] |
 |**category** | [**Category**](Category.md) |  |  [optional] |
-|**name** | **String** |  |  |
-|**photoUrls** | **List&lt;String&gt;** |  |  |
+|**name** | **String** |  |  [optional] |
+|**photoUrls** | **List&lt;String&gt;** |  |  [optional] |
 |**tags** | [**List&lt;Tag&gt;**](Tag.md) |  |  [optional] |
 |**status** | [**StatusEnum**](#StatusEnum) | Order Status |  [optional] |
 |**petId** | **Long** |  |  [optional] |

--- a/samples/client/petstore/java/okhttp-gson/docs/FruitReq.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/FruitReq.md
@@ -7,9 +7,9 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-|**cultivar** | **String** |  |  |
+|**cultivar** | **String** |  |  [optional] |
 |**mealy** | **Boolean** |  |  [optional] |
-|**lengthCm** | **BigDecimal** |  |  |
+|**lengthCm** | **BigDecimal** |  |  [optional] |
 |**sweet** | **Boolean** |  |  [optional] |
 
 

--- a/samples/client/petstore/java/okhttp-gson/docs/NullableShape.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/NullableShape.md
@@ -9,8 +9,8 @@ The value may be a shape or the 'null' value. The 'nullable' attribute was intro
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 |**shapeType** | **String** |  |  |
-|**triangleType** | **String** |  |  |
-|**quadrilateralType** | **String** |  |  |
+|**triangleType** | **String** |  |  [optional] |
+|**quadrilateralType** | **String** |  |  [optional] |
 
 
 

--- a/samples/client/petstore/java/okhttp-gson/docs/Shape.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/Shape.md
@@ -8,8 +8,8 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 |**shapeType** | **String** |  |  |
-|**triangleType** | **String** |  |  |
-|**quadrilateralType** | **String** |  |  |
+|**triangleType** | **String** |  |  [optional] |
+|**quadrilateralType** | **String** |  |  [optional] |
 
 
 

--- a/samples/client/petstore/java/okhttp-gson/docs/ShapeOrNull.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/ShapeOrNull.md
@@ -9,8 +9,8 @@ The value may be a shape or the 'null' value. This is introduced in OAS schema >
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 |**shapeType** | **String** |  |  |
-|**triangleType** | **String** |  |  |
-|**quadrilateralType** | **String** |  |  |
+|**triangleType** | **String** |  |  [optional] |
+|**quadrilateralType** | **String** |  |  [optional] |
 
 
 

--- a/samples/client/petstore/javascript-apollo/docs/Pig.md
+++ b/samples/client/petstore/javascript-apollo/docs/Pig.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **className** | **String** |  | 
-**color** | **String** |  | 
-**size** | **Number** |  | 
+**color** | **String** |  | [optional] 
+**size** | **Number** |  | [optional] 
 
 

--- a/samples/client/petstore/javascript-es6/docs/Pig.md
+++ b/samples/client/petstore/javascript-es6/docs/Pig.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **className** | **String** |  | 
-**color** | **String** |  | 
-**size** | **Number** |  | 
+**color** | **String** |  | [optional] 
+**size** | **Number** |  | [optional] 
 
 

--- a/samples/client/petstore/javascript-promise-es6/docs/Pig.md
+++ b/samples/client/petstore/javascript-promise-es6/docs/Pig.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **className** | **String** |  | 
-**color** | **String** |  | 
-**size** | **Number** |  | 
+**color** | **String** |  | [optional] 
+**size** | **Number** |  | [optional] 
 
 

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/docs/AnyOfUserOrPet.md
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/docs/AnyOfUserOrPet.md
@@ -4,10 +4,8 @@
 ## Properties
 | Name | Type | Description | Notes |
 | ------------ | ------------- | ------------- | ------------- |
-| **username** | **kotlin.String** |  |  |
-| **name** | **kotlin.String** |  |  |
-| **photoUrls** | **kotlin.collections.List&lt;kotlin.String&gt;** |  |  |
 | **id** | **kotlin.Long** |  |  [optional] |
+| **username** | **kotlin.String** |  |  [optional] |
 | **firstName** | **kotlin.String** |  |  [optional] |
 | **lastName** | **kotlin.String** |  |  [optional] |
 | **email** | **kotlin.String** |  |  [optional] |
@@ -15,6 +13,8 @@
 | **phone** | **kotlin.String** |  |  [optional] |
 | **userStatus** | **kotlin.Int** | User Status |  [optional] |
 | **category** | [**Category**](Category.md) |  |  [optional] |
+| **name** | **kotlin.String** |  |  [optional] |
+| **photoUrls** | **kotlin.collections.List&lt;kotlin.String&gt;** |  |  [optional] |
 | **tags** | [**kotlin.collections.List&lt;Tag&gt;**](Tag.md) |  |  [optional] |
 | **status** | [**inline**](#Status) | pet status in the store |  [optional] |
 

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/docs/AnyOfUserOrPetOrArrayString.md
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/docs/AnyOfUserOrPetOrArrayString.md
@@ -4,10 +4,8 @@
 ## Properties
 | Name | Type | Description | Notes |
 | ------------ | ------------- | ------------- | ------------- |
-| **username** | **kotlin.String** |  |  |
-| **name** | **kotlin.String** |  |  |
-| **photoUrls** | **kotlin.collections.List&lt;kotlin.String&gt;** |  |  |
 | **id** | **kotlin.Long** |  |  [optional] |
+| **username** | **kotlin.String** |  |  [optional] |
 | **firstName** | **kotlin.String** |  |  [optional] |
 | **lastName** | **kotlin.String** |  |  [optional] |
 | **email** | **kotlin.String** |  |  [optional] |
@@ -15,6 +13,8 @@
 | **phone** | **kotlin.String** |  |  [optional] |
 | **userStatus** | **kotlin.Int** | User Status |  [optional] |
 | **category** | [**Category**](Category.md) |  |  [optional] |
+| **name** | **kotlin.String** |  |  [optional] |
+| **photoUrls** | **kotlin.collections.List&lt;kotlin.String&gt;** |  |  [optional] |
 | **tags** | [**kotlin.collections.List&lt;Tag&gt;**](Tag.md) |  |  [optional] |
 | **status** | [**inline**](#Status) | pet status in the store |  [optional] |
 

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/docs/UserOrPet.md
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/docs/UserOrPet.md
@@ -4,10 +4,8 @@
 ## Properties
 | Name | Type | Description | Notes |
 | ------------ | ------------- | ------------- | ------------- |
-| **username** | **kotlin.String** |  |  |
-| **name** | **kotlin.String** |  |  |
-| **photoUrls** | **kotlin.collections.List&lt;kotlin.String&gt;** |  |  |
 | **id** | **kotlin.Long** |  |  [optional] |
+| **username** | **kotlin.String** |  |  [optional] |
 | **firstName** | **kotlin.String** |  |  [optional] |
 | **lastName** | **kotlin.String** |  |  [optional] |
 | **email** | **kotlin.String** |  |  [optional] |
@@ -15,6 +13,8 @@
 | **phone** | **kotlin.String** |  |  [optional] |
 | **userStatus** | **kotlin.Int** | User Status |  [optional] |
 | **category** | [**Category**](Category.md) |  |  [optional] |
+| **name** | **kotlin.String** |  |  [optional] |
+| **photoUrls** | **kotlin.collections.List&lt;kotlin.String&gt;** |  |  [optional] |
 | **tags** | [**kotlin.collections.List&lt;Tag&gt;**](Tag.md) |  |  [optional] |
 | **status** | [**inline**](#Status) | pet status in the store |  [optional] |
 

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/docs/UserOrPetOrArrayString.md
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/docs/UserOrPetOrArrayString.md
@@ -4,10 +4,8 @@
 ## Properties
 | Name | Type | Description | Notes |
 | ------------ | ------------- | ------------- | ------------- |
-| **username** | **kotlin.String** |  |  |
-| **name** | **kotlin.String** |  |  |
-| **photoUrls** | **kotlin.collections.List&lt;kotlin.String&gt;** |  |  |
 | **id** | **kotlin.Long** |  |  [optional] |
+| **username** | **kotlin.String** |  |  [optional] |
 | **firstName** | **kotlin.String** |  |  [optional] |
 | **lastName** | **kotlin.String** |  |  [optional] |
 | **email** | **kotlin.String** |  |  [optional] |
@@ -15,6 +13,8 @@
 | **phone** | **kotlin.String** |  |  [optional] |
 | **userStatus** | **kotlin.Int** | User Status |  [optional] |
 | **category** | [**Category**](Category.md) |  |  [optional] |
+| **name** | **kotlin.String** |  |  [optional] |
+| **photoUrls** | **kotlin.collections.List&lt;kotlin.String&gt;** |  |  [optional] |
 | **tags** | [**kotlin.collections.List&lt;Tag&gt;**](Tag.md) |  |  [optional] |
 | **status** | [**inline**](#Status) | pet status in the store |  [optional] |
 

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/models/AnyOfUserOrPet.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/models/AnyOfUserOrPet.kt
@@ -33,10 +33,8 @@ import com.google.gson.annotations.SerializedName
 /**
  * 
  *
- * @param username 
- * @param name 
- * @param photoUrls 
  * @param id 
+ * @param username 
  * @param firstName 
  * @param lastName 
  * @param email 
@@ -44,6 +42,8 @@ import com.google.gson.annotations.SerializedName
  * @param phone 
  * @param userStatus User Status
  * @param category 
+ * @param name 
+ * @param photoUrls 
  * @param tags 
  * @param status pet status in the store
  */
@@ -51,17 +51,11 @@ import com.google.gson.annotations.SerializedName
 
 data class AnyOfUserOrPet (
 
-    @SerializedName("username")
-    val username: kotlin.String,
-
-    @SerializedName("name")
-    val name: kotlin.String,
-
-    @SerializedName("photoUrls")
-    val photoUrls: kotlin.collections.List<kotlin.String>,
-
     @SerializedName("id")
     val id: kotlin.Long? = null,
+
+    @SerializedName("username")
+    val username: kotlin.String? = null,
 
     @SerializedName("firstName")
     val firstName: kotlin.String? = null,
@@ -84,6 +78,12 @@ data class AnyOfUserOrPet (
 
     @SerializedName("category")
     val category: Category? = null,
+
+    @SerializedName("name")
+    val name: kotlin.String? = null,
+
+    @SerializedName("photoUrls")
+    val photoUrls: kotlin.collections.List<kotlin.String>? = null,
 
     @SerializedName("tags")
     val tags: kotlin.collections.List<Tag>? = null,

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/models/AnyOfUserOrPetOrArrayString.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/models/AnyOfUserOrPetOrArrayString.kt
@@ -33,10 +33,8 @@ import com.google.gson.annotations.SerializedName
 /**
  * 
  *
- * @param username 
- * @param name 
- * @param photoUrls 
  * @param id 
+ * @param username 
  * @param firstName 
  * @param lastName 
  * @param email 
@@ -44,6 +42,8 @@ import com.google.gson.annotations.SerializedName
  * @param phone 
  * @param userStatus User Status
  * @param category 
+ * @param name 
+ * @param photoUrls 
  * @param tags 
  * @param status pet status in the store
  */
@@ -51,17 +51,11 @@ import com.google.gson.annotations.SerializedName
 
 data class AnyOfUserOrPetOrArrayString (
 
-    @SerializedName("username")
-    val username: kotlin.String,
-
-    @SerializedName("name")
-    val name: kotlin.String,
-
-    @SerializedName("photoUrls")
-    val photoUrls: kotlin.collections.List<kotlin.String>,
-
     @SerializedName("id")
     val id: kotlin.Long? = null,
+
+    @SerializedName("username")
+    val username: kotlin.String? = null,
 
     @SerializedName("firstName")
     val firstName: kotlin.String? = null,
@@ -84,6 +78,12 @@ data class AnyOfUserOrPetOrArrayString (
 
     @SerializedName("category")
     val category: Category? = null,
+
+    @SerializedName("name")
+    val name: kotlin.String? = null,
+
+    @SerializedName("photoUrls")
+    val photoUrls: kotlin.collections.List<kotlin.String>? = null,
 
     @SerializedName("tags")
     val tags: kotlin.collections.List<Tag>? = null,

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/models/UserOrPet.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/models/UserOrPet.kt
@@ -33,10 +33,8 @@ import com.google.gson.annotations.SerializedName
 /**
  * A schema that can be either a User or a Pet
  *
- * @param username 
- * @param name 
- * @param photoUrls 
  * @param id 
+ * @param username 
  * @param firstName 
  * @param lastName 
  * @param email 
@@ -44,6 +42,8 @@ import com.google.gson.annotations.SerializedName
  * @param phone 
  * @param userStatus User Status
  * @param category 
+ * @param name 
+ * @param photoUrls 
  * @param tags 
  * @param status pet status in the store
  */
@@ -51,17 +51,11 @@ import com.google.gson.annotations.SerializedName
 
 data class UserOrPet (
 
-    @SerializedName("username")
-    val username: kotlin.String,
-
-    @SerializedName("name")
-    val name: kotlin.String,
-
-    @SerializedName("photoUrls")
-    val photoUrls: kotlin.collections.List<kotlin.String>,
-
     @SerializedName("id")
     val id: kotlin.Long? = null,
+
+    @SerializedName("username")
+    val username: kotlin.String? = null,
 
     @SerializedName("firstName")
     val firstName: kotlin.String? = null,
@@ -84,6 +78,12 @@ data class UserOrPet (
 
     @SerializedName("category")
     val category: Category? = null,
+
+    @SerializedName("name")
+    val name: kotlin.String? = null,
+
+    @SerializedName("photoUrls")
+    val photoUrls: kotlin.collections.List<kotlin.String>? = null,
 
     @SerializedName("tags")
     val tags: kotlin.collections.List<Tag>? = null,

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/models/UserOrPetOrArrayString.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/models/UserOrPetOrArrayString.kt
@@ -33,10 +33,8 @@ import com.google.gson.annotations.SerializedName
 /**
  * A schema that can be either a User, a Pet, or an array of strings
  *
- * @param username 
- * @param name 
- * @param photoUrls 
  * @param id 
+ * @param username 
  * @param firstName 
  * @param lastName 
  * @param email 
@@ -44,6 +42,8 @@ import com.google.gson.annotations.SerializedName
  * @param phone 
  * @param userStatus User Status
  * @param category 
+ * @param name 
+ * @param photoUrls 
  * @param tags 
  * @param status pet status in the store
  */
@@ -51,17 +51,11 @@ import com.google.gson.annotations.SerializedName
 
 data class UserOrPetOrArrayString (
 
-    @SerializedName("username")
-    val username: kotlin.String,
-
-    @SerializedName("name")
-    val name: kotlin.String,
-
-    @SerializedName("photoUrls")
-    val photoUrls: kotlin.collections.List<kotlin.String>,
-
     @SerializedName("id")
     val id: kotlin.Long? = null,
+
+    @SerializedName("username")
+    val username: kotlin.String? = null,
 
     @SerializedName("firstName")
     val firstName: kotlin.String? = null,
@@ -84,6 +78,12 @@ data class UserOrPetOrArrayString (
 
     @SerializedName("category")
     val category: Category? = null,
+
+    @SerializedName("name")
+    val name: kotlin.String? = null,
+
+    @SerializedName("photoUrls")
+    val photoUrls: kotlin.collections.List<kotlin.String>? = null,
 
     @SerializedName("tags")
     val tags: kotlin.collections.List<Tag>? = null,

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/docs/AnyOfUserOrPet.md
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/docs/AnyOfUserOrPet.md
@@ -4,10 +4,8 @@
 ## Properties
 | Name | Type | Description | Notes |
 | ------------ | ------------- | ------------- | ------------- |
-| **username** | **kotlin.String** |  |  |
-| **name** | **kotlin.String** |  |  |
-| **photoUrls** | **kotlin.collections.List&lt;kotlin.String&gt;** |  |  |
 | **id** | **kotlin.Long** |  |  [optional] |
+| **username** | **kotlin.String** |  |  [optional] |
 | **firstName** | **kotlin.String** |  |  [optional] |
 | **lastName** | **kotlin.String** |  |  [optional] |
 | **email** | **kotlin.String** |  |  [optional] |
@@ -15,6 +13,8 @@
 | **phone** | **kotlin.String** |  |  [optional] |
 | **userStatus** | **kotlin.Int** | User Status |  [optional] |
 | **category** | [**ApiCategory**](ApiCategory.md) |  |  [optional] |
+| **name** | **kotlin.String** |  |  [optional] |
+| **photoUrls** | **kotlin.collections.List&lt;kotlin.String&gt;** |  |  [optional] |
 | **tags** | [**kotlin.collections.List&lt;ApiTag&gt;**](ApiTag.md) |  |  [optional] |
 | **status** | [**inline**](#Status) | pet status in the store |  [optional] |
 

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/docs/AnyOfUserOrPetOrArrayString.md
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/docs/AnyOfUserOrPetOrArrayString.md
@@ -4,10 +4,8 @@
 ## Properties
 | Name | Type | Description | Notes |
 | ------------ | ------------- | ------------- | ------------- |
-| **username** | **kotlin.String** |  |  |
-| **name** | **kotlin.String** |  |  |
-| **photoUrls** | **kotlin.collections.List&lt;kotlin.String&gt;** |  |  |
 | **id** | **kotlin.Long** |  |  [optional] |
+| **username** | **kotlin.String** |  |  [optional] |
 | **firstName** | **kotlin.String** |  |  [optional] |
 | **lastName** | **kotlin.String** |  |  [optional] |
 | **email** | **kotlin.String** |  |  [optional] |
@@ -15,6 +13,8 @@
 | **phone** | **kotlin.String** |  |  [optional] |
 | **userStatus** | **kotlin.Int** | User Status |  [optional] |
 | **category** | [**ApiCategory**](ApiCategory.md) |  |  [optional] |
+| **name** | **kotlin.String** |  |  [optional] |
+| **photoUrls** | **kotlin.collections.List&lt;kotlin.String&gt;** |  |  [optional] |
 | **tags** | [**kotlin.collections.List&lt;ApiTag&gt;**](ApiTag.md) |  |  [optional] |
 | **status** | [**inline**](#Status) | pet status in the store |  [optional] |
 

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/docs/UserOrPet.md
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/docs/UserOrPet.md
@@ -4,10 +4,8 @@
 ## Properties
 | Name | Type | Description | Notes |
 | ------------ | ------------- | ------------- | ------------- |
-| **username** | **kotlin.String** |  |  |
-| **name** | **kotlin.String** |  |  |
-| **photoUrls** | **kotlin.collections.List&lt;kotlin.String&gt;** |  |  |
 | **id** | **kotlin.Long** |  |  [optional] |
+| **username** | **kotlin.String** |  |  [optional] |
 | **firstName** | **kotlin.String** |  |  [optional] |
 | **lastName** | **kotlin.String** |  |  [optional] |
 | **email** | **kotlin.String** |  |  [optional] |
@@ -15,6 +13,8 @@
 | **phone** | **kotlin.String** |  |  [optional] |
 | **userStatus** | **kotlin.Int** | User Status |  [optional] |
 | **category** | [**ApiCategory**](ApiCategory.md) |  |  [optional] |
+| **name** | **kotlin.String** |  |  [optional] |
+| **photoUrls** | **kotlin.collections.List&lt;kotlin.String&gt;** |  |  [optional] |
 | **tags** | [**kotlin.collections.List&lt;ApiTag&gt;**](ApiTag.md) |  |  [optional] |
 | **status** | [**inline**](#Status) | pet status in the store |  [optional] |
 

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/docs/UserOrPetOrArrayString.md
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/docs/UserOrPetOrArrayString.md
@@ -4,10 +4,8 @@
 ## Properties
 | Name | Type | Description | Notes |
 | ------------ | ------------- | ------------- | ------------- |
-| **username** | **kotlin.String** |  |  |
-| **name** | **kotlin.String** |  |  |
-| **photoUrls** | **kotlin.collections.List&lt;kotlin.String&gt;** |  |  |
 | **id** | **kotlin.Long** |  |  [optional] |
+| **username** | **kotlin.String** |  |  [optional] |
 | **firstName** | **kotlin.String** |  |  [optional] |
 | **lastName** | **kotlin.String** |  |  [optional] |
 | **email** | **kotlin.String** |  |  [optional] |
@@ -15,6 +13,8 @@
 | **phone** | **kotlin.String** |  |  [optional] |
 | **userStatus** | **kotlin.Int** | User Status |  [optional] |
 | **category** | [**ApiCategory**](ApiCategory.md) |  |  [optional] |
+| **name** | **kotlin.String** |  |  [optional] |
+| **photoUrls** | **kotlin.collections.List&lt;kotlin.String&gt;** |  |  [optional] |
 | **tags** | [**kotlin.collections.List&lt;ApiTag&gt;**](ApiTag.md) |  |  [optional] |
 | **status** | [**inline**](#Status) | pet status in the store |  [optional] |
 

--- a/samples/client/petstore/powershell/docs/FruitReq.md
+++ b/samples/client/petstore/powershell/docs/FruitReq.md
@@ -3,9 +3,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Cultivar** | **String** |  | 
+**Cultivar** | **String** |  | [optional] 
 **Mealy** | **Boolean** |  | [optional] 
-**LengthCm** | **Decimal** |  | 
+**LengthCm** | **Decimal** |  | [optional] 
 **Sweet** | **Boolean** |  | [optional] 
 
 ## Examples

--- a/samples/client/petstore/powershell/docs/NullableShape.md
+++ b/samples/client/petstore/powershell/docs/NullableShape.md
@@ -4,8 +4,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **String** |  | 
-**TriangleType** | **String** |  | 
-**QuadrilateralType** | **String** |  | 
+**TriangleType** | **String** |  | [optional] 
+**QuadrilateralType** | **String** |  | [optional] 
 
 ## Examples
 

--- a/samples/client/petstore/powershell/docs/Shape.md
+++ b/samples/client/petstore/powershell/docs/Shape.md
@@ -4,8 +4,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **String** |  | 
-**TriangleType** | **String** |  | 
-**QuadrilateralType** | **String** |  | 
+**TriangleType** | **String** |  | [optional] 
+**QuadrilateralType** | **String** |  | [optional] 
 
 ## Examples
 

--- a/samples/client/petstore/powershell/docs/ShapeOrNull.md
+++ b/samples/client/petstore/powershell/docs/ShapeOrNull.md
@@ -4,8 +4,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ShapeType** | **String** |  | 
-**TriangleType** | **String** |  | 
-**QuadrilateralType** | **String** |  | 
+**TriangleType** | **String** |  | [optional] 
+**QuadrilateralType** | **String** |  | [optional] 
 
 ## Examples
 

--- a/samples/client/petstore/rust/hyper/test-duplicates/src/models/_tests_discriminator_duplicate_enums_get_200_response.rs
+++ b/samples/client/petstore/rust/hyper/test-duplicates/src/models/_tests_discriminator_duplicate_enums_get_200_response.rs
@@ -18,28 +18,28 @@ pub enum TestsDiscriminatorDuplicateEnumsGet200Response {
     Vehicle {
         #[serde(rename = "type")]
         r#type: String,
-        #[serde(rename = "name")]
-        name: String,
-        #[serde(rename = "speed")]
-        speed: f64,
+        #[serde(rename = "name", skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        #[serde(rename = "speed", skip_serializing_if = "Option::is_none")]
+        speed: Option<f64>,
     },
     #[serde(rename="student")]
     PersonStudent {
         #[serde(rename = "type")]
         r#type: String,
-        #[serde(rename = "name")]
-        name: String,
-        #[serde(rename = "speed")]
-        speed: f64,
+        #[serde(rename = "name", skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        #[serde(rename = "speed", skip_serializing_if = "Option::is_none")]
+        speed: Option<f64>,
     },
     #[serde(rename="teacher")]
     PersonTeacher {
         #[serde(rename = "type")]
         r#type: String,
-        #[serde(rename = "name")]
-        name: String,
-        #[serde(rename = "speed")]
-        speed: f64,
+        #[serde(rename = "name", skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        #[serde(rename = "speed", skip_serializing_if = "Option::is_none")]
+        speed: Option<f64>,
     },
 }
 

--- a/samples/client/petstore/rust/reqwest/test-duplicates/src/models/_tests_discriminator_duplicate_enums_get_200_response.rs
+++ b/samples/client/petstore/rust/reqwest/test-duplicates/src/models/_tests_discriminator_duplicate_enums_get_200_response.rs
@@ -18,28 +18,28 @@ pub enum TestsDiscriminatorDuplicateEnumsGet200Response {
     Vehicle {
         #[serde(rename = "type")]
         r#type: String,
-        #[serde(rename = "name")]
-        name: String,
-        #[serde(rename = "speed")]
-        speed: f64,
+        #[serde(rename = "name", skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        #[serde(rename = "speed", skip_serializing_if = "Option::is_none")]
+        speed: Option<f64>,
     },
     #[serde(rename="student")]
     PersonStudent {
         #[serde(rename = "type")]
         r#type: String,
-        #[serde(rename = "name")]
-        name: String,
-        #[serde(rename = "speed")]
-        speed: f64,
+        #[serde(rename = "name", skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        #[serde(rename = "speed", skip_serializing_if = "Option::is_none")]
+        speed: Option<f64>,
     },
     #[serde(rename="teacher")]
     PersonTeacher {
         #[serde(rename = "type")]
         r#type: String,
-        #[serde(rename = "name")]
-        name: String,
-        #[serde(rename = "speed")]
-        speed: f64,
+        #[serde(rename = "name", skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        #[serde(rename = "speed", skip_serializing_if = "Option::is_none")]
+        speed: Option<f64>,
     },
 }
 

--- a/samples/client/petstore/typescript-axios/builds/composed-schemas/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/composed-schemas/api.ts
@@ -64,9 +64,9 @@ export const PetByTypePetTypeEnum = {
 export type PetByTypePetTypeEnum = typeof PetByTypePetTypeEnum[keyof typeof PetByTypePetTypeEnum];
 
 export interface PetsFilteredPatchRequest {
-    'age': number;
+    'age'?: number;
     'nickname'?: string;
-    'pet_type': PetsFilteredPatchRequestPetTypeEnum;
+    'pet_type'?: PetsFilteredPatchRequestPetTypeEnum;
     'hunts'?: boolean;
 }
 

--- a/samples/client/petstore/typescript-axios/builds/composed-schemas/docs/PetsFilteredPatchRequest.md
+++ b/samples/client/petstore/typescript-axios/builds/composed-schemas/docs/PetsFilteredPatchRequest.md
@@ -5,9 +5,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**age** | **number** |  | [default to undefined]
+**age** | **number** |  | [optional] [default to undefined]
 **nickname** | **string** |  | [optional] [default to undefined]
-**pet_type** | **string** |  | [default to undefined]
+**pet_type** | **string** |  | [optional] [default to undefined]
 **hunts** | **boolean** |  | [optional] [default to undefined]
 
 ## Example

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/docs/FruitReq.md
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/docs/FruitReq.md
@@ -5,9 +5,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**cultivar** | **string** |  | [default to undefined]
+**cultivar** | **string** |  | [optional] [default to undefined]
 **mealy** | **boolean** |  | [optional] [default to undefined]
-**lengthCm** | **number** |  | [default to undefined]
+**lengthCm** | **number** |  | [optional] [default to undefined]
 **sweet** | **boolean** |  | [optional] [default to undefined]
 
 ## Example

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/docs/NullableShape.md
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/docs/NullableShape.md
@@ -7,8 +7,8 @@ The value may be a shape or the \'null\' value. The \'nullable\' attribute was i
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **shapeType** | **string** |  | [default to undefined]
-**triangleType** | **string** |  | [default to undefined]
-**quadrilateralType** | **string** |  | [default to undefined]
+**triangleType** | **string** |  | [optional] [default to undefined]
+**quadrilateralType** | **string** |  | [optional] [default to undefined]
 
 ## Example
 

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/docs/Shape.md
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/docs/Shape.md
@@ -6,8 +6,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **shapeType** | **string** |  | [default to undefined]
-**triangleType** | **string** |  | [default to undefined]
-**quadrilateralType** | **string** |  | [default to undefined]
+**triangleType** | **string** |  | [optional] [default to undefined]
+**quadrilateralType** | **string** |  | [optional] [default to undefined]
 
 ## Example
 

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/docs/ShapeOrNull.md
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/docs/ShapeOrNull.md
@@ -7,8 +7,8 @@ The value may be a shape or the \'null\' value. This is introduced in OAS schema
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **shapeType** | **string** |  | [default to undefined]
-**triangleType** | **string** |  | [default to undefined]
-**quadrilateralType** | **string** |  | [default to undefined]
+**triangleType** | **string** |  | [optional] [default to undefined]
+**quadrilateralType** | **string** |  | [optional] [default to undefined]
 
 ## Example
 

--- a/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/docs/FruitReq.md
+++ b/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/docs/FruitReq.md
@@ -5,9 +5,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**cultivar** | **string** |  | [default to undefined]
+**cultivar** | **string** |  | [optional] [default to undefined]
 **mealy** | **boolean** |  | [optional] [default to undefined]
-**lengthCm** | **number** |  | [default to undefined]
+**lengthCm** | **number** |  | [optional] [default to undefined]
 **sweet** | **boolean** |  | [optional] [default to undefined]
 
 ## Example

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/doc/BarRefOrValue.md
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/doc/BarRefOrValue.md
@@ -9,7 +9,7 @@ import 'package:openapi/api.dart';
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **href** | **String** | Hyperlink reference | [optional] 
-**id** | **String** | unique identifier | 
+**id** | **String** | unique identifier | [optional] 
 **atSchemaLocation** | **String** | A URI to a JSON-Schema file that defines additional attributes and relationships | [optional] 
 **atBaseType** | **String** | When sub-classing, this defines the super-class | [optional] 
 **atType** | **String** | When sub-classing, this defines the sub-class Extensible name | 

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/doc/Fruit.md
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/doc/Fruit.md
@@ -9,8 +9,8 @@ import 'package:openapi/api.dart';
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **fruitType** | [**FruitType**](FruitType.md) |  | 
-**seeds** | **int** |  | 
-**length** | **int** |  | 
+**seeds** | **int** |  | [optional] 
+**length** | **int** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/FruitReq.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/FruitReq.md
@@ -4,16 +4,16 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Cultivar** | **string** |  | 
+**Cultivar** | Pointer to **string** |  | [optional] 
 **Mealy** | Pointer to **bool** |  | [optional] 
-**LengthCm** | **float32** |  | 
+**LengthCm** | Pointer to **float32** |  | [optional] 
 **Sweet** | Pointer to **bool** |  | [optional] 
 
 ## Methods
 
 ### NewFruitReq
 
-`func NewFruitReq(cultivar string, lengthCm float32, ) *FruitReq`
+`func NewFruitReq() *FruitReq`
 
 NewFruitReq instantiates a new FruitReq object
 This constructor will assign default values to properties that have it defined,
@@ -47,6 +47,11 @@ and a boolean to check if the value has been set.
 
 SetCultivar sets Cultivar field to given value.
 
+### HasCultivar
+
+`func (o *FruitReq) HasCultivar() bool`
+
+HasCultivar returns a boolean if a field has been set.
 
 ### GetMealy
 
@@ -92,6 +97,11 @@ and a boolean to check if the value has been set.
 
 SetLengthCm sets LengthCm field to given value.
 
+### HasLengthCm
+
+`func (o *FruitReq) HasLengthCm() bool`
+
+HasLengthCm returns a boolean if a field has been set.
 
 ### GetSweet
 

--- a/samples/openapi3/client/petstore/python-aiohttp/docs/AnyOfPig.md
+++ b/samples/openapi3/client/petstore/python-aiohttp/docs/AnyOfPig.md
@@ -6,8 +6,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **class_name** | **str** |  | 
-**color** | **str** |  | 
-**size** | **int** |  | 
+**color** | **str** |  | [optional] 
+**size** | **int** |  | [optional] 
 
 ## Example
 

--- a/samples/openapi3/client/petstore/python-aiohttp/docs/Pig.md
+++ b/samples/openapi3/client/petstore/python-aiohttp/docs/Pig.md
@@ -6,8 +6,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **class_name** | **str** |  | 
-**color** | **str** |  | 
-**size** | **int** |  | 
+**color** | **str** |  | [optional] 
+**size** | **int** |  | [optional] 
 
 ## Example
 

--- a/samples/openapi3/client/petstore/python-httpx/docs/AnyOfPig.md
+++ b/samples/openapi3/client/petstore/python-httpx/docs/AnyOfPig.md
@@ -6,8 +6,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **class_name** | **str** |  | 
-**color** | **str** |  | 
-**size** | **int** |  | 
+**color** | **str** |  | [optional] 
+**size** | **int** |  | [optional] 
 
 ## Example
 

--- a/samples/openapi3/client/petstore/python-httpx/docs/Pig.md
+++ b/samples/openapi3/client/petstore/python-httpx/docs/Pig.md
@@ -6,8 +6,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **class_name** | **str** |  | 
-**color** | **str** |  | 
-**size** | **int** |  | 
+**color** | **str** |  | [optional] 
+**size** | **int** |  | [optional] 
 
 ## Example
 

--- a/samples/openapi3/client/petstore/python-lazyImports/docs/AnyOfPig.md
+++ b/samples/openapi3/client/petstore/python-lazyImports/docs/AnyOfPig.md
@@ -6,8 +6,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **class_name** | **str** |  | 
-**color** | **str** |  | 
-**size** | **int** |  | 
+**color** | **str** |  | [optional] 
+**size** | **int** |  | [optional] 
 
 ## Example
 

--- a/samples/openapi3/client/petstore/python-lazyImports/docs/Pig.md
+++ b/samples/openapi3/client/petstore/python-lazyImports/docs/Pig.md
@@ -6,8 +6,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **class_name** | **str** |  | 
-**color** | **str** |  | 
-**size** | **int** |  | 
+**color** | **str** |  | [optional] 
+**size** | **int** |  | [optional] 
 
 ## Example
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/docs/AnyOfPig.md
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/docs/AnyOfPig.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **class_name** | **str** |  | 
-**color** | **str** |  | 
-**size** | **int** |  | 
+**color** | **str** |  | [optional] 
+**size** | **int** |  | [optional] 
 
 ## Example
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/docs/Pig.md
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/docs/Pig.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **class_name** | **str** |  | 
-**color** | **str** |  | 
-**size** | **int** |  | 
+**color** | **str** |  | [optional] 
+**size** | **int** |  | [optional] 
 
 ## Example
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/docs/AnyOfPig.md
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/docs/AnyOfPig.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **class_name** | **str** |  | 
-**color** | **str** |  | 
-**size** | **int** |  | 
+**color** | **str** |  | [optional] 
+**size** | **int** |  | [optional] 
 
 ## Example
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/docs/Pig.md
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/docs/Pig.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **class_name** | **str** |  | 
-**color** | **str** |  | 
-**size** | **int** |  | 
+**color** | **str** |  | [optional] 
+**size** | **int** |  | [optional] 
 
 ## Example
 

--- a/samples/openapi3/client/petstore/python/docs/AnyOfPig.md
+++ b/samples/openapi3/client/petstore/python/docs/AnyOfPig.md
@@ -6,8 +6,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **class_name** | **str** |  | 
-**color** | **str** |  | 
-**size** | **int** |  | 
+**color** | **str** |  | [optional] 
+**size** | **int** |  | [optional] 
 
 ## Example
 

--- a/samples/openapi3/client/petstore/python/docs/Pig.md
+++ b/samples/openapi3/client/petstore/python/docs/Pig.md
@@ -6,8 +6,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **class_name** | **str** |  | 
-**color** | **str** |  | 
-**size** | **int** |  | 
+**color** | **str** |  | [optional] 
+**size** | **int** |  | [optional] 
 
 ## Example
 

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsFilteredPatchRequest.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsFilteredPatchRequest.ts
@@ -15,9 +15,9 @@ import { PetByType } from '../models/PetByType';
 import { HttpFile } from '../http/http';
 
 export class PetsFilteredPatchRequest {
-    'age': number;
+    'age'?: number;
     'nickname'?: string;
-    'petType': PetsFilteredPatchRequestPetTypeEnum;
+    'petType'?: PetsFilteredPatchRequestPetTypeEnum;
     'hunts'?: boolean;
 
     static readonly discriminator: string | undefined = undefined;

--- a/samples/server/others/kotlin-server/polymorphism-and-discriminator/src/main/kotlin/org/openapitools/server/models/Pet.kt
+++ b/samples/server/others/kotlin-server/polymorphism-and-discriminator/src/main/kotlin/org/openapitools/server/models/Pet.kt
@@ -27,6 +27,7 @@ sealed class Pet(
     
     @field:com.fasterxml.jackson.annotation.JsonProperty("petType")
     open val petType: kotlin.String
+,
 
 )
 

--- a/samples/server/others/kotlin-server/polymorphism/src/main/kotlin/org/openapitools/server/models/Pet.kt
+++ b/samples/server/others/kotlin-server/polymorphism/src/main/kotlin/org/openapitools/server/models/Pet.kt
@@ -31,11 +31,11 @@ data class Pet(
     /* The measured skill for hunting */
     
     @field:com.fasterxml.jackson.annotation.JsonProperty("huntingSkill")
-    val huntingSkill: Pet.HuntingSkill,
+    val huntingSkill: Pet.HuntingSkill? = null,
     /* the size of the pack the dog is from */
     
     @field:com.fasterxml.jackson.annotation.JsonProperty("packSize")
-    val packSize: kotlin.Int = 0
+    val packSize: kotlin.Int? = 0
 )
 {
     /**

--- a/samples/server/petstore/cpp-httplib-server/feature-test/models/PaymentMethod.h
+++ b/samples/server/petstore/cpp-httplib-server/feature-test/models/PaymentMethod.h
@@ -8,6 +8,7 @@
 // System headers
 #include <nlohmann/json.hpp>
 #include <variant>
+#include <optional>
 #include <string>
 #include "BankAccount.h"
 #include "CreditCard.h"

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/AnyOfUserOrPet.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/AnyOfUserOrPet.kt
@@ -21,10 +21,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 /**
  * 
- * @param username 
- * @param name 
- * @param photoUrls 
  * @param id 
+ * @param username 
  * @param firstName 
  * @param lastName 
  * @param email 
@@ -32,22 +30,18 @@ import io.swagger.v3.oas.annotations.media.Schema
  * @param phone 
  * @param userStatus User Status
  * @param category 
+ * @param name 
+ * @param photoUrls 
  * @param tags 
  * @param status pet status in the store
  */
 data class AnyOfUserOrPet(
 
-    @Schema(example = "null", required = true, description = "")
-    @get:JsonProperty("username", required = true) val username: kotlin.String,
-
-    @Schema(example = "doggie", required = true, description = "")
-    @get:JsonProperty("name", required = true) val name: kotlin.String,
-
-    @Schema(example = "null", required = true, description = "")
-    @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
-
     @Schema(example = "null", description = "")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
+
+    @Schema(example = "null", description = "")
+    @get:JsonProperty("username") val username: kotlin.String? = null,
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("firstName") val firstName: kotlin.String? = null,
@@ -70,6 +64,12 @@ data class AnyOfUserOrPet(
     @field:Valid
     @Schema(example = "null", description = "")
     @get:JsonProperty("category") val category: Category? = null,
+
+    @Schema(example = "doggie", description = "")
+    @get:JsonProperty("name") val name: kotlin.String? = null,
+
+    @Schema(example = "null", description = "")
+    @get:JsonProperty("photoUrls") val photoUrls: kotlin.collections.List<kotlin.String>? = null,
 
     @field:Valid
     @Schema(example = "null", description = "")

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/AnyOfUserOrPetOrArrayString.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/AnyOfUserOrPetOrArrayString.kt
@@ -21,10 +21,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 /**
  * 
- * @param username 
- * @param name 
- * @param photoUrls 
  * @param id 
+ * @param username 
  * @param firstName 
  * @param lastName 
  * @param email 
@@ -32,22 +30,18 @@ import io.swagger.v3.oas.annotations.media.Schema
  * @param phone 
  * @param userStatus User Status
  * @param category 
+ * @param name 
+ * @param photoUrls 
  * @param tags 
  * @param status pet status in the store
  */
 data class AnyOfUserOrPetOrArrayString(
 
-    @Schema(example = "null", required = true, description = "")
-    @get:JsonProperty("username", required = true) val username: kotlin.String,
-
-    @Schema(example = "doggie", required = true, description = "")
-    @get:JsonProperty("name", required = true) val name: kotlin.String,
-
-    @Schema(example = "null", required = true, description = "")
-    @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
-
     @Schema(example = "null", description = "")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
+
+    @Schema(example = "null", description = "")
+    @get:JsonProperty("username") val username: kotlin.String? = null,
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("firstName") val firstName: kotlin.String? = null,
@@ -70,6 +64,12 @@ data class AnyOfUserOrPetOrArrayString(
     @field:Valid
     @Schema(example = "null", description = "")
     @get:JsonProperty("category") val category: Category? = null,
+
+    @Schema(example = "doggie", description = "")
+    @get:JsonProperty("name") val name: kotlin.String? = null,
+
+    @Schema(example = "null", description = "")
+    @get:JsonProperty("photoUrls") val photoUrls: kotlin.collections.List<kotlin.String>? = null,
 
     @field:Valid
     @Schema(example = "null", description = "")


### PR DESCRIPTION
Closes #23667.

The merged composed model from `anyOf`/`oneOf` adds every member's `required` fields to the resulting `required` set. Per OAS / JSON Schema semantics, a value is only guaranteed present if EVERY member of an `anyOf`/`oneOf` requires it, so the merged set should be the intersection.

```yaml
response:
  anyOf:
    - $ref: '#/components/schemas/VoteResponse'   # required: [status, voteId]
    - $ref: '#/components/schemas/APIError'       # required: [status, reason, code]
```

Previously: `status, voteId, reason, code` all marked required. Now: only `status` is required (the only field present in both).

`allOf` semantics are unchanged (still union).

### Affects
Every generator that consumes `CodegenModel.required` for non-null types or constructor signatures (Swift, Kotlin, Java POJOs, Dart, etc.). Sample regeneration may flip previously-required fields to optional in generated code where this pattern is in use; that is the intended behavior.

### Test
`anyOfRequiredFieldsIntersectionTest` in `Swift6ClientCodegenModelTest` covers the contract against `swift6_anyof_required.yaml` (chosen because swift6 is one of the affected generators; the change itself lives in `DefaultCodegen` and applies everywhere). All 164 `DefaultCodegenTest` cases and 39 swift6 codegen tests pass.

### Sample regeneration
The source change is intentionally landed without a multi-language sample regen since this affects ~every generator and the diff would be unmanageable. Maintainers may want to follow up with a samples regeneration pass; happy to spin out a follow-up PR if that's preferred.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/OpenAPITools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to build the project and update samples:
   ```
   ./mvnw clean package
   ```
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.x.x) (patches will be cascaded from `master` to other branches by the maintainers)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @wing328 @jimschubert