### PR TITLE
[csharp] Fix HTTP signature auth failure on .NET 8 when query params contain special characters

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/HttpSigningConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/HttpSigningConfiguration.mustache
@@ -25,6 +25,9 @@ namespace {{packageName}}.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
+            string framework = RuntimeInformation.FrameworkDescription;
+            _skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>
@@ -66,6 +69,14 @@ namespace {{packageName}}.Client
         /// Gets the Signature validity period in seconds
         /// </summary>
         public int SignatureValidityPeriod { get; set; }
+
+        // On .NET 9+, HttpUtility.ParseQueryString already URL-encodes keys internally,
+        // so calling UrlEncode again would cause double-encoding and produce a signature
+        // that does not match the actual request sent by RestSharp 112+.
+        // On .NET 8 and earlier, keys must be explicitly URL-encoded so that special
+        // characters (e.g. '$' in OData params like $filter) are encoded the same way
+        // in the signature as they are in the outgoing HTTP request.
+        private readonly bool _skipUrlEncode;
 
         private enum PrivateKeyType
         {
@@ -133,8 +144,7 @@ namespace {{packageName}}.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9") ? parameter.Key : {{#net90OrLater}}HttpUtility.UrlEncode({{/net90OrLater}}parameter.Key{{#net90OrLater}}){{/net90OrLater}};
+                string key = _skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/httpclient/net10/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/httpclient/net10/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,6 +33,9 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
+            string framework = RuntimeInformation.FrameworkDescription;
+            _skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>
@@ -74,6 +77,14 @@ namespace Org.OpenAPITools.Client
         /// Gets the Signature validity period in seconds
         /// </summary>
         public int SignatureValidityPeriod { get; set; }
+
+        // On .NET 9+, HttpUtility.ParseQueryString already URL-encodes keys internally,
+        // so calling UrlEncode again would cause double-encoding and produce a signature
+        // that does not match the actual request sent by RestSharp 112+.
+        // On .NET 8 and earlier, keys must be explicitly URL-encoded so that special
+        // characters (e.g. '$' in OData params like $filter) are encoded the same way
+        // in the signature as they are in the outgoing HTTP request.
+        private readonly bool _skipUrlEncode;
 
         private enum PrivateKeyType
         {
@@ -141,8 +152,7 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9") ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
+                string key = _skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/httpclient/net9/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/httpclient/net9/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,6 +33,9 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
+            string framework = RuntimeInformation.FrameworkDescription;
+            _skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>
@@ -74,6 +77,14 @@ namespace Org.OpenAPITools.Client
         /// Gets the Signature validity period in seconds
         /// </summary>
         public int SignatureValidityPeriod { get; set; }
+
+        // On .NET 9+, HttpUtility.ParseQueryString already URL-encodes keys internally,
+        // so calling UrlEncode again would cause double-encoding and produce a signature
+        // that does not match the actual request sent by RestSharp 112+.
+        // On .NET 8 and earlier, keys must be explicitly URL-encoded so that special
+        // characters (e.g. '$' in OData params like $filter) are encoded the same way
+        // in the signature as they are in the outgoing HTTP request.
+        private readonly bool _skipUrlEncode;
 
         private enum PrivateKeyType
         {
@@ -141,8 +152,7 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9") ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
+                string key = _skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,6 +33,9 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
+            string framework = RuntimeInformation.FrameworkDescription;
+            _skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>
@@ -74,6 +77,14 @@ namespace Org.OpenAPITools.Client
         /// Gets the Signature validity period in seconds
         /// </summary>
         public int SignatureValidityPeriod { get; set; }
+
+        // On .NET 9+, HttpUtility.ParseQueryString already URL-encodes keys internally,
+        // so calling UrlEncode again would cause double-encoding and produce a signature
+        // that does not match the actual request sent by RestSharp 112+.
+        // On .NET 8 and earlier, keys must be explicitly URL-encoded so that special
+        // characters (e.g. '$' in OData params like $filter) are encoded the same way
+        // in the signature as they are in the outgoing HTTP request.
+        private readonly bool _skipUrlEncode;
 
         private enum PrivateKeyType
         {
@@ -141,8 +152,7 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9") ? parameter.Key : parameter.Key;
+                string key = _skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/restsharp/net10/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/net10/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,6 +33,9 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
+            string framework = RuntimeInformation.FrameworkDescription;
+            _skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>
@@ -74,6 +77,14 @@ namespace Org.OpenAPITools.Client
         /// Gets the Signature validity period in seconds
         /// </summary>
         public int SignatureValidityPeriod { get; set; }
+
+        // On .NET 9+, HttpUtility.ParseQueryString already URL-encodes keys internally,
+        // so calling UrlEncode again would cause double-encoding and produce a signature
+        // that does not match the actual request sent by RestSharp 112+.
+        // On .NET 8 and earlier, keys must be explicitly URL-encoded so that special
+        // characters (e.g. '$' in OData params like $filter) are encoded the same way
+        // in the signature as they are in the outgoing HTTP request.
+        private readonly bool _skipUrlEncode;
 
         private enum PrivateKeyType
         {
@@ -141,8 +152,7 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9") ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
+                string key = _skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,6 +33,9 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
+            string framework = RuntimeInformation.FrameworkDescription;
+            _skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>
@@ -74,6 +77,14 @@ namespace Org.OpenAPITools.Client
         /// Gets the Signature validity period in seconds
         /// </summary>
         public int SignatureValidityPeriod { get; set; }
+
+        // On .NET 9+, HttpUtility.ParseQueryString already URL-encodes keys internally,
+        // so calling UrlEncode again would cause double-encoding and produce a signature
+        // that does not match the actual request sent by RestSharp 112+.
+        // On .NET 8 and earlier, keys must be explicitly URL-encoded so that special
+        // characters (e.g. '$' in OData params like $filter) are encoded the same way
+        // in the signature as they are in the outgoing HTTP request.
+        private readonly bool _skipUrlEncode;
 
         private enum PrivateKeyType
         {
@@ -141,8 +152,7 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9") ? parameter.Key : parameter.Key;
+                string key = _skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,6 +33,9 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
+            string framework = RuntimeInformation.FrameworkDescription;
+            _skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>
@@ -74,6 +77,14 @@ namespace Org.OpenAPITools.Client
         /// Gets the Signature validity period in seconds
         /// </summary>
         public int SignatureValidityPeriod { get; set; }
+
+        // On .NET 9+, HttpUtility.ParseQueryString already URL-encodes keys internally,
+        // so calling UrlEncode again would cause double-encoding and produce a signature
+        // that does not match the actual request sent by RestSharp 112+.
+        // On .NET 8 and earlier, keys must be explicitly URL-encoded so that special
+        // characters (e.g. '$' in OData params like $filter) are encoded the same way
+        // in the signature as they are in the outgoing HTTP request.
+        private readonly bool _skipUrlEncode;
 
         private enum PrivateKeyType
         {
@@ -141,8 +152,7 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9") ? parameter.Key : parameter.Key;
+                string key = _skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/restsharp/net8/EnumMappings/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/net8/EnumMappings/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,6 +33,9 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
+            string framework = RuntimeInformation.FrameworkDescription;
+            _skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>
@@ -74,6 +77,14 @@ namespace Org.OpenAPITools.Client
         /// Gets the Signature validity period in seconds
         /// </summary>
         public int SignatureValidityPeriod { get; set; }
+
+        // On .NET 9+, HttpUtility.ParseQueryString already URL-encodes keys internally,
+        // so calling UrlEncode again would cause double-encoding and produce a signature
+        // that does not match the actual request sent by RestSharp 112+.
+        // On .NET 8 and earlier, keys must be explicitly URL-encoded so that special
+        // characters (e.g. '$' in OData params like $filter) are encoded the same way
+        // in the signature as they are in the outgoing HTTP request.
+        private readonly bool _skipUrlEncode;
 
         private enum PrivateKeyType
         {
@@ -141,8 +152,7 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9") ? parameter.Key : parameter.Key;
+                string key = _skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/restsharp/net8/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/net8/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,6 +33,9 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
+            string framework = RuntimeInformation.FrameworkDescription;
+            _skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>
@@ -74,6 +77,14 @@ namespace Org.OpenAPITools.Client
         /// Gets the Signature validity period in seconds
         /// </summary>
         public int SignatureValidityPeriod { get; set; }
+
+        // On .NET 9+, HttpUtility.ParseQueryString already URL-encodes keys internally,
+        // so calling UrlEncode again would cause double-encoding and produce a signature
+        // that does not match the actual request sent by RestSharp 112+.
+        // On .NET 8 and earlier, keys must be explicitly URL-encoded so that special
+        // characters (e.g. '$' in OData params like $filter) are encoded the same way
+        // in the signature as they are in the outgoing HTTP request.
+        private readonly bool _skipUrlEncode;
 
         private enum PrivateKeyType
         {
@@ -141,8 +152,7 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9") ? parameter.Key : parameter.Key;
+                string key = _skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/restsharp/net9/EnumMappings/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/net9/EnumMappings/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,6 +33,9 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
+            string framework = RuntimeInformation.FrameworkDescription;
+            _skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>
@@ -74,6 +77,14 @@ namespace Org.OpenAPITools.Client
         /// Gets the Signature validity period in seconds
         /// </summary>
         public int SignatureValidityPeriod { get; set; }
+
+        // On .NET 9+, HttpUtility.ParseQueryString already URL-encodes keys internally,
+        // so calling UrlEncode again would cause double-encoding and produce a signature
+        // that does not match the actual request sent by RestSharp 112+.
+        // On .NET 8 and earlier, keys must be explicitly URL-encoded so that special
+        // characters (e.g. '$' in OData params like $filter) are encoded the same way
+        // in the signature as they are in the outgoing HTTP request.
+        private readonly bool _skipUrlEncode;
 
         private enum PrivateKeyType
         {
@@ -141,8 +152,7 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9") ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
+                string key = _skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,6 +33,9 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
+            string framework = RuntimeInformation.FrameworkDescription;
+            _skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>
@@ -74,6 +77,14 @@ namespace Org.OpenAPITools.Client
         /// Gets the Signature validity period in seconds
         /// </summary>
         public int SignatureValidityPeriod { get; set; }
+
+        // On .NET 9+, HttpUtility.ParseQueryString already URL-encodes keys internally,
+        // so calling UrlEncode again would cause double-encoding and produce a signature
+        // that does not match the actual request sent by RestSharp 112+.
+        // On .NET 8 and earlier, keys must be explicitly URL-encoded so that special
+        // characters (e.g. '$' in OData params like $filter) are encoded the same way
+        // in the signature as they are in the outgoing HTTP request.
+        private readonly bool _skipUrlEncode;
 
         private enum PrivateKeyType
         {
@@ -141,8 +152,7 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9") ? parameter.Key : parameter.Key;
+                string key = _skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,6 +33,9 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
+            string framework = RuntimeInformation.FrameworkDescription;
+            _skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>
@@ -74,6 +77,14 @@ namespace Org.OpenAPITools.Client
         /// Gets the Signature validity period in seconds
         /// </summary>
         public int SignatureValidityPeriod { get; set; }
+
+        // On .NET 9+, HttpUtility.ParseQueryString already URL-encodes keys internally,
+        // so calling UrlEncode again would cause double-encoding and produce a signature
+        // that does not match the actual request sent by RestSharp 112+.
+        // On .NET 8 and earlier, keys must be explicitly URL-encoded so that special
+        // characters (e.g. '$' in OData params like $filter) are encoded the same way
+        // in the signature as they are in the outgoing HTTP request.
+        private readonly bool _skipUrlEncode;
 
         private enum PrivateKeyType
         {
@@ -141,8 +152,7 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9") ? parameter.Key : parameter.Key;
+                string key = _skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/unityWebRequest/net10/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/net10/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,6 +33,9 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
+            string framework = RuntimeInformation.FrameworkDescription;
+            _skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>
@@ -74,6 +77,14 @@ namespace Org.OpenAPITools.Client
         /// Gets the Signature validity period in seconds
         /// </summary>
         public int SignatureValidityPeriod { get; set; }
+
+        // On .NET 9+, HttpUtility.ParseQueryString already URL-encodes keys internally,
+        // so calling UrlEncode again would cause double-encoding and produce a signature
+        // that does not match the actual request sent by RestSharp 112+.
+        // On .NET 8 and earlier, keys must be explicitly URL-encoded so that special
+        // characters (e.g. '$' in OData params like $filter) are encoded the same way
+        // in the signature as they are in the outgoing HTTP request.
+        private readonly bool _skipUrlEncode;
 
         private enum PrivateKeyType
         {
@@ -141,8 +152,7 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9") ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
+                string key = _skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,6 +33,9 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
+            string framework = RuntimeInformation.FrameworkDescription;
+            _skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>
@@ -74,6 +77,14 @@ namespace Org.OpenAPITools.Client
         /// Gets the Signature validity period in seconds
         /// </summary>
         public int SignatureValidityPeriod { get; set; }
+
+        // On .NET 9+, HttpUtility.ParseQueryString already URL-encodes keys internally,
+        // so calling UrlEncode again would cause double-encoding and produce a signature
+        // that does not match the actual request sent by RestSharp 112+.
+        // On .NET 8 and earlier, keys must be explicitly URL-encoded so that special
+        // characters (e.g. '$' in OData params like $filter) are encoded the same way
+        // in the signature as they are in the outgoing HTTP request.
+        private readonly bool _skipUrlEncode;
 
         private enum PrivateKeyType
         {
@@ -141,8 +152,7 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9") ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
+                string key = _skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,6 +33,9 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
+            string framework = RuntimeInformation.FrameworkDescription;
+            _skipUrlEncode = framework.StartsWith(".NET ") &&
+                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>
@@ -74,6 +77,14 @@ namespace Org.OpenAPITools.Client
         /// Gets the Signature validity period in seconds
         /// </summary>
         public int SignatureValidityPeriod { get; set; }
+
+        // On .NET 9+, HttpUtility.ParseQueryString already URL-encodes keys internally,
+        // so calling UrlEncode again would cause double-encoding and produce a signature
+        // that does not match the actual request sent by RestSharp 112+.
+        // On .NET 8 and earlier, keys must be explicitly URL-encoded so that special
+        // characters (e.g. '$' in OData params like $filter) are encoded the same way
+        // in the signature as they are in the outgoing HTTP request.
+        private readonly bool _skipUrlEncode;
 
         private enum PrivateKeyType
         {
@@ -141,8 +152,7 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-                string framework = RuntimeInformation.FrameworkDescription;
-                string key = framework.StartsWith(".NET 9") ? parameter.Key : parameter.Key;
+                string key = _skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)


### PR DESCRIPTION
### Summary

Replace compile-time Mustache `{{#net90OrLater}}` conditional with runtime .NET version detection for URL-encoding query parameter keys in HTTP signature computation.

### Problem

When targeting `net8.0`, the `{{#net90OrLater}}` Mustache conditional evaluates to **false**, causing `HttpUtility.UrlEncode()` to be completely omitted from the generated `HttpSigningConfiguration.cs`. The generated code becomes:

```csharp
string key = framework.StartsWith(".NET 9") ? parameter.Key : parameter.Key; // no-op!
```

Meanwhile, RestSharp 112+ always URL-encodes query parameters on the wire. This mismatch means the HTTP signature is computed over unencoded keys (e.g. $filter) while the actual request sends encoded keys (e.g. %24filter), resulting in HTTP 401 on every request with special characters in query parameter names (OData $filter, $top, $orderby, etc.).

Solution:

Use RuntimeInformation.FrameworkDescription to detect the .NET major version at runtime:

.NET 9+: Skip explicit URL-encoding (HttpUtility.ParseQueryString already encodes keys internally on .NET 9+, so encoding again would cause double-encoding)
.NET 8 and earlier: Explicitly call HttpUtility.UrlEncode(parameter.Key) so the signature matches what RestSharp sends
```
string framework = RuntimeInformation.FrameworkDescription;
bool skipUrlEncode = framework.StartsWith(".NET ") &&
    int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
// ...
string key = skipUrlEncode ? parameter.Key : HttpUtility.UrlEncode(parameter.Key);
```

PR checklist
 Read the [contribution guidelines](vscode-file://vscode-app/c:/Users/sagadira/AppData/Local/Programs/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
 Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
 Run the following to [build the project](vscode-file://vscode-app/c:/Users/sagadira/AppData/Local/Programs/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and update samples:
 ```
 ./mvnw clean package -DskipTests
./bin/generate-samples.sh bin/configs/csharp-restsharp*.yaml bin/configs/csharp-httpclient*.yaml
./bin/utils/export_docs_generators.sh
```
File the PR against the [correct branch](vscode-file://vscode-app/c:/Users/sagadira/AppData/Local/Programs/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html): master
 If your PR is targeting a particular programming language, @mention the [technical committee](vscode-file://vscode-app/c:/Users/sagadira/AppData/Local/Programs/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) members for that language.
@muttleyxd @devhl-labs @lucasheim @shibayan (C# generators)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes HTTP signature auth failures on .NET 8 and ensures correct behavior on .NET 9+ when query parameter names contain special characters by aligning URL-encoding with the actual request. We now detect the .NET version at runtime to decide whether to URL-encode query keys.

- **Bug Fixes**
  - Replaced Mustache `{{#net90OrLater}}` with runtime detection via `RuntimeInformation.FrameworkDescription`.
  - .NET 9+: skip UrlEncode to avoid double-encoding; .NET 8 and earlier: UrlEncode keys to match `RestSharp` 112+ requests.
  - Updated `HttpSigningConfiguration` template and regenerated C# samples (`httpclient`, `restsharp`, `unityWebRequest`).

<sup>Written for commit b56455a8b2d405b2f1d9b2009b75f64304271008. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

