### PR TITLE
[jaxrs-spec][quarkus] Emit @PermitAll for unauthenticated operations (op/global empty security, anonymous OR alternative, no security defined)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JakartaSecurityAnnotationProcessor.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JakartaSecurityAnnotationProcessor.java
@@ -40,25 +40,28 @@ import org.slf4j.LoggerFactory;
  * always be reconciled, so this class emits the least restrictive annotation that
  * is still correct for the OR group.
  *
- * <p>A single vendor extension {@code x-jakarta-roles-allowed} carries the value to
- * emit:
+ * <p>Two mutually exclusive vendor extensions carry the emission decision:
  * <ul>
- *   <li>{@code ["**"]} for the any-authenticated-user case, producing
- *       {@code @RolesAllowed({"**"})}.
- *   <li>A sorted, deduplicated list of scope names (e.g. {@code ["admin", "user"]})
- *       when every OR alternative is scoped, producing
+ *   <li>{@code x-jakarta-roles-allowed} = {@code ["**"]} for the any-authenticated-user
+ *       case, producing {@code @RolesAllowed({"**"})}.
+ *   <li>{@code x-jakarta-roles-allowed} = sorted, deduplicated list of scope names
+ *       (e.g. {@code ["admin", "user"]}) when every OR alternative is scoped, producing
  *       {@code @RolesAllowed({"admin","user"})}.
- *   <li>Unset when the operation does not qualify (anonymous OR alternative,
- *       mixed-scope AND group, etc.).
+ *   <li>{@code x-jakarta-permit-all} = {@code true} when the operation is unauthenticated
+ *       (explicit {@code security: []}, an anonymous {@code - {}} OR alternative, or an
+ *       entirely unsecured spec), producing {@code @PermitAll}.
+ *   <li>Neither set when the operation does not qualify (mixed-scope AND group,
+ *       undefined scheme, etc.) — nothing is emitted and a warning is logged.
  * </ul>
  *
- * <p>The wildcard and scoped emissions are mutually exclusive per operation: if any
- * OR alternative qualifies as "any authenticated user", the wildcard wins and the
- * scoped path is skipped.
+ * <p>The three emissions are mutually exclusive per operation: if any OR alternative
+ * qualifies as "any authenticated user", the wildcard wins; otherwise the scoped path
+ * is tried; otherwise {@code @PermitAll} is tried.
  */
 final class JakartaSecurityAnnotationProcessor {
 
     static final String VENDOR_X_JAKARTA_ROLES_ALLOWED = "x-jakarta-roles-allowed";
+    static final String VENDOR_X_JAKARTA_PERMIT_ALL = "x-jakarta-permit-all";
 
     private static final List<String> ANY_AUTHENTICATED_ROLE = Collections.singletonList("**");
 
@@ -66,9 +69,9 @@ final class JakartaSecurityAnnotationProcessor {
 
     /**
      * Inspects {@code rawOp}'s security requirements (falling back to the global
-     * {@code openAPI.security} when the operation does not override) and sets
-     * {@code x-jakarta-roles-allowed} on {@code op} when the operation qualifies
-     * for {@code @RolesAllowed} emission.
+     * {@code openAPI.security} when the operation does not override) and sets either
+     * {@code x-jakarta-roles-allowed} (for {@code @RolesAllowed}) or
+     * {@code x-jakarta-permit-all} (for {@code @PermitAll}) on {@code op}.
      */
     void applyTo(CodegenOperation op, Operation rawOp, OpenAPI openAPI) {
         // Use the raw Operation here rather than op.authMethods: by the time postProcessOperationsWithModels
@@ -88,6 +91,10 @@ final class JakartaSecurityAnnotationProcessor {
         List<String> scopes = collectRolesAllowedScopes(requirements, schemes);
         if (scopes != null && !scopes.isEmpty()) {
             op.vendorExtensions.put(VENDOR_X_JAKARTA_ROLES_ALLOWED, scopes);
+            return;
+        }
+        if (qualifiesForPermitAll(rawOp, openAPI, requirements)) {
+            op.vendorExtensions.put(VENDOR_X_JAKARTA_PERMIT_ALL, Boolean.TRUE);
         }
     }
 
@@ -118,6 +125,55 @@ final class JakartaSecurityAnnotationProcessor {
             }
         }
         return anyQualifies;
+    }
+
+    /**
+     * Returns true when the operation should emit {@code @PermitAll} -- the
+     * "no authentication required" cases that {@code qualifiesForAnyRoles} and
+     * {@code collectRolesAllowedScopes} deliberately reject.
+     *
+     * <p>The decision uses raw op-level and global security fields (not the already
+     * resolved {@code effectiveRequirements}) so it can distinguish explicit op-level
+     * opt-out ({@code security: []}) from global inheritance.
+     *
+     * <ul>
+     *   <li>Op-level {@code security: []} -> always permit-all (overrides any global).
+     *   <li>No op-level security AND global {@code security: []} -> inherits empty.
+     *   <li>No op-level security AND no global security -> the spec declares the
+     *       entire API unauthenticated.
+     *   <li>Op-level OR list contains {@code - {}} -> least-restrictive wins.
+     * </ul>
+     *
+     * <p>This method returns false for mixed-scope AND groups, undefined schemes, and
+     * other ambiguous cases -- those bail with a warning at the {@code @RolesAllowed}
+     * stage and must NOT silently fall through to {@code @PermitAll}.
+     */
+    private boolean qualifiesForPermitAll(Operation rawOp, OpenAPI openAPI, List<SecurityRequirement> effectiveRequirements) {
+        List<SecurityRequirement> opSecurity = rawOp.getSecurity();
+        if (opSecurity != null && opSecurity.isEmpty()) {
+            // Explicit op-level opt-out wins over any global setting.
+            return true;
+        }
+        if (opSecurity == null) {
+            List<SecurityRequirement> globalSecurity = openAPI.getSecurity();
+            if (globalSecurity == null) {
+                // Spec defines no security at all -- every operation is unauthenticated.
+                return true;
+            }
+            if (globalSecurity.isEmpty()) {
+                // Operation inherits the global empty list -- unauthenticated.
+                return true;
+            }
+        }
+        if (effectiveRequirements != null) {
+            for (SecurityRequirement requirement : effectiveRequirements) {
+                if (requirement.isEmpty()) {
+                    // Anonymous OR alternative -- least restrictive wins.
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/libraries/quarkus/apiInterface.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/libraries/quarkus/apiInterface.mustache
@@ -56,4 +56,7 @@
 {{#vendorExtensions.x-jakarta-roles-allowed.0}}
     @jakarta.annotation.security.RolesAllowed({{openbrace}}{{#vendorExtensions.x-jakarta-roles-allowed}}"{{.}}"{{^-last}},{{/-last}}{{/vendorExtensions.x-jakarta-roles-allowed}}{{closebrace}})
 {{/vendorExtensions.x-jakarta-roles-allowed.0}}
+{{#vendorExtensions.x-jakarta-permit-all}}
+    @jakarta.annotation.security.PermitAll
+{{/vendorExtensions.x-jakarta-permit-all}}
     {{#supportAsync}}{{>returnAsyncTypeInterface}}{{/supportAsync}}{{^supportAsync}}{{#returnJBossResponse}}{{>returnResponseTypeInterface}}{{/returnJBossResponse}}{{^returnJBossResponse}}{{#returnResponse}}Response{{/returnResponse}}{{^returnResponse}}{{>returnTypeInterface}}{{/returnResponse}}{{/returnJBossResponse}}{{/supportAsync}} {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>cookieParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{^-last}},{{/-last}}{{/allParams}});

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/libraries/quarkus/apiMethod.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/libraries/quarkus/apiMethod.mustache
@@ -50,6 +50,9 @@
 {{#vendorExtensions.x-jakarta-roles-allowed.0}}
     @jakarta.annotation.security.RolesAllowed({{openbrace}}{{#vendorExtensions.x-jakarta-roles-allowed}}"{{.}}"{{^-last}},{{/-last}}{{/vendorExtensions.x-jakarta-roles-allowed}}{{closebrace}})
 {{/vendorExtensions.x-jakarta-roles-allowed.0}}
+{{#vendorExtensions.x-jakarta-permit-all}}
+    @jakarta.annotation.security.PermitAll
+{{/vendorExtensions.x-jakarta-permit-all}}
     public {{#supportAsync}}{{#useMutiny}}Uni{{/useMutiny}}{{^useMutiny}}CompletionStage{{/useMutiny}}<{{/supportAsync}}{{#returnJBossResponse}}{{>returnResponseTypeInterface}}{{/returnJBossResponse}}{{^returnJBossResponse}}Response{{/returnJBossResponse}}{{#supportAsync}}>{{/supportAsync}} {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>cookieParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{^-last}},{{/-last}}{{/allParams}}) {
         return {{#supportAsync}}{{#useMutiny}}Uni.createFrom().item({{/useMutiny}}{{^useMutiny}}CompletableFuture.supplyAsync(() -> {{/useMutiny}}{{/supportAsync}}Response.ok().entity("magic!").build(){{#supportAsync}}){{/supportAsync}};
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
@@ -55,6 +55,11 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
                     + "(?:," + '"' + "[^" + '"' + "]+" + '"' + ")*"
                     + "\\}\\)";
 
+    // Regex matching @jakarta.annotation.security.PermitAll. Negative lookahead guards against
+    // a hypothetical @PermitAllSomething identifier in the generated source.
+    private static final String PERMIT_ALL_PATTERN =
+            "@jakarta\\.annotation\\.security\\.PermitAll(?![A-Za-z0-9_])";
+
     @BeforeMethod
     public void before() {
         codegen = new JavaJAXRSSpecServerCodegen();
@@ -1633,7 +1638,10 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
 
     /**
      * Single parameterised test exercising every spec fixture that drives @RolesAllowed({"**"}) emission.
-     * Each row: (spec path, interfaceOnly, useJakartaSecurityAnnotations, expected occurrences in generated API file).
+     * Each row: (spec path, interfaceOnly, useJakartaSecurityAnnotations, expected wildcard occurrences, expected @PermitAll occurrences).
+     *
+     * The @PermitAll column proves mutual exclusion: wildcard and @PermitAll never appear on the same method,
+     * and any operation that flips to "no security" must surface as @PermitAll rather than vanishing.
      *
      * Consolidates per-scheme test methods (HttpBasic, HttpBearer, ApiKey, OpenIdConnect, OAuth2, global, mixed-OR, AND-group)
      * since they only differ by spec path and expected count.
@@ -1641,58 +1649,79 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
     @DataProvider(name = "quarkusJakartaSecurityCases")
     public Object[][] quarkusJakartaSecurityCases() {
         return new Object[][] {
-                // single OAuth2 flow, no scopes — flag on → @RolesAllowed({"**"}); flag off → absent
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-no-scopes.yaml", true,  true,  1},
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-no-scopes.yaml", true,  false, 0},
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-no-scopes.yaml", false, true,  1},
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-no-scopes.yaml", false, false, 0},
-                // single OAuth2 flow, non-empty scopes → no @RolesAllowed({"**"}) regardless of flag
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-with-scopes.yaml", true,  true,  0},
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-with-scopes.yaml", false, true,  0},
-                // multiple OAuth2 flows, all no scopes — flag on → exactly once (no per-flow duplication)
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-multi-flow-no-scopes.yaml", true,  true,  1},
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-multi-flow-no-scopes.yaml", false, true,  1},
-                // OR: one scheme no-scope + one scheme scoped — flag on → one op gets @RolesAllowed({"**"})
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-or-empty-and-scoped.yaml", true,  true,  1},
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-or-empty-and-scoped.yaml", false, true,  1},
-                // HTTP Basic — always qualifies (no scope concept)
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-http-basic.yaml", true,  true,  1},
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-http-basic.yaml", true,  false, 0},
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-http-basic.yaml", false, true,  1},
-                // HTTP Bearer — always qualifies
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-http-bearer.yaml", true,  true,  1},
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-http-bearer.yaml", false, true,  1},
-                // API Key — always qualifies
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-api-key.yaml", true,  true,  1},
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-api-key.yaml", false, true,  1},
-                // OpenID Connect — empty scopes qualifies
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-openidconnect-no-scopes.yaml", true,  true,  1},
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-openidconnect-no-scopes.yaml", false, true,  1},
-                // OpenID Connect — explicit scopes does not qualify
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-openidconnect-with-scopes.yaml", true,  true,  0},
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-openidconnect-with-scopes.yaml", false, true,  0},
-                // global HTTP Basic + Bearer; GET inherits (→ @RolesAllowed({"**"})), POST has security:[] (→ none)
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-global-security-one-op-disabled.yaml", true,  true,  1},
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-global-security-one-op-disabled.yaml", false, true,  1},
+                // single OAuth2 flow, no scopes — GET → wildcard, POST has no security (Rule D) → @PermitAll
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-no-scopes.yaml", true,  true,  1, 1},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-no-scopes.yaml", true,  false, 0, 0},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-no-scopes.yaml", false, true,  1, 1},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-no-scopes.yaml", false, false, 0, 0},
+                // single OAuth2 flow, non-empty scopes → no @RolesAllowed({"**"}); both ops have security → no PermitAll
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-with-scopes.yaml", true,  true,  0, 0},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-with-scopes.yaml", false, true,  0, 0},
+                // multiple OAuth2 flows, all no scopes — GET → wildcard; POST has no security (Rule D) → @PermitAll
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-multi-flow-no-scopes.yaml", true,  true,  1, 1},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-multi-flow-no-scopes.yaml", false, true,  1, 1},
+                // OR: one scheme no-scope + one scheme scoped — GET → wildcard, POST → scoped @RolesAllowed (no PermitAll)
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-or-empty-and-scoped.yaml", true,  true,  1, 0},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-or-empty-and-scoped.yaml", false, true,  1, 0},
+                // HTTP Basic — GET qualifies (wildcard); POST has no security (Rule D) → @PermitAll
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-http-basic.yaml", true,  true,  1, 1},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-http-basic.yaml", true,  false, 0, 0},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-http-basic.yaml", false, true,  1, 1},
+                // HTTP Bearer — GET wildcard, POST no security (Rule D) → @PermitAll
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-http-bearer.yaml", true,  true,  1, 1},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-http-bearer.yaml", false, true,  1, 1},
+                // API Key — GET wildcard, POST no security (Rule D) → @PermitAll
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-api-key.yaml", true,  true,  1, 1},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-api-key.yaml", false, true,  1, 1},
+                // OpenID Connect — GET (oidc:[]) wildcard, POST no security (Rule D) → @PermitAll
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-openidconnect-no-scopes.yaml", true,  true,  1, 1},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-openidconnect-no-scopes.yaml", false, true,  1, 1},
+                // OpenID Connect — both ops scoped → no wildcard, no PermitAll
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-openidconnect-with-scopes.yaml", true,  true,  0, 0},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-openidconnect-with-scopes.yaml", false, true,  0, 0},
+                // global HTTP Basic + Bearer; GET inherits (→ @RolesAllowed({"**"})), POST has security:[] (→ @PermitAll)
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-global-security-one-op-disabled.yaml", true,  true,  1, 1},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-global-security-one-op-disabled.yaml", false, true,  1, 1},
                 // global OR: unscoped OAuth2 + scoped OAuth2; both ops inherit → both get @RolesAllowed({"**"})
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-global-oauth2-or-scoped-and-unscoped.yaml", true,  true,  2},
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-global-oauth2-or-scoped-and-unscoped.yaml", false, true,  2},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-global-oauth2-or-scoped-and-unscoped.yaml", true,  true,  2, 0},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-global-oauth2-or-scoped-and-unscoped.yaml", false, true,  2, 0},
                 // cross-type OR: scoped OAuth2 OR API Key — API Key qualifies even though OAuth2 alone would not
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-scoped-or-api-key.yaml", true,  true,  1},
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-scoped-or-api-key.yaml", false, true,  1},
-                // AND group: oauth2 empty scopes AND openIdConnect admin:create → never emits
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-and-group-mixed-scopes.yaml", true,  true,  0},
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-and-group-mixed-scopes.yaml", false, true,  0},
-                // OR list with anonymous alternative ({}) — least-restrictive wins, no @RolesAllowed
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-or-with-anonymous.yaml", true,  true,  0},
-                {"src/test/resources/3_0/jaxrs-spec/quarkus-or-with-anonymous.yaml", false, true,  0},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-scoped-or-api-key.yaml", true,  true,  1, 0},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-scoped-or-api-key.yaml", false, true,  1, 0},
+                // AND group: oauth2 empty scopes AND openIdConnect admin:create → never emits (Rule H — no fall-through to @PermitAll)
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-and-group-mixed-scopes.yaml", true,  true,  0, 0},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-and-group-mixed-scopes.yaml", false, true,  0, 0},
+                // OR list with anonymous alternative ({}) — least-restrictive wins, emits @PermitAll (Rule F)
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-or-with-anonymous.yaml", true,  true,  0, 1},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-or-with-anonymous.yaml", false, true,  0, 1},
+                // Rule A: op-level security:[] with no global -- emits @PermitAll
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-permit-all-op-empty-security.yaml", true,  true,  0, 1},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-permit-all-op-empty-security.yaml", true,  false, 0, 0},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-permit-all-op-empty-security.yaml", false, true,  0, 1},
+                // Rule B: op-level security:[] AND global security:[] -- emits @PermitAll
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-permit-all-op-empty-global-empty.yaml", true,  true,  0, 1},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-permit-all-op-empty-global-empty.yaml", false, true,  0, 1},
+                // Rule C: op-level security:[] overrides non-empty global -- GET inherits wildcard, POST gets @PermitAll
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-permit-all-op-empty-global-non-empty.yaml", true,  true,  1, 1},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-permit-all-op-empty-global-non-empty.yaml", false, true,  1, 1},
+                // Rule D: spec has no security defined anywhere -- emits @PermitAll
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-permit-all-no-security-defined.yaml", true,  true,  0, 1},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-permit-all-no-security-defined.yaml", true,  false, 0, 0},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-permit-all-no-security-defined.yaml", false, true,  0, 1},
+                // Rule E: global security:[] inherited by op without local security -- emits @PermitAll (two ops)
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-global-empty-security.yaml", true,  true,  0, 2},
+                {"src/test/resources/3_0/jaxrs-spec/quarkus-global-empty-security.yaml", false, true,  0, 2},
         };
     }
 
     @Test(dataProvider = "quarkusJakartaSecurityCases")
-    public void quarkusEmitsExpectedRolesAllowedWildcardCount(String specPath, boolean interfaceOnly, boolean useFlag, int expectedCount) throws Exception {
+    public void quarkusEmitsExpectedRolesAllowedWildcardCount(String specPath, boolean interfaceOnly, boolean useFlag,
+            int expectedWildcardCount, int expectedPermitAllCount) throws Exception {
         final String content = generateQuarkusItemsApi(specPath, interfaceOnly, useFlag, false);
-        Assert.assertEquals(TestUtils.countOccurrences(content, ROLES_ALLOWED_WILDCARD_PATTERN), expectedCount);
+        Assert.assertEquals(TestUtils.countOccurrences(content, ROLES_ALLOWED_WILDCARD_PATTERN), expectedWildcardCount,
+                "wildcard @RolesAllowed count mismatch for " + specPath);
+        Assert.assertEquals(TestUtils.countOccurrences(content, PERMIT_ALL_PATTERN), expectedPermitAllCount,
+                "@PermitAll count mismatch for " + specPath);
     }
 
     /**
@@ -1713,39 +1742,41 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
     @DataProvider(name = "quarkusJakartaScopedRolesCases")
     public Object[][] quarkusJakartaScopedRolesCases() {
         return new Object[][] {
-            // {specPath, interfaceOnly, expectedScopedAnnotationCount, expectedWildcardCount}
+            // {specPath, interfaceOnly, expectedScopedAnnotationCount, expectedWildcardCount, expectedPermitAllCount}
             // OAuth2 scoped -- reuse PR-1 fixtures; must now emit scoped, not wildcard.
             // Both interfaceOnly modes exercised to guard against regressions in apiInterface.mustache vs apiMethod.mustache.
-            {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-with-scopes.yaml", true, 2, 0},
-            {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-with-scopes.yaml", false, 2, 0},
+            {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-with-scopes.yaml", true, 2, 0, 0},
+            {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-with-scopes.yaml", false, 2, 0, 0},
             // Single scope, both interface and implementation modes
-            {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-single-scope.yaml", true, 2, 0},
-            {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-single-scope.yaml", false, 2, 0},
+            {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-single-scope.yaml", true, 2, 0, 0},
+            {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-single-scope.yaml", false, 2, 0, 0},
             // Multiple scopes and OR-union
-            {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-multiple-scopes.yaml", true, 1, 0},
-            {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-multiple-scopes.yaml", false, 1, 0},
-            {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-or-different-scopes.yaml", true, 1, 0},
+            {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-multiple-scopes.yaml", true, 1, 0, 0},
+            {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-multiple-scopes.yaml", false, 1, 0, 0},
+            {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-or-different-scopes.yaml", true, 1, 0, 0},
             // OpenID Connect scoped -- reuse PR-1 fixture
-            {"src/test/resources/3_0/jaxrs-spec/quarkus-openidconnect-with-scopes.yaml", true, 2, 0},
+            {"src/test/resources/3_0/jaxrs-spec/quarkus-openidconnect-with-scopes.yaml", true, 2, 0, 0},
             // Global security inheritance and override paths
-            {"src/test/resources/3_0/jaxrs-spec/quarkus-global-with-scopes.yaml", true, 2, 0},
-            {"src/test/resources/3_0/jaxrs-spec/quarkus-global-scopes-op-override.yaml", true, 1, 0},
+            {"src/test/resources/3_0/jaxrs-spec/quarkus-global-with-scopes.yaml", true, 2, 0, 0},
+            // POST disables with security:[] -- now emits @PermitAll alongside GET's scoped @RolesAllowed
+            {"src/test/resources/3_0/jaxrs-spec/quarkus-global-scopes-op-override.yaml", true, 1, 0, 1},
             // AND groups
-            {"src/test/resources/3_0/jaxrs-spec/quarkus-and-with-apikey-and-scoped-oauth2.yaml", true, 1, 0},
-            {"src/test/resources/3_0/jaxrs-spec/quarkus-and-multi-scoped-warns.yaml", true, 0, 0},
+            {"src/test/resources/3_0/jaxrs-spec/quarkus-and-with-apikey-and-scoped-oauth2.yaml", true, 1, 0, 0},
+            // Rule H: mixed-scope AND group bails -- must NOT fall through to @PermitAll
+            {"src/test/resources/3_0/jaxrs-spec/quarkus-and-multi-scoped-warns.yaml", true, 0, 0, 0},
             // GET: unscoped OR scoped -> wildcard wins. POST: scoped-only -> scoped emitted. One of each.
             // Exercised in both modes since this is the canonical "mutual exclusion at file level" fixture.
-            {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-or-empty-and-scoped.yaml", true, 1, 1},
-            {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-or-empty-and-scoped.yaml", false, 1, 1},
-            // Anonymous OR alternative -- neither annotation emitted
-            {"src/test/resources/3_0/jaxrs-spec/quarkus-or-empty-anonymous-with-scopes.yaml", true, 0, 0},
-            {"src/test/resources/3_0/jaxrs-spec/quarkus-or-empty-anonymous-with-scopes.yaml", false, 0, 0},
+            {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-or-empty-and-scoped.yaml", true, 1, 1, 0},
+            {"src/test/resources/3_0/jaxrs-spec/quarkus-oauth2-or-empty-and-scoped.yaml", false, 1, 1, 0},
+            // Anonymous OR alternative alongside scoped -- emits @PermitAll (Rule F)
+            {"src/test/resources/3_0/jaxrs-spec/quarkus-or-empty-anonymous-with-scopes.yaml", true, 0, 0, 1},
+            {"src/test/resources/3_0/jaxrs-spec/quarkus-or-empty-anonymous-with-scopes.yaml", false, 0, 0, 1},
         };
     }
 
     @Test(dataProvider = "quarkusJakartaScopedRolesCases")
     public void quarkusEmitsExpectedScopedRolesAllowedCount(String specPath, boolean interfaceOnly,
-            int expectedScopedCount, int expectedWildcardCount) throws Exception {
+            int expectedScopedCount, int expectedWildcardCount, int expectedPermitAllCount) throws Exception {
         final String content = generateQuarkusItemsApi(specPath, interfaceOnly, true, false);
         Assert.assertEquals(TestUtils.countOccurrences(content, ROLES_ALLOWED_SCOPED_PATTERN),
                 expectedScopedCount,
@@ -1753,6 +1784,9 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
         Assert.assertEquals(TestUtils.countOccurrences(content, ROLES_ALLOWED_WILDCARD_PATTERN),
                 expectedWildcardCount,
                 "wildcard @RolesAllowed count mismatch for " + specPath);
+        Assert.assertEquals(TestUtils.countOccurrences(content, PERMIT_ALL_PATTERN),
+                expectedPermitAllCount,
+                "@PermitAll count mismatch for " + specPath);
     }
 
     @Test
@@ -1794,9 +1828,9 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
     }
 
     @Test
-    public void quarkusGlobalEmptySecurityListEmitsNothing() throws Exception {
-        // A top-level empty `security: []` block means "no security requirements at all" -- neither
-        // @RolesAllowed nor (future) @PermitAll should be emitted on inheriting operations.
+    public void quarkusGlobalEmptySecurityListEmitsPermitAll() throws Exception {
+        // A top-level empty `security: []` block means "no security requirements at all" -- both
+        // operations inherit the empty list and receive @PermitAll (Rule E).
         final String content = generateQuarkusItemsApi(
                 "src/test/resources/3_0/jaxrs-spec/quarkus-global-empty-security.yaml",
                 true, true, false);
@@ -1804,6 +1838,61 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
                 "Expected no wildcard @RolesAllowed when global security is empty");
         Assert.assertEquals(TestUtils.countOccurrences(content, ROLES_ALLOWED_SCOPED_PATTERN), 0,
                 "Expected no scoped @RolesAllowed when global security is empty");
+        Assert.assertEquals(TestUtils.countOccurrences(content, PERMIT_ALL_PATTERN), 2,
+                "Expected @PermitAll on both inheriting operations when global security is empty");
+    }
+
+    @Test
+    public void quarkusOrAnonymousAlternativeEmitsPermitAll() throws Exception {
+        // Rule F: OR list contains `- {}` (anonymous) alongside an authenticated scheme.
+        // Least-restrictive wins -- emit @PermitAll, never @RolesAllowed.
+        final String content = generateQuarkusItemsApi(
+                "src/test/resources/3_0/jaxrs-spec/quarkus-or-with-anonymous.yaml",
+                true, true, false);
+        Assert.assertEquals(TestUtils.countOccurrences(content, PERMIT_ALL_PATTERN), 1,
+                "Expected exactly one @PermitAll for OR with anonymous alternative");
+        Assert.assertEquals(TestUtils.countOccurrences(content, ROLES_ALLOWED_WILDCARD_PATTERN), 0,
+                "Anonymous OR must not emit @RolesAllowed({\"**\"})");
+        Assert.assertEquals(TestUtils.countOccurrences(content, ROLES_ALLOWED_SCOPED_PATTERN), 0,
+                "Anonymous OR must not emit scoped @RolesAllowed");
+    }
+
+    @Test
+    public void quarkusMixedAndGroupDoesNotFallThroughToPermitAll() throws Exception {
+        // Rule H: a mixed-scope AND group bails with a warning. The processor must NOT
+        // silently emit @PermitAll as a fallback -- absence of authentication metadata is
+        // semantically different from "unauthenticated allowed".
+        final String content = generateQuarkusItemsApi(
+                "src/test/resources/3_0/jaxrs-spec/quarkus-and-multi-scoped-warns.yaml",
+                true, true, false);
+        Assert.assertEquals(TestUtils.countOccurrences(content, PERMIT_ALL_PATTERN), 0,
+                "Mixed-scope AND group must not fall through to @PermitAll");
+        Assert.assertEquals(TestUtils.countOccurrences(content, ROLES_ALLOWED_WILDCARD_PATTERN), 0);
+        Assert.assertEquals(TestUtils.countOccurrences(content, ROLES_ALLOWED_SCOPED_PATTERN), 0);
+    }
+
+    @Test
+    public void quarkusNoSecurityDefinedAnywhereEmitsPermitAll() throws Exception {
+        // Rule D: spec declares no security at all -- emit @PermitAll on every operation.
+        final String content = generateQuarkusItemsApi(
+                "src/test/resources/3_0/jaxrs-spec/quarkus-permit-all-no-security-defined.yaml",
+                true, true, false);
+        Assert.assertEquals(TestUtils.countOccurrences(content, PERMIT_ALL_PATTERN), 1,
+                "Expected @PermitAll when no security is defined anywhere in the spec");
+    }
+
+    @Test
+    public void quarkusPermitAllCoexistsWithMicroProfileAnnotations() throws Exception {
+        // @PermitAll and MicroProfile OpenAPI annotations come from independent template branches;
+        // they must both render on the same method without ordering or duplication regressions.
+        // (security:[] means no @SecurityRequirement, so assert against @Operation which is always emitted.)
+        final String content = generateQuarkusItemsApi(
+                "src/test/resources/3_0/jaxrs-spec/quarkus-permit-all-microprofile-coexist.yaml",
+                true, true, true);
+        Assert.assertEquals(TestUtils.countOccurrences(content, PERMIT_ALL_PATTERN), 1,
+                "Expected exactly one @PermitAll annotation");
+        Assert.assertTrue(content.contains("org.eclipse.microprofile.openapi.annotations.Operation"),
+                "Expected MicroProfile @Operation annotation alongside @PermitAll");
     }
 
     @Test
@@ -1855,27 +1944,44 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
         final List<File> files = generator.opts(new ClientOptInput().openAPI(openAPI).config(codegen)).generate();
         validateJavaSourceFiles(files);
 
-        // /public -- security: [] -- no annotation
+        // /public -- security: [] -- emits @PermitAll, no @RolesAllowed
         String publicApi = readGeneratedApi(output, "PublicApi.java");
         Assert.assertEquals(TestUtils.countOccurrences(publicApi, ROLES_ALLOWED_WILDCARD_PATTERN), 0,
                 "PublicApi should not have @RolesAllowed -- security: [] disables it");
         Assert.assertEquals(TestUtils.countOccurrences(publicApi, ROLES_ALLOWED_SCOPED_PATTERN), 0,
                 "PublicApi should not have scoped @RolesAllowed");
+        Assert.assertEquals(TestUtils.countOccurrences(publicApi, PERMIT_ALL_PATTERN), 1,
+                "PublicApi should have @PermitAll -- security: [] declares the operation unauthenticated");
 
         // /authenticated -- oauth2: [] -- wildcard @RolesAllowed({"**"})
         String authenticatedApi = readGeneratedApi(output, "AuthenticatedApi.java");
         Assert.assertEquals(TestUtils.countOccurrences(authenticatedApi, ROLES_ALLOWED_WILDCARD_PATTERN), 1,
                 "AuthenticatedApi should have exactly one wildcard @RolesAllowed");
+        Assert.assertEquals(TestUtils.countOccurrences(authenticatedApi, PERMIT_ALL_PATTERN), 0,
+                "AuthenticatedApi must not have @PermitAll");
 
         // /admin -- oauth2: [admin] -- @RolesAllowed({"admin"})
         String adminApi = readGeneratedApi(output, "AdminApi.java");
         Assert.assertEquals(TestUtils.countOccurrences(adminApi, ROLES_ALLOWED_SCOPED_PATTERN), 1);
+        Assert.assertEquals(TestUtils.countOccurrences(adminApi, PERMIT_ALL_PATTERN), 0,
+                "AdminApi must not have @PermitAll");
         assertContainsRolesAllowed(adminApi, "admin");
 
         // /admin-or-user -- oauth2: [admin] OR oauth2: [user] -- @RolesAllowed({"admin","user"})
         String adminOrUserApi = readGeneratedApi(output, "AdminOrUserApi.java");
         Assert.assertEquals(TestUtils.countOccurrences(adminOrUserApi, ROLES_ALLOWED_SCOPED_PATTERN), 1);
+        Assert.assertEquals(TestUtils.countOccurrences(adminOrUserApi, PERMIT_ALL_PATTERN), 0,
+                "AdminOrUserApi must not have @PermitAll");
         assertContainsRolesAllowed(adminOrUserApi, "admin", "user");
+
+        // /anonymous-or-authenticated -- oauth2: [] OR {} -- emits @PermitAll (Rule F)
+        String anonymousOrAuthenticatedApi = readGeneratedApi(output, "AnonymousOrAuthenticatedApi.java");
+        Assert.assertEquals(TestUtils.countOccurrences(anonymousOrAuthenticatedApi, PERMIT_ALL_PATTERN), 1,
+                "AnonymousOrAuthenticatedApi should have @PermitAll -- anonymous OR alternative wins");
+        Assert.assertEquals(TestUtils.countOccurrences(anonymousOrAuthenticatedApi, ROLES_ALLOWED_WILDCARD_PATTERN), 0,
+                "AnonymousOrAuthenticatedApi must not have wildcard @RolesAllowed");
+        Assert.assertEquals(TestUtils.countOccurrences(anonymousOrAuthenticatedApi, ROLES_ALLOWED_SCOPED_PATTERN), 0,
+                "AnonymousOrAuthenticatedApi must not have scoped @RolesAllowed");
     }
 
     private static String readGeneratedApi(File outputDir, String apiFileName) throws Exception {

--- a/modules/openapi-generator/src/test/resources/3_0/jaxrs-spec/quarkus-mixed-security.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/jaxrs-spec/quarkus-mixed-security.yaml
@@ -44,6 +44,16 @@ paths:
       responses:
         '200':
           description: OK
+  /anonymous-or-authenticated:
+    get:
+      operationId: getAnonymousOrAuthenticated
+      summary: OR with anonymous alternative — emits @PermitAll (least-restrictive wins)
+      security:
+        - oauth2_scheme: []
+        - {}
+      responses:
+        '200':
+          description: OK
 components:
   securitySchemes:
     oauth2_scheme:

--- a/modules/openapi-generator/src/test/resources/3_0/jaxrs-spec/quarkus-permit-all-microprofile-coexist.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/jaxrs-spec/quarkus-permit-all-microprofile-coexist.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.1
+info:
+  title: Quarkus permit-all coexists with MicroProfile SecurityRequirement annotations
+  version: '1.0'
+servers:
+  - url: 'http://localhost:8080/'
+paths:
+  /items:
+    get:
+      operationId: getItems
+      summary: Op-level security:[] -- emits @PermitAll alongside MicroProfile annotations
+      security: []
+      responses:
+        '200':
+          description: OK
+components:
+  securitySchemes:
+    oauth2_scheme:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://example.com/oauth/token
+          scopes:
+            admin: Admin access

--- a/modules/openapi-generator/src/test/resources/3_0/jaxrs-spec/quarkus-permit-all-no-security-defined.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/jaxrs-spec/quarkus-permit-all-no-security-defined.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.1
+info:
+  title: Quarkus spec with no security defined anywhere -- emits @PermitAll
+  version: '1.0'
+servers:
+  - url: 'http://localhost:8080/'
+paths:
+  /items:
+    get:
+      operationId: getItems
+      summary: No global, no op-level security, no components.securitySchemes -- emits @PermitAll
+      responses:
+        '200':
+          description: OK

--- a/modules/openapi-generator/src/test/resources/3_0/jaxrs-spec/quarkus-permit-all-op-empty-global-empty.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/jaxrs-spec/quarkus-permit-all-op-empty-global-empty.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.1
+info:
+  title: Quarkus op-level empty AND global empty -- emits @PermitAll
+  version: '1.0'
+servers:
+  - url: 'http://localhost:8080/'
+security: []
+paths:
+  /items:
+    get:
+      operationId: getItems
+      summary: Op-level security:[] redundantly mirrors global security:[] -- emits @PermitAll
+      security: []
+      responses:
+        '200':
+          description: OK
+components:
+  securitySchemes:
+    oauth2_scheme:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://example.com/oauth/token
+          scopes: {}

--- a/modules/openapi-generator/src/test/resources/3_0/jaxrs-spec/quarkus-permit-all-op-empty-global-non-empty.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/jaxrs-spec/quarkus-permit-all-op-empty-global-non-empty.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.1
+info:
+  title: Quarkus op-level empty overrides non-empty global -- emits @PermitAll for that op
+  version: '1.0'
+servers:
+  - url: 'http://localhost:8080/'
+security:
+  - oauth2_scheme: []
+paths:
+  /items:
+    get:
+      operationId: getItems
+      summary: Inherits global oauth2:[] -- emits @RolesAllowed({"**"})
+      responses:
+        '200':
+          description: OK
+    post:
+      operationId: createItem
+      summary: Op-level security:[] overrides global -- emits @PermitAll
+      security: []
+      responses:
+        '201':
+          description: Created
+components:
+  securitySchemes:
+    oauth2_scheme:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://example.com/oauth/token
+          scopes: {}

--- a/modules/openapi-generator/src/test/resources/3_0/jaxrs-spec/quarkus-permit-all-op-empty-security.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/jaxrs-spec/quarkus-permit-all-op-empty-security.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.1
+info:
+  title: Quarkus op-level explicit empty security with no global -- emits @PermitAll
+  version: '1.0'
+servers:
+  - url: 'http://localhost:8080/'
+paths:
+  /items:
+    get:
+      operationId: getItems
+      summary: Op-level security:[] -- explicit opt-out, emits @PermitAll
+      security: []
+      responses:
+        '200':
+          description: OK
+components:
+  securitySchemes:
+    oauth2_scheme:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://example.com/oauth/token
+          scopes:
+            admin: Admin access

--- a/samples/server/petstore/jaxrs-spec/quarkus-security/.openapi-generator/FILES
+++ b/samples/server/petstore/jaxrs-spec/quarkus-security/.openapi-generator/FILES
@@ -3,6 +3,7 @@ README.md
 pom.xml
 src/gen/java/org/openapitools/api/AdminApi.java
 src/gen/java/org/openapitools/api/AdminOrUserApi.java
+src/gen/java/org/openapitools/api/AnonymousOrAuthenticatedApi.java
 src/gen/java/org/openapitools/api/AuthenticatedApi.java
 src/gen/java/org/openapitools/api/PublicApi.java
 src/main/docker/Dockerfile.jvm

--- a/samples/server/petstore/jaxrs-spec/quarkus-security/src/gen/java/org/openapitools/api/AnonymousOrAuthenticatedApi.java
+++ b/samples/server/petstore/jaxrs-spec/quarkus-security/src/gen/java/org/openapitools/api/AnonymousOrAuthenticatedApi.java
@@ -14,13 +14,13 @@ import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
 
-@Path("/public")
+@Path("/anonymous-or-authenticated")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.23.0-SNAPSHOT")
-public interface PublicApi {
+public interface AnonymousOrAuthenticatedApi {
 
     @GET
     @ResponseStatus(200)
     @jakarta.annotation.security.PermitAll
-    void getPublic();
+    void getAnonymousOrAuthenticated();
 
 }

--- a/samples/server/petstore/jaxrs-spec/quarkus-security/src/main/resources/META-INF/openapi.yaml
+++ b/samples/server/petstore/jaxrs-spec/quarkus-security/src/main/resources/META-INF/openapi.yaml
@@ -53,6 +53,19 @@ paths:
         })"
       x-accepts:
       - application/json
+  /anonymous-or-authenticated:
+    get:
+      operationId: getAnonymousOrAuthenticated
+      responses:
+        "200":
+          description: OK
+      security:
+      - oauth2_scheme: []
+      - {}
+      summary: OR with anonymous alternative — emits @PermitAll (least-restrictive
+        wins)
+      x-accepts:
+      - application/json
 components:
   schemas: {}
   securitySchemes:


### PR DESCRIPTION
This is part 4 of #23691 to improve authentication and authorisation support in the `jaxrs-spec/quarkus` server generator, building on #23680 and #23752.

## What this PR does

Extends the `useJakartaSecurityAnnotations` flag (Quarkus library only, requires `useJakartaEe=true`) to emit `@jakarta.annotation.security.PermitAll` on JAX-RS interface methods and implementation stubs for operations whose OpenAPI security requirements mean *no authentication is required*.

This PR covers the *unauthenticated* case (`@PermitAll`). The generator has 3 mutually exclusive emission per operation:
- `@RolesAllowed({"**}): Any authentication is required
- `@RolesAllowed({"scope"}): Specific scope is required
- `@PermitAll`: No authentication is required

## Semantic rules

### When `@PermitAll` is emitted

| Condition | Result |
|---|---|
| Op-level `security: []` (explicit opt-out) | `@PermitAll` — overrides any global setting |
| No op-level `security` AND global `security: []` | `@PermitAll` — inherits empty list |
| No op-level `security` AND no global `security` block at all | `@PermitAll` — entire API is unauthenticated |
| OR list contains an anonymous alternative `- {}` | `@PermitAll` — least-restrictive alternative wins |
| Mixed-scope AND group / undefined scheme / other ambiguous case | No annotation + `WARN` log (does **not** fall through to `@PermitAll`) |

### Anonymous OR alternative (`- {}`) — least restrictive wins

OpenAPI 3 allows an empty `SecurityRequirement` inside the OR list to indicate anonymous access is acceptable alongside other alternatives. When present, the least-restrictive alternative is "no auth required":

```yaml
security:
  - oauth2: [admin]
  - {}                 # anonymous allowed → @PermitAll emitted
```

This was previously deferred (PR #23680 left these operations unannotated). They now emit `@PermitAll`.

### Global vs per-operation security

| Op-level `security` | Global `security` | Result |
|---|---|---|
| `[]` (empty) | anything | `@PermitAll` |
| absent | absent | `@PermitAll` |
| absent | `[]` (empty) | `@PermitAll` |
| absent | non-empty | inherits global — falls through to `@RolesAllowed` paths |
| non-empty | anything | uses op-level — falls through to `@RolesAllowed` paths |

### Why mixed-scope AND groups do not fall through

PR #23752 already returns `null` and logs a `WARN` for AND groups with more than one scoped scheme — Jakarta annotations cannot express AND-of-different-scope-sets. Silently emitting `@PermitAll` in that case would turn an authorisation gap into a security hole, so the processor explicitly evaluates only the unauthenticated cases above and leaves the operation unannotated otherwise.

## Implementation notes

**New vendor extension.** The processor sets `x-jakarta-permit-all = true` (mutually exclusive with `x-jakarta-roles-allowed`) on qualifying operations. The shared partial `jakartaSecurityAnnotations.mustache` (and the equivalent blocks in `apiInterface.mustache` / `apiMethod.mustache`) gains a section guarded by the new extension to emit `@jakarta.annotation.security.PermitAll`.

**Processor changes in `JakartaSecurityAnnotationProcessor`:**
- Added `qualifiesForPermitAll(rawOp, openAPI, effectiveRequirements)` that inspects the **raw** op-level and global `security` fields (not the already-resolved effective list) so it can distinguish explicit op-level opt-out from inherited global. This is necessary because the resolved list collapses `op.security == []` and "no op.security, inherits global == []" into the same value.
- `applyTo` now has three short-circuit branches: wildcard `@RolesAllowed({"**"})` → scoped `@RolesAllowed({scopes})` → `@PermitAll`. The first match wins; subsequent branches are skipped.
- Mutual exclusion is enforced by the data shape: at most one of `x-jakarta-roles-allowed` and `x-jakarta-permit-all` is ever set on a given operation.

**No changes to `JavaJAXRSSpecServerCodegen`.** The existing `fromOperation` override from #23680 already delegates to the processor.

**CI sample fixture** `bin/configs/jaxrs-spec-quarkus-security.yaml` and `samples/server/petstore/jaxrs-spec/quarkus-security/` (added in #23752) gain a `PublicApi` endpoint that exercises the `@PermitAll` path end-to-end alongside the existing scoped and wildcard endpoints, so the four annotation outcomes (`@PermitAll`, `@RolesAllowed({"**"})`, `@RolesAllowed({scope})`, `@RolesAllowed({scope1,scope2})`) all render in the committed sample.

## Test coverage

The existing `quarkusJakartaSecurityCases` data provider (introduced in #23680) is extended with 10 new rows covering the four `@PermitAll` cases across `interfaceOnly={true,false}` and `useJakartaSecurityAnnotations={true,false}`:

| Scenario | Fixture |
|---|---|
| Op-level `security: []` (overrides non-empty global) | `quarkus-permit-all-op-empty-security.yaml` |
| Op-level `security: []` AND global `security: []` | `quarkus-permit-all-op-empty-global-empty.yaml` |
| Op-level `security: []` AND non-empty global (per-op opt-out only) | `quarkus-permit-all-op-empty-global-non-empty.yaml` |
| No `security` field anywhere in the spec | `quarkus-permit-all-no-security-defined.yaml` |

Plus targeted tests:
- `quarkusGlobalEmptySecurityListEmitsPermitAll` — global `security: []` inheritance.
- `quarkusOrAnonymousAlternativeEmitsPermitAll` — OR list containing `- {}`.
- `quarkusNoSecurityDefinedAnywhereEmitsPermitAll` — entire spec unauthenticated.
- `quarkusMixedAndGroupDoesNotFallThroughToPermitAll` — guards the security-hole regression: mixed-scope AND groups must emit nothing, not `@PermitAll`.
- `quarkusPermitAllCoexistsWithMicroProfileAnnotations` — `@PermitAll` renders alongside MicroProfile `@SecurityRequirement` annotations on the same method (`quarkus-permit-all-microprofile-coexist.yaml`).
- `quarkusMixedSecuritySampleEmitsAllExpectedAnnotations` — end-to-end check against the committed CI sample asserting all four annotation outcomes render in `PublicApi`, `AuthenticatedApi`, `AdminApi`, `AdminOrUserApi`, `AnonymousOrAuthenticatedApi`.

All test rows from #23680 and #23752 continue to pass unchanged.

Closes #23691

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ```
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files.
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master.
  These must match the expectations made by your contribution.
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`.
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generate `@PermitAll` for unauthenticated endpoints in the `jaxrs-spec` `quarkus` generator, and keep Jakarta security annotations mutually exclusive with wildcard or scoped `@RolesAllowed`. Generated APIs now cleanly mirror OpenAPI security: public, any-authenticated, or role-scoped.

- **New Features**
  - Emit `@PermitAll` when an operation is unauthenticated: op-level `security: []`, global `security: []`, no security anywhere, or an OR list with `{}`.
  - Keep `@RolesAllowed({"**"})` for “any authenticated user”; emit scoped `@RolesAllowed({"admin","user"})` when all OR alternatives are scoped (unioned/deduped/sorted). For mixed-scope AND groups, log and emit nothing.
  - Enforce mutual exclusion between `@PermitAll`, wildcard `@RolesAllowed`, and scoped `@RolesAllowed`, driven by `x-jakarta-permit-all` and `x-jakarta-roles-allowed`. Updated `apiInterface.mustache` and `apiMethod.mustache` to render them.
  - Add sample `AnonymousOrAuthenticatedApi` and new test fixtures to cover global empty security, op-level opt-out, anonymous OR alternatives, “no security defined,” and coexistence with MicroProfile annotations.

<sup>Written for commit 27b61d59209cde345088164cb7d67781b161c000. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


