### PR TITLE
[Kotlin] Fix `explicitApi`/`nonPublicApi`/`generateOneOfAnyOfWrappers` generation for `kotlinx_serialization`

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/anyof_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/anyof_class.mustache
@@ -107,7 +107,7 @@ import java.io.IOException
 {{#anyOf}}
 {{^vendorExtensions.x-duplicated-data-type}}
     @JvmInline
-    {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}value class {{#fnToValueClassName}}{{{dataType}}}{{/fnToValueClassName}}(val value: {{{dataType}}}) : {{classname}}
+    {{#explicitApi}}public {{/explicitApi}}value class {{#fnToValueClassName}}{{{dataType}}}{{/fnToValueClassName}}({{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val value: {{{dataType}}}) : {{classname}}
 
 {{/vendorExtensions.x-duplicated-data-type}}
 {{/anyOf}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/BigDecimalAdapter.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/BigDecimalAdapter.kt.mustache
@@ -18,7 +18,7 @@ import java.math.BigDecimal
 {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}object BigDecimalAdapter : KSerializer<BigDecimal> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("BigDecimal", PrimitiveKind.STRING)
     override fun deserialize(decoder: Decoder): BigDecimal = BigDecimal(decoder.decodeString())
-    override fun serialize(encoder: Encoder, value: BigDecimal) = encoder.encodeString(value.toPlainString())
+    override fun serialize(encoder: Encoder, value: BigDecimal){{#explicitApi}}: Unit{{/explicitApi}} = encoder.encodeString(value.toPlainString())
 }
 {{/kotlinx_serialization}}
 {{#moshi}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/Serializer.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/Serializer.kt.mustache
@@ -134,7 +134,7 @@ import java.util.concurrent.atomic.AtomicLong
     private var isAdaptersInitialized = false
 
     @JvmStatic
-    val kotlinxSerializationAdapters: SerializersModule by lazy {
+    {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val kotlinxSerializationAdapters: SerializersModule by lazy {
         isAdaptersInitialized = true
         SerializersModule {
             contextual(BigDecimal::class, BigDecimalAdapter)
@@ -156,7 +156,7 @@ import java.util.concurrent.atomic.AtomicLong
         }
     }
 
-    var kotlinxSerializationAdaptersConfiguration: SerializersModuleBuilder.() -> Unit = {}
+    {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}var kotlinxSerializationAdaptersConfiguration: SerializersModuleBuilder.() -> Unit = {}
         set(value) {
             check(!isAdaptersInitialized) {
                 "Cannot configure kotlinxSerializationAdaptersConfiguration after kotlinxSerializationAdapters has been initialized."
@@ -167,7 +167,7 @@ import java.util.concurrent.atomic.AtomicLong
     private var isJsonInitialized = false
 
     @JvmStatic
-    val kotlinxSerializationJson: Json by lazy {
+    {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val kotlinxSerializationJson: Json by lazy {
         isJsonInitialized = true
         Json {
             serializersModule = kotlinxSerializationAdapters
@@ -179,7 +179,7 @@ import java.util.concurrent.atomic.AtomicLong
         }
     }
 
-    var kotlinxSerializationJsonConfiguration: JsonBuilder.() -> Unit = {}
+    {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}var kotlinxSerializationJsonConfiguration: JsonBuilder.() -> Unit = {}
         set(value) {
             check(!isJsonInitialized) {
                 "Cannot configure kotlinxSerializationJsonConfiguration after kotlinxSerializationJson has been initialized."

--- a/modules/openapi-generator/src/main/resources/kotlin-client/oneof_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/oneof_class.mustache
@@ -169,7 +169,7 @@ import java.io.IOException
 {{#oneOf}}
 {{^vendorExtensions.x-duplicated-data-type}}
     @JvmInline
-    {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}value class {{#fnToValueClassName}}{{{dataType}}}{{/fnToValueClassName}}(val value: {{{dataType}}}) : {{classname}}
+    {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}value class {{#fnToValueClassName}}{{{dataType}}}{{/fnToValueClassName}}({{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val value: {{{dataType}}}) : {{classname}}
 
 {{/vendorExtensions.x-duplicated-data-type}}
 {{/oneOf}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
@@ -685,6 +685,57 @@ public class KotlinClientCodegenModelTest {
         TestUtils.assertFileContains(parentModelKt, "val id: ObjectWithComplexAnyOfId?");
     }
 
+    @Test(description = "generate oneOf/anyOf wrappers with explicit API mode using kotlinx_serialization")
+    public void oneOfAnyOfKotlinxSerializationExplicitApi() throws IOException {
+        File output = generateKotlinxOneOfAnyOf(new HashMap<>() {{ put(KotlinClientCodegen.EXPLICIT_API, true); }});
+        // value class nested inside sealed interface: public is valid, internal is not
+        TestUtils.assertFileContains(modelPath(output, "ObjectWithComplexOneOfId"),
+                "public value class StringValue(public val value: kotlin.String) : ObjectWithComplexOneOfId");
+        TestUtils.assertFileContains(modelPath(output, "ObjectWithComplexAnyOfId"),
+                "public value class StringValue(public val value: kotlin.String) : ObjectWithComplexAnyOfId");
+    }
+
+    @Test(description = "generate oneOf/anyOf wrappers with non-public API mode using kotlinx_serialization")
+    public void oneOfAnyOfKotlinxSerializationNonPublicApi() throws IOException {
+        File output = generateKotlinxOneOfAnyOf(new HashMap<>() {{ put(CodegenConstants.NON_PUBLIC_API, true); }});
+        // Kotlin doesn't allow internal subclasses of internal interfaces, make sure subclasses are generated correctly
+        TestUtils.assertFileContains(modelPath(output, "ObjectWithComplexOneOfId"),
+                "internal sealed interface ObjectWithComplexOneOfId");
+        TestUtils.assertFileNotContains(modelPath(output, "ObjectWithComplexOneOfId"),
+                "internal value class StringValue");
+        TestUtils.assertFileContains(modelPath(output, "ObjectWithComplexOneOfId"),
+                "value class StringValue(internal val value: kotlin.String) : ObjectWithComplexOneOfId");
+        TestUtils.assertFileContains(modelPath(output, "ObjectWithComplexAnyOfId"),
+                "internal sealed interface ObjectWithComplexAnyOfId");
+        TestUtils.assertFileNotContains(modelPath(output, "ObjectWithComplexAnyOfId"),
+                "internal value class StringValue");
+        TestUtils.assertFileContains(modelPath(output, "ObjectWithComplexAnyOfId"),
+                "value class StringValue(internal val value: kotlin.String) : ObjectWithComplexAnyOfId");
+    }
+
+    private File generateKotlinxOneOfAnyOf(Map<String, Object> extraProps) throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+        Map<String, Object> props = new HashMap<>();
+        props.put(CodegenConstants.SERIALIZATION_LIBRARY, "kotlinx_serialization");
+        props.put(GENERATE_ONEOF_ANYOF_WRAPPERS, true);
+        props.putAll(extraProps);
+        new DefaultGenerator()
+                .opts(new CodegenConfigurator()
+                        .setGeneratorName("kotlin")
+                        .setLibrary("jvm-retrofit2")
+                        .setAdditionalProperties(props)
+                        .setInputSpec("src/test/resources/3_0/issue_19942.json")
+                        .setOutputDir(output.getAbsolutePath().replace("\\", "/"))
+                        .toClientOptInput())
+                .generate();
+        return output;
+    }
+
+    private static Path modelPath(File output, String modelName) {
+        return Paths.get(output + "/src/main/kotlin/org/openapitools/client/models/" + modelName + ".kt");
+    }
+
     @Test(description = "generate polymorphic jackson model")
     public void polymorphicJacksonSerialization() throws IOException {
         File output = Files.createTempDirectory("test").toFile();


### PR DESCRIPTION
There are currently issues with the `explicitApi`, `nonPublicApi`, and `generateOneOfAnyOfWrappers` options when used together with `kotlinx_serialization`

1. `explicitApi` + `generateOneOfAnyOfWrappers`: This generates a wrapper which is missing the `public` keyword inside of the value class' `val value` property, which makes the library fail to compile when `explicitApi()` is enabled in the library since the property doesn't have an explicit `public`
2. `nonPublicApi` + `generateOneOfAnyOfWrappers`: I haven't run into this myself, but while fixing the above I noticed that the template attempts to insert `internal` in the subclass of the `internal interface`, but Kotlin doesn't allow this, so it generates invalid code

This also fixes the `infrastructure.*` classes not generating valid code for `explicitApi`.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@karismann @Zomzog @andrewemery @4brunu @stefankoppier @e5l @dennisameling @wing328

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Kotlin `kotlinx_serialization` codegen for `explicitApi` and `nonPublicApi`. Corrects wrapper visibility and adds missing explicit `public`/return types in infrastructure so projects compile cleanly.

- **Bug Fixes**
  - For `explicitApi` + `generateOneOfAnyOfWrappers`: make the wrapper value class and its `val value` explicitly `public`.
  - For `nonPublicApi` + `generateOneOfAnyOfWrappers`: stop marking the nested value class as `internal`; only the constructor `value` is `internal`.
  - For `explicitApi` templates: add `: Unit` to `BigDecimalAdapter.serialize`; expose `public` `kotlinxSerializationAdapters`, `kotlinxSerializationJson`, and their config lambdas (when not `nonPublicApi`).

<sup>Written for commit 4a2e32a73537ddd182ca6499cc177635c75a25ee. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23796?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

