### PR TITLE
Blubber pydantic aliases

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonPydanticV1Codegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonPydanticV1Codegen.java
@@ -908,7 +908,8 @@ public abstract class AbstractPythonPydanticV1Codegen extends DefaultCodegen imp
 
                 // field
                 if (cp.baseName != null && !cp.baseName.equals(cp.name)) { // base name not the same as name
-                    fields.add(String.format(Locale.ROOT, "alias=\"%s\"", cp.baseName));
+                    fields.add(String.format(Locale.ROOT, "validation_alias=\"%s\"", cp.baseName));
+                    fields.add(String.format(Locale.ROOT, "serialization_alias=\"%s\"", cp.baseName));
                 }
 
                 if (!StringUtils.isEmpty(cp.description)) { // has description

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/models/data_query.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/models/data_query.py
@@ -29,7 +29,7 @@ class DataQuery(Query):
     """
     suffix: Optional[StrictStr] = Field(default=None, description="test suffix")
     text: Optional[StrictStr] = Field(default=None, description="Some text containing white spaces")
-    var_date: Optional[datetime] = Field(default=None, alias="date", description="A date")
+    var_date: Optional[datetime] = Field(default=None, validation_alias="date", serialization_alias="date", description="A date")
     __properties = ["id", "outcomes", "suffix", "text", "date"]
 
     class Config:

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/models/pet.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/models/pet.py
@@ -31,7 +31,7 @@ class Pet(BaseModel):
     id: Optional[StrictInt] = None
     name: StrictStr = Field(...)
     category: Optional[Category] = None
-    photo_urls: conlist(StrictStr) = Field(default=..., alias="photoUrls")
+    photo_urls: conlist(StrictStr) = Field(default=..., validation_alias="photoUrls", serialization_alias="photoUrls")
     tags: Optional[conlist(Tag)] = None
     status: Optional[StrictStr] = Field(default=None, description="pet status in the store")
     __properties = ["id", "name", "category", "photoUrls", "tags", "status"]

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/all_of_super_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/all_of_super_model.py
@@ -25,7 +25,7 @@ class AllOfSuperModel(BaseModel):
     """
     AllOfSuperModel
     """
-    name: Optional[StrictStr] = Field(default=None, alias="_name")
+    name: Optional[StrictStr] = Field(default=None, validation_alias="_name", serialization_alias="_name")
     __properties = ["_name"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/all_of_with_single_ref.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/all_of_with_single_ref.py
@@ -27,7 +27,7 @@ class AllOfWithSingleRef(BaseModel):
     AllOfWithSingleRef
     """
     username: Optional[StrictStr] = None
-    single_ref_type: Optional[SingleRefType] = Field(default=None, alias="SingleRefType")
+    single_ref_type: Optional[SingleRefType] = Field(default=None, validation_alias="SingleRefType", serialization_alias="SingleRefType")
     __properties = ["username", "SingleRefType"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/animal.py
@@ -31,7 +31,7 @@ class Animal(BaseModel):
     """
     Animal
     """
-    class_name: StrictStr = Field(default=..., alias="className")
+    class_name: StrictStr = Field(default=..., validation_alias="className", serialization_alias="className")
     color: Optional[StrictStr] = 'red'
     __properties = ["className", "color"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/array_of_array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/array_of_array_of_number_only.py
@@ -25,7 +25,7 @@ class ArrayOfArrayOfNumberOnly(BaseModel):
     """
     ArrayOfArrayOfNumberOnly
     """
-    array_array_number: Optional[conlist(conlist(float))] = Field(default=None, alias="ArrayArrayNumber")
+    array_array_number: Optional[conlist(conlist(float))] = Field(default=None, validation_alias="ArrayArrayNumber", serialization_alias="ArrayArrayNumber")
     __properties = ["ArrayArrayNumber"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/array_of_number_only.py
@@ -25,7 +25,7 @@ class ArrayOfNumberOnly(BaseModel):
     """
     ArrayOfNumberOnly
     """
-    array_number: Optional[conlist(float)] = Field(default=None, alias="ArrayNumber")
+    array_number: Optional[conlist(float)] = Field(default=None, validation_alias="ArrayNumber", serialization_alias="ArrayNumber")
     __properties = ["ArrayNumber"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/base_discriminator.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/base_discriminator.py
@@ -31,7 +31,7 @@ class BaseDiscriminator(BaseModel):
     """
     BaseDiscriminator
     """
-    type_name: Optional[StrictStr] = Field(default=None, alias="_typeName")
+    type_name: Optional[StrictStr] = Field(default=None, validation_alias="_typeName", serialization_alias="_typeName")
     __properties = ["_typeName"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/basque_pig.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/basque_pig.py
@@ -25,7 +25,7 @@ class BasquePig(BaseModel):
     """
     BasquePig
     """
-    class_name: StrictStr = Field(default=..., alias="className")
+    class_name: StrictStr = Field(default=..., validation_alias="className", serialization_alias="className")
     color: StrictStr = Field(...)
     __properties = ["className", "color"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/capitalization.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/capitalization.py
@@ -25,12 +25,12 @@ class Capitalization(BaseModel):
     """
     Capitalization
     """
-    small_camel: Optional[StrictStr] = Field(default=None, alias="smallCamel")
-    capital_camel: Optional[StrictStr] = Field(default=None, alias="CapitalCamel")
-    small_snake: Optional[StrictStr] = Field(default=None, alias="small_Snake")
-    capital_snake: Optional[StrictStr] = Field(default=None, alias="Capital_Snake")
-    sca_eth_flow_points: Optional[StrictStr] = Field(default=None, alias="SCA_ETH_Flow_Points")
-    att_name: Optional[StrictStr] = Field(default=None, alias="ATT_NAME", description="Name of the pet ")
+    small_camel: Optional[StrictStr] = Field(default=None, validation_alias="smallCamel", serialization_alias="smallCamel")
+    capital_camel: Optional[StrictStr] = Field(default=None, validation_alias="CapitalCamel", serialization_alias="CapitalCamel")
+    small_snake: Optional[StrictStr] = Field(default=None, validation_alias="small_Snake", serialization_alias="small_Snake")
+    capital_snake: Optional[StrictStr] = Field(default=None, validation_alias="Capital_Snake", serialization_alias="Capital_Snake")
+    sca_eth_flow_points: Optional[StrictStr] = Field(default=None, validation_alias="SCA_ETH_Flow_Points", serialization_alias="SCA_ETH_Flow_Points")
+    att_name: Optional[StrictStr] = Field(default=None, validation_alias="ATT_NAME", serialization_alias="ATT_NAME", description="Name of the pet ")
     __properties = ["smallCamel", "CapitalCamel", "small_Snake", "Capital_Snake", "SCA_ETH_Flow_Points", "ATT_NAME"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/circular_all_of_ref.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/circular_all_of_ref.py
@@ -25,8 +25,8 @@ class CircularAllOfRef(BaseModel):
     """
     CircularAllOfRef
     """
-    name: Optional[StrictStr] = Field(default=None, alias="_name")
-    second_circular_all_of_ref: Optional[conlist(SecondCircularAllOfRef)] = Field(default=None, alias="secondCircularAllOfRef")
+    name: Optional[StrictStr] = Field(default=None, validation_alias="_name", serialization_alias="_name")
+    second_circular_all_of_ref: Optional[conlist(SecondCircularAllOfRef)] = Field(default=None, validation_alias="secondCircularAllOfRef", serialization_alias="secondCircularAllOfRef")
     __properties = ["_name", "secondCircularAllOfRef"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/class_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/class_model.py
@@ -25,7 +25,7 @@ class ClassModel(BaseModel):
     """
     Model for testing model with \"_class\" property  # noqa: E501
     """
-    var_class: Optional[StrictStr] = Field(default=None, alias="_class")
+    var_class: Optional[StrictStr] = Field(default=None, validation_alias="_class", serialization_alias="_class")
     __properties = ["_class"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/danish_pig.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/danish_pig.py
@@ -25,7 +25,7 @@ class DanishPig(BaseModel):
     """
     DanishPig
     """
-    class_name: StrictStr = Field(default=..., alias="className")
+    class_name: StrictStr = Field(default=..., validation_alias="className", serialization_alias="className")
     size: StrictInt = Field(...)
     __properties = ["className", "size"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/discriminator_all_of_super.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/discriminator_all_of_super.py
@@ -30,7 +30,7 @@ class DiscriminatorAllOfSuper(BaseModel):
     """
     DiscriminatorAllOfSuper
     """
-    element_type: StrictStr = Field(default=..., alias="elementType")
+    element_type: StrictStr = Field(default=..., validation_alias="elementType", serialization_alias="elementType")
     __properties = ["elementType"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/enum_test.py
@@ -38,12 +38,12 @@ class EnumTest(BaseModel):
     enum_number: Optional[float] = None
     enum_string_single_member: Optional[StrictStr] = None
     enum_integer_single_member: Optional[StrictInt] = None
-    outer_enum: Optional[OuterEnum] = Field(default=None, alias="outerEnum")
-    outer_enum_integer: Optional[OuterEnumInteger] = Field(default=None, alias="outerEnumInteger")
-    outer_enum_default_value: Optional[OuterEnumDefaultValue] = Field(default=None, alias="outerEnumDefaultValue")
-    outer_enum_integer_default_value: Optional[OuterEnumIntegerDefaultValue] = Field(default=None, alias="outerEnumIntegerDefaultValue")
-    enum_number_vendor_ext: Optional[EnumNumberVendorExt] = Field(default=None, alias="enumNumberVendorExt")
-    enum_string_vendor_ext: Optional[EnumStringVendorExt] = Field(default=None, alias="enumStringVendorExt")
+    outer_enum: Optional[OuterEnum] = Field(default=None, validation_alias="outerEnum", serialization_alias="outerEnum")
+    outer_enum_integer: Optional[OuterEnumInteger] = Field(default=None, validation_alias="outerEnumInteger", serialization_alias="outerEnumInteger")
+    outer_enum_default_value: Optional[OuterEnumDefaultValue] = Field(default=None, validation_alias="outerEnumDefaultValue", serialization_alias="outerEnumDefaultValue")
+    outer_enum_integer_default_value: Optional[OuterEnumIntegerDefaultValue] = Field(default=None, validation_alias="outerEnumIntegerDefaultValue", serialization_alias="outerEnumIntegerDefaultValue")
+    enum_number_vendor_ext: Optional[EnumNumberVendorExt] = Field(default=None, validation_alias="enumNumberVendorExt", serialization_alias="enumNumberVendorExt")
+    enum_string_vendor_ext: Optional[EnumStringVendorExt] = Field(default=None, validation_alias="enumStringVendorExt", serialization_alias="enumStringVendorExt")
     __properties = ["enum_string", "enum_string_required", "enum_integer_default", "enum_integer", "enum_number", "enum_string_single_member", "enum_integer_single_member", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue", "enumNumberVendorExt", "enumStringVendorExt"]
 
     @validator('enum_string')

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/file.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/file.py
@@ -25,7 +25,7 @@ class File(BaseModel):
     """
     Must be named `File` for test.  # noqa: E501
     """
-    source_uri: Optional[StrictStr] = Field(default=None, alias="sourceURI", description="Test capitalization")
+    source_uri: Optional[StrictStr] = Field(default=None, validation_alias="sourceURI", serialization_alias="sourceURI", description="Test capitalization")
     __properties = ["sourceURI"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/format_test.py
@@ -36,8 +36,8 @@ class FormatTest(BaseModel):
     string_with_double_quote_pattern: Optional[constr(strict=True)] = None
     byte: Optional[Union[StrictBytes, StrictStr]] = None
     binary: Optional[Union[StrictBytes, StrictStr]] = None
-    var_date: date = Field(default=..., alias="date")
-    date_time: Optional[datetime] = Field(default=None, alias="dateTime")
+    var_date: date = Field(default=..., validation_alias="date", serialization_alias="date")
+    date_time: Optional[datetime] = Field(default=None, validation_alias="dateTime", serialization_alias="dateTime")
     uuid: Optional[StrictStr] = None
     password: constr(strict=True, max_length=64, min_length=10) = Field(...)
     pattern_with_digits: Optional[constr(strict=True)] = Field(default=None, description="A string that is a 10 digit number. Can have leading zeros.")

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/health_check_result.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/health_check_result.py
@@ -25,7 +25,7 @@ class HealthCheckResult(BaseModel):
     """
     Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.  # noqa: E501
     """
-    nullable_message: Optional[StrictStr] = Field(default=None, alias="NullableMessage")
+    nullable_message: Optional[StrictStr] = Field(default=None, validation_alias="NullableMessage", serialization_alias="NullableMessage")
     __properties = ["NullableMessage"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/hunting_dog.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/hunting_dog.py
@@ -27,7 +27,7 @@ class HuntingDog(Creature):
     """
     HuntingDog
     """
-    is_trained: Optional[StrictBool] = Field(default=None, alias="isTrained")
+    is_trained: Optional[StrictBool] = Field(default=None, validation_alias="isTrained", serialization_alias="isTrained")
     __properties = ["info", "type", "isTrained"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/inner_dict_with_property.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/inner_dict_with_property.py
@@ -25,7 +25,7 @@ class InnerDictWithProperty(BaseModel):
     """
     InnerDictWithProperty
     """
-    a_property: Optional[Dict[str, Any]] = Field(default=None, alias="aProperty")
+    a_property: Optional[Dict[str, Any]] = Field(default=None, validation_alias="aProperty", serialization_alias="aProperty")
     __properties = ["aProperty"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/list_class.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/list_class.py
@@ -25,7 +25,7 @@ class ListClass(BaseModel):
     """
     ListClass
     """
-    var_123_list: Optional[StrictStr] = Field(default=None, alias="123-list")
+    var_123_list: Optional[StrictStr] = Field(default=None, validation_alias="123-list", serialization_alias="123-list")
     __properties = ["123-list"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/map_of_array_of_model.py
@@ -26,7 +26,7 @@ class MapOfArrayOfModel(BaseModel):
     """
     MapOfArrayOfModel
     """
-    shop_id_to_org_online_lip_map: Optional[Dict[str, conlist(Tag)]] = Field(default=None, alias="shopIdToOrgOnlineLipMap")
+    shop_id_to_org_online_lip_map: Optional[Dict[str, conlist(Tag)]] = Field(default=None, validation_alias="shopIdToOrgOnlineLipMap", serialization_alias="shopIdToOrgOnlineLipMap")
     __properties = ["shopIdToOrgOnlineLipMap"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -27,7 +27,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
     MixedPropertiesAndAdditionalPropertiesClass
     """
     uuid: Optional[StrictStr] = None
-    date_time: Optional[datetime] = Field(default=None, alias="dateTime")
+    date_time: Optional[datetime] = Field(default=None, validation_alias="dateTime", serialization_alias="dateTime")
     map: Optional[Dict[str, Animal]] = None
     __properties = ["uuid", "dateTime", "map"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/model200_response.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/model200_response.py
@@ -26,7 +26,7 @@ class Model200Response(BaseModel):
     Model for testing model name starting with number  # noqa: E501
     """
     name: Optional[StrictInt] = None
-    var_class: Optional[StrictStr] = Field(default=None, alias="class")
+    var_class: Optional[StrictStr] = Field(default=None, validation_alias="class", serialization_alias="class")
     __properties = ["name", "class"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/model_return.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/model_return.py
@@ -25,7 +25,7 @@ class ModelReturn(BaseModel):
     """
     Model for testing reserved words  # noqa: E501
     """
-    var_return: Optional[StrictInt] = Field(default=None, alias="return")
+    var_return: Optional[StrictInt] = Field(default=None, validation_alias="return", serialization_alias="return")
     __properties = ["return"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/name.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/name.py
@@ -27,8 +27,8 @@ class Name(BaseModel):
     """
     name: StrictInt = Field(...)
     snake_case: Optional[StrictInt] = None
-    var_property: Optional[StrictStr] = Field(default=None, alias="property")
-    var_123_number: Optional[StrictInt] = Field(default=None, alias="123Number")
+    var_property: Optional[StrictStr] = Field(default=None, validation_alias="property", serialization_alias="property")
+    var_123_number: Optional[StrictInt] = Field(default=None, validation_alias="123Number", serialization_alias="123Number")
     __properties = ["name", "snake_case", "property", "123Number"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/number_only.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/number_only.py
@@ -25,7 +25,7 @@ class NumberOnly(BaseModel):
     """
     NumberOnly
     """
-    just_number: Optional[float] = Field(default=None, alias="JustNumber")
+    just_number: Optional[float] = Field(default=None, validation_alias="JustNumber", serialization_alias="JustNumber")
     __properties = ["JustNumber"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/object_to_test_additional_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/object_to_test_additional_properties.py
@@ -25,7 +25,7 @@ class ObjectToTestAdditionalProperties(BaseModel):
     """
     Minimal object  # noqa: E501
     """
-    var_property: Optional[StrictBool] = Field(default=False, alias="property", description="Property")
+    var_property: Optional[StrictBool] = Field(default=False, validation_alias="property", serialization_alias="property", description="Property")
     __properties = ["property"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/object_with_deprecated_fields.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/object_with_deprecated_fields.py
@@ -28,7 +28,7 @@ class ObjectWithDeprecatedFields(BaseModel):
     """
     uuid: Optional[StrictStr] = None
     id: Optional[float] = None
-    deprecated_ref: Optional[DeprecatedObject] = Field(default=None, alias="deprecatedRef")
+    deprecated_ref: Optional[DeprecatedObject] = Field(default=None, validation_alias="deprecatedRef", serialization_alias="deprecatedRef")
     bars: Optional[conlist(StrictStr)] = None
     __properties = ["uuid", "id", "deprecatedRef", "bars"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/order.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/order.py
@@ -26,9 +26,9 @@ class Order(BaseModel):
     Order
     """
     id: Optional[StrictInt] = None
-    pet_id: Optional[StrictInt] = Field(default=None, alias="petId")
+    pet_id: Optional[StrictInt] = Field(default=None, validation_alias="petId", serialization_alias="petId")
     quantity: Optional[StrictInt] = None
-    ship_date: Optional[datetime] = Field(default=None, alias="shipDate")
+    ship_date: Optional[datetime] = Field(default=None, validation_alias="shipDate", serialization_alias="shipDate")
     status: Optional[StrictStr] = Field(default=None, description="Order Status")
     complete: Optional[StrictBool] = False
     __properties = ["id", "petId", "quantity", "shipDate", "status", "complete"]

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/parent.py
@@ -26,7 +26,7 @@ class Parent(BaseModel):
     """
     Parent
     """
-    optional_dict: Optional[Dict[str, InnerDictWithProperty]] = Field(default=None, alias="optionalDict")
+    optional_dict: Optional[Dict[str, InnerDictWithProperty]] = Field(default=None, validation_alias="optionalDict", serialization_alias="optionalDict")
     __properties = ["optionalDict"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/parent_with_optional_dict.py
@@ -26,7 +26,7 @@ class ParentWithOptionalDict(BaseModel):
     """
     ParentWithOptionalDict
     """
-    optional_dict: Optional[Dict[str, InnerDictWithProperty]] = Field(default=None, alias="optionalDict")
+    optional_dict: Optional[Dict[str, InnerDictWithProperty]] = Field(default=None, validation_alias="optionalDict", serialization_alias="optionalDict")
     __properties = ["optionalDict"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/pet.py
@@ -30,7 +30,7 @@ class Pet(BaseModel):
     id: Optional[StrictInt] = None
     category: Optional[Category] = None
     name: StrictStr = Field(...)
-    photo_urls: conlist(StrictStr, min_items=0, unique_items=True) = Field(default=..., alias="photoUrls")
+    photo_urls: conlist(StrictStr, min_items=0, unique_items=True) = Field(default=..., validation_alias="photoUrls", serialization_alias="photoUrls")
     tags: Optional[conlist(Tag)] = None
     status: Optional[StrictStr] = Field(default=None, description="pet status in the store")
     __properties = ["id", "category", "name", "photoUrls", "tags", "status"]

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/primitive_string.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/primitive_string.py
@@ -26,7 +26,7 @@ class PrimitiveString(BaseDiscriminator):
     """
     PrimitiveString
     """
-    value: Optional[StrictStr] = Field(default=None, alias="_value")
+    value: Optional[StrictStr] = Field(default=None, validation_alias="_value", serialization_alias="_value")
     __properties = ["_typeName", "_value"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/property_name_collision.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/property_name_collision.py
@@ -25,7 +25,7 @@ class PropertyNameCollision(BaseModel):
     """
     PropertyNameCollision
     """
-    type: Optional[StrictStr] = Field(default=None, alias="_type")
+    type: Optional[StrictStr] = Field(default=None, validation_alias="_type", serialization_alias="_type")
     type: Optional[StrictStr] = None
     type_: Optional[StrictStr] = None
     __properties = ["_type", "type", "type_"]

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/second_circular_all_of_ref.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/second_circular_all_of_ref.py
@@ -25,8 +25,8 @@ class SecondCircularAllOfRef(BaseModel):
     """
     SecondCircularAllOfRef
     """
-    name: Optional[StrictStr] = Field(default=None, alias="_name")
-    circular_all_of_ref: Optional[conlist(CircularAllOfRef)] = Field(default=None, alias="circularAllOfRef")
+    name: Optional[StrictStr] = Field(default=None, validation_alias="_name", serialization_alias="_name")
+    circular_all_of_ref: Optional[conlist(CircularAllOfRef)] = Field(default=None, validation_alias="circularAllOfRef", serialization_alias="circularAllOfRef")
     __properties = ["_name", "circularAllOfRef"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/special_model_name.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/special_model_name.py
@@ -25,7 +25,7 @@ class SpecialModelName(BaseModel):
     """
     SpecialModelName
     """
-    special_property_name: Optional[StrictInt] = Field(default=None, alias="$special[property.name]")
+    special_property_name: Optional[StrictInt] = Field(default=None, validation_alias="$special[property.name]", serialization_alias="$special[property.name]")
     __properties = ["$special[property.name]"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/special_name.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/special_name.py
@@ -26,9 +26,9 @@ class SpecialName(BaseModel):
     """
     SpecialName
     """
-    var_property: Optional[StrictInt] = Field(default=None, alias="property")
-    var_async: Optional[Category] = Field(default=None, alias="async")
-    var_schema: Optional[StrictStr] = Field(default=None, alias="schema", description="pet status in the store")
+    var_property: Optional[StrictInt] = Field(default=None, validation_alias="property", serialization_alias="property")
+    var_async: Optional[Category] = Field(default=None, validation_alias="async", serialization_alias="async")
+    var_schema: Optional[StrictStr] = Field(default=None, validation_alias="schema", serialization_alias="schema", description="pet status in the store")
     __properties = ["property", "async", "schema"]
 
     @validator('var_schema')

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/test_inline_freeform_additional_properties_request.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/test_inline_freeform_additional_properties_request.py
@@ -25,7 +25,7 @@ class TestInlineFreeformAdditionalPropertiesRequest(BaseModel):
     """
     TestInlineFreeformAdditionalPropertiesRequest
     """
-    some_property: Optional[StrictStr] = Field(default=None, alias="someProperty")
+    some_property: Optional[StrictStr] = Field(default=None, validation_alias="someProperty", serialization_alias="someProperty")
     additional_properties: Dict[str, Any] = {}
     __properties = ["someProperty"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -26,7 +26,7 @@ class UnnamedDictWithAdditionalModelListProperties(BaseModel):
     """
     UnnamedDictWithAdditionalModelListProperties
     """
-    dict_property: Optional[Dict[str, conlist(CreatureInfo)]] = Field(default=None, alias="dictProperty")
+    dict_property: Optional[Dict[str, conlist(CreatureInfo)]] = Field(default=None, validation_alias="dictProperty", serialization_alias="dictProperty")
     __properties = ["dictProperty"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
@@ -25,7 +25,7 @@ class UnnamedDictWithAdditionalStringListProperties(BaseModel):
     """
     UnnamedDictWithAdditionalStringListProperties
     """
-    dict_property: Optional[Dict[str, conlist(StrictStr)]] = Field(default=None, alias="dictProperty")
+    dict_property: Optional[Dict[str, conlist(StrictStr)]] = Field(default=None, validation_alias="dictProperty", serialization_alias="dictProperty")
     __properties = ["dictProperty"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/user.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/user.py
@@ -27,12 +27,12 @@ class User(BaseModel):
     """
     id: Optional[StrictInt] = None
     username: Optional[StrictStr] = None
-    first_name: Optional[StrictStr] = Field(default=None, alias="firstName")
-    last_name: Optional[StrictStr] = Field(default=None, alias="lastName")
+    first_name: Optional[StrictStr] = Field(default=None, validation_alias="firstName", serialization_alias="firstName")
+    last_name: Optional[StrictStr] = Field(default=None, validation_alias="lastName", serialization_alias="lastName")
     email: Optional[StrictStr] = None
     password: Optional[StrictStr] = None
     phone: Optional[StrictStr] = None
-    user_status: Optional[StrictInt] = Field(default=None, alias="userStatus", description="User Status")
+    user_status: Optional[StrictInt] = Field(default=None, validation_alias="userStatus", serialization_alias="userStatus", description="User Status")
     __properties = ["id", "username", "firstName", "lastName", "email", "password", "phone", "userStatus"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/all_of_super_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/all_of_super_model.py
@@ -25,7 +25,7 @@ class AllOfSuperModel(BaseModel):
     """
     AllOfSuperModel
     """
-    name: Optional[StrictStr] = Field(default=None, alias="_name")
+    name: Optional[StrictStr] = Field(default=None, validation_alias="_name", serialization_alias="_name")
     additional_properties: Dict[str, Any] = {}
     __properties = ["_name"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/all_of_with_single_ref.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/all_of_with_single_ref.py
@@ -27,7 +27,7 @@ class AllOfWithSingleRef(BaseModel):
     AllOfWithSingleRef
     """
     username: Optional[StrictStr] = None
-    single_ref_type: Optional[SingleRefType] = Field(default=None, alias="SingleRefType")
+    single_ref_type: Optional[SingleRefType] = Field(default=None, validation_alias="SingleRefType", serialization_alias="SingleRefType")
     additional_properties: Dict[str, Any] = {}
     __properties = ["username", "SingleRefType"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/animal.py
@@ -31,7 +31,7 @@ class Animal(BaseModel):
     """
     Animal
     """
-    class_name: StrictStr = Field(default=..., alias="className")
+    class_name: StrictStr = Field(default=..., validation_alias="className", serialization_alias="className")
     color: Optional[StrictStr] = 'red'
     additional_properties: Dict[str, Any] = {}
     __properties = ["className", "color"]

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/array_of_array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/array_of_array_of_number_only.py
@@ -25,7 +25,7 @@ class ArrayOfArrayOfNumberOnly(BaseModel):
     """
     ArrayOfArrayOfNumberOnly
     """
-    array_array_number: Optional[conlist(conlist(StrictFloat))] = Field(default=None, alias="ArrayArrayNumber")
+    array_array_number: Optional[conlist(conlist(StrictFloat))] = Field(default=None, validation_alias="ArrayArrayNumber", serialization_alias="ArrayArrayNumber")
     additional_properties: Dict[str, Any] = {}
     __properties = ["ArrayArrayNumber"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/array_of_number_only.py
@@ -25,7 +25,7 @@ class ArrayOfNumberOnly(BaseModel):
     """
     ArrayOfNumberOnly
     """
-    array_number: Optional[conlist(StrictFloat)] = Field(default=None, alias="ArrayNumber")
+    array_number: Optional[conlist(StrictFloat)] = Field(default=None, validation_alias="ArrayNumber", serialization_alias="ArrayNumber")
     additional_properties: Dict[str, Any] = {}
     __properties = ["ArrayNumber"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/base_discriminator.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/base_discriminator.py
@@ -31,7 +31,7 @@ class BaseDiscriminator(BaseModel):
     """
     BaseDiscriminator
     """
-    type_name: Optional[StrictStr] = Field(default=None, alias="_typeName")
+    type_name: Optional[StrictStr] = Field(default=None, validation_alias="_typeName", serialization_alias="_typeName")
     additional_properties: Dict[str, Any] = {}
     __properties = ["_typeName"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/basque_pig.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/basque_pig.py
@@ -25,7 +25,7 @@ class BasquePig(BaseModel):
     """
     BasquePig
     """
-    class_name: StrictStr = Field(default=..., alias="className")
+    class_name: StrictStr = Field(default=..., validation_alias="className", serialization_alias="className")
     color: StrictStr = Field(...)
     additional_properties: Dict[str, Any] = {}
     __properties = ["className", "color"]

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/capitalization.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/capitalization.py
@@ -25,12 +25,12 @@ class Capitalization(BaseModel):
     """
     Capitalization
     """
-    small_camel: Optional[StrictStr] = Field(default=None, alias="smallCamel")
-    capital_camel: Optional[StrictStr] = Field(default=None, alias="CapitalCamel")
-    small_snake: Optional[StrictStr] = Field(default=None, alias="small_Snake")
-    capital_snake: Optional[StrictStr] = Field(default=None, alias="Capital_Snake")
-    sca_eth_flow_points: Optional[StrictStr] = Field(default=None, alias="SCA_ETH_Flow_Points")
-    att_name: Optional[StrictStr] = Field(default=None, alias="ATT_NAME", description="Name of the pet ")
+    small_camel: Optional[StrictStr] = Field(default=None, validation_alias="smallCamel", serialization_alias="smallCamel")
+    capital_camel: Optional[StrictStr] = Field(default=None, validation_alias="CapitalCamel", serialization_alias="CapitalCamel")
+    small_snake: Optional[StrictStr] = Field(default=None, validation_alias="small_Snake", serialization_alias="small_Snake")
+    capital_snake: Optional[StrictStr] = Field(default=None, validation_alias="Capital_Snake", serialization_alias="Capital_Snake")
+    sca_eth_flow_points: Optional[StrictStr] = Field(default=None, validation_alias="SCA_ETH_Flow_Points", serialization_alias="SCA_ETH_Flow_Points")
+    att_name: Optional[StrictStr] = Field(default=None, validation_alias="ATT_NAME", serialization_alias="ATT_NAME", description="Name of the pet ")
     additional_properties: Dict[str, Any] = {}
     __properties = ["smallCamel", "CapitalCamel", "small_Snake", "Capital_Snake", "SCA_ETH_Flow_Points", "ATT_NAME"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/circular_all_of_ref.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/circular_all_of_ref.py
@@ -25,8 +25,8 @@ class CircularAllOfRef(BaseModel):
     """
     CircularAllOfRef
     """
-    name: Optional[StrictStr] = Field(default=None, alias="_name")
-    second_circular_all_of_ref: Optional[conlist(SecondCircularAllOfRef)] = Field(default=None, alias="secondCircularAllOfRef")
+    name: Optional[StrictStr] = Field(default=None, validation_alias="_name", serialization_alias="_name")
+    second_circular_all_of_ref: Optional[conlist(SecondCircularAllOfRef)] = Field(default=None, validation_alias="secondCircularAllOfRef", serialization_alias="secondCircularAllOfRef")
     additional_properties: Dict[str, Any] = {}
     __properties = ["_name", "secondCircularAllOfRef"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/class_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/class_model.py
@@ -25,7 +25,7 @@ class ClassModel(BaseModel):
     """
     Model for testing model with \"_class\" property  # noqa: E501
     """
-    var_class: Optional[StrictStr] = Field(default=None, alias="_class")
+    var_class: Optional[StrictStr] = Field(default=None, validation_alias="_class", serialization_alias="_class")
     additional_properties: Dict[str, Any] = {}
     __properties = ["_class"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/danish_pig.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/danish_pig.py
@@ -25,7 +25,7 @@ class DanishPig(BaseModel):
     """
     DanishPig
     """
-    class_name: StrictStr = Field(default=..., alias="className")
+    class_name: StrictStr = Field(default=..., validation_alias="className", serialization_alias="className")
     size: StrictInt = Field(...)
     additional_properties: Dict[str, Any] = {}
     __properties = ["className", "size"]

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/discriminator_all_of_super.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/discriminator_all_of_super.py
@@ -30,7 +30,7 @@ class DiscriminatorAllOfSuper(BaseModel):
     """
     DiscriminatorAllOfSuper
     """
-    element_type: StrictStr = Field(default=..., alias="elementType")
+    element_type: StrictStr = Field(default=..., validation_alias="elementType", serialization_alias="elementType")
     additional_properties: Dict[str, Any] = {}
     __properties = ["elementType"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/enum_test.py
@@ -38,12 +38,12 @@ class EnumTest(BaseModel):
     enum_number: Optional[StrictFloat] = None
     enum_string_single_member: Optional[StrictStr] = None
     enum_integer_single_member: Optional[StrictInt] = None
-    outer_enum: Optional[OuterEnum] = Field(default=None, alias="outerEnum")
-    outer_enum_integer: Optional[OuterEnumInteger] = Field(default=None, alias="outerEnumInteger")
-    outer_enum_default_value: Optional[OuterEnumDefaultValue] = Field(default=None, alias="outerEnumDefaultValue")
-    outer_enum_integer_default_value: Optional[OuterEnumIntegerDefaultValue] = Field(default=None, alias="outerEnumIntegerDefaultValue")
-    enum_number_vendor_ext: Optional[EnumNumberVendorExt] = Field(default=None, alias="enumNumberVendorExt")
-    enum_string_vendor_ext: Optional[EnumStringVendorExt] = Field(default=None, alias="enumStringVendorExt")
+    outer_enum: Optional[OuterEnum] = Field(default=None, validation_alias="outerEnum", serialization_alias="outerEnum")
+    outer_enum_integer: Optional[OuterEnumInteger] = Field(default=None, validation_alias="outerEnumInteger", serialization_alias="outerEnumInteger")
+    outer_enum_default_value: Optional[OuterEnumDefaultValue] = Field(default=None, validation_alias="outerEnumDefaultValue", serialization_alias="outerEnumDefaultValue")
+    outer_enum_integer_default_value: Optional[OuterEnumIntegerDefaultValue] = Field(default=None, validation_alias="outerEnumIntegerDefaultValue", serialization_alias="outerEnumIntegerDefaultValue")
+    enum_number_vendor_ext: Optional[EnumNumberVendorExt] = Field(default=None, validation_alias="enumNumberVendorExt", serialization_alias="enumNumberVendorExt")
+    enum_string_vendor_ext: Optional[EnumStringVendorExt] = Field(default=None, validation_alias="enumStringVendorExt", serialization_alias="enumStringVendorExt")
     additional_properties: Dict[str, Any] = {}
     __properties = ["enum_string", "enum_string_required", "enum_integer_default", "enum_integer", "enum_number", "enum_string_single_member", "enum_integer_single_member", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue", "enumNumberVendorExt", "enumStringVendorExt"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/file.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/file.py
@@ -25,7 +25,7 @@ class File(BaseModel):
     """
     Must be named `File` for test.  # noqa: E501
     """
-    source_uri: Optional[StrictStr] = Field(default=None, alias="sourceURI", description="Test capitalization")
+    source_uri: Optional[StrictStr] = Field(default=None, validation_alias="sourceURI", serialization_alias="sourceURI", description="Test capitalization")
     additional_properties: Dict[str, Any] = {}
     __properties = ["sourceURI"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/format_test.py
@@ -36,8 +36,8 @@ class FormatTest(BaseModel):
     string_with_double_quote_pattern: Optional[constr(strict=True)] = None
     byte: Optional[Union[StrictBytes, StrictStr]] = None
     binary: Optional[Union[StrictBytes, StrictStr]] = None
-    var_date: date = Field(default=..., alias="date")
-    date_time: Optional[datetime] = Field(default=None, alias="dateTime")
+    var_date: date = Field(default=..., validation_alias="date", serialization_alias="date")
+    date_time: Optional[datetime] = Field(default=None, validation_alias="dateTime", serialization_alias="dateTime")
     uuid: Optional[StrictStr] = None
     password: constr(strict=True, max_length=64, min_length=10) = Field(...)
     pattern_with_digits: Optional[constr(strict=True)] = Field(default=None, description="A string that is a 10 digit number. Can have leading zeros.")

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/health_check_result.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/health_check_result.py
@@ -25,7 +25,7 @@ class HealthCheckResult(BaseModel):
     """
     Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.  # noqa: E501
     """
-    nullable_message: Optional[StrictStr] = Field(default=None, alias="NullableMessage")
+    nullable_message: Optional[StrictStr] = Field(default=None, validation_alias="NullableMessage", serialization_alias="NullableMessage")
     additional_properties: Dict[str, Any] = {}
     __properties = ["NullableMessage"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/hunting_dog.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/hunting_dog.py
@@ -27,7 +27,7 @@ class HuntingDog(Creature):
     """
     HuntingDog
     """
-    is_trained: Optional[StrictBool] = Field(default=None, alias="isTrained")
+    is_trained: Optional[StrictBool] = Field(default=None, validation_alias="isTrained", serialization_alias="isTrained")
     additional_properties: Dict[str, Any] = {}
     __properties = ["info", "type", "isTrained"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/inner_dict_with_property.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/inner_dict_with_property.py
@@ -25,7 +25,7 @@ class InnerDictWithProperty(BaseModel):
     """
     InnerDictWithProperty
     """
-    a_property: Optional[Dict[str, Any]] = Field(default=None, alias="aProperty")
+    a_property: Optional[Dict[str, Any]] = Field(default=None, validation_alias="aProperty", serialization_alias="aProperty")
     additional_properties: Dict[str, Any] = {}
     __properties = ["aProperty"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/list_class.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/list_class.py
@@ -25,7 +25,7 @@ class ListClass(BaseModel):
     """
     ListClass
     """
-    var_123_list: Optional[StrictStr] = Field(default=None, alias="123-list")
+    var_123_list: Optional[StrictStr] = Field(default=None, validation_alias="123-list", serialization_alias="123-list")
     additional_properties: Dict[str, Any] = {}
     __properties = ["123-list"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/map_of_array_of_model.py
@@ -26,7 +26,7 @@ class MapOfArrayOfModel(BaseModel):
     """
     MapOfArrayOfModel
     """
-    shop_id_to_org_online_lip_map: Optional[Dict[str, conlist(Tag)]] = Field(default=None, alias="shopIdToOrgOnlineLipMap")
+    shop_id_to_org_online_lip_map: Optional[Dict[str, conlist(Tag)]] = Field(default=None, validation_alias="shopIdToOrgOnlineLipMap", serialization_alias="shopIdToOrgOnlineLipMap")
     additional_properties: Dict[str, Any] = {}
     __properties = ["shopIdToOrgOnlineLipMap"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -27,7 +27,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
     MixedPropertiesAndAdditionalPropertiesClass
     """
     uuid: Optional[StrictStr] = None
-    date_time: Optional[datetime] = Field(default=None, alias="dateTime")
+    date_time: Optional[datetime] = Field(default=None, validation_alias="dateTime", serialization_alias="dateTime")
     map: Optional[Dict[str, Animal]] = None
     additional_properties: Dict[str, Any] = {}
     __properties = ["uuid", "dateTime", "map"]

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/model200_response.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/model200_response.py
@@ -26,7 +26,7 @@ class Model200Response(BaseModel):
     Model for testing model name starting with number  # noqa: E501
     """
     name: Optional[StrictInt] = None
-    var_class: Optional[StrictStr] = Field(default=None, alias="class")
+    var_class: Optional[StrictStr] = Field(default=None, validation_alias="class", serialization_alias="class")
     additional_properties: Dict[str, Any] = {}
     __properties = ["name", "class"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/model_return.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/model_return.py
@@ -25,7 +25,7 @@ class ModelReturn(BaseModel):
     """
     Model for testing reserved words  # noqa: E501
     """
-    var_return: Optional[StrictInt] = Field(default=None, alias="return")
+    var_return: Optional[StrictInt] = Field(default=None, validation_alias="return", serialization_alias="return")
     additional_properties: Dict[str, Any] = {}
     __properties = ["return"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/name.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/name.py
@@ -27,8 +27,8 @@ class Name(BaseModel):
     """
     name: StrictInt = Field(...)
     snake_case: Optional[StrictInt] = None
-    var_property: Optional[StrictStr] = Field(default=None, alias="property")
-    var_123_number: Optional[StrictInt] = Field(default=None, alias="123Number")
+    var_property: Optional[StrictStr] = Field(default=None, validation_alias="property", serialization_alias="property")
+    var_123_number: Optional[StrictInt] = Field(default=None, validation_alias="123Number", serialization_alias="123Number")
     additional_properties: Dict[str, Any] = {}
     __properties = ["name", "snake_case", "property", "123Number"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/number_only.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/number_only.py
@@ -25,7 +25,7 @@ class NumberOnly(BaseModel):
     """
     NumberOnly
     """
-    just_number: Optional[StrictFloat] = Field(default=None, alias="JustNumber")
+    just_number: Optional[StrictFloat] = Field(default=None, validation_alias="JustNumber", serialization_alias="JustNumber")
     additional_properties: Dict[str, Any] = {}
     __properties = ["JustNumber"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/object_to_test_additional_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/object_to_test_additional_properties.py
@@ -25,7 +25,7 @@ class ObjectToTestAdditionalProperties(BaseModel):
     """
     Minimal object  # noqa: E501
     """
-    var_property: Optional[StrictBool] = Field(default=False, alias="property", description="Property")
+    var_property: Optional[StrictBool] = Field(default=False, validation_alias="property", serialization_alias="property", description="Property")
     additional_properties: Dict[str, Any] = {}
     __properties = ["property"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/object_with_deprecated_fields.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/object_with_deprecated_fields.py
@@ -28,7 +28,7 @@ class ObjectWithDeprecatedFields(BaseModel):
     """
     uuid: Optional[StrictStr] = None
     id: Optional[StrictFloat] = None
-    deprecated_ref: Optional[DeprecatedObject] = Field(default=None, alias="deprecatedRef")
+    deprecated_ref: Optional[DeprecatedObject] = Field(default=None, validation_alias="deprecatedRef", serialization_alias="deprecatedRef")
     bars: Optional[conlist(StrictStr)] = None
     additional_properties: Dict[str, Any] = {}
     __properties = ["uuid", "id", "deprecatedRef", "bars"]

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/order.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/order.py
@@ -26,9 +26,9 @@ class Order(BaseModel):
     Order
     """
     id: Optional[StrictInt] = None
-    pet_id: Optional[StrictInt] = Field(default=None, alias="petId")
+    pet_id: Optional[StrictInt] = Field(default=None, validation_alias="petId", serialization_alias="petId")
     quantity: Optional[StrictInt] = None
-    ship_date: Optional[datetime] = Field(default=None, alias="shipDate")
+    ship_date: Optional[datetime] = Field(default=None, validation_alias="shipDate", serialization_alias="shipDate")
     status: Optional[StrictStr] = Field(default=None, description="Order Status")
     complete: Optional[StrictBool] = False
     additional_properties: Dict[str, Any] = {}

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/parent.py
@@ -26,7 +26,7 @@ class Parent(BaseModel):
     """
     Parent
     """
-    optional_dict: Optional[Dict[str, InnerDictWithProperty]] = Field(default=None, alias="optionalDict")
+    optional_dict: Optional[Dict[str, InnerDictWithProperty]] = Field(default=None, validation_alias="optionalDict", serialization_alias="optionalDict")
     additional_properties: Dict[str, Any] = {}
     __properties = ["optionalDict"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/parent_with_optional_dict.py
@@ -26,7 +26,7 @@ class ParentWithOptionalDict(BaseModel):
     """
     ParentWithOptionalDict
     """
-    optional_dict: Optional[Dict[str, InnerDictWithProperty]] = Field(default=None, alias="optionalDict")
+    optional_dict: Optional[Dict[str, InnerDictWithProperty]] = Field(default=None, validation_alias="optionalDict", serialization_alias="optionalDict")
     additional_properties: Dict[str, Any] = {}
     __properties = ["optionalDict"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/pet.py
@@ -30,7 +30,7 @@ class Pet(BaseModel):
     id: Optional[StrictInt] = None
     category: Optional[Category] = None
     name: StrictStr = Field(...)
-    photo_urls: conlist(StrictStr, min_items=0, unique_items=True) = Field(default=..., alias="photoUrls")
+    photo_urls: conlist(StrictStr, min_items=0, unique_items=True) = Field(default=..., validation_alias="photoUrls", serialization_alias="photoUrls")
     tags: Optional[conlist(Tag)] = None
     status: Optional[StrictStr] = Field(default=None, description="pet status in the store")
     additional_properties: Dict[str, Any] = {}

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/primitive_string.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/primitive_string.py
@@ -26,7 +26,7 @@ class PrimitiveString(BaseDiscriminator):
     """
     PrimitiveString
     """
-    value: Optional[StrictStr] = Field(default=None, alias="_value")
+    value: Optional[StrictStr] = Field(default=None, validation_alias="_value", serialization_alias="_value")
     additional_properties: Dict[str, Any] = {}
     __properties = ["_typeName", "_value"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/property_name_collision.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/property_name_collision.py
@@ -25,9 +25,9 @@ class PropertyNameCollision(BaseModel):
     """
     PropertyNameCollision
     """
-    underscore_type: Optional[StrictStr] = Field(default=None, alias="_type")
+    underscore_type: Optional[StrictStr] = Field(default=None, validation_alias="_type", serialization_alias="_type")
     type: Optional[StrictStr] = None
-    type_with_underscore: Optional[StrictStr] = Field(default=None, alias="type_")
+    type_with_underscore: Optional[StrictStr] = Field(default=None, validation_alias="type_", serialization_alias="type_")
     additional_properties: Dict[str, Any] = {}
     __properties = ["_type", "type", "type_"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/second_circular_all_of_ref.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/second_circular_all_of_ref.py
@@ -25,8 +25,8 @@ class SecondCircularAllOfRef(BaseModel):
     """
     SecondCircularAllOfRef
     """
-    name: Optional[StrictStr] = Field(default=None, alias="_name")
-    circular_all_of_ref: Optional[conlist(CircularAllOfRef)] = Field(default=None, alias="circularAllOfRef")
+    name: Optional[StrictStr] = Field(default=None, validation_alias="_name", serialization_alias="_name")
+    circular_all_of_ref: Optional[conlist(CircularAllOfRef)] = Field(default=None, validation_alias="circularAllOfRef", serialization_alias="circularAllOfRef")
     additional_properties: Dict[str, Any] = {}
     __properties = ["_name", "circularAllOfRef"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/special_model_name.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/special_model_name.py
@@ -25,7 +25,7 @@ class SpecialModelName(BaseModel):
     """
     SpecialModelName
     """
-    special_property_name: Optional[StrictInt] = Field(default=None, alias="$special[property.name]")
+    special_property_name: Optional[StrictInt] = Field(default=None, validation_alias="$special[property.name]", serialization_alias="$special[property.name]")
     additional_properties: Dict[str, Any] = {}
     __properties = ["$special[property.name]"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/special_name.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/special_name.py
@@ -26,9 +26,9 @@ class SpecialName(BaseModel):
     """
     SpecialName
     """
-    var_property: Optional[StrictInt] = Field(default=None, alias="property")
-    var_async: Optional[Category] = Field(default=None, alias="async")
-    var_schema: Optional[StrictStr] = Field(default=None, alias="schema", description="pet status in the store")
+    var_property: Optional[StrictInt] = Field(default=None, validation_alias="property", serialization_alias="property")
+    var_async: Optional[Category] = Field(default=None, validation_alias="async", serialization_alias="async")
+    var_schema: Optional[StrictStr] = Field(default=None, validation_alias="schema", serialization_alias="schema", description="pet status in the store")
     additional_properties: Dict[str, Any] = {}
     __properties = ["property", "async", "schema"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/test_inline_freeform_additional_properties_request.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/test_inline_freeform_additional_properties_request.py
@@ -25,7 +25,7 @@ class TestInlineFreeformAdditionalPropertiesRequest(BaseModel):
     """
     TestInlineFreeformAdditionalPropertiesRequest
     """
-    some_property: Optional[StrictStr] = Field(default=None, alias="someProperty")
+    some_property: Optional[StrictStr] = Field(default=None, validation_alias="someProperty", serialization_alias="someProperty")
     additional_properties: Dict[str, Any] = {}
     __properties = ["someProperty"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -26,7 +26,7 @@ class UnnamedDictWithAdditionalModelListProperties(BaseModel):
     """
     UnnamedDictWithAdditionalModelListProperties
     """
-    dict_property: Optional[Dict[str, conlist(CreatureInfo)]] = Field(default=None, alias="dictProperty")
+    dict_property: Optional[Dict[str, conlist(CreatureInfo)]] = Field(default=None, validation_alias="dictProperty", serialization_alias="dictProperty")
     additional_properties: Dict[str, Any] = {}
     __properties = ["dictProperty"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
@@ -25,7 +25,7 @@ class UnnamedDictWithAdditionalStringListProperties(BaseModel):
     """
     UnnamedDictWithAdditionalStringListProperties
     """
-    dict_property: Optional[Dict[str, conlist(StrictStr)]] = Field(default=None, alias="dictProperty")
+    dict_property: Optional[Dict[str, conlist(StrictStr)]] = Field(default=None, validation_alias="dictProperty", serialization_alias="dictProperty")
     additional_properties: Dict[str, Any] = {}
     __properties = ["dictProperty"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/user.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/user.py
@@ -27,12 +27,12 @@ class User(BaseModel):
     """
     id: Optional[StrictInt] = None
     username: Optional[StrictStr] = None
-    first_name: Optional[StrictStr] = Field(default=None, alias="firstName")
-    last_name: Optional[StrictStr] = Field(default=None, alias="lastName")
+    first_name: Optional[StrictStr] = Field(default=None, validation_alias="firstName", serialization_alias="firstName")
+    last_name: Optional[StrictStr] = Field(default=None, validation_alias="lastName", serialization_alias="lastName")
     email: Optional[StrictStr] = None
     password: Optional[StrictStr] = None
     phone: Optional[StrictStr] = None
-    user_status: Optional[StrictInt] = Field(default=None, alias="userStatus", description="User Status")
+    user_status: Optional[StrictInt] = Field(default=None, validation_alias="userStatus", serialization_alias="userStatus", description="User Status")
     additional_properties: Dict[str, Any] = {}
     __properties = ["id", "username", "firstName", "lastName", "email", "password", "phone", "userStatus"]
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch generated `pydantic` v1 models to use `validation_alias` and `serialization_alias` instead of `alias` for fields whose wire name differs from the Python attribute. This preserves behavior with `populate_by_name=True` and removes IDE/LSP warnings while updating all affected samples.

- **Bug Fixes**
  - Generator now emits `Field(..., validation_alias="...", serialization_alias="...")` when `baseName != name`.
  - Keeps validation/serialization using wire names and allows init with Python names when `populate_by_name=True`.
  - Regenerated `python-pydantic-v1` and `python-pydantic-v1-aiohttp` samples to reflect the change.

<sup>Written for commit dd0405625a36ad9dee2872d0f4ab0ead80853b87. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

