### PR TITLE
[python-fastapi] Check regex pattern on array items

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -1423,6 +1423,10 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
     @Override
     public void postProcessModelProperty(CodegenModel model, CodegenProperty property) {
         postProcessPattern(property.pattern, property.vendorExtensions);
+
+        if (property.isArray) {
+            postProcessPattern(property.items.pattern, property.items.vendorExtensions);
+        }
     }
 
     /*

--- a/modules/openapi-generator/src/main/resources/python-fastapi/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python-fastapi/model_generic.mustache
@@ -50,6 +50,36 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
             raise ValueError(r"must validate the regular expression {{{vendorExtensions.x-pattern}}}")
         return value
     {{/vendorExtensions.x-regex}}
+    {{#isArray}}
+    {{#items}}
+    {{#vendorExtensions.x-regex}}
+
+    @field_validator('{{{name}}}')
+    def {{{name}}}_items_validate_regular_expression(cls, value):
+        """Validates the regular expression"""
+        {{^required}}
+        if value is None:
+            return value
+        {{/required}}
+        {{#required}}
+        {{#isNullable}}
+        if value is None:
+            return value
+        {{/isNullable}}
+        {{/required}}
+
+        for item in value:
+        {{#isNullable}}
+            if item is None:
+                continue
+
+        {{/isNullable}}
+            if not re.match(r"{{{.}}}", item{{#vendorExtensions.x-modifiers}} ,re.{{{.}}}{{/vendorExtensions.x-modifiers}}):
+                raise ValueError(r"must validate the regular expression {{{vendorExtensions.x-pattern}}}")
+        return value
+    {{/vendorExtensions.x-regex}}
+    {{/items}}
+    {{/isArray}}
     {{#isEnum}}
 
     @field_validator('{{{name}}}')

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonFastapiCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonFastapiCodegenTest.java
@@ -71,4 +71,22 @@ public class PythonFastapiCodegenTest {
         TestUtils.assertFileContains(Paths.get(output + "/src/openapi_server/apis/default_api.py"),
                 "r\"^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$\"");
     }
+
+    @Test
+    public void testRegexPatternCheckedForArrayItems() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("python-fastapi")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"))
+                .setInputSpec("src/test/resources/3_1/issue_23102.yaml");
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        TestUtils.assertFileContains(Paths.get(output + "/src/openapi_server/models/test_object.py"),
+                "raise ValueError(r\"must validate the regular expression /^[A-Z0-9_\\- ]+$/\")");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_1/issue_23102.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/issue_23102.yaml
@@ -1,0 +1,26 @@
+openapi: 3.1.0
+info:
+  title: List items regex test
+  version: 0.0.1
+paths:
+  /test:
+    get:
+      responses:
+        "200":
+          description: test
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TestObject"
+components:
+  schemas:
+    TestObject:
+      properties:
+        tags:
+          items:
+            pattern: "/^[A-Z0-9_\\- ]+$/"
+            type:
+              oneOf:
+                - string
+                - type: "null"
+          type: array


### PR DESCRIPTION
When a model field is an array rather than a single value, no regex check is performed on the array's items even if the OpenAPI spec defines one. This adds a per-item check to a field if it is an array, based on the existing code used to validate single values. Given the provided test case, the result would look like this: 
```
@field_validator('tags')
def tags_items_validate_regular_expression(cls, value):
    """Validates the regular expression"""
    if value is None:
        return value

    for item in value:
        if item is None:
            continue

        if not re.match(r"^[A-Z0-9_\- ]+$", item):
            raise ValueError(r"must validate the regular expression /^[A-Z0-9_\- ]+$/")
    return value
```

Fixes #23102 

@cbornet @tomplus @krjakbrjak @fa0311 @multani


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-item regex validation for array fields in `python-fastapi` models so item patterns from the OpenAPI spec are enforced at runtime. Fixes #23102.

- **Bug Fixes**
  - Generate an item-wise `@field_validator` for array fields that applies the item regex (incl. nullable handling and regex modifiers).
  - Process item patterns in codegen by calling `postProcessPattern` on `property.items`.
  - Add test `testRegexPatternCheckedForArrayItems` using `3_1/issue_23102.yaml`.

<sup>Written for commit f75cf04ae7c1e368441291de9e795651afa8cb8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

