### PR TITLE
refactor: centralize handling of enum extension x-enum-varnames and x-enum-descriptions

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -499,4 +499,6 @@ public class CodegenConstants {
     public static final String X_DISCRIMINATOR_VALUE = "x-discriminator-value";
     public static final String X_ONE_OF_NAME = "x-one-of-name";
     public static final String X_NULLABLE = "x-nullable";
+    public static final String X_ENUM_VARNAMES = "x-enum-varnames";
+    public static final String X_ENUM_DESCRIPTIONS = "x-enum-descriptions";
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -82,6 +82,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.regex.Matcher;
@@ -7032,19 +7033,28 @@ public class DefaultCodegen implements CodegenConfig {
 
     protected void updateEnumVarsWithExtensions(List<Map<String, Object>> enumVars, Map<String, Object> vendorExtensions, String dataType) {
         if (vendorExtensions != null) {
-            updateEnumVarsWithExtensions(enumVars, vendorExtensions, "x-enum-varnames", "name", dataType);
-            updateEnumVarsWithExtensions(enumVars, vendorExtensions, "x-enum-descriptions", "enumDescription", dataType);
+            updateEnumVarsWithExtensions(enumVars, vendorExtensions, X_ENUM_VARNAMES, "name", dataType);
+            updateEnumVarsWithExtensions(enumVars, vendorExtensions, X_ENUM_DESCRIPTIONS, "enumDescription", dataType);
         }
     }
 
-    private void updateEnumVarsWithExtensions(List<Map<String, Object>> enumVars, Map<String, Object> vendorExtensions, String extensionKey, String key, String dataType) {
+    protected void updateEnumVarsWithExtensions(List<Map<String, Object>> enumVars, Map<String, Object> vendorExtensions, String extensionKey, String key, String dataType) {
+        updateEnumVarsWithExtensions(enumVars, vendorExtensions, extensionKey, key, dataType, (a, b) -> a);
+    }
+
+    protected void updateEnumVarsWithExtensions(List<Map<String, Object>> enumVars,
+                                                Map<String, Object> vendorExtensions,
+                                                String extensionKey,
+                                                String key,
+                                                String dataType,
+                                                BiFunction<String, String, String> enumDataTypeMapping) {
         if (vendorExtensions.containsKey(extensionKey)) {
             Object extensionValue = vendorExtensions.get(extensionKey);
             if (extensionValue instanceof List) {
                 List<String> values = (List<String>) extensionValue;
                 int size = Math.min(enumVars.size(), values.size());
                 for (int i = 0; i < size; i++) {
-                    enumVars.get(i).put(key, values.get(i));
+                    enumVars.get(i).put(key, enumDataTypeMapping.apply(values.get(i), dataType));
                 }
             } else if (extensionValue instanceof Map) {
                 Map<String, String> valueMap = (Map<String, String>) extensionValue;
@@ -7052,7 +7062,7 @@ public class DefaultCodegen implements CodegenConfig {
                     String enumValue = (String) enumVar.get("value");
                     for (Map.Entry<String, String> entry : valueMap.entrySet()) {
                         if (toEnumValue(entry.getKey(), dataType).equals(enumValue)) {
-                            enumVar.put(key, entry.getValue());
+                            enumVar.put(key, enumDataTypeMapping.apply(entry.getValue(), dataType));
                             break;
                         }
                     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -1510,7 +1510,7 @@ public class OpenAPINormalizer {
         originalSchema.setEnum(new ArrayList<>(enumValues.keySet()));
         if(enumValues.values().stream().anyMatch(e -> !e.isEmpty())) {
             //set x-enum-descriptions only if there's at least one non-empty description
-            originalSchema.addExtension("x-enum-descriptions", new ArrayList<>(enumValues.values()));
+            originalSchema.addExtension(X_ENUM_DESCRIPTIONS, new ArrayList<>(enumValues.values()));
         }
 
         LOGGER.debug("Simplified {} with enum sub-schemas to single enum: {}", composedType, originalSchema);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -38,6 +38,8 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.openapitools.codegen.CodegenConstants.X_ENUM_DESCRIPTIONS;
+import static org.openapitools.codegen.CodegenConstants.X_ENUM_VARNAMES;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.CamelizeOption.UPPERCASE_FIRST_CHAR;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
@@ -753,49 +755,8 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
     @Override
     protected void updateEnumVarsWithExtensions(List<Map<String, Object>> enumVars, Map<String, Object> vendorExtensions, String dataType) {
         if (vendorExtensions != null) {
-            if (vendorExtensions.containsKey("x-enum-varnames")) {
-                Object extensionValue = vendorExtensions.get("x-enum-varnames");
-                if (extensionValue instanceof List) {
-                    List<String> values = (List<String>) extensionValue;
-                    int size = Math.min(enumVars.size(), values.size());
-                    for (int i = 0; i < size; i++) {
-                        enumVars.get(i).put("name", toEnumVarName(values.get(i), dataType));
-                    }
-                } else if (extensionValue instanceof Map) {
-                    Map<String, String> valueMap = (Map<String, String>) extensionValue;
-                    for (Map<String, Object> enumVar : enumVars) {
-                        String enumValue = (String) enumVar.get("value");
-                        for (Map.Entry<String, String> entry : valueMap.entrySet()) {
-                            if (toEnumValue(entry.getKey(), dataType).equals(enumValue)) {
-                                enumVar.put("name", toEnumVarName(entry.getValue(), dataType));
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (vendorExtensions.containsKey("x-enum-descriptions")) {
-                Object extensionValue = vendorExtensions.get("x-enum-descriptions");
-                if (extensionValue instanceof List) {
-                    List<String> values = (List<String>) extensionValue;
-                    int size = Math.min(enumVars.size(), values.size());
-                    for (int i = 0; i < size; i++) {
-                        enumVars.get(i).put("enumDescription", values.get(i));
-                    }
-                } else if (extensionValue instanceof Map) {
-                    Map<String, String> valueMap = (Map<String, String>) extensionValue;
-                    for (Map<String, Object> enumVar : enumVars) {
-                        String enumValue = (String) enumVar.get("value");
-                        for (Map.Entry<String, String> entry : valueMap.entrySet()) {
-                            if (toEnumValue(entry.getKey(), dataType).equals(enumValue)) {
-                                enumVar.put("enumDescription", entry.getValue());
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
+            updateEnumVarsWithExtensions(enumVars, vendorExtensions, X_ENUM_VARNAMES, "name", dataType, this::toEnumVarName);
+            updateEnumVarsWithExtensions(enumVars, vendorExtensions, X_ENUM_DESCRIPTIONS, "enumDescription", dataType);
         }
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -42,8 +42,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.openapitools.codegen.CodegenConstants.X_MODIFIERS;
-import static org.openapitools.codegen.CodegenConstants.X_REGEX;
+import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.StringUtils.*;
 
 
@@ -1064,13 +1063,13 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                     if ((Boolean) enumVars.get("isString")) {
                         model.vendorExtensions.putIfAbsent("x-py-enum-type", "str");
                         // Do not overwrite the variable name if already set through x-enum-varnames
-                        if (model.vendorExtensions.get("x-enum-varnames") == null) {
+                        if (model.vendorExtensions.get(X_ENUM_VARNAMES) == null) {
                             enumVars.put("name", toEnumVariableName((String) enumVars.get("value"), "str"));
                         }
                     } else {
                         model.vendorExtensions.putIfAbsent("x-py-enum-type", "int");
                         // Do not overwrite the variable name if already set through x-enum-varnames
-                        if (model.vendorExtensions.get("x-enum-varnames") == null) {
+                        if (model.vendorExtensions.get(X_ENUM_VARNAMES) == null) {
                             enumVars.put("name", toEnumVariableName((String) enumVars.get("value"), "int"));
                         }
                     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -59,6 +59,8 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.openapitools.codegen.CodegenConstants.X_ENUM_DESCRIPTIONS;
+import static org.openapitools.codegen.CodegenConstants.X_ENUM_VARNAMES;
 
 public class DefaultCodegenTest {
 
@@ -2302,7 +2304,7 @@ public class DefaultCodegenTest {
         allowableValues.put("values", values);
         var.setAllowableValues(allowableValues);
         var.dataType = "String";
-        Map<String, Object> extensions = Collections.singletonMap("x-enum-varnames", aliases);
+        Map<String, Object> extensions = Collections.singletonMap(X_ENUM_VARNAMES, aliases);
         var.setVendorExtensions(extensions);
         return var;
     }
@@ -2327,8 +2329,8 @@ public class DefaultCodegenTest {
         final List<String> aliases = Arrays.asList("DOGVAR", "CATVAR");
         final List<String> descriptions = Arrays.asList("This is a dog", "This is a cat");
         Map<String, Object> extensions = new HashMap<>();
-        extensions.put("x-enum-varnames", aliases);
-        extensions.put("x-enum-descriptions", descriptions);
+        extensions.put(X_ENUM_VARNAMES, aliases);
+        extensions.put(X_ENUM_DESCRIPTIONS, descriptions);
         cm.setVendorExtensions(extensions);
         cm.setVars(Collections.emptyList());
         return TestUtils.createCodegenModelWrapper(cm);
@@ -2348,8 +2350,8 @@ public class DefaultCodegenTest {
         descriptions.put("dog", "This is a dog");
         descriptions.put("cat", "This is a cat");
         Map<String, Object> extensions = new HashMap<>();
-        extensions.put("x-enum-varnames", aliases);
-        extensions.put("x-enum-descriptions", descriptions);
+        extensions.put(X_ENUM_VARNAMES, aliases);
+        extensions.put(X_ENUM_DESCRIPTIONS, descriptions);
         cm.setVendorExtensions(extensions);
         cm.setVars(Collections.emptyList());
         return TestUtils.createCodegenModelWrapper(cm);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.Test;
 import java.math.BigDecimal;
 import java.util.*;
 
+import static org.openapitools.codegen.CodegenConstants.X_ENUM_DESCRIPTIONS;
 import static org.testng.Assert.*;
 
 public class OpenAPINormalizerTest {
@@ -226,7 +227,7 @@ public class OpenAPINormalizerTest {
         assertNull(anyOfParam.getSchema().getAnyOf());
         assertEquals(anyOfParam.getSchema().getType(), "string");
         assertEquals(anyOfParam.getSchema().getEnum(), Arrays.asList("anyof 1", "anyof 2"));
-        assertEquals(anyOfParam.getSchema().getExtensions().get("x-enum-descriptions"), Arrays.asList("title 1", "title 2"));
+        assertEquals(anyOfParam.getSchema().getExtensions().get(X_ENUM_DESCRIPTIONS), Arrays.asList("title 1", "title 2"));
 
         Schema combinedRefsEnum = openAPI.getComponents().getSchemas().get("combinedRefsEnum");
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -403,7 +403,7 @@ public class JavaClientCodegenTest {
     public void updateCodegenPropertyEnumWithCustomNames() {
         final JavaClientCodegen codegen = new JavaClientCodegen();
         CodegenProperty array = codegenPropertyWithArrayOfIntegerValues();
-        array.getItems().setVendorExtensions(Map.of("x-enum-varnames", Collections.singletonList("ONE")));
+        array.getItems().setVendorExtensions(Map.of(X_ENUM_VARNAMES, Collections.singletonList("ONE")));
 
         codegen.updateCodegenPropertyEnum(array);
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/AbstractPhpCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/AbstractPhpCodegenTest.java
@@ -19,19 +19,23 @@ package org.openapitools.codegen.php;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.Schema;
+import org.junit.jupiter.api.Assertions;
 import org.mockito.Answers;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.languages.AbstractPhpCodegen;
+import org.openapitools.codegen.model.ModelsMap;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
-import java.util.HashMap;
+import java.util.*;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.withSettings;
+import static org.openapitools.codegen.CodegenConstants.X_ENUM_DESCRIPTIONS;
+import static org.openapitools.codegen.CodegenConstants.X_ENUM_VARNAMES;
 
 public class AbstractPhpCodegenTest {
 
@@ -180,5 +184,44 @@ public class AbstractPhpCodegenTest {
         Assert.assertEquals(codegen.toEnumValue("\"", "string"), "'\"'");
         Assert.assertEquals(codegen.toEnumValue("1.0", "float"), "1.0");
         Assert.assertEquals(codegen.toEnumValue("1", "int"), "1");
+    }
+
+    @Test
+    void postProcessModelsEnumWithMapExtension() {
+        ModelsMap objs = codegenModelWithXEnumVarNameAsMap();
+        CodegenModel cm = objs.getModels().get(0).getModel();
+
+        codegen.postProcessModelsEnum(objs);
+
+        List<Map<String, Object>> enumVars = (List<Map<String, Object>>) cm.getAllowableValues().get("enumVars");
+        Assertions.assertNotNull(enumVars);
+        Assertions.assertNotNull(enumVars.get(0));
+        assertEquals("DOGVAR", enumVars.get(0).getOrDefault("name", ""));
+        assertEquals("'dog'", enumVars.get(0).getOrDefault("value", ""));
+        assertEquals("This is a dog", enumVars.get(0).getOrDefault("enumDescription", ""));
+        Assertions.assertNotNull(enumVars.get(1));
+        assertEquals("CATVAR", enumVars.get(1).getOrDefault("name", ""));
+        assertEquals("'cat'", enumVars.get(1).getOrDefault("value", ""));
+    }
+
+    private ModelsMap codegenModelWithXEnumVarNameAsMap() {
+        final CodegenModel cm = new CodegenModel();
+        cm.isEnum = true;
+        final HashMap<String, Object> allowableValues = new HashMap<>();
+        allowableValues.put("values", Arrays.asList("dog", "cat"));
+        cm.setAllowableValues(allowableValues);
+        cm.dataType = "String";
+        Map<String, String> aliases = new LinkedHashMap<>();
+        aliases.put("dog", "_DOGVAR");
+        aliases.put("cat", "_CATVAR");
+        Map<String, String> descriptions = new LinkedHashMap<>();
+        descriptions.put("dog", "This is a dog");
+        descriptions.put("cat", "This is a cat");
+        Map<String, Object> extensions = new HashMap<>();
+        extensions.put(X_ENUM_VARNAMES, aliases);
+        extensions.put(X_ENUM_DESCRIPTIONS, descriptions);
+        cm.setVendorExtensions(extensions);
+        cm.setVars(Collections.emptyList());
+        return TestUtils.createCodegenModelWrapper(cm);
     }
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

I was investigating https://github.com/OpenAPITools/openapi-generator/issues/23764 and saw that there were some duplicated logic that could be removed with a small refactor. This PR removes that duplicated logic for handling `x-enum-varnames` and `x-enum-descriptions`.

The difference between `PHP` and the `Default` is that PHP applies a mapping for the enum name. Instead of duplicating the logic I have introduced an overloaded method that can take a mapping function.

The minimal difference between PHP and Default can be more clearly view in last [PR that affected this logic](https://github.com/OpenAPITools/openapi-generator/pull/23540/changes).

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes handling of enum extensions x-enum-varnames and x-enum-descriptions to remove duplicated logic and keep behavior consistent across generators. PHP now applies its enum-name mapping via a single shared path.

- **Refactors**
  - Added constants `X_ENUM_VARNAMES` and `X_ENUM_DESCRIPTIONS` in `CodegenConstants` and replaced string literals.
  - Moved extension parsing into `DefaultCodegen.updateEnumVarsWithExtensions`, with an overload that accepts a mapping function for enum var names; supports both List and Map extension forms.
  - Updated `AbstractPhpCodegen` to delegate to the new method with `toEnumVarName`; updated `AbstractPythonCodegen` to use the new constants.
  - Switched `OpenAPINormalizer` to use the constant for x-enum-descriptions.
  - Updated/added tests to cover list/map inputs and ensure no behavior changes.

<sup>Written for commit a1007b83781c710cefc3ed133aa98e1c1c1debd3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

