### PR TITLE
[BUG] FIX protobuf-schema generator wraps standalone enums in message types but does not update field references #23559

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
@@ -731,6 +731,24 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
                     }
                 }
 
+                // Fix for enum wrapping when NOT extracting enums to separate files
+                // Since v7.20.0, all enums are wrapped in messages but field references 
+                // weren't updated to use .Enum suffix when not extracted
+                boolean isDirectEnumForFix = property.isEnum;
+                boolean isArrayOfEnumsForFix = property.isArray && property.items != null && property.items.isEnum;
+                
+                if ((isDirectEnumForFix || isArrayOfEnumsForFix) && !this.extractEnumsToSeparateFiles) {
+                    // For enums that are wrapped but not extracted, update the data type to use .Enum suffix
+                    CodegenProperty enumPropertyForFix = isArrayOfEnumsForFix ? property.items : property;
+                    String enumTypeName = enumPropertyForFix.dataType;
+                    
+                    if (StringUtils.isNotBlank(enumTypeName)) {
+                        // Update x-protobuf-data-type to reference the wrapped enum's inner Enum
+                        String wrappedEnumType = enumTypeName + "." + ENUM_WRAPPER_INNER_NAME;
+                        property.vendorExtensions.put("x-protobuf-data-type", wrappedEnumType);
+                    }
+                }
+
                 // Check if this property is an enum or an array of enums.
                 // 
                 // This handles two distinct cases:


### PR DESCRIPTION
fixes #23559 

## Problem
Since v7.20.0, protobuf-schema wraps enums in message containers, but field references are not updated when enums are not extracted to separate files. Fields still reference `ResourceType` instead of `ResourceType.Enum`, leading to incorrect generated code.

## Root Cause
The enum template was updated to always wrap enums, but ProtobufSchemaCodegen only handled extracted enums and missed the wrapped enum case.

## Solution
Updated the codegen logic to set `x-protobuf-data-type` correctly for wrapped enums when `extractEnumsToSeparateFiles` is false, ensuring field references use the `.Enum` suffix.

## Impact
Fixes incorrect enum references in generated protobuf files and aligns field types with the wrapped enum structure introduced in v7.20.0.
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect enum field references when protobuf enums are wrapped in message types but not extracted. Fields now point to the inner `.Enum` type. Fixes #23559.

- **Bug Fixes**
  - Set `x-protobuf-data-type` to `<Type>.Enum` for direct enums and arrays of enums when `extractEnumsToSeparateFiles` is false.
  - Aligns generated field types with the enum wrapping introduced in v7.20.0, preventing invalid code generation.

<sup>Written for commit b559692d34946ec91aee2287bffe0e7cd204dd02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

