### PR TITLE
[BUG] Fix Patch operations reset fields to default if not specified #23650

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -442,6 +442,7 @@ public class PythonClientCodegen extends AbstractPythonCodegen implements Codege
         for (ModelMap mo : objs.getModels()) {
             CodegenModel cm = mo.getModel();
             if (cm.getClassname().startsWith("Patched")) {
+                // Mark as PATCH model for template handling
                 cm.vendorExtensions.put("isPatchedModel", true);
             }
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -25,6 +25,8 @@ import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.GeneratorMetadata;
 import org.openapitools.codegen.meta.Stability;
 import org.openapitools.codegen.meta.features.*;
+import org.openapitools.codegen.model.ModelMap;
+import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.openapitools.codegen.utils.ProcessUtils;
 import org.slf4j.Logger;
@@ -432,6 +434,18 @@ public class PythonClientCodegen extends AbstractPythonCodegen implements Codege
     @Override
     public String modelTestFileFolder() {
         return outputFolder + File.separatorChar + testFolder;
+    }
+
+    @Override
+    public ModelsMap postProcessModels(ModelsMap objs) {
+        // Process models to detect PATCH models (models starting with 'Patched')
+        for (ModelMap mo : objs.getModels()) {
+            CodegenModel cm = mo.getModel();
+            if (cm.getClassname().startsWith("Patched")) {
+                cm.vendorExtensions.put("isPatchedModel", true);
+            }
+        }
+        return super.postProcessModels(objs);
     }
 
     public String packagePath() {

--- a/modules/openapi-generator/src/main/resources/python/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_generic.mustache
@@ -164,22 +164,20 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
             {{/isAdditionalPropertiesTrue}}
         ])
 
-        {{#classname}}
-        {{#isPatchedModel}}
+        {{#vendorExtensions.isPatchedModel}}
         _dict = self.model_dump(
             by_alias=True,
             exclude=excluded_fields,
             exclude_unset=True,  # For PATCH models, exclude unset fields to avoid sending default values
         )
-        {{/isPatchedModel}}
-        {{^isPatchedModel}}
+{{/vendorExtensions.isPatchedModel}}
+{{^vendorExtensions.isPatchedModel}}
         _dict = self.model_dump(
             by_alias=True,
             exclude=excluded_fields,
             exclude_none=True,
         )
-        {{/isPatchedModel}}
-{{/classname}}
+{{/vendorExtensions.isPatchedModel}}
         {{#allVars}}
         {{#isContainer}}
         {{#isArray}}

--- a/modules/openapi-generator/src/main/resources/python/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_generic.mustache
@@ -164,20 +164,16 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
             {{/isAdditionalPropertiesTrue}}
         ])
 
-        {{#vendorExtensions.isPatchedModel}}
         _dict = self.model_dump(
             by_alias=True,
             exclude=excluded_fields,
+            {{#vendorExtensions.isPatchedModel}}
             exclude_unset=True,  # For PATCH models, exclude unset fields to avoid sending default values
-        )
-{{/vendorExtensions.isPatchedModel}}
-{{^vendorExtensions.isPatchedModel}}
-        _dict = self.model_dump(
-            by_alias=True,
-            exclude=excluded_fields,
+            {{/vendorExtensions.isPatchedModel}}
+            {{^vendorExtensions.isPatchedModel}}
             exclude_none=True,
+            {{/vendorExtensions.isPatchedModel}}
         )
-{{/vendorExtensions.isPatchedModel}}
         {{#allVars}}
         {{#isContainer}}
         {{#isArray}}

--- a/modules/openapi-generator/src/main/resources/python/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_generic.mustache
@@ -164,11 +164,22 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
             {{/isAdditionalPropertiesTrue}}
         ])
 
+        {{#classname}}
+        {{#isPatchedModel}}
+        _dict = self.model_dump(
+            by_alias=True,
+            exclude=excluded_fields,
+            exclude_unset=True,  # For PATCH models, exclude unset fields to avoid sending default values
+        )
+        {{/isPatchedModel}}
+        {{^isPatchedModel}}
         _dict = self.model_dump(
             by_alias=True,
             exclude=excluded_fields,
             exclude_none=True,
         )
+        {{/isPatchedModel}}
+{{/classname}}
         {{#allVars}}
         {{#isContainer}}
         {{#isArray}}


### PR DESCRIPTION
Fixes #23650

## Problem
In the Python generator, PATCH models were sending default values even when fields were not explicitly set by the client. This caused unintended updates where fields were reset to defaults.

## Root Cause
The generated `to_dict()` method uses `exclude_none=True`, which only skips `None` values but still includes fields with default values.

## Solution
Use `exclude_unset=True` for PATCH models so that only explicitly set fields are included in the payload. Non-PATCH models continue using `exclude_none=True` to avoid breaking existing behavior.

## Changes
- Updated `model_generic.mustache` to conditionally use `exclude_unset=True` for PATCH models
- Added logic in `PythonClientCodegen` to detect PATCH models (based on naming convention) and set a flag

## Impact
PATCH requests now send only modified fields, preventing unintended resets. Behavior for non-PATCH models remains unchanged.


### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #23650. Python PATCH models now send only explicitly set fields for classes prefixed with `Patched`, preventing defaults from overwriting existing data; non-PATCH behavior is unchanged. Also fixes template formatting to avoid broken Python output.

- **Bug Fixes**
  - In `model_generic.mustache`, use inline conditional args in `model_dump(...)`: `exclude_unset=True` for `vendorExtensions.isPatchedModel`, otherwise `exclude_none=True`.
  - In `PythonClientCodegen#postProcessModels`, mark `Patched*` models with `isPatchedModel` for template handling.

<sup>Written for commit 2d3bd2ec57b5148f6e6adfba6634b19aaecaa6c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

