### PR TITLE
feat: add skipUnusedModels option to validate command and Gradle task

### DIFF
--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Validate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Validate.java
@@ -45,6 +45,10 @@ public class Validate extends OpenApiGeneratorCommand {
     @Option(name = {"--recommend"}, title = "recommend spec improvements")
     private Boolean recommend;
 
+    @Option(name = {"--skip-unused-models"}, title = "skip unused models warning",
+            description = "skips the recommendation warning for schemas defined in components/schemas that are not referenced by any operation")
+    private Boolean skipUnusedModels;
+
     @Option(
             name = {"-a", "--auth"},
             title = "authorization",
@@ -70,6 +74,8 @@ public class Validate extends OpenApiGeneratorCommand {
 
         if (recommend != null) ruleConfiguration.setEnableRecommendations(recommend);
         else ruleConfiguration.setEnableRecommendations(false);
+
+        if (Boolean.TRUE.equals(skipUnusedModels)) ruleConfiguration.setEnableUnusedSchemasRecommendation(false);
 
         OpenApiEvaluator evaluator = new OpenApiEvaluator(ruleConfiguration);
         ValidationResult validationResult = evaluator.validate(specification);

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
@@ -87,6 +87,7 @@ class OpenApiGeneratorPlugin : Plugin<Project> {
                     remoteInputSpec.set(validate.remoteInputSpec)
                     recommend.set(validate.recommend)
                     treatWarningsAsErrors.set(validate.treatWarningsAsErrors)
+                    skipUnusedModels.set(validate.skipUnusedModels)
                 }
 
                 register("openApiGenerate", GenerateTask::class.java).configure {

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorValidateExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorValidateExtension.kt
@@ -49,6 +49,11 @@ open class OpenApiGeneratorValidateExtension(private val project: Project) {
      */
     val treatWarningsAsErrors: Property<Boolean> = project.objects.property<Boolean>().convention(false)
 
+    /**
+     * Whether to suppress warnings for schemas defined in components/schemas that are not referenced by any operation.
+     */
+    val skipUnusedModels: Property<Boolean> = project.objects.property<Boolean>().convention(false)
+
     // ========================================================================
     // Backwards-compatibility bridge setter for Groovy DSL
     // This allows Groovy users to use assignment syntax: inputSpec = "path"

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/ValidateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/ValidateTask.kt
@@ -70,9 +70,14 @@ abstract class ValidateTask : DefaultTask() {
     @get:Input
     abstract val treatWarningsAsErrors: Property<Boolean>
 
+    @get:Optional
+    @get:Input
+    abstract val skipUnusedModels: Property<Boolean>
+
     init {
         recommend.convention(true)
         treatWarningsAsErrors.convention(false)
+        skipUnusedModels.convention(false)
     }
 
     @Suppress("unused")
@@ -98,6 +103,7 @@ abstract class ValidateTask : DefaultTask() {
 
         val recommendations = recommend.get()
         val failOnWarnings = treatWarningsAsErrors.get()
+        val shouldSkipUnusedModels = skipUnusedModels.get()
 
         logger.lifecycle("Validating spec $specLocation")
 
@@ -110,6 +116,9 @@ abstract class ValidateTask : DefaultTask() {
 
         val ruleConfiguration = RuleConfiguration()
         ruleConfiguration.isEnableRecommendations = recommendations
+        if (shouldSkipUnusedModels) {
+            ruleConfiguration.isEnableUnusedSchemasRecommendation = false
+        }
 
         val evaluator = OpenApiEvaluator(ruleConfiguration)
         val validationResult = evaluator.validate(result.openAPI)

--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/ValidateTaskDslTest.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/ValidateTaskDslTest.kt
@@ -503,6 +503,87 @@ paths:
         )
     }
 
+    @Test(dataProvider = "gradle_version_provider")
+    fun `openApiValidate should warn about unused models by default`(gradleVersion: String?, format: String) {
+        val propertyFormat = PropertyFormat.valueOf(format)
+        // Arrange
+        val projectFiles = mapOf(
+            "spec.yaml" to javaClass.classLoader.getResourceAsStream("specs/petstore-v3.0-with-unused-schema.yaml")
+        )
+
+        withProject(
+            """
+            | plugins {
+            |   id 'org.openapi.generator'
+            | }
+            |
+            | openApiValidate {
+            |   ${inputSpecProperty("spec.yaml", propertyFormat)}
+            | }
+        """.trimMargin(), projectFiles
+        )
+
+        // Act
+        val result = getGradleRunner(gradleVersion)
+            .withProjectDir(temp)
+            .withArguments("openApiValidate")
+            .withPluginClasspath()
+            .build()
+
+        // Assert
+        assertTrue(
+            result.output.contains("Unused model: UnusedSchema"),
+            "Expected unused model warning to be present by default."
+        )
+        assertEquals(
+            SUCCESS, result.task(":openApiValidate")?.outcome,
+            "Expected a successful run, but found ${result.task(":openApiValidate")?.outcome}"
+        )
+    }
+
+    @Test(dataProvider = "gradle_version_provider")
+    fun `openApiValidate should suppress unused model warnings when skipUnusedModels is true`(gradleVersion: String?, format: String) {
+        val propertyFormat = PropertyFormat.valueOf(format)
+        // Arrange
+        val projectFiles = mapOf(
+            "spec.yaml" to javaClass.classLoader.getResourceAsStream("specs/petstore-v3.0-with-unused-schema.yaml")
+        )
+
+        withProject(
+            """
+            | plugins {
+            |   id 'org.openapi.generator'
+            | }
+            |
+            | openApiValidate {
+            |   ${inputSpecProperty("spec.yaml", propertyFormat)}
+            |   skipUnusedModels = true
+            | }
+        """.trimMargin(), projectFiles
+        )
+
+        // Act
+        val result = getGradleRunner(gradleVersion)
+            .withProjectDir(temp)
+            .withArguments("openApiValidate")
+            .withPluginClasspath()
+            .build()
+
+        // Assert
+        assertTrue(
+            result.output.contains("Unused model: UnusedSchema").not(),
+            "Expected unused model warning to be suppressed when skipUnusedModels = true."
+        )
+        assertTrue(
+            result.output.contains("Spec is valid."),
+            "Expected spec to be reported as valid."
+        )
+        assertEquals(
+            SUCCESS, result.task(":openApiValidate")?.outcome,
+            "Expected a successful run, but found ${result.task(":openApiValidate")?.outcome}"
+        )
+    }
+
     @Test(dataProvider = "gradle_version_only_provider")
     fun `openApiValidate should support task-level configuration with Kotlin DSL set String syntax`(gradleVersion: String?) {
         // Create a valid spec file

--- a/modules/openapi-generator-gradle-plugin/src/test/resources/specs/petstore-v3.0-with-unused-schema.yaml
+++ b/modules/openapi-generator-gradle-plugin/src/test/resources/specs/petstore-v3.0-with-unused-schema.yaml
@@ -1,0 +1,45 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      responses:
+        '200':
+          description: A list of pets
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    UnusedSchema:
+      description: This schema is defined but never referenced by any operation.
+      type: object
+      properties:
+        id:
+          type: integer


### PR DESCRIPTION
## Description

Closes #17679

Adds a way to suppress the `Unused model: <name>` recommendation warnings emitted during spec validation for schemas that are defined in `components/schemas` but not directly referenced by any operation. This is a common pattern in specs that serve as shared model libraries or that are bundled across multiple spec files.

## Prior art / existing workaround

`RuleConfiguration` already reads the `openapi.generator.rule.unused-schemas` system property to default `enableUnusedSchemasRecommendation`. This means the warning can already be suppressed without this PR, but only via undocumented JVM flags:

**Gradle** — add to `gradle.properties`:
```properties
org.gradle.jvmargs=-Dopenapi.generator.rule.unused-schemas=false
```

**CLI** — pass the flag when invoking the JVM:
```sh
JAVA_OPTS="-Dopenapi.generator.rule.unused-schemas=false" openapi-generator-cli validate -i api.yaml --recommend
# or
java -Dopenapi.generator.rule.unused-schemas=false -jar openapi-generator-cli.jar validate -i api.yaml --recommend
```

This PR surfaces the same control as a first-class, documented, per-invocation option.

## Changes

**CLI (`validate` command):**
- New `--skip-unused-models` flag. When set, `enableUnusedSchemasRecommendation` is disabled on the `RuleConfiguration` before validation runs.

**Gradle plugin (`ValidateTask` + `OpenApiGeneratorValidateExtension`):**
- New `skipUnusedModels` property (default: `false`) on both the extension (for `openApiValidate {}` block) and the task.
- Wired through `OpenApiGeneratorPlugin` alongside the existing `recommend` and `treatWarningsAsErrors` properties.

## Usage

CLI:
```sh
openapi-generator-cli validate -i api.yaml --recommend --skip-unused-models
```

Gradle (Groovy DSL):
```groovy
openApiValidate {
  inputSpec = "$rootDir/api.yaml"
  skipUnusedModels = true
}
```

Gradle (Kotlin DSL):
```kotlin
openApiValidate {
  inputSpec.set("$rootDir/api.yaml")
  skipUnusedModels.set(true)
}
```

## Tests

Added two new `ValidateTaskDslTest` cases and a companion test spec (`petstore-v3.0-with-unused-schema.yaml`):
- Verifies that the `Unused model` warning appears by default.
- Verifies that `skipUnusedModels = true` suppresses the warning while the build still succeeds.