### PR TITLE
[Java][jaxrs-spec] Fix generated `JsonTypeName` when using underscore in schema names

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
@@ -373,7 +373,7 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
                     CodegenDiscriminator discriminator = model.parentModel.getDiscriminator();
                     if (discriminator != null) {
                         for (CodegenDiscriminator.MappedModel mappedModel : discriminator.getMappedModels()) {
-                            if (mappedModel.getModelName().equals(model.name)) {
+                            if (mappedModel.getSchemaName().equals(model.schemaName)) {
                                 model.getVendorExtensions().put("x-discriminator-value", mappedModel.getMappingName());
                                 break;
                             }

--- a/modules/openapi-generator/src/test/resources/3_0/jaxrs/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/jaxrs/petstore.yaml
@@ -771,12 +771,12 @@ components:
           type: string
       oneOf:
         - $ref: '#/components/schemas/CatRequest'
-        - $ref: '#/components/schemas/DogRequest'
+        - $ref: '#/components/schemas/Dog_Request'
       discriminator:
         propertyName: petType
         mapping:
           CAT: '#/components/schemas/CatRequest'
-          DOG: '#/components/schemas/DogRequest'
+          DOG: '#/components/schemas/Dog_Request'
     CatRequest:
       allOf:
         - $ref: '#/components/schemas/PetRequest'
@@ -784,7 +784,7 @@ components:
           properties:
             indoor:
               type: boolean
-    DogRequest:
+    Dog_Request:
       allOf:
         - $ref: '#/components/schemas/PetRequest'
         - type: object

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/DogRequest.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/DogRequest.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.PetRequest;


### PR DESCRIPTION
# Description
When using underscores in schema names and using discriminator mappings, the `JsonTypeName` wasn't correctly generated. This fixes the issue I mentioned in [#10822](https://github.com/OpenAPITools/openapi-generator/issues/10822#issuecomment-4337511664)

The `name` field in `CodegenModel` and the `modelName` field in `CodegenDiscriminator.MappedModel` are **not** equal when using underscores. The `CodegenDiscriminator.MappedModel` field uses the sanitized name, which is equal to the `classname` field of `CodgenModel`. I don't know if the non equality is intended or not, since from the naming of the fields i would also assume they would be equal. I opted for using the raw `schemaName` in both classes to check for equality.

# Open Question
When i added the undescores in the test file, the jaxrs-cxf-cdi sample suddenly included the `JsonTypeName` import. I couldn't figure out why this is happening. It would be great, if someone could help me avoid this unused import.


@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect `@JsonTypeName` generation in the JAX-RS (jaxrs-spec) generator when schemas with underscores are used in discriminator mappings. Ensures the correct discriminator value by matching on raw schema names.

- **Bug Fixes**
  - In `JavaJAXRSSpecServerCodegen`, compare `mappedModel.schemaName` to `model.schemaName` to set `x-discriminator-value`.
  - Updated test spec to use `Dog_Request` in `oneOf` and mapping; regenerated sample adds `JsonTypeName` import in `DogRequest`.

<sup>Written for commit dd8957640f941398f70b4fab8877d4d7c5080da8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



