### PR TITLE
feat(java/jersey3): support Spring Boot 4

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -287,7 +287,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         cliOptions.add(CliOption.newBoolean(USE_JSPECIFY, "Use Jspecify for null checks. Only supported for " + JSPECIFY_SUPPORTED_LIBRARIES, useJspecify));
 
         supportedLibraries.put(JERSEY2, "HTTP client: Jersey client 2.25.1. JSON processing: Jackson 2.17.1");
-        supportedLibraries.put(JERSEY3, "HTTP client: Jersey client 3.1.1. JSON processing: Jackson 2.17.1");
+        supportedLibraries.put(JERSEY3, "HTTP client: Jersey client 3.1.1. JSON processing: Jackson 2.17.1. Use `useSpringBoot4=true` to align dependency versions (jakarta.annotation 3.0.0, jakarta.validation 3.1.1) and Java target (17) with Spring Boot 4.x.");
         supportedLibraries.put(FEIGN, "HTTP client: OpenFeign 13.2.1. JSON processing: Jackson 2.17.1 or Gson 2.10.1");
         supportedLibraries.put(FEIGN_HC5, "HTTP client: OpenFeign 13.2.1/HttpClient5 5.4.2. JSON processing: Jackson 2.17.1 or Gson 2.10.1");
         supportedLibraries.put(OKHTTP_GSON, "[DEFAULT] HTTP client: OkHttp 4.11.0. JSON processing: Gson 2.10.1. Enable Parcelable models on Android using '-DparcelableModel=true'. Enable gzip request encoding using '-DuseGzipFeature=true'.");

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/build.gradle.mustache
@@ -33,8 +33,14 @@ if(hasProperty('target') && target == 'android') {
             targetSdkVersion 25
         }
         compileOptions {
+            {{#useSpringBoot4}}
+            sourceCompatibility JavaVersion.VERSION_17
+            targetCompatibility JavaVersion.VERSION_17
+            {{/useSpringBoot4}}
+            {{^useSpringBoot4}}
             sourceCompatibility JavaVersion.VERSION_1_8
             targetCompatibility JavaVersion.VERSION_1_8
+            {{/useSpringBoot4}}
         }
 
         // Rename the aar correctly
@@ -78,8 +84,14 @@ if(hasProperty('target') && target == 'android') {
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'
+    {{#useSpringBoot4}}
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+    {{/useSpringBoot4}}
+    {{^useSpringBoot4}}
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
+    {{/useSpringBoot4}}
 
     publishing {
         publications {
@@ -105,9 +117,19 @@ ext {
     {{#openApiNullable}}
     jackson_databind_nullable_version = "0.2.10"
     {{/openApiNullable}}
+    {{#useSpringBoot4}}
+    jakarta_annotation_version = "3.0.0"
+    {{/useSpringBoot4}}
+    {{^useSpringBoot4}}
     jakarta_annotation_version = "2.1.0"
+    {{/useSpringBoot4}}
     {{#useBeanValidation}}
+    {{#useSpringBoot4}}
+    bean_validation_version = "3.1.1"
+    {{/useSpringBoot4}}
+    {{^useSpringBoot4}}
     bean_validation_version = "3.0.2"
+    {{/useSpringBoot4}}
     {{/useBeanValidation}}
     jersey_version = "3.0.4"
     junit_version = "5.8.2"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pom.mustache
@@ -142,8 +142,14 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.10.1</version>
                 <configuration>
+                    {{#useSpringBoot4}}
+                    <source>17</source>
+                    <target>17</target>
+                    {{/useSpringBoot4}}
+                    {{^useSpringBoot4}}
                     <source>1.8</source>
                     <target>1.8</target>
+                    {{/useSpringBoot4}}
                     <fork>true</fork>
                     <meminitial>128m</meminitial>
                     <maxmem>512m</maxmem>
@@ -167,7 +173,12 @@
                 </executions>
                 <configuration>
                     <doclint>none</doclint>
+                    {{#useSpringBoot4}}
+                    <source>17</source>
+                    {{/useSpringBoot4}}
+                    {{^useSpringBoot4}}
                     <source>1.8</source>
+                    {{/useSpringBoot4}}
                     <tags>
                         <tag>
                             <name>http.response.details</name>
@@ -409,6 +420,11 @@
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-version>2.21.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
+        {{#useSpringBoot4}}
+        <jakarta-annotation-version>3.0.0</jakarta-annotation-version>
+        <beanvalidation-version>3.1.1</beanvalidation-version>
+        {{/useSpringBoot4}}
+        {{^useSpringBoot4}}
         {{#useJakartaEe}}
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
         <beanvalidation-version>3.0.2</beanvalidation-version>
@@ -417,6 +433,7 @@
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         {{/useJakartaEe}}
+        {{/useSpringBoot4}}
         <junit-version>5.10.0</junit-version>
         {{#hasHttpSignatureMethods}}
         <http-signature-version>1.8</http-signature-version>


### PR DESCRIPTION
Wire the existing useSpringBoot4 client option into the jersey3 library templates so generated projects align with the Spring Boot 4.x baseline:

- Java 17 compiler/source/target (was 1.8)
- jakarta.annotation 3.0.0 (was 2.1.1)
- jakarta.validation 3.1.1 (was 3.0.2)

Defaults are unchanged when useSpringBoot4 is not set.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Spring Boot 4 support to Java `jersey3` clients behind the `useSpringBoot4=true` option. When enabled, generated projects compile with Java 17 and use `jakarta.annotation` 3.0.0 and `jakarta.validation` 3.1.1; defaults are unchanged.

- **New Features**
  - Wire `useSpringBoot4` into `jersey3` Gradle and Maven templates to set Java 17 and dependency versions.
  - Update `supportedLibraries` help text to document the flag.

<sup>Written for commit 7d2787320df2114f2b4f505882d38aebd03ce39f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

