### PR TITLE
[jaxrs-spec][quarkus] - Add CLI flag (useQuarkusSecurityAnnotations) to enable emitting security annotation (@Authenticated, @RolesAllowed, @PermitAll)

### DIFF
--- a/docs/generators/jaxrs-cxf-cdi.md
+++ b/docs/generators/jaxrs-cxf-cdi.md
@@ -85,6 +85,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |useMicroProfileOpenAPIAnnotations|Whether to generate Microprofile OpenAPI annotations. Only valid when library is set to quarkus.| |false|
 |useMutiny|Whether to use Smallrye Mutiny instead of CompletionStage for asynchronous computation. Only valid when library is set to quarkus.| |false|
 |useOneOfInterfaces|whether to use a java interface to describe a set of oneOf options, where each option is a class that implements the interface| |false|
+|useQuarkusSecurityAnnotations|Whether to generate Quarkus security annotations (@Authenticated, @RolesAllowed, @PermitAll). Only valid when library is set to quarkus.| |false|
 |useSwaggerAnnotations|Whether to generate Swagger annotations.| |true|
 |useSwaggerV3Annotations|Whether to generate Swagger v3 (OpenAPI v3) annotations.| |false|
 |useTags|use tags for creating interface and controller classnames| |false|

--- a/docs/generators/jaxrs-spec.md
+++ b/docs/generators/jaxrs-spec.md
@@ -86,6 +86,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |useMicroProfileOpenAPIAnnotations|Whether to generate Microprofile OpenAPI annotations. Only valid when library is set to quarkus.| |false|
 |useMutiny|Whether to use Smallrye Mutiny instead of CompletionStage for asynchronous computation. Only valid when library is set to quarkus.| |false|
 |useOneOfInterfaces|whether to use a java interface to describe a set of oneOf options, where each option is a class that implements the interface| |false|
+|useQuarkusSecurityAnnotations|Whether to generate Quarkus security annotations (@Authenticated, @RolesAllowed, @PermitAll). Only valid when library is set to quarkus.| |false|
 |useSwaggerAnnotations|Whether to generate Swagger annotations.| |true|
 |useSwaggerV3Annotations|Whether to generate Swagger v3 (OpenAPI v3) annotations.| |false|
 |useTags|use tags for creating interface and controller classnames| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
@@ -53,6 +53,7 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
     public static final String USE_MUTINY = "useMutiny";
     public static final String OPEN_API_SPEC_FILE_LOCATION = "openApiSpecFileLocation";
     public static final String GENERATE_JSON_CREATOR = "generateJsonCreator";
+    public static final String USE_QUARKUS_SECURITY_ANNOTATIONS = "useQuarkusSecurityAnnotations";
 
     public static final String QUARKUS_LIBRARY = "quarkus";
     public static final String THORNTAIL_LIBRARY = "thorntail";
@@ -68,6 +69,7 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
     private boolean useSwaggerV3Annotations = false;
     private boolean useMicroProfileOpenAPIAnnotations = false;
     private boolean useMutiny = false;
+    private boolean useQuarkusSecurityAnnotations = false;
 
     @Getter @Setter
     protected boolean generateJsonCreator = true;
@@ -147,6 +149,7 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
         cliOptions.add(CliOption.newString(OPEN_API_SPEC_FILE_LOCATION, "Location where the file containing the spec will be generated in the output folder. No file generated when set to null or empty string."));
         cliOptions.add(CliOption.newBoolean(SUPPORT_ASYNC, "Wrap responses in CompletionStage type, allowing asynchronous computation (requires JAX-RS 2.1).", supportAsync));
         cliOptions.add(CliOption.newBoolean(USE_MUTINY, "Whether to use Smallrye Mutiny instead of CompletionStage for asynchronous computation. Only valid when library is set to quarkus.", useMutiny));
+        cliOptions.add(CliOption.newBoolean(USE_QUARKUS_SECURITY_ANNOTATIONS, "Whether to generate Quarkus security annotations (@Authenticated, @RolesAllowed, @PermitAll). Only valid when library is set to quarkus.", useQuarkusSecurityAnnotations));
         cliOptions.add(CliOption.newBoolean(GENERATE_JSON_CREATOR, "Whether to generate @JsonCreator constructor for required properties.", generateJsonCreator));
     }
 
@@ -187,6 +190,10 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
 
         if (QUARKUS_LIBRARY.equals(library)) {
             convertPropertyToBooleanAndWriteBack(USE_MUTINY, value -> useMutiny = value);
+        }
+
+        if (QUARKUS_LIBRARY.equals(library)) {
+            convertPropertyToBooleanAndWriteBack(USE_QUARKUS_SECURITY_ANNOTATIONS, value -> useQuarkusSecurityAnnotations = value);
         }
 
         convertPropertyToBooleanAndWriteBack(GENERATE_JSON_CREATOR, this::setGenerateJsonCreator);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
@@ -1545,4 +1545,45 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
                 "@ResponseStatus",
                 "import org.jboss.resteasy.reactive.ResponseStatus");
     }
+
+    @Test
+    public void useQuarkusSecurityAnnotationsIsRegisteredWithDefaultFalse() {
+        final JavaJAXRSSpecServerCodegen codegen = new JavaJAXRSSpecServerCodegen();
+        Assert.assertTrue(
+            codegen.cliOptions().stream()
+                .anyMatch(opt -> USE_QUARKUS_SECURITY_ANNOTATIONS.equals(opt.getOpt()) && "false".equals(opt.getDefault())),
+            "useQuarkusSecurityAnnotations should be a registered CLI option defaulting to false"
+        );
+    }
+
+    @Test
+    public void useQuarkusSecurityAnnotationsDefaultsToFalseForQuarkusLibrary() {
+        codegen.setLibrary(QUARKUS_LIBRARY);
+        codegen.processOpts();
+
+        Assert.assertFalse(
+            (boolean) codegen.additionalProperties().getOrDefault(USE_QUARKUS_SECURITY_ANNOTATIONS, false)
+        );
+    }
+
+    @Test
+    public void useQuarkusSecurityAnnotationsCanBeEnabledForQuarkusLibrary() {
+        codegen.setLibrary(QUARKUS_LIBRARY);
+        codegen.additionalProperties().put(USE_QUARKUS_SECURITY_ANNOTATIONS, true);
+        codegen.processOpts();
+
+        new ConfigAssert(codegen.additionalProperties())
+            .assertValue(USE_QUARKUS_SECURITY_ANNOTATIONS, true);
+    }
+
+    @Test
+    public void useQuarkusSecurityAnnotationsNotProcessedForNonQuarkusLibrary() {
+        // flag is only consumed when library=quarkus; for other libraries the block is skipped
+        codegen.additionalProperties().put(USE_QUARKUS_SECURITY_ANNOTATIONS, true);
+        codegen.processOpts();
+
+        // convertPropertyToBooleanAndWriteBack was never called, so the value was never
+        // written back as a boolean — the key holds the raw Object we put in, not false
+        Assert.assertNotEquals(false, codegen.additionalProperties().get(USE_QUARKUS_SECURITY_ANNOTATIONS));
+    }
 }


### PR DESCRIPTION
This is part 1 of #23691 to improve the support for Authentication and Authorisation in the jaxrx-spec/quarkus server generator. 

It introduces a new CLI flag to enable emitting the security annotations for Authentication and Authorisation in the jaxrs-spec/quarkus server. The flag `useQuarkusSecurityAnnotations` defaults to `false` to keep the current code generator behaviour. When `true`, it will allow the generator to add the security annotations as per #23691

The enhancements to emit the annotations will be added in subsequent PRs.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in CLI flag to enable future emission of Quarkus security annotations in `jaxrs-spec` servers using the `quarkus` library. Default is off; no annotations are generated yet.

- **New Features**
  - Registers `useQuarkusSecurityAnnotations` (boolean, `quarkus` only, default false) to gate `@Authenticated`, `@RolesAllowed`, `@PermitAll`.
  - Processes the flag only when `library=quarkus`; ignored for other libraries.
  - Updates docs to list the option and adds tests for registration and behavior.

- **Migration**
  - To enable: pass `-p useQuarkusSecurityAnnotations=true` (or set in config) when using `quarkus`.

<sup>Written for commit 93390a5900aa3f9d22d79d307f775f2cd54d1ab1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



