### PR TITLE
fix: [BUG][JAVA] vendorExtension.x-class-extra-annotation doesn't generate lists of annotations correctly

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -2079,24 +2079,12 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         }
         // make sure the x-implements is always a List and always at least empty
         for (ModelMap mo : objs.getModels()) {
-            CodegenModel cm = mo.getModel();
-            if (cm.getVendorExtensions().containsKey(X_IMPLEMENTS)) {
-                List<String> xImplements = getObjectAsStringList(cm.getVendorExtensions().get(X_IMPLEMENTS));
-                cm.getVendorExtensions().replace(X_IMPLEMENTS, xImplements);
-            } else {
-                cm.getVendorExtensions().put(X_IMPLEMENTS, new ArrayList<String>());
-            }
+            normalizeVendorExtensionWithStringList(mo.getModel(), X_IMPLEMENTS);
         }
 
         // make sure the x-class-extra-annotation is always a List and always at least empty
         for (ModelMap mo : objs.getModels()) {
-            CodegenModel cm = mo.getModel();
-            if (cm.getVendorExtensions().containsKey(VendorExtension.X_CLASS_EXTRA_ANNOTATION.getName())) {
-                List<String> xClassExtraAnnotation = getObjectAsStringList(cm.getVendorExtensions().get(VendorExtension.X_CLASS_EXTRA_ANNOTATION.getName()));
-                cm.getVendorExtensions().replace(VendorExtension.X_CLASS_EXTRA_ANNOTATION.getName(), xClassExtraAnnotation);
-            } else {
-                cm.getVendorExtensions().put(VendorExtension.X_CLASS_EXTRA_ANNOTATION.getName(), new ArrayList<String>());
-            }
+            normalizeVendorExtensionWithStringList(mo.getModel(), VendorExtension.X_CLASS_EXTRA_ANNOTATION.getName());
         }
 
         // skip interfaces predefined in open api spec in x-implements via additional property xImplementsSkip
@@ -2767,6 +2755,15 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                 .put("jSpecifyDatatype", jSpecifyDatatypeLambda)
                 .put("jSpecifyNullable", jSpecifyNullableLambda);
 
+    }
+
+    private void normalizeVendorExtensionWithStringList(CodegenModel cm , String name) {
+        if (cm.getVendorExtensions().containsKey(name)) {
+            List<String> annotations = getObjectAsStringList(cm.getVendorExtensions().get(name));
+            cm.getVendorExtensions().replace(name, annotations);
+        } else {
+            cm.getVendorExtensions().put(name, new ArrayList<String>());
+        }
     }
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -2088,18 +2088,15 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             }
         }
 
-        // normalize x-class-extra-annotation to always be a List<String> so that
-        // mustache templates can iterate over it for both single and multiple annotations.
-        // This also ensures allOf schemas with x-class-extra-annotation are handled correctly.
+        // make sure the x-class-extra-annotation is always a List and always at least empty
         for (ModelMap mo : objs.getModels()) {
             CodegenModel cm = mo.getModel();
-            Object annotation = cm.getVendorExtensions().get(VendorExtension.X_CLASS_EXTRA_ANNOTATION.getName());
-            if (annotation instanceof String) {
-                cm.getVendorExtensions().put(
-                        VendorExtension.X_CLASS_EXTRA_ANNOTATION.getName(),
-                        Collections.singletonList(annotation));
+            if (cm.getVendorExtensions().containsKey(VendorExtension.X_CLASS_EXTRA_ANNOTATION.getName())) {
+                List<String> xClassExtraAnnotation = getObjectAsStringList(cm.getVendorExtensions().get(VendorExtension.X_CLASS_EXTRA_ANNOTATION.getName()));
+                cm.getVendorExtensions().replace(VendorExtension.X_CLASS_EXTRA_ANNOTATION.getName(), xClassExtraAnnotation);
+            } else {
+                cm.getVendorExtensions().put(VendorExtension.X_CLASS_EXTRA_ANNOTATION.getName(), new ArrayList<String>());
             }
-            // if annotation is already a List (e.g. from a YAML sequence), leave it as-is
         }
 
         // skip interfaces predefined in open api spec in x-implements via additional property xImplementsSkip

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -2088,6 +2088,20 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             }
         }
 
+        // normalize x-class-extra-annotation to always be a List<String> so that
+        // mustache templates can iterate over it for both single and multiple annotations.
+        // This also ensures allOf schemas with x-class-extra-annotation are handled correctly.
+        for (ModelMap mo : objs.getModels()) {
+            CodegenModel cm = mo.getModel();
+            Object annotation = cm.getVendorExtensions().get(VendorExtension.X_CLASS_EXTRA_ANNOTATION.getName());
+            if (annotation instanceof String) {
+                cm.getVendorExtensions().put(
+                        VendorExtension.X_CLASS_EXTRA_ANNOTATION.getName(),
+                        Collections.singletonList(annotation));
+            }
+            // if annotation is already a List (e.g. from a YAML sequence), leave it as-is
+        }
+
         // skip interfaces predefined in open api spec in x-implements via additional property xImplementsSkip
         if (!this.xImplementsSkip.isEmpty()) {
             for (ModelMap mo : objs.getModels()) {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/pojo.mustache
@@ -22,7 +22,7 @@
 {{/jackson}}
 {{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.x-implements}}{
 {{#serializableModel}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pojo.mustache
@@ -25,7 +25,7 @@
 {{/jackson}}
 {{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.x-implements}}{
 {{#serializableModel}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pojo.mustache
@@ -25,7 +25,7 @@
 {{/jackson}}
 {{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.x-implements}}{
 {{#serializableModel}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/pojo.mustache
@@ -25,7 +25,7 @@
 {{/description}}
 {{>additionalModelTypeAnnotations}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
   {{#vars}}{{#isEnum}}{{^isContainer}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/pojo.mustache
@@ -28,7 +28,7 @@ import {{invokerPackage}}.ApiClient;
 {{/jackson}}
 {{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.x-implements}}{
 {{#serializableModel}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pojo.mustache
@@ -38,7 +38,7 @@ import {{invokerPackage}}.JSON;
 {{/swagger2AnnotationLibrary}}
 {{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.x-implements}}{
 {{#serializableModel}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/pojo.mustache
@@ -27,7 +27,7 @@
 {{/jackson}}
 {{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public {{>sealed}}class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.x-implements}}{{>permits}}{
 {{#serializableModel}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pojo.mustache
@@ -27,7 +27,7 @@
 {{/jackson}}
 {{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.x-implements}}{
 {{#serializableModel}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pojo.mustache
@@ -27,7 +27,7 @@
 {{/jackson}}
 {{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public {{>sealed}}class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.x-implements}}{{>permits}}{
 {{#serializableModel}}

--- a/modules/openapi-generator/src/main/resources/Java/oneof_interface.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/oneof_interface.mustache
@@ -1,6 +1,6 @@
 {{>additionalOneOfTypeAnnotations}}{{>generatedAnnotation}}{{>typeInfoAnnotation}}{{>xmlAnnotation}}
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public {{>sealed}}interface {{classname}} {{#vendorExtensions.x-implements}}{{#-first}}extends {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.x-implements}}{{>permits}}{
     {{#discriminator}}

--- a/modules/openapi-generator/src/main/resources/Java/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pojo.mustache
@@ -30,7 +30,7 @@
 {{/jackson}}
 {{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.x-implements}}{
 {{#serializableModel}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/pojo.mustache
@@ -7,7 +7,7 @@ import {{javaxPackage}}.xml.bind.annotation.*;
 
 {{#description}}@ApiModel(description = "{{{.}}}"){{/description}}{{>additionalModelTypeAnnotations}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
   {{#vars}}{{#isEnum}}{{^isContainer}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/pojo.mustache
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @ApiModel(description="{{{description}}}")
 {{/description}}{{>additionalModelTypeAnnotations}}
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
   {{#vars}}{{#isEnum}}{{^isContainer}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/pojo.mustache
@@ -32,7 +32,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 {{/description}}
 {{>additionalModelTypeAnnotations}}{{>xmlPojoAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
   {{#vars}}{{#isEnum}}{{^isContainer}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/libraries/jersey3/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/libraries/jersey3/pojo.mustache
@@ -11,7 +11,7 @@
 {{/jackson}}
 {{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
   {{#vars}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/pojo.mustache
@@ -11,7 +11,7 @@
 {{/jackson}}
 {{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
   {{#vars}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/pojo.mustache
@@ -2,7 +2,7 @@ import io.swagger.annotations.*;
 
 {{#description}}@ApiModel(description="{{{.}}}"){{/description}}{{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
 {{#serializableModel}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/pojo.mustache
@@ -2,7 +2,7 @@ import io.swagger.annotations.*;
 
 {{#description}}@ApiModel(description="{{{.}}}"){{/description}}{{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
 {{#serializableModel}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
@@ -51,7 +51,7 @@ import {{javaxPackage}}.xml.bind.annotation.XmlEnumValue;
 {{/jackson}}
 {{>generatedAnnotation}}{{>additionalModelTypeAnnotations}}{{>xmlPojoAnnotation}}
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
   {{#vars}}

--- a/modules/openapi-generator/src/main/resources/JavaPlayFramework/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaPlayFramework/pojo.mustache
@@ -9,7 +9,7 @@ import {{javaxPackage}}.validation.Valid;
 {{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}
 @SuppressWarnings({"UnusedReturnValue", "WeakerAccess"})
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
   {{#vars}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/oneof_interface.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/oneof_interface.mustache
@@ -13,7 +13,7 @@
     @JsonSubTypes.Type(value = {{classname}}.class){{^-last}}, {{/-last}}
     {{/interfaceModels}}
 })
-{{/useDeductionForOneOfInterfaces}}{{#vendorExtensions.x-class-extra-annotation}}{{{vendorExtensions.x-class-extra-annotation}}}
+{{/useDeductionForOneOfInterfaces}}{{#vendorExtensions.x-class-extra-annotation}}{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 {{/discriminator}}
 {{>generatedAnnotation}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
@@ -33,7 +33,7 @@
 {{>generatedAnnotation}}
 
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}{{^parent}}{{#hateoas}} extends RepresentationModel<{{classname}}> {{/hateoas}}{{/parent}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {{>permits}}{
 {{#serializableModel}}

--- a/modules/openapi-generator/src/main/resources/java-camel-server/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/java-camel-server/pojo.mustache
@@ -33,7 +33,7 @@
 {{>generatedAnnotation}}
 
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}{{^parent}}{{#hateoas}} extends RepresentationModel<{{classname}}> {{/hateoas}}{{/parent}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
 {{#serializableModel}}

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/pojo.mustache
@@ -23,7 +23,7 @@ import {{rootJavaEEPackage}}.json.bind.annotation.JsonbCreator;
 {{>additionalModelTypeAnnotations}}
 
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
   {{#vars}}{{#isEnum}}{{^isContainer}}

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/se/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/se/pojo.mustache
@@ -23,7 +23,7 @@ import {{rootJavaEEPackage}}.json.bind.annotation.JsonbCreator;
 {{>additionalModelTypeAnnotations}}
 
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
   {{#vars}}{{#isEnum}}{{^isContainer}}

--- a/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/mp/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/mp/pojo.mustache
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 {{>additionalModelTypeAnnotations}}
 
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
   {{#vars}}{{#isEnum}}{{^isContainer}}

--- a/modules/openapi-generator/src/main/resources/java-micronaut/common/model/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/common/model/pojo.mustache
@@ -27,7 +27,7 @@
 @Introspected
 {{/useBeanValidation}}
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}{{!
 Declare the class with extends and implements
 }}public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.x-implements}}{

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -4237,6 +4237,24 @@ public class JavaClientCodegenTest {
     }
 
     @Test
+    public void testAllOfClassWithSingleAnnotation() {
+        final Map<String, File> files = generateFromContract("src/test/resources/3_0/java/allOf-with-annotations.yaml", RESTCLIENT);
+        JavaFileAssert.assertThat(files.get("Cat.java"))
+                .isNormalClass()
+                .assertTypeAnnotations().containsWithName("SuppressWarnings");
+    }
+
+    @Test
+    public void testAllOfClassWithMultipleAnnotations() {
+        final Map<String, File> files = generateFromContract("src/test/resources/3_0/java/allOf-with-annotations.yaml", RESTCLIENT);
+        JavaFileAssert.assertThat(files.get("Dog.java"))
+                .isNormalClass()
+                .assertTypeAnnotations()
+                .containsWithName("SuppressWarnings")
+                .containsWithName("Deprecated");
+    }
+
+    @Test
     public void testOneOfClassWithAnnotation() {
         final Map<String, File> files = generateFromContract("src/test/resources/3_0/java/oneOf-with-annotations.yaml", RESTCLIENT);
         JavaFileAssert.assertThat(files.get("Fruit.java"))

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -6104,6 +6104,24 @@ public class SpringCodegenTest {
     }
 
     @Test
+    public void testAllOfClassWithSingleAnnotation() throws IOException {
+        final Map<String, File> files = generateFromContract("src/test/resources/3_0/java/allOf-with-annotations.yaml", SPRING_BOOT);
+        JavaFileAssert.assertThat(files.get("Cat.java"))
+                .isNormalClass()
+                .assertTypeAnnotations().containsWithName("SuppressWarnings");
+    }
+
+    @Test
+    public void testAllOfClassWithMultipleAnnotations() throws IOException {
+        final Map<String, File> files = generateFromContract("src/test/resources/3_0/java/allOf-with-annotations.yaml", SPRING_BOOT);
+        JavaFileAssert.assertThat(files.get("Dog.java"))
+                .isNormalClass()
+                .assertTypeAnnotations()
+                .containsWithName("SuppressWarnings")
+                .containsWithName("Deprecated");
+    }
+
+    @Test
     public void testApiVersion() throws IOException {
         final Map<String, File> files = generateFromContract("src/test/resources/3_0/spring/apiVersion.yaml", SPRING_BOOT,
                 Map.of(SpringCodegen.SPRING_API_VERSION, "v1",

--- a/modules/openapi-generator/src/test/resources/3_0/java/allOf-with-annotations.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/java/allOf-with-annotations.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.1
+info:
+  title: allOf Annotations Test
+  version: 0.0.1
+paths:
+  /:
+    get:
+      responses:
+        '200':
+          description: desc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dog'
+components:
+  schemas:
+    Animal:
+      type: object
+      properties:
+        name:
+          type: string
+    Dog:
+      x-class-extra-annotation:
+        - '@SuppressWarnings("unchecked")'
+        - '@Deprecated'
+      allOf:
+        - $ref: '#/components/schemas/Animal'
+      properties:
+        breed:
+          type: string
+    Cat:
+      x-class-extra-annotation: '@SuppressWarnings("unchecked")'
+      allOf:
+        - $ref: '#/components/schemas/Animal'
+      properties:
+        indoor:
+          type: boolean


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Fixes #23749 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
> @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Java/Spring codegen so `x-class-extra-annotation` accepts a single string or a YAML list and emits all annotations. Also defaults to an empty list when missing, and applies to `allOf` models and oneOf interfaces.

- **Bug Fixes**
  - Normalized `x-class-extra-annotation` to `List<String>` in `AbstractJavaCodegen` with an empty-list default.
  - Updated POJO and `oneof_interface` templates to loop and emit each annotation using `{{{.}}}`.
  - Added RESTClient and Spring Boot tests for single and multiple annotations on `allOf` models, plus `allOf-with-annotations.yaml`.

- **Refactors**
  - Extracted `normalizeVendorExtensionWithStringList` and reused it for `x-implements` and `x-class-extra-annotation` normalization.

<sup>Written for commit 9db08fc9f8e74bbc0136b348d2c954eb1eef18c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





