### PR TITLE
fix date encoding in path params in swift5

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/api.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/api.mustache
@@ -401,7 +401,7 @@ extension {{projectName}}API {
     {{/isDeprecated}}
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class func {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}[{{enumName}}_{{operationId}}]{{/isContainer}}{{^isContainer}}{{enumName}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{^-last}}, {{/-last}}{{/allParams}}) -> RequestBuilder<{{{returnType}}}{{#returnType}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
         {{^pathParams}}let{{/pathParams}}{{#pathParams}}{{#-first}}var{{/-first}}{{/pathParams}} localVariablePath = "{{{path}}}"{{#pathParams}}
-        let {{paramName}}PreEscape = "\({{#isEnum}}{{paramName}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}.rawValue{{/isContainer}}{{/isEnum}}{{^isEnum}}APIHelper.mapValueToPathItem({{paramName}}){{/isEnum}})"
+        let {{paramName}}PreEscape = "\({{#isEnum}}{{paramName}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}.rawValue{{/isContainer}}{{/isEnum}}{{^isEnum}}APIHelper.mapValueToPathItem({{paramName}}.encodeToJSON()){{/isEnum}})"
         let {{paramName}}PostEscape = {{paramName}}PreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{{=<% %>=}}{<%baseName%>}<%={{ }}=%>", with: {{paramName}}PostEscape, options: .literal, range: nil){{/pathParams}}
         let localVariableURLString = {{projectName}}API.basePath + localVariablePath

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -93,7 +93,7 @@ open class PetAPI {
      */
     open class func deletePetWithRequestBuilder(petId: Int64, apiKey: String? = nil) -> RequestBuilder<Void> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -254,7 +254,7 @@ open class PetAPI {
      */
     open class func getPetByIdWithRequestBuilder(petId: Int64) -> RequestBuilder<Pet> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -353,7 +353,7 @@ open class PetAPI {
      */
     open class func updatePetWithFormWithRequestBuilder(petId: Int64, name: String? = nil, status: String? = nil) -> RequestBuilder<Void> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -412,7 +412,7 @@ open class PetAPI {
      */
     open class func uploadFileWithRequestBuilder(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil) -> RequestBuilder<ApiResponse> {
         var localVariablePath = "/pet/{petId}/uploadImage"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -471,7 +471,7 @@ open class PetAPI {
      */
     open class func uploadFileWithRequiredFileWithRequestBuilder(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil) -> RequestBuilder<ApiResponse> {
         var localVariablePath = "/fake/{petId}/uploadImageWithRequiredFile"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
@@ -40,7 +40,7 @@ open class StoreAPI {
      */
     open class func deleteOrderWithRequestBuilder(orderId: String) -> RequestBuilder<Void> {
         var localVariablePath = "/store/order/{order_id}"
-        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId))"
+        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId.encodeToJSON()))"
         let orderIdPostEscape = orderIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{order_id}", with: orderIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -132,7 +132,7 @@ open class StoreAPI {
      */
     open class func getOrderByIdWithRequestBuilder(orderId: Int64) -> RequestBuilder<Order> {
         var localVariablePath = "/store/order/{order_id}"
-        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId))"
+        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId.encodeToJSON()))"
         let orderIdPostEscape = orderIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{order_id}", with: orderIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
@@ -170,7 +170,7 @@ open class UserAPI {
      */
     open class func deleteUserWithRequestBuilder(username: String) -> RequestBuilder<Void> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -216,7 +216,7 @@ open class UserAPI {
      */
     open class func getUserByNameWithRequestBuilder(username: String) -> RequestBuilder<User> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -356,7 +356,7 @@ open class UserAPI {
      */
     open class func updateUserWithRequestBuilder(username: String, body: User) -> RequestBuilder<Void> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -77,7 +77,7 @@ open class PetAPI {
      */
     open class func deletePetWithRequestBuilder(petId: Int64, apiKey: String? = nil) -> RequestBuilder<Void> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -214,7 +214,7 @@ open class PetAPI {
      */
     open class func getPetByIdWithRequestBuilder(petId: Int64) -> RequestBuilder<Pet> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -297,7 +297,7 @@ open class PetAPI {
      */
     open class func updatePetWithFormWithRequestBuilder(petId: Int64, name: String? = nil, status: String? = nil) -> RequestBuilder<Void> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -348,7 +348,7 @@ open class PetAPI {
      */
     open class func uploadFileWithRequestBuilder(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil) -> RequestBuilder<ApiResponse> {
         var localVariablePath = "/pet/{petId}/uploadImage"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -399,7 +399,7 @@ open class PetAPI {
      */
     open class func uploadFileWithRequiredFileWithRequestBuilder(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil) -> RequestBuilder<ApiResponse> {
         var localVariablePath = "/fake/{petId}/uploadImageWithRequiredFile"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
@@ -32,7 +32,7 @@ open class StoreAPI {
      */
     open class func deleteOrderWithRequestBuilder(orderId: String) -> RequestBuilder<Void> {
         var localVariablePath = "/store/order/{order_id}"
-        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId))"
+        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId.encodeToJSON()))"
         let orderIdPostEscape = orderIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{order_id}", with: orderIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -108,7 +108,7 @@ open class StoreAPI {
      */
     open class func getOrderByIdWithRequestBuilder(orderId: Int64) -> RequestBuilder<Order> {
         var localVariablePath = "/store/order/{order_id}"
-        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId))"
+        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId.encodeToJSON()))"
         let orderIdPostEscape = orderIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{order_id}", with: orderIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
@@ -138,7 +138,7 @@ open class UserAPI {
      */
     open class func deleteUserWithRequestBuilder(username: String) -> RequestBuilder<Void> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -176,7 +176,7 @@ open class UserAPI {
      */
     open class func getUserByNameWithRequestBuilder(username: String) -> RequestBuilder<User> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -292,7 +292,7 @@ open class UserAPI {
      */
     open class func updateUserWithRequestBuilder(username: String, body: User) -> RequestBuilder<Void> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -114,7 +114,7 @@ open class PetAPI {
      */
     open class func deletePetWithRequestBuilder(petId: Int64, apiKey: String? = nil) -> RequestBuilder<Void> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -302,7 +302,7 @@ open class PetAPI {
      */
     open class func getPetByIdWithRequestBuilder(petId: Int64) -> RequestBuilder<Pet> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -419,7 +419,7 @@ open class PetAPI {
      */
     open class func updatePetWithFormWithRequestBuilder(petId: Int64, name: String? = nil, status: String? = nil) -> RequestBuilder<Void> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -487,7 +487,7 @@ open class PetAPI {
      */
     open class func uploadFileWithRequestBuilder(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil) -> RequestBuilder<ApiResponse> {
         var localVariablePath = "/pet/{petId}/uploadImage"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -555,7 +555,7 @@ open class PetAPI {
      */
     open class func uploadFileWithRequiredFileWithRequestBuilder(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil) -> RequestBuilder<ApiResponse> {
         var localVariablePath = "/fake/{petId}/uploadImageWithRequiredFile"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
@@ -52,7 +52,7 @@ open class StoreAPI {
      */
     open class func deleteOrderWithRequestBuilder(orderId: String) -> RequestBuilder<Void> {
         var localVariablePath = "/store/order/{order_id}"
-        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId))"
+        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId.encodeToJSON()))"
         let orderIdPostEscape = orderIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{order_id}", with: orderIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -162,7 +162,7 @@ open class StoreAPI {
      */
     open class func getOrderByIdWithRequestBuilder(orderId: Int64) -> RequestBuilder<Order> {
         var localVariablePath = "/store/order/{order_id}"
-        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId))"
+        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId.encodeToJSON()))"
         let orderIdPostEscape = orderIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{order_id}", with: orderIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
@@ -209,7 +209,7 @@ open class UserAPI {
      */
     open class func deleteUserWithRequestBuilder(username: String) -> RequestBuilder<Void> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -264,7 +264,7 @@ open class UserAPI {
      */
     open class func getUserByNameWithRequestBuilder(username: String) -> RequestBuilder<User> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -431,7 +431,7 @@ open class UserAPI {
      */
     open class func updateUserWithRequestBuilder(username: String, body: User) -> RequestBuilder<Void> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -90,7 +90,7 @@ open class PetAPI {
      */
     open class func deletePetWithRequestBuilder(petId: Int64, apiKey: String? = nil) -> RequestBuilder<Void> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -251,7 +251,7 @@ open class PetAPI {
      */
     open class func getPetByIdWithRequestBuilder(petId: Int64) -> RequestBuilder<Pet> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -350,7 +350,7 @@ open class PetAPI {
      */
     open class func updatePetWithFormWithRequestBuilder(petId: Int64, name: String? = nil, status: String? = nil) -> RequestBuilder<Void> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -409,7 +409,7 @@ open class PetAPI {
      */
     open class func uploadFileWithRequestBuilder(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil) -> RequestBuilder<ApiResponse> {
         var localVariablePath = "/pet/{petId}/uploadImage"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -468,7 +468,7 @@ open class PetAPI {
      */
     open class func uploadFileWithRequiredFileWithRequestBuilder(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil) -> RequestBuilder<ApiResponse> {
         var localVariablePath = "/fake/{petId}/uploadImageWithRequiredFile"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
@@ -40,7 +40,7 @@ open class StoreAPI {
      */
     open class func deleteOrderWithRequestBuilder(orderId: String) -> RequestBuilder<Void> {
         var localVariablePath = "/store/order/{order_id}"
-        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId))"
+        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId.encodeToJSON()))"
         let orderIdPostEscape = orderIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{order_id}", with: orderIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -132,7 +132,7 @@ open class StoreAPI {
      */
     open class func getOrderByIdWithRequestBuilder(orderId: Int64) -> RequestBuilder<Order> {
         var localVariablePath = "/store/order/{order_id}"
-        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId))"
+        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId.encodeToJSON()))"
         let orderIdPostEscape = orderIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{order_id}", with: orderIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
@@ -170,7 +170,7 @@ open class UserAPI {
      */
     open class func deleteUserWithRequestBuilder(username: String) -> RequestBuilder<Void> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -216,7 +216,7 @@ open class UserAPI {
      */
     open class func getUserByNameWithRequestBuilder(username: String) -> RequestBuilder<User> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -356,7 +356,7 @@ open class UserAPI {
      */
     open class func updateUserWithRequestBuilder(username: String, body: User) -> RequestBuilder<Void> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -93,7 +93,7 @@ import AnyCodable
      */
     open class func deletePetWithRequestBuilder(petId: Int64, apiKey: String? = nil) -> RequestBuilder<Void> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -254,7 +254,7 @@ import AnyCodable
      */
     open class func getPetByIdWithRequestBuilder(petId: Int64) -> RequestBuilder<Pet> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -353,7 +353,7 @@ import AnyCodable
      */
     open class func updatePetWithFormWithRequestBuilder(petId: Int64, name: String? = nil, status: String? = nil) -> RequestBuilder<Void> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -412,7 +412,7 @@ import AnyCodable
      */
     open class func uploadFileWithRequestBuilder(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil) -> RequestBuilder<ApiResponse> {
         var localVariablePath = "/pet/{petId}/uploadImage"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -471,7 +471,7 @@ import AnyCodable
      */
     open class func uploadFileWithRequiredFileWithRequestBuilder(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil) -> RequestBuilder<ApiResponse> {
         var localVariablePath = "/fake/{petId}/uploadImageWithRequiredFile"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
@@ -40,7 +40,7 @@ import AnyCodable
      */
     open class func deleteOrderWithRequestBuilder(orderId: String) -> RequestBuilder<Void> {
         var localVariablePath = "/store/order/{order_id}"
-        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId))"
+        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId.encodeToJSON()))"
         let orderIdPostEscape = orderIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{order_id}", with: orderIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -132,7 +132,7 @@ import AnyCodable
      */
     open class func getOrderByIdWithRequestBuilder(orderId: Int64) -> RequestBuilder<Order> {
         var localVariablePath = "/store/order/{order_id}"
-        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId))"
+        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId.encodeToJSON()))"
         let orderIdPostEscape = orderIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{order_id}", with: orderIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
@@ -170,7 +170,7 @@ import AnyCodable
      */
     open class func deleteUserWithRequestBuilder(username: String) -> RequestBuilder<Void> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -216,7 +216,7 @@ import AnyCodable
      */
     open class func getUserByNameWithRequestBuilder(username: String) -> RequestBuilder<User> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -356,7 +356,7 @@ import AnyCodable
      */
     open class func updateUserWithRequestBuilder(username: String, body: User) -> RequestBuilder<Void> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -94,7 +94,7 @@ open class PetAPI {
      */
     open class func deletePetWithRequestBuilder(petId: Int64, apiKey: String? = nil) -> RequestBuilder<Void> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -255,7 +255,7 @@ open class PetAPI {
      */
     open class func getPetByIdWithRequestBuilder(petId: Int64) -> RequestBuilder<Pet> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -354,7 +354,7 @@ open class PetAPI {
      */
     open class func updatePetWithFormWithRequestBuilder(petId: Int64, name: String? = nil, status: String? = nil) -> RequestBuilder<Void> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -413,7 +413,7 @@ open class PetAPI {
      */
     open class func uploadFileWithRequestBuilder(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil) -> RequestBuilder<ApiResponse> {
         var localVariablePath = "/pet/{petId}/uploadImage"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -472,7 +472,7 @@ open class PetAPI {
      */
     open class func uploadFileWithRequiredFileWithRequestBuilder(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil) -> RequestBuilder<ApiResponse> {
         var localVariablePath = "/fake/{petId}/uploadImageWithRequiredFile"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
@@ -41,7 +41,7 @@ open class StoreAPI {
      */
     open class func deleteOrderWithRequestBuilder(orderId: String) -> RequestBuilder<Void> {
         var localVariablePath = "/store/order/{order_id}"
-        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId))"
+        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId.encodeToJSON()))"
         let orderIdPostEscape = orderIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{order_id}", with: orderIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -133,7 +133,7 @@ open class StoreAPI {
      */
     open class func getOrderByIdWithRequestBuilder(orderId: Int64) -> RequestBuilder<Order> {
         var localVariablePath = "/store/order/{order_id}"
-        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId))"
+        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId.encodeToJSON()))"
         let orderIdPostEscape = orderIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{order_id}", with: orderIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
@@ -171,7 +171,7 @@ open class UserAPI {
      */
     open class func deleteUserWithRequestBuilder(username: String) -> RequestBuilder<Void> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -217,7 +217,7 @@ open class UserAPI {
      */
     open class func getUserByNameWithRequestBuilder(username: String) -> RequestBuilder<User> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -357,7 +357,7 @@ open class UserAPI {
      */
     open class func updateUserWithRequestBuilder(username: String, body: User) -> RequestBuilder<Void> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -93,7 +93,7 @@ internal class PetAPI {
      */
     internal class func deletePetWithRequestBuilder(apiKey: String? = nil, petId: Int64) -> RequestBuilder<Void> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -254,7 +254,7 @@ internal class PetAPI {
      */
     internal class func getPetByIdWithRequestBuilder(petId: Int64) -> RequestBuilder<Pet> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -353,7 +353,7 @@ internal class PetAPI {
      */
     internal class func updatePetWithFormWithRequestBuilder(petId: Int64, name: String? = nil, status: String? = nil) -> RequestBuilder<Void> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -412,7 +412,7 @@ internal class PetAPI {
      */
     internal class func uploadFileWithRequestBuilder(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil) -> RequestBuilder<ApiResponse> {
         var localVariablePath = "/pet/{petId}/uploadImage"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -471,7 +471,7 @@ internal class PetAPI {
      */
     internal class func uploadFileWithRequiredFileWithRequestBuilder(petId: Int64, additionalMetadata: String? = nil, requiredFile: URL) -> RequestBuilder<ApiResponse> {
         var localVariablePath = "/fake/{petId}/uploadImageWithRequiredFile"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
@@ -40,7 +40,7 @@ internal class StoreAPI {
      */
     internal class func deleteOrderWithRequestBuilder(orderId: String) -> RequestBuilder<Void> {
         var localVariablePath = "/store/order/{order_id}"
-        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId))"
+        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId.encodeToJSON()))"
         let orderIdPostEscape = orderIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{order_id}", with: orderIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -132,7 +132,7 @@ internal class StoreAPI {
      */
     internal class func getOrderByIdWithRequestBuilder(orderId: Int64) -> RequestBuilder<Order> {
         var localVariablePath = "/store/order/{order_id}"
-        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId))"
+        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId.encodeToJSON()))"
         let orderIdPostEscape = orderIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{order_id}", with: orderIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
@@ -170,7 +170,7 @@ internal class UserAPI {
      */
     internal class func deleteUserWithRequestBuilder(username: String) -> RequestBuilder<Void> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -216,7 +216,7 @@ internal class UserAPI {
      */
     internal class func getUserByNameWithRequestBuilder(username: String) -> RequestBuilder<User> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -356,7 +356,7 @@ internal class UserAPI {
      */
     internal class func updateUserWithRequestBuilder(username: String, body: User) -> RequestBuilder<Void> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -106,7 +106,7 @@ open class PetAPI {
      */
     open class func deletePetWithRequestBuilder(petId: Int64, apiKey: String? = nil) -> RequestBuilder<Void> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -285,7 +285,7 @@ open class PetAPI {
      */
     open class func getPetByIdWithRequestBuilder(petId: Int64) -> RequestBuilder<Pet> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -396,7 +396,7 @@ open class PetAPI {
      */
     open class func updatePetWithFormWithRequestBuilder(petId: Int64, name: String? = nil, status: String? = nil) -> RequestBuilder<Void> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -461,7 +461,7 @@ open class PetAPI {
      */
     open class func uploadFileWithRequestBuilder(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil) -> RequestBuilder<ApiResponse> {
         var localVariablePath = "/pet/{petId}/uploadImage"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -526,7 +526,7 @@ open class PetAPI {
      */
     open class func uploadFileWithRequiredFileWithRequestBuilder(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil) -> RequestBuilder<ApiResponse> {
         var localVariablePath = "/fake/{petId}/uploadImageWithRequiredFile"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
@@ -47,7 +47,7 @@ open class StoreAPI {
      */
     open class func deleteOrderWithRequestBuilder(orderId: String) -> RequestBuilder<Void> {
         var localVariablePath = "/store/order/{order_id}"
-        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId))"
+        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId.encodeToJSON()))"
         let orderIdPostEscape = orderIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{order_id}", with: orderIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -151,7 +151,7 @@ open class StoreAPI {
      */
     open class func getOrderByIdWithRequestBuilder(orderId: Int64) -> RequestBuilder<Order> {
         var localVariablePath = "/store/order/{order_id}"
-        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId))"
+        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId.encodeToJSON()))"
         let orderIdPostEscape = orderIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{order_id}", with: orderIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
@@ -195,7 +195,7 @@ open class UserAPI {
      */
     open class func deleteUserWithRequestBuilder(username: String) -> RequestBuilder<Void> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -247,7 +247,7 @@ open class UserAPI {
      */
     open class func getUserByNameWithRequestBuilder(username: String) -> RequestBuilder<User> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -405,7 +405,7 @@ open class UserAPI {
      */
     open class func updateUserWithRequestBuilder(username: String, body: User) -> RequestBuilder<Void> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/APIs/PetAPI.swift
@@ -96,7 +96,7 @@ open class PetAPI {
      */
     open class func deletePetWithRequestBuilder(petId: Int64, apiKey: String? = nil) -> RequestBuilder<Void> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -257,7 +257,7 @@ open class PetAPI {
      */
     open class func getPetByIdWithRequestBuilder(petId: Int64) -> RequestBuilder<Pet> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -356,7 +356,7 @@ open class PetAPI {
      */
     open class func updatePetWithFormWithRequestBuilder(petId: Int64, name: String? = nil, status: String? = nil) -> RequestBuilder<Void> {
         var localVariablePath = "/pet/{petId}"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -415,7 +415,7 @@ open class PetAPI {
      */
     open class func uploadFileWithRequestBuilder(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil) -> RequestBuilder<ApiResponse> {
         var localVariablePath = "/pet/{petId}/uploadImage"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -474,7 +474,7 @@ open class PetAPI {
      */
     open class func uploadFileWithRequiredFileWithRequestBuilder(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil) -> RequestBuilder<ApiResponse> {
         var localVariablePath = "/fake/{petId}/uploadImageWithRequiredFile"
-        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId))"
+        let petIdPreEscape = "\(APIHelper.mapValueToPathItem(petId.encodeToJSON()))"
         let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/APIs/StoreAPI.swift
@@ -43,7 +43,7 @@ open class StoreAPI {
      */
     open class func deleteOrderWithRequestBuilder(orderId: String) -> RequestBuilder<Void> {
         var localVariablePath = "/store/order/{order_id}"
-        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId))"
+        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId.encodeToJSON()))"
         let orderIdPostEscape = orderIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{order_id}", with: orderIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -135,7 +135,7 @@ open class StoreAPI {
      */
     open class func getOrderByIdWithRequestBuilder(orderId: Int64) -> RequestBuilder<Order> {
         var localVariablePath = "/store/order/{order_id}"
-        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId))"
+        let orderIdPreEscape = "\(APIHelper.mapValueToPathItem(orderId.encodeToJSON()))"
         let orderIdPostEscape = orderIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{order_id}", with: orderIdPostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/APIs/UserAPI.swift
@@ -173,7 +173,7 @@ open class UserAPI {
      */
     open class func deleteUserWithRequestBuilder(username: String) -> RequestBuilder<Void> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -219,7 +219,7 @@ open class UserAPI {
      */
     open class func getUserByNameWithRequestBuilder(username: String) -> RequestBuilder<User> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath
@@ -359,7 +359,7 @@ open class UserAPI {
      */
     open class func updateUserWithRequestBuilder(username: String, body: User) -> RequestBuilder<Void> {
         var localVariablePath = "/user/{username}"
-        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username))"
+        let usernamePreEscape = "\(APIHelper.mapValueToPathItem(username.encodeToJSON()))"
         let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         localVariablePath = localVariablePath.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let localVariableURLString = PetstoreClientAPI.basePath + localVariablePath


### PR DESCRIPTION
This fixes date encoding in path params in swift5. This fix is similar to https://github.com/OpenAPITools/openapi-generator/issues/18074 but in that is usable without the custom `useCustomDateWithoutTime` configuration

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jgavris @ehyche @Edubits @jaz-ah @4brunu @dydus0x14 