### PR TITLE
[gradle-plugin] bump kotlin-dsl, kotlin.jvm, and kotlin-test-testng to fix Kotlin compile error

### DIFF
--- a/modules/openapi-generator-gradle-plugin/build.gradle
+++ b/modules/openapi-generator-gradle-plugin/build.gradle
@@ -7,8 +7,8 @@ plugins {
     id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
     id("java-gradle-plugin")
     id("maven-publish")
-    id("org.gradle.kotlin.kotlin-dsl") version "5.2.0"
-    id("org.jetbrains.kotlin.jvm") version "2.0.21"
+    id("org.gradle.kotlin.kotlin-dsl") version "6.6.4"
+    id("org.jetbrains.kotlin.jvm") version "2.3.21"
     id("signing")
 }
 
@@ -41,7 +41,7 @@ repositories {
 
 dependencies {
     implementation("org.openapitools:openapi-generator:$openApiGeneratorVersion")
-    testImplementation("org.jetbrains.kotlin:kotlin-test-testng:1.9.0")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-testng:2.2.0")
 }
 
 tasks.named("test", Test).configure {


### PR DESCRIPTION
## Summary

Fixes Kotlin compilation errors in the `openapi-generator-gradle-plugin` module caused by outdated Kotlin Gradle plugin and dependency versions.

- `org.gradle.kotlin.kotlin-dsl`: `5.2.0` → `6.6.4`
- `org.jetbrains.kotlin.jvm`: `2.0.21` → `2.3.21`
- `org.jetbrains.kotlin:kotlin-test-testng`: `1.9.0` → `2.2.0`

Closes #23678

## Test plan

- [ ] `cd modules/openapi-generator-gradle-plugin && ./gradlew compileKotlin` compiles without errors
- [ ] `./gradlew test` passes in the plugin module

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Kotlin Gradle plugins and test library to fix compile errors in the `openapi-generator-gradle-plugin` module. Addresses #23678 and restores successful compilation.

- **Dependencies**
  - `org.gradle.kotlin.kotlin-dsl`: 5.2.0 → 6.6.4
  - `org.jetbrains.kotlin.jvm`: 2.0.21 → 2.3.21
  - `org.jetbrains.kotlin:kotlin-test-testng`: 1.9.0 → 2.2.0

<sup>Written for commit a9a6933cc32dc347e1f80f285b19821ec8c62e7f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

