### PR TITLE
docs: fix duplicated "the" in debugging guide

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -216,7 +216,7 @@ The steps are shown here for a specific version of the generator, but apply the 
         ]
     }
     ```
-    to attach the the suspended process above.
+    to attach the suspended process above.
 
 ## Logs
 


### PR DESCRIPTION
One-line typo fix in `docs/debugging.md`: "to attach the the suspended process above." → "to attach the suspended process above.". No code/behavior change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix typo in docs/debugging.md by removing a duplicated "the" in the debugging guide to improve clarity. No code or behavior changes.

<sup>Written for commit a9ad775ae0225884b3199715fb3a3637b9f2d5ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

