### PR TITLE
Add package version option for python fastapi generator

### DIFF
--- a/bin/configs/python-fastapi.yaml
+++ b/bin/configs/python-fastapi.yaml
@@ -5,3 +5,4 @@ templateDir: modules/openapi-generator/src/main/resources/python-fastapi
 sourceFolder: "src"
 additionalProperties:
   hideGenerationTimestamp: "true"
+  packageVersion: "3.4.5"

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonFastAPIServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonFastAPIServerCodegen.java
@@ -110,6 +110,7 @@ public class PythonFastAPIServerCodegen extends AbstractPythonCodegen {
         additionalProperties.put("baseSuffix", BASE_CLASS_SUFFIX);
         additionalProperties.put(CodegenConstants.SOURCE_FOLDER, DEFAULT_SOURCE_FOLDER);
         additionalProperties.put(CodegenConstants.PACKAGE_NAME, DEFAULT_PACKAGE_NAME);
+        additionalProperties.put(CodegenConstants.PACKAGE_VERSION, DEFAULT_PACKAGE_VERSION);
         additionalProperties.put(CodegenConstants.FASTAPI_IMPLEMENTATION_PACKAGE, DEFAULT_IMPL_FOLDER);
 
         languageSpecificPrimitives.add("List");
@@ -146,6 +147,10 @@ public class PythonFastAPIServerCodegen extends AbstractPythonCodegen {
 
         if (additionalProperties.containsKey(CodegenConstants.PACKAGE_NAME)) {
             setPackageName((String) additionalProperties.get(CodegenConstants.PACKAGE_NAME));
+        }
+
+        if (additionalProperties.containsKey(CodegenConstants.PACKAGE_VERSION)) {
+            setPackageVersion((String) additionalProperties.get(CodegenConstants.PACKAGE_VERSION));
         }
 
         if (additionalProperties.containsKey(CodegenConstants.SOURCE_FOLDER)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonFastAPIServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonFastAPIServerCodegen.java
@@ -153,6 +153,9 @@ public class PythonFastAPIServerCodegen extends AbstractPythonCodegen {
 
         if (additionalProperties.containsKey(CodegenConstants.PACKAGE_NAME)) {
             setPackageName((String) additionalProperties.get(CodegenConstants.PACKAGE_NAME));
+        } else {
+            // default to appVersion in the spec
+            setPackageName((String) additionalProperties.get("appVersion"));
         }
 
         if (additionalProperties.containsKey(CodegenConstants.PACKAGE_VERSION)) {

--- a/modules/openapi-generator/src/main/resources/python-fastapi/requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python-fastapi/requirements.mustache
@@ -29,7 +29,7 @@ Rx==1.6.1
 starlette==0.49.1
 typing-extensions==4.13.2
 ujson==4.0.2
-urllib3==2.6.3
+urllib3==2.7.0
 uvicorn==0.13.4
 uvloop==0.21.0
 watchgod==0.7

--- a/modules/openapi-generator/src/main/resources/python-fastapi/setup_cfg.mustache
+++ b/modules/openapi-generator/src/main/resources/python-fastapi/setup_cfg.mustache
@@ -1,6 +1,6 @@
 [metadata]
 name = {{packageName}}
-version = {{appVersion}}
+version = {{packageVersion}}
 description = {{appDescription}}
 long_description = file: README.md
 keywords = OpenAPI {{appName}}

--- a/samples/server/petstore/python-fastapi/requirements.txt
+++ b/samples/server/petstore/python-fastapi/requirements.txt
@@ -29,7 +29,7 @@ Rx==1.6.1
 starlette==0.49.1
 typing-extensions==4.13.2
 ujson==4.0.2
-urllib3==2.6.3
+urllib3==2.7.0
 uvicorn==0.13.4
 uvloop==0.21.0
 watchgod==0.7

--- a/samples/server/petstore/python-fastapi/setup.cfg
+++ b/samples/server/petstore/python-fastapi/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = openapi_server
-version = 1.0.0
+version = 3.4.5
 description = This is a sample server Petstore server. For this sample, you can use the api key &#x60;special-key&#x60; to test the authorization filters.
 long_description = file: README.md
 keywords = OpenAPI OpenAPI Petstore


### PR DESCRIPTION
based on https://github.com/OpenAPITools/openapi-generator/pull/21609 with minor improvements, updated urlib3 to latest version

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for explicit package versioning in the Python FastAPI generator using `packageVersion`, now used in `setup.cfg` for generated servers. Updates samples to demonstrate the new field.

- **New Features**
  - The generator reads `packageVersion` and sets it as the package version in `setup.cfg` (independent from `appVersion`). Samples use `3.4.5`.

- **Dependencies**
  - Bumped `urllib3` from 2.6.3 to `2.7.0` in templates and samples.

<sup>Written for commit 582a6043a407d4830805f87033ccd00b8edd55eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

