### PR TITLE
[java] Support 'duration' format

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -676,6 +676,8 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             importMapping.put("LocalTime", "java.time.LocalTime");
             typeMapping.put("date-time-local", "LocalDateTime");
             importMapping.put("LocalDateTime", "java.time.LocalDateTime");
+            typeMapping.put("duration", "Duration");
+            importMapping.put("Duration", "java.time.Duration");
             if ("java8-localdatetime".equals(dateLibrary)) {
                 typeMapping.put("DateTime", "LocalDateTime");
             } else {
@@ -1458,6 +1460,13 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                 }
             }
             return null;
+        } else if (ModelUtils.isDurationSchema(schema)) {
+            if (schema.getDefault() != null) {
+                if ("java8".equals(getDateLibrary())) {
+                    return String.format(Locale.ROOT, "Duration.parse(\"%s\")", schema.getDefault());
+                }
+            }
+            return null;
         } else if (ModelUtils.isStringSchema(schema)) {
             if (schema.getDefault() != null) {
                 String _default;
@@ -1547,6 +1556,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                             } else if(ModelUtils.isDateTimeLocalSchema(propertySchema)) {
                                 if("java8".equals(getDateLibrary())) {
                                     defaultPropertyExpression = String.format(Locale.ROOT, "java.time.LocalDateTime.parse(\"%s\")", value.asText());
+                                }
+                            } else if(ModelUtils.isDurationSchema(propertySchema)) {
+                                if("java8".equals(getDateLibrary())) {
+                                    defaultPropertyExpression = String.format(Locale.ROOT, "java.time.Duration.parse(\"%s\")", value.asText());
                                 }
                             } else if(ModelUtils.isUUIDSchema(propertySchema)) {
                                 defaultPropertyExpression = "java.util.UUID.fromString(\"" + value.asText() + "\")";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -721,6 +721,12 @@ public class ModelUtils {
                         && "date-time-local".equals(schema.getFormat()));
     }
 
+    public static boolean isDurationSchema(Schema schema) {
+        // format: duration, see https://spec.openapis.org/registry/format/duration.html
+        return (SchemaTypeUtil.STRING_TYPE.equals(getType(schema))
+                        && "duration".equals(schema.getFormat()));
+    }
+
     public static boolean isTimeLocalSchema(Schema schema) {
         // format: time-local, see https://spec.openapis.org/registry/format/time-local.html
         return (SchemaTypeUtil.STRING_TYPE.equals(getType(schema))

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -546,6 +546,15 @@ public class AbstractJavaCodegenTest {
 
         // dateLibrary <> java8
         Assert.assertEquals(defaultValue, "2007-12-03T10:15:30");
+
+        // Test default value for duration format
+        StringSchema durationSchema = new StringSchema();
+        durationSchema.setFormat("duration");
+        durationSchema.setDefault(Duration.parse("PT20.345S"));
+        defaultValue = codegen.toDefaultValue(durationSchema);
+
+        // dateLibrary <> java8
+        Assert.assertEquals(defaultValue, "PT20.345S");
     }
 
     @Test
@@ -622,6 +631,13 @@ public class AbstractJavaCodegenTest {
         dateTimeLocalSchema.setDefault("2007-12-03T10:15:30");
         defaultValue = codegen.toDefaultValue(codegen.fromProperty("", dateTimeLocalSchema), dateTimeLocalSchema);
         Assert.assertEquals(defaultValue, "LocalDateTime.parse(\"2007-12-03T10:15:30\")");
+
+        // Test default value for duration format
+        StringSchema durationSchema = new StringSchema();
+        durationSchema.setFormat("duration");
+        durationSchema.setDefault("PT20.345S");
+        defaultValue = codegen.toDefaultValue(codegen.fromProperty("", durationSchema), durationSchema);
+        Assert.assertEquals(defaultValue, "Duration.parse(\"PT20.345S\")");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -442,6 +442,35 @@ public class SpringCodegenTest {
     }
 
     @Test
+    public void generateDurationForDurationFormat() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/spring/date-time-parameter-types-for-testing.yml", null, new ParseOptions()).getOpenAPI();
+
+        SpringCodegen codegen = new SpringCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput input = new ClientOptInput();
+        input.openAPI(openAPI);
+        input.config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "false");
+        generator.setGenerateMetadata(false);
+        generator.opts(input).generate();
+
+        JavaFileAssert.assertThat(Paths.get(outputPath + "/src/main/java/org/openapitools/model/Pet.java"))
+                .hasImports("java.time.Duration")
+                .assertProperty("tripDuration").withType("Duration");
+    }
+
+    @Test
     public void interfaceDefaultImplDisableWithResponseWrapper() {
         final SpringCodegen codegen = new SpringCodegen();
         codegen.additionalProperties().put(RESPONSE_WRAPPER, "aWrapper");

--- a/modules/openapi-generator/src/test/resources/3_0/spring/date-time-parameter-types-for-testing.yml
+++ b/modules/openapi-generator/src/test/resources/3_0/spring/date-time-parameter-types-for-testing.yml
@@ -110,3 +110,7 @@ components:
           type: string
           format: date-time-local
           default: '2007-12-03T10:15:30'
+        tripDuration:
+          type: string
+          format: duration
+          default: 'PT10H15M30S'

--- a/samples/client/petstore/spring-cloud-date-time/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud-date-time/src/main/java/org/openapitools/model/Pet.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -45,6 +46,8 @@ public class Pet {
   private LocalTime feedingTime = LocalTime.parse("10:15:30");
 
   private LocalDateTime adoptionDate = LocalDateTime.parse("2007-12-03T10:15:30");
+
+  private Duration tripDuration = Duration.parse("PT10H15M30S");
 
   public Pet() {
     super();
@@ -225,6 +228,27 @@ public class Pet {
     this.adoptionDate = adoptionDate;
   }
 
+  public Pet tripDuration(Duration tripDuration) {
+    this.tripDuration = tripDuration;
+    return this;
+  }
+
+  /**
+   * Get tripDuration
+   * @return tripDuration
+   */
+  @Valid 
+  @Schema(name = "tripDuration", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("tripDuration")
+  public Duration getTripDuration() {
+    return tripDuration;
+  }
+
+  @JsonProperty("tripDuration")
+  public void setTripDuration(Duration tripDuration) {
+    this.tripDuration = tripDuration;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -241,12 +265,13 @@ public class Pet {
         Objects.equals(this.lastFeed, pet.lastFeed) &&
         Objects.equals(this.dateOfBirth, pet.dateOfBirth) &&
         Objects.equals(this.feedingTime, pet.feedingTime) &&
-        Objects.equals(this.adoptionDate, pet.adoptionDate);
+        Objects.equals(this.adoptionDate, pet.adoptionDate) &&
+        Objects.equals(this.tripDuration, pet.tripDuration);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(atType, age, happy, price, lastFeed, dateOfBirth, feedingTime, adoptionDate);
+    return Objects.hash(atType, age, happy, price, lastFeed, dateOfBirth, feedingTime, adoptionDate, tripDuration);
   }
 
   @Override
@@ -261,6 +286,7 @@ public class Pet {
     sb.append("    dateOfBirth: ").append(toIndentedString(dateOfBirth)).append("\n");
     sb.append("    feedingTime: ").append(toIndentedString(feedingTime)).append("\n");
     sb.append("    adoptionDate: ").append(toIndentedString(adoptionDate)).append("\n");
+    sb.append("    tripDuration: ").append(toIndentedString(tripDuration)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/openapi3/client/petstore/spring-cloud-date-time/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-date-time/src/main/java/org/openapitools/model/Pet.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -45,6 +46,8 @@ public class Pet {
   private LocalTime feedingTime = LocalTime.parse("10:15:30");
 
   private LocalDateTime adoptionDate = LocalDateTime.parse("2007-12-03T10:15:30");
+
+  private Duration tripDuration = Duration.parse("PT10H15M30S");
 
   public Pet() {
     super();
@@ -225,6 +228,27 @@ public class Pet {
     this.adoptionDate = adoptionDate;
   }
 
+  public Pet tripDuration(Duration tripDuration) {
+    this.tripDuration = tripDuration;
+    return this;
+  }
+
+  /**
+   * Get tripDuration
+   * @return tripDuration
+   */
+  @Valid 
+  @Schema(name = "tripDuration", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("tripDuration")
+  public Duration getTripDuration() {
+    return tripDuration;
+  }
+
+  @JsonProperty("tripDuration")
+  public void setTripDuration(Duration tripDuration) {
+    this.tripDuration = tripDuration;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -241,12 +265,13 @@ public class Pet {
         Objects.equals(this.lastFeed, pet.lastFeed) &&
         Objects.equals(this.dateOfBirth, pet.dateOfBirth) &&
         Objects.equals(this.feedingTime, pet.feedingTime) &&
-        Objects.equals(this.adoptionDate, pet.adoptionDate);
+        Objects.equals(this.adoptionDate, pet.adoptionDate) &&
+        Objects.equals(this.tripDuration, pet.tripDuration);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(atType, age, happy, price, lastFeed, dateOfBirth, feedingTime, adoptionDate);
+    return Objects.hash(atType, age, happy, price, lastFeed, dateOfBirth, feedingTime, adoptionDate, tripDuration);
   }
 
   @Override
@@ -261,6 +286,7 @@ public class Pet {
     sb.append("    dateOfBirth: ").append(toIndentedString(dateOfBirth)).append("\n");
     sb.append("    feedingTime: ").append(toIndentedString(feedingTime)).append("\n");
     sb.append("    adoptionDate: ").append(toIndentedString(adoptionDate)).append("\n");
+    sb.append("    tripDuration: ").append(toIndentedString(tripDuration)).append("\n");
     sb.append("}");
     return sb.toString();
   }


### PR DESCRIPTION
See https://spec.openapis.org/registry/format/duration.html

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Java support for the OpenAPI `duration` string format (per https://spec.openapis.org/registry/format/duration.html). Properties with `format: duration` now generate as `java.time.Duration` with correct default handling.

- **New Features**
  - Map `duration` -> `Duration` and import `java.time.Duration`.
  - Parse defaults with `Duration.parse(...)` when using the `java8` date library; otherwise keep the raw string default. Works for nested object defaults too.
  - Added `ModelUtils.isDurationSchema`, tests, and Spring sample updates to cover generation and defaults.

<sup>Written for commit 9e782e02a4079e3b16937f5ed54f8a69e6782d23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

