### PR TITLE
minor refactoring (avoid another variable declaration)

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/HttpSigningConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/HttpSigningConfiguration.mustache
@@ -25,9 +25,8 @@ namespace {{packageName}}.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
-            string framework = RuntimeInformation.FrameworkDescription;
-            _skipUrlEncode = framework.StartsWith(".NET ") &&
-                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
+            _skipUrlEncode = RuntimeInformation.FrameworkDescription.StartsWith(".NET ") &&
+                int.TryParse(RuntimeInformation.FrameworkDescription.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/httpclient/net10/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/httpclient/net10/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,9 +33,8 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
-            string framework = RuntimeInformation.FrameworkDescription;
-            _skipUrlEncode = framework.StartsWith(".NET ") &&
-                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
+            _skipUrlEncode = RuntimeInformation.FrameworkDescription.StartsWith(".NET ") &&
+                int.TryParse(RuntimeInformation.FrameworkDescription.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/httpclient/net9/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/httpclient/net9/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,9 +33,8 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
-            string framework = RuntimeInformation.FrameworkDescription;
-            _skipUrlEncode = framework.StartsWith(".NET ") &&
-                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
+            _skipUrlEncode = RuntimeInformation.FrameworkDescription.StartsWith(".NET ") &&
+                int.TryParse(RuntimeInformation.FrameworkDescription.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,9 +33,8 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
-            string framework = RuntimeInformation.FrameworkDescription;
-            _skipUrlEncode = framework.StartsWith(".NET ") &&
-                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
+            _skipUrlEncode = RuntimeInformation.FrameworkDescription.StartsWith(".NET ") &&
+                int.TryParse(RuntimeInformation.FrameworkDescription.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net10/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/net10/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,9 +33,8 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
-            string framework = RuntimeInformation.FrameworkDescription;
-            _skipUrlEncode = framework.StartsWith(".NET ") &&
-                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
+            _skipUrlEncode = RuntimeInformation.FrameworkDescription.StartsWith(".NET ") &&
+                int.TryParse(RuntimeInformation.FrameworkDescription.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,9 +33,8 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
-            string framework = RuntimeInformation.FrameworkDescription;
-            _skipUrlEncode = framework.StartsWith(".NET ") &&
-                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
+            _skipUrlEncode = RuntimeInformation.FrameworkDescription.StartsWith(".NET ") &&
+                int.TryParse(RuntimeInformation.FrameworkDescription.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,9 +33,8 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
-            string framework = RuntimeInformation.FrameworkDescription;
-            _skipUrlEncode = framework.StartsWith(".NET ") &&
-                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
+            _skipUrlEncode = RuntimeInformation.FrameworkDescription.StartsWith(".NET ") &&
+                int.TryParse(RuntimeInformation.FrameworkDescription.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net8/EnumMappings/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/net8/EnumMappings/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,9 +33,8 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
-            string framework = RuntimeInformation.FrameworkDescription;
-            _skipUrlEncode = framework.StartsWith(".NET ") &&
-                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
+            _skipUrlEncode = RuntimeInformation.FrameworkDescription.StartsWith(".NET ") &&
+                int.TryParse(RuntimeInformation.FrameworkDescription.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net8/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/net8/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,9 +33,8 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
-            string framework = RuntimeInformation.FrameworkDescription;
-            _skipUrlEncode = framework.StartsWith(".NET ") &&
-                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
+            _skipUrlEncode = RuntimeInformation.FrameworkDescription.StartsWith(".NET ") &&
+                int.TryParse(RuntimeInformation.FrameworkDescription.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/net9/EnumMappings/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/net9/EnumMappings/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,9 +33,8 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
-            string framework = RuntimeInformation.FrameworkDescription;
-            _skipUrlEncode = framework.StartsWith(".NET ") &&
-                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
+            _skipUrlEncode = RuntimeInformation.FrameworkDescription.StartsWith(".NET ") &&
+                int.TryParse(RuntimeInformation.FrameworkDescription.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,9 +33,8 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
-            string framework = RuntimeInformation.FrameworkDescription;
-            _skipUrlEncode = framework.StartsWith(".NET ") &&
-                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
+            _skipUrlEncode = RuntimeInformation.FrameworkDescription.StartsWith(".NET ") &&
+                int.TryParse(RuntimeInformation.FrameworkDescription.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,9 +33,8 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
-            string framework = RuntimeInformation.FrameworkDescription;
-            _skipUrlEncode = framework.StartsWith(".NET ") &&
-                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
+            _skipUrlEncode = RuntimeInformation.FrameworkDescription.StartsWith(".NET ") &&
+                int.TryParse(RuntimeInformation.FrameworkDescription.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/unityWebRequest/net10/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/net10/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,9 +33,8 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
-            string framework = RuntimeInformation.FrameworkDescription;
-            _skipUrlEncode = framework.StartsWith(".NET ") &&
-                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
+            _skipUrlEncode = RuntimeInformation.FrameworkDescription.StartsWith(".NET ") &&
+                int.TryParse(RuntimeInformation.FrameworkDescription.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,9 +33,8 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
-            string framework = RuntimeInformation.FrameworkDescription;
-            _skipUrlEncode = framework.StartsWith(".NET ") &&
-                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
+            _skipUrlEncode = RuntimeInformation.FrameworkDescription.StartsWith(".NET ") &&
+                int.TryParse(RuntimeInformation.FrameworkDescription.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -33,9 +33,8 @@ namespace Org.OpenAPITools.Client
         {
             HashAlgorithm = HashAlgorithmName.SHA256;
             SigningAlgorithm = "PKCS1-v15";
-            string framework = RuntimeInformation.FrameworkDescription;
-            _skipUrlEncode = framework.StartsWith(".NET ") &&
-                int.TryParse(framework.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
+            _skipUrlEncode = RuntimeInformation.FrameworkDescription.StartsWith(".NET ") &&
+                int.TryParse(RuntimeInformation.FrameworkDescription.Substring(5).Split('.')[0], out int fwMajor) && fwMajor >= 9;
         }
 
         /// <summary>


### PR DESCRIPTION
a follow up pr to #23714

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inlined RuntimeInformation.FrameworkDescription in C# HttpSigningConfiguration to remove a temporary variable and keep the same behavior. Updated the template and regenerated C# samples.

- **Refactors**
  - Use RuntimeInformation.FrameworkDescription directly in the _skipUrlEncode check (removes the local "framework" variable).
  - Updated the C# mustache template and regenerated affected samples (httpclient, restsharp, unityWebRequest). No behavior change.

<sup>Written for commit 05395258692a1bb38bc0ff84c3d8cdb5990d4bfa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

