### PR TITLE
[go] support io.Reader and []byte response types in client decode

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/client.mustache
+++ b/modules/openapi-generator/src/main/resources/go/client.mustache
@@ -539,6 +539,15 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 		*s = string(b)
 		return nil
 	}
+	if r, ok := v.(*io.Reader); ok {
+		*r = bytes.NewReader(b)
+		return nil
+	}
+	// Must stay before the JSON branch: json.Unmarshal would base64-decode into *[]byte.
+	if p, ok := v.(*[]byte); ok {
+		*p = b
+		return nil
+	}
 	if f, ok := v.(*os.File); ok {
 		f, err = os.CreateTemp("", "HttpClientFile")
 		if err != nil {

--- a/samples/client/echo_api/go-external-refs/client.go
+++ b/samples/client/echo_api/go-external-refs/client.go
@@ -460,6 +460,15 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 		*s = string(b)
 		return nil
 	}
+	if r, ok := v.(*io.Reader); ok {
+		*r = bytes.NewReader(b)
+		return nil
+	}
+	// Must stay before the JSON branch: json.Unmarshal would base64-decode into *[]byte.
+	if p, ok := v.(*[]byte); ok {
+		*p = b
+		return nil
+	}
 	if f, ok := v.(*os.File); ok {
 		f, err = os.CreateTemp("", "HttpClientFile")
 		if err != nil {

--- a/samples/client/echo_api/go/client.go
+++ b/samples/client/echo_api/go/client.go
@@ -460,6 +460,15 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 		*s = string(b)
 		return nil
 	}
+	if r, ok := v.(*io.Reader); ok {
+		*r = bytes.NewReader(b)
+		return nil
+	}
+	// Must stay before the JSON branch: json.Unmarshal would base64-decode into *[]byte.
+	if p, ok := v.(*[]byte); ok {
+		*p = b
+		return nil
+	}
 	if f, ok := v.(*os.File); ok {
 		f, err = os.CreateTemp("", "HttpClientFile")
 		if err != nil {

--- a/samples/client/others/go/allof_multiple_ref_and_discriminator/client.go
+++ b/samples/client/others/go/allof_multiple_ref_and_discriminator/client.go
@@ -431,6 +431,15 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 		*s = string(b)
 		return nil
 	}
+	if r, ok := v.(*io.Reader); ok {
+		*r = bytes.NewReader(b)
+		return nil
+	}
+	// Must stay before the JSON branch: json.Unmarshal would base64-decode into *[]byte.
+	if p, ok := v.(*[]byte); ok {
+		*p = b
+		return nil
+	}
 	if f, ok := v.(*os.File); ok {
 		f, err = os.CreateTemp("", "HttpClientFile")
 		if err != nil {

--- a/samples/client/others/go/oneof-anyof-required/client.go
+++ b/samples/client/others/go/oneof-anyof-required/client.go
@@ -431,6 +431,15 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 		*s = string(b)
 		return nil
 	}
+	if r, ok := v.(*io.Reader); ok {
+		*r = bytes.NewReader(b)
+		return nil
+	}
+	// Must stay before the JSON branch: json.Unmarshal would base64-decode into *[]byte.
+	if p, ok := v.(*[]byte); ok {
+		*p = b
+		return nil
+	}
 	if f, ok := v.(*os.File); ok {
 		f, err = os.CreateTemp("", "HttpClientFile")
 		if err != nil {

--- a/samples/client/others/go/oneof-discriminator-lookup/client.go
+++ b/samples/client/others/go/oneof-discriminator-lookup/client.go
@@ -431,6 +431,15 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 		*s = string(b)
 		return nil
 	}
+	if r, ok := v.(*io.Reader); ok {
+		*r = bytes.NewReader(b)
+		return nil
+	}
+	// Must stay before the JSON branch: json.Unmarshal would base64-decode into *[]byte.
+	if p, ok := v.(*[]byte); ok {
+		*p = b
+		return nil
+	}
 	if f, ok := v.(*os.File); ok {
 		f, err = os.CreateTemp("", "HttpClientFile")
 		if err != nil {

--- a/samples/client/petstore/go/go-petstore/client.go
+++ b/samples/client/petstore/go/go-petstore/client.go
@@ -466,6 +466,15 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 		*s = string(b)
 		return nil
 	}
+	if r, ok := v.(*io.Reader); ok {
+		*r = bytes.NewReader(b)
+		return nil
+	}
+	// Must stay before the JSON branch: json.Unmarshal would base64-decode into *[]byte.
+	if p, ok := v.(*[]byte); ok {
+		*p = b
+		return nil
+	}
 	if f, ok := v.(*os.File); ok {
 		f, err = os.CreateTemp("", "HttpClientFile")
 		if err != nil {

--- a/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/client.go
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/client.go
@@ -434,6 +434,15 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 		*s = string(b)
 		return nil
 	}
+	if r, ok := v.(*io.Reader); ok {
+		*r = bytes.NewReader(b)
+		return nil
+	}
+	// Must stay before the JSON branch: json.Unmarshal would base64-decode into *[]byte.
+	if p, ok := v.(*[]byte); ok {
+		*p = b
+		return nil
+	}
 	if f, ok := v.(*os.File); ok {
 		f, err = os.CreateTemp("", "HttpClientFile")
 		if err != nil {

--- a/samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/client.go
+++ b/samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/client.go
@@ -446,6 +446,15 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 		*s = string(b)
 		return nil
 	}
+	if r, ok := v.(*io.Reader); ok {
+		*r = bytes.NewReader(b)
+		return nil
+	}
+	// Must stay before the JSON branch: json.Unmarshal would base64-decode into *[]byte.
+	if p, ok := v.(*[]byte); ok {
+		*p = b
+		return nil
+	}
 	if f, ok := v.(*os.File); ok {
 		f, err = os.CreateTemp("", "HttpClientFile")
 		if err != nil {

--- a/samples/openapi3/client/petstore/go-petstore-withXml/client.go
+++ b/samples/openapi3/client/petstore/go-petstore-withXml/client.go
@@ -446,6 +446,15 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 		*s = string(b)
 		return nil
 	}
+	if r, ok := v.(*io.Reader); ok {
+		*r = bytes.NewReader(b)
+		return nil
+	}
+	// Must stay before the JSON branch: json.Unmarshal would base64-decode into *[]byte.
+	if p, ok := v.(*[]byte); ok {
+		*p = b
+		return nil
+	}
 	if f, ok := v.(*os.File); ok {
 		f, err = os.CreateTemp("", "HttpClientFile")
 		if err != nil {

--- a/samples/openapi3/client/petstore/go/go-petstore-aws-signature/client.go
+++ b/samples/openapi3/client/petstore/go/go-petstore-aws-signature/client.go
@@ -488,6 +488,15 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 		*s = string(b)
 		return nil
 	}
+	if r, ok := v.(*io.Reader); ok {
+		*r = bytes.NewReader(b)
+		return nil
+	}
+	// Must stay before the JSON branch: json.Unmarshal would base64-decode into *[]byte.
+	if p, ok := v.(*[]byte); ok {
+		*p = b
+		return nil
+	}
 	if f, ok := v.(*os.File); ok {
 		f, err = os.CreateTemp("", "HttpClientFile")
 		if err != nil {

--- a/samples/openapi3/client/petstore/go/go-petstore/client.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/client.go
@@ -484,6 +484,15 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 		*s = string(b)
 		return nil
 	}
+	if r, ok := v.(*io.Reader); ok {
+		*r = bytes.NewReader(b)
+		return nil
+	}
+	// Must stay before the JSON branch: json.Unmarshal would base64-decode into *[]byte.
+	if p, ok := v.(*[]byte); ok {
+		*p = b
+		return nil
+	}
 	if f, ok := v.(*os.File); ok {
 		f, err = os.CreateTemp("", "HttpClientFile")
 		if err != nil {


### PR DESCRIPTION
The Go generator maps `type: string` + `format: binary` to `*os.File` by default. Consumers can override that with `--type-mappings` to get `io.Reader` or `[]byte`.

`setBody` already has branches for both, so request bodies work. The shared `decode` helper does not: it only asserts `*string`, `*os.File`, and `**os.File`. When `Execute` declares `var localVarReturnValue io.Reader` or `[]byte` and calls `decode(&localVarReturnValue, ...)`, no branch matches and the call returns `"undefined response type"`.

This PR adds two `decode` branches that close the symmetry with `setBody`:

```go
if r, ok := v.(*io.Reader); ok {
    *r = bytes.NewReader(b)
    return nil
}
// Must stay before the JSON branch: json.Unmarshal would base64-decode into *[]byte.
if p, ok := v.(*[]byte); ok {
    *p = b
    return nil
}
```

`bytes` is already imported in every generated `client.go`. The same additive patch is applied to the eleven Go client samples.

### Notes on choice of type

Both mappings are useful but for different scenarios:

- `[]byte` is honest: the payload is fully buffered in memory anyway (the caller pre-slurps the response body for shared error/success handling). Callers get the bytes directly with no wrapper.
- `io.Reader` is forward-compatible: if the response path is ever refactored to skip the eager buffering and stream the body, the same return type stays valid for consumers without changing call sites.

Neither offers true streaming today; that would require changes to `api.mustache` and is out of scope here.

### Verification

Generated the [libre-graph-api](https://github.com/opencloud-eu/libre-graph-api/pull/47) spec with the type mappings against this branch and ran `httptest`-backed integration tests covering both shapes:

- `io.Reader` upload (plain `io.Reader`, `*os.File` for backward compat, 1 MiB `bytes.Reader`), `io.Reader` download, empty-body download.
- `[]byte` upload, `[]byte` download, empty-body download.

All pass.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] PR title clearly describes the work.
- [x] Samples updated. `./mvnw clean package` was not run locally (no JDK), but the change is purely additive and isolated to one block in `decode`. No other template, generator, or model output is affected.
- [x] Filed against `master`.

cc @antihax @grokify @kemokemo @jirikuncar @ph4r5h4d @lwj5
