### PR TITLE
[kotlin][jvm-ktor] Fix query parameters typed as type:object (Map and model)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
@@ -1161,6 +1161,24 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
     public void postProcessParameter(CodegenParameter parameter) {
         super.postProcessParameter(parameter);
         adjustEnumRefDefault(parameter);
+        propagateParamBaseNameToVars(parameter);
+    }
+
+    /**
+     * For query parameters with `type: object, properties: ...`, expose the
+     * parameter's OAS baseName on each generated field via the
+     * `x-kotlin-param-base-name` vendor extension. Templates that iterate
+     * `vars` (e.g. jvm-ktor) need the outer baseName to build URL keys like
+     * `paramBaseName[fieldBaseName]` per the OAS deepObject style, and
+     * Mustache provides no access to the outer scope from inside `{{#vars}}`.
+     */
+    private void propagateParamBaseNameToVars(CodegenParameter param) {
+        if (!param.isQueryParam || !param.isModel || param.vars == null) {
+            return;
+        }
+        for (CodegenProperty v : param.vars) {
+            v.vendorExtensions.put("x-kotlin-param-base-name", param.baseName);
+        }
     }
 
     /**

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-ktor/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-ktor/api.mustache
@@ -132,7 +132,41 @@ import com.fasterxml.jackson.databind.ObjectMapper
 
             val localVariableQuery = mutableMapOf<String, List<String>>()
         {{#queryParams}}
+            {{#isModel}}
+            {{#isDeepObject}}
+            {{#vars}}
+            {{{paramName}}}?.{{{name}}}?.let { localVariableQuery["{{vendorExtensions.x-kotlin-param-base-name}}[{{baseName}}]"] = listOf("$it") }
+            {{/vars}}
+            {{/isDeepObject}}
+            {{^isDeepObject}}
+            {{#isExplode}}
+            {{#vars}}
+            {{{paramName}}}?.{{{name}}}?.let { localVariableQuery["{{baseName}}"] = listOf("$it") }
+            {{/vars}}
+            {{/isExplode}}
+            {{^isExplode}}
+            {{{paramName}}}?.let { _model -> listOfNotNull({{#vars}}_model.{{{name}}}?.let { "{{baseName}},$it" }{{^-last}}, {{/-last}}{{/vars}}).takeIf { it.isNotEmpty() }?.let { localVariableQuery["{{baseName}}"] = listOf(it.joinToString(",")) } }
+            {{/isExplode}}
+            {{/isDeepObject}}
+            {{/isModel}}
+            {{^isModel}}
+            {{#isMap}}
+            {{#isDeepObject}}
+            {{{paramName}}}?.forEach { (key, value) -> localVariableQuery["{{baseName}}[$key]"] = listOf("$value") }
+            {{/isDeepObject}}
+            {{^isDeepObject}}
+            {{#isExplode}}
+            {{{paramName}}}?.forEach { (key, value) -> localVariableQuery[key] = listOf("$value") }
+            {{/isExplode}}
+            {{^isExplode}}
+            {{{paramName}}}?.takeIf { it.isNotEmpty() }?.let { localVariableQuery["{{baseName}}"] = listOf(it.entries.joinToString(",") { (k, v) -> "$k,$v" }) }
+            {{/isExplode}}
+            {{/isDeepObject}}
+            {{/isMap}}
+            {{^isMap}}
             {{{paramName}}}?.apply { localVariableQuery["{{baseName}}"] = {{#isContainer}}toMultiValue(this, "{{collectionFormat}}"){{/isContainer}}{{^isContainer}}listOf("${{{paramName}}}"){{/isContainer}} }
+            {{/isMap}}
+            {{/isModel}}
         {{/queryParams}}
 
             val localVariableHeaders = mutableMapOf<String, String>()

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenApiTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenApiTest.java
@@ -190,6 +190,28 @@ public class KotlinClientCodegenApiTest {
         assertFileNotContains(queryApi.toPath(), "parseDateToQueryString(it)");
     }
 
+    @Test
+    public void testJvmKtorQueryParamWithTypeObject() throws IOException {
+        OpenAPI openAPI = readOpenAPI("3_0/kotlin/jvm-ktor-type-object-query.yaml");
+
+        KotlinClientCodegen codegen = createCodegen(ClientLibrary.JVM_KTOR);
+        DefaultGenerator generator = new DefaultGenerator();
+        enableOnlyApiGeneration(generator);
+
+        List<File> files = generator.opts(createClientOptInput(openAPI, codegen)).generate();
+        File defaultApi = files.stream().filter(file -> file.getName().equals("DefaultApi.kt")).findAny().orElseThrow();
+
+        assertFileContains(defaultApi.toPath(), "mapFormExplode?.forEach { (key, value) -> localVariableQuery[key]");
+        assertFileContains(defaultApi.toPath(), "mapFormNoexplode?.takeIf");
+        assertFileContains(defaultApi.toPath(), "localVariableQuery[\"map_deep[$key]\"]");
+
+        assertFileContains(defaultApi.toPath(), "modelFormExplode?.a?.let { localVariableQuery[\"a\"]");
+        assertFileContains(defaultApi.toPath(), "modelFormNoexplode?.let { _model -> listOfNotNull(_model.a?.let { \"a,$it\" }, _model.b?.let { \"b,$it\" })");
+        assertFileContains(defaultApi.toPath(), "localVariableQuery[\"model_deep[a]\"]");
+
+        assertFileNotContains(defaultApi.toPath(), "mapDeep?.apply {");
+    }
+
     private static void assertFileContainsLine(List<String> lines, String line) {
         Assert.assertListContains(lines, s -> s.equals(line), line);
     }

--- a/modules/openapi-generator/src/test/resources/3_0/kotlin/jvm-ktor-type-object-query.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/kotlin/jvm-ktor-type-object-query.yaml
@@ -1,0 +1,89 @@
+openapi: 3.0.3
+info:
+  title: jvm-ktor type:object query param coverage
+  version: 1.0.0
+paths:
+  /probe:
+    get:
+      operationId: probe
+      parameters:
+        - name: scalar_form
+          in: query
+          schema:
+            type: string
+        - name: array_form_explode
+          in: query
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+        - name: array_form_noexplode
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: map_form_explode
+          in: query
+          style: form
+          explode: true
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+        - name: map_form_noexplode
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+        - name: map_deep
+          in: query
+          style: deepObject
+          explode: true
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+        - name: model_form_explode
+          in: query
+          style: form
+          explode: true
+          schema:
+            type: object
+            properties:
+              a:
+                type: string
+              b:
+                type: integer
+        - name: model_form_noexplode
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: object
+            properties:
+              a:
+                type: string
+              b:
+                type: integer
+        - name: model_deep
+          in: query
+          style: deepObject
+          explode: true
+          schema:
+            type: object
+            properties:
+              a:
+                type: string
+              b:
+                type: integer
+      responses:
+        '200':
+          description: ok


### PR DESCRIPTION
Fixes #23762

### Summary

Reworks query parameter handling in the jvm-ktor template to correctly serialize `type: object` schemas, plus a small `KotlinClientCodegen` change so the template can build correct deepObject URLs for models.

Three branches in `kotlin-client/libraries/jvm-ktor/api.mustache`:
- `isModel`
  - deepObject → per-field, key = `paramBaseName[fieldBaseName]`
  - form+explode=true → per-field, key = `fieldBaseName`
  - form+explode=false → single entry, CSV of `field,value` pairs (non-null fields only) under `baseName`
- `isMap`
  - deepObject → `forEach` with `baseName[$key]`
  - form+explode=true → `forEach` with bare `$key`
  - form+explode=false → `joinToString(",")` of map entries under `baseName`
- default (scalar / array) — unchanged

### Behavior after the fix

| schema | style / explode | URL |
|---|---|---|
| Map (`additionalProperties:`) | `form` / `true` | `?k1=v1&k2=v2` |
| Map | `form` / `false` | `?param=k1,v1,k2,v2` |
| Map | `deepObject` | `?param[k1]=v1&param[k2]=v2` |
| Model (`properties:`) | `form` / `true` | `?field1=…&field2=…` |
| Model | `form` / `false` | `?param=field1,value1,field2,value2` |
| Model | `deepObject` | `?paramBaseName[field1]=…&paramBaseName[field2]=…` |

### Implementation notes

`KotlinClientCodegen` now exposes the outer parameter's OAS baseName on each generated field via the `x-kotlin-param-base-name` vendor extension. The jvm-ktor template uses it for the deepObject URL prefix on models, since Mustache provides no access to the outer scope from inside `{{#vars}}`.

### Note on parameter naming (snake_case vs camelCase)

For models with `style: deepObject`, the URL prefix is the OAS `baseName`, not the Kotlin identifier. Example: a parameter declared as

```yaml
- name: model_deep
  in: query
  style: deepObject
  schema:
    type: object
    properties:
      a:
        type: string
```

generates a Kotlin parameter named `modelDeep` (camelCase), but the URL key remains `?model_deep[a]=…` per OAS. This is the role of the new `x-kotlin-param-base-name` vendor extension: it propagates the parameter's `baseName` into the `vars` scope, which Mustache otherwise cannot reach.

For comparison, the existing `jvm-okhttp` template currently emits `?modelDeep[a]=…` (kotlin paramName) in the same scenario. This PR does not touch `jvm-okhttp` — scope is intentionally limited to `jvm-ktor`.

### Test plan

- [x] New unit test `KotlinClientCodegenApiTest#testJvmKtorQueryParamWithTypeObject` covering the 6 affected (schema × style/explode) combinations plus a regression assertion that the old broken `mapDeep?.apply {` shape is gone.
- [x] All 71 `KotlinClient*Test` cases pass.
- [x] `./bin/generate-samples.sh ./bin/configs/kotlin-jvm-ktor-{gson,jackson,kotlinx_serialization}.yaml` — **no existing sample changed**, the fix only activates new branches for previously broken cases.
- [x] Additional runtime sanity check on a private playground: generated client routed through Ktor `MockEngine` produces the URLs in the table above for all 6 cases.