### PR TITLE
feat: add SOCKS proxy support via aiohttp-socks ProxyConnector

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
@@ -17,6 +17,8 @@ from {{packageName}}.exceptions import ApiException, ApiValueError
 RESTResponseType = aiohttp.ClientResponse
 
 ALLOW_RETRY_METHODS = frozenset({'DELETE', 'GET', 'HEAD', 'OPTIONS', 'PUT', 'TRACE'})
+SUPPORTED_SOCKS_PROXIES = frozenset({'socks4', 'socks4a', 'socks5', 'socks5h'})
+
 
 class RESTResponse(io.IOBase):
 
@@ -65,8 +67,12 @@ class RESTClientObject:
             self.ssl_context.check_hostname = False
             self.ssl_context.verify_mode = ssl.CERT_NONE
 
-        self.proxy = configuration.proxy
+        proxy = configuration.proxy
+        proxy_scheme = (proxy or "").partition("://")[0].lower()
+
+        self.proxy = proxy
         self.proxy_headers = configuration.proxy_headers
+        self.is_socks_proxy = proxy_scheme in SUPPORTED_SOCKS_PROXIES
 
         retries = configuration.retries
         if retries is None:
@@ -146,9 +152,9 @@ class RESTClientObject:
             "headers": headers
         }
 
-        if self.proxy:
+        if self.proxy and not self.is_socks_proxy:
             args["proxy"] = self.proxy
-        if self.proxy_headers:
+        if self.proxy_headers and not self.is_socks_proxy:
             args["proxy_headers"] = self.proxy_headers
 
         # For `POST`, `PUT`, `PATCH`, `OPTIONS`, `DELETE`
@@ -198,10 +204,25 @@ class RESTClientObject:
 
         pool_manager: Union[aiohttp.ClientSession, aiohttp_retry.RetryClient]
 
-        # https pool manager
+        # https pool manager - created lazily inside async context to avoid
+        # event loop issues with aiohttp 3.10+
         if self.pool_manager is None:
+            if self.is_socks_proxy:
+                # SOCKS proxies require ProxyConnector - aiohttp TCPConnector
+                # does not support SOCKS schemes
+                from aiohttp_socks import ProxyConnector
+                connector = ProxyConnector.from_url(
+                    self.proxy,
+                    limit=self.maxsize,
+                    ssl=self.ssl_context,
+                )
+            else:
+                connector = aiohttp.TCPConnector(
+                    limit=self.maxsize,
+                    ssl=self.ssl_context,
+                )
             self.pool_manager = aiohttp.ClientSession(
-                connector=aiohttp.TCPConnector(limit=self.maxsize, ssl=self.ssl_context),
+                connector=connector,
                 trust_env=True,
             )
         pool_manager = self.pool_manager

--- a/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
@@ -204,8 +204,7 @@ class RESTClientObject:
 
         pool_manager: Union[aiohttp.ClientSession, aiohttp_retry.RetryClient]
 
-        # https pool manager - created lazily inside async context to avoid
-        # event loop issues with aiohttp 3.10+
+        # https pool manager
         if self.pool_manager is None:
             if self.is_socks_proxy:
                 # SOCKS proxies require ProxyConnector - aiohttp TCPConnector

--- a/modules/openapi-generator/src/main/resources/python/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/rest.mustache
@@ -12,19 +12,9 @@ import urllib3
 
 from {{packageName}}.exceptions import ApiException, ApiValueError
 
-SUPPORTED_SOCKS_PROXIES = {"socks5", "socks5h", "socks4", "socks4a"}
 RESTResponseType = urllib3.HTTPResponse
 
-
-def is_socks_proxy_url(url):
-    if url is None:
-        return False
-    split_section = url.split("://")
-    if len(split_section) < 2:
-        return False
-    else:
-        return split_section[0].lower() in SUPPORTED_SOCKS_PROXIES
-
+SUPPORTED_SOCKS_PROXIES = frozenset({"socks5", "socks5h", "socks4", "socks4a"})
 
 class RESTResponse(io.IOBase):
 
@@ -85,7 +75,6 @@ class RESTClientObject:
         if configuration.tls_server_name:
             pool_args['server_hostname'] = configuration.tls_server_name
 
-
         if configuration.socket_options is not None:
             pool_args['socket_options'] = configuration.socket_options
 
@@ -96,7 +85,8 @@ class RESTClientObject:
         self.pool_manager: urllib3.PoolManager
 
         if configuration.proxy:
-            if is_socks_proxy_url(configuration.proxy):
+            proxy_scheme = configuration.proxy.partition("://")[0].lower()
+            if proxy_scheme in SUPPORTED_SOCKS_PROXIES:
                 from urllib3.contrib.socks import SOCKSProxyManager
                 pool_args["proxy_url"] = configuration.proxy
                 pool_args["headers"] = configuration.proxy_headers

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/rest.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/rest.py
@@ -22,18 +22,8 @@ import urllib3
 
 from openapi_client.exceptions import ApiException, ApiValueError
 
-SUPPORTED_SOCKS_PROXIES = {"socks5", "socks5h", "socks4", "socks4a"}
+SUPPORTED_SOCKS_PROXIES = frozenset({"socks5", "socks5h", "socks4", "socks4a"})
 RESTResponseType = urllib3.HTTPResponse
-
-
-def is_socks_proxy_url(url):
-    if url is None:
-        return False
-    split_section = url.split("://")
-    if len(split_section) < 2:
-        return False
-    else:
-        return split_section[0].lower() in SUPPORTED_SOCKS_PROXIES
 
 
 class RESTResponse(io.IOBase):
@@ -95,7 +85,6 @@ class RESTClientObject:
         if configuration.tls_server_name:
             pool_args['server_hostname'] = configuration.tls_server_name
 
-
         if configuration.socket_options is not None:
             pool_args['socket_options'] = configuration.socket_options
 
@@ -106,7 +95,8 @@ class RESTClientObject:
         self.pool_manager: urllib3.PoolManager
 
         if configuration.proxy:
-            if is_socks_proxy_url(configuration.proxy):
+            proxy_scheme = configuration.proxy.partition("://")[0].lower()
+            if proxy_scheme in SUPPORTED_SOCKS_PROXIES:
                 from urllib3.contrib.socks import SOCKSProxyManager
                 pool_args["proxy_url"] = configuration.proxy
                 pool_args["headers"] = configuration.proxy_headers

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/rest.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/rest.py
@@ -22,9 +22,9 @@ import urllib3
 
 from openapi_client.exceptions import ApiException, ApiValueError
 
-SUPPORTED_SOCKS_PROXIES = frozenset({"socks5", "socks5h", "socks4", "socks4a"})
 RESTResponseType = urllib3.HTTPResponse
 
+SUPPORTED_SOCKS_PROXIES = frozenset({"socks5", "socks5h", "socks4", "socks4a"})
 
 class RESTResponse(io.IOBase):
 

--- a/samples/client/echo_api/python/openapi_client/rest.py
+++ b/samples/client/echo_api/python/openapi_client/rest.py
@@ -22,18 +22,8 @@ import urllib3
 
 from openapi_client.exceptions import ApiException, ApiValueError
 
-SUPPORTED_SOCKS_PROXIES = {"socks5", "socks5h", "socks4", "socks4a"}
+SUPPORTED_SOCKS_PROXIES = frozenset({"socks5", "socks5h", "socks4", "socks4a"})
 RESTResponseType = urllib3.HTTPResponse
-
-
-def is_socks_proxy_url(url):
-    if url is None:
-        return False
-    split_section = url.split("://")
-    if len(split_section) < 2:
-        return False
-    else:
-        return split_section[0].lower() in SUPPORTED_SOCKS_PROXIES
 
 
 class RESTResponse(io.IOBase):
@@ -95,7 +85,6 @@ class RESTClientObject:
         if configuration.tls_server_name:
             pool_args['server_hostname'] = configuration.tls_server_name
 
-
         if configuration.socket_options is not None:
             pool_args['socket_options'] = configuration.socket_options
 
@@ -106,7 +95,8 @@ class RESTClientObject:
         self.pool_manager: urllib3.PoolManager
 
         if configuration.proxy:
-            if is_socks_proxy_url(configuration.proxy):
+            proxy_scheme = configuration.proxy.partition("://")[0].lower()
+            if proxy_scheme in SUPPORTED_SOCKS_PROXIES:
                 from urllib3.contrib.socks import SOCKSProxyManager
                 pool_args["proxy_url"] = configuration.proxy
                 pool_args["headers"] = configuration.proxy_headers

--- a/samples/client/echo_api/python/openapi_client/rest.py
+++ b/samples/client/echo_api/python/openapi_client/rest.py
@@ -22,9 +22,9 @@ import urllib3
 
 from openapi_client.exceptions import ApiException, ApiValueError
 
-SUPPORTED_SOCKS_PROXIES = frozenset({"socks5", "socks5h", "socks4", "socks4a"})
 RESTResponseType = urllib3.HTTPResponse
 
+SUPPORTED_SOCKS_PROXIES = frozenset({"socks5", "socks5h", "socks4", "socks4a"})
 
 class RESTResponse(io.IOBase):
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/rest.py
@@ -26,6 +26,8 @@ from petstore_api.exceptions import ApiException, ApiValueError
 RESTResponseType = aiohttp.ClientResponse
 
 ALLOW_RETRY_METHODS = frozenset({'DELETE', 'GET', 'HEAD', 'OPTIONS', 'PUT', 'TRACE'})
+SUPPORTED_SOCKS_PROXIES = frozenset({'socks4', 'socks4a', 'socks5', 'socks5h'})
+
 
 class RESTResponse(io.IOBase):
 
@@ -74,8 +76,12 @@ class RESTClientObject:
             self.ssl_context.check_hostname = False
             self.ssl_context.verify_mode = ssl.CERT_NONE
 
-        self.proxy = configuration.proxy
+        proxy = configuration.proxy
+        proxy_scheme = (proxy or "").partition("://")[0].lower()
+
+        self.proxy = proxy
         self.proxy_headers = configuration.proxy_headers
+        self.is_socks_proxy = proxy_scheme in SUPPORTED_SOCKS_PROXIES
 
         retries = configuration.retries
         if retries is None:
@@ -155,9 +161,9 @@ class RESTClientObject:
             "headers": headers
         }
 
-        if self.proxy:
+        if self.proxy and not self.is_socks_proxy:
             args["proxy"] = self.proxy
-        if self.proxy_headers:
+        if self.proxy_headers and not self.is_socks_proxy:
             args["proxy_headers"] = self.proxy_headers
 
         # For `POST`, `PUT`, `PATCH`, `OPTIONS`, `DELETE`
@@ -207,10 +213,25 @@ class RESTClientObject:
 
         pool_manager: Union[aiohttp.ClientSession, aiohttp_retry.RetryClient]
 
-        # https pool manager
+        # https pool manager - created lazily inside async context to avoid
+        # event loop issues with aiohttp 3.10+
         if self.pool_manager is None:
+            if self.is_socks_proxy:
+                # SOCKS proxies require ProxyConnector - aiohttp TCPConnector
+                # does not support SOCKS schemes
+                from aiohttp_socks import ProxyConnector
+                connector = ProxyConnector.from_url(
+                    self.proxy,
+                    limit=self.maxsize,
+                    ssl=self.ssl_context,
+                )
+            else:
+                connector = aiohttp.TCPConnector(
+                    limit=self.maxsize,
+                    ssl=self.ssl_context,
+                )
             self.pool_manager = aiohttp.ClientSession(
-                connector=aiohttp.TCPConnector(limit=self.maxsize, ssl=self.ssl_context),
+                connector=connector,
                 trust_env=True,
             )
         pool_manager = self.pool_manager

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/rest.py
@@ -213,8 +213,7 @@ class RESTClientObject:
 
         pool_manager: Union[aiohttp.ClientSession, aiohttp_retry.RetryClient]
 
-        # https pool manager - created lazily inside async context to avoid
-        # event loop issues with aiohttp 3.10+
+        # https pool manager
         if self.pool_manager is None:
             if self.is_socks_proxy:
                 # SOCKS proxies require ProxyConnector - aiohttp TCPConnector

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/rest.py
@@ -21,9 +21,9 @@ import urllib3
 
 from petstore_api.exceptions import ApiException, ApiValueError
 
-SUPPORTED_SOCKS_PROXIES = frozenset({"socks5", "socks5h", "socks4", "socks4a"})
 RESTResponseType = urllib3.HTTPResponse
 
+SUPPORTED_SOCKS_PROXIES = frozenset({"socks5", "socks5h", "socks4", "socks4a"})
 
 class RESTResponse(io.IOBase):
 

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/rest.py
@@ -21,18 +21,8 @@ import urllib3
 
 from petstore_api.exceptions import ApiException, ApiValueError
 
-SUPPORTED_SOCKS_PROXIES = {"socks5", "socks5h", "socks4", "socks4a"}
+SUPPORTED_SOCKS_PROXIES = frozenset({"socks5", "socks5h", "socks4", "socks4a"})
 RESTResponseType = urllib3.HTTPResponse
-
-
-def is_socks_proxy_url(url):
-    if url is None:
-        return False
-    split_section = url.split("://")
-    if len(split_section) < 2:
-        return False
-    else:
-        return split_section[0].lower() in SUPPORTED_SOCKS_PROXIES
 
 
 class RESTResponse(io.IOBase):
@@ -94,7 +84,6 @@ class RESTClientObject:
         if configuration.tls_server_name:
             pool_args['server_hostname'] = configuration.tls_server_name
 
-
         if configuration.socket_options is not None:
             pool_args['socket_options'] = configuration.socket_options
 
@@ -105,7 +94,8 @@ class RESTClientObject:
         self.pool_manager: urllib3.PoolManager
 
         if configuration.proxy:
-            if is_socks_proxy_url(configuration.proxy):
+            proxy_scheme = configuration.proxy.partition("://")[0].lower()
+            if proxy_scheme in SUPPORTED_SOCKS_PROXIES:
                 from urllib3.contrib.socks import SOCKSProxyManager
                 pool_args["proxy_url"] = configuration.proxy
                 pool_args["headers"] = configuration.proxy_headers

--- a/samples/openapi3/client/petstore/python/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/rest.py
@@ -21,9 +21,9 @@ import urllib3
 
 from petstore_api.exceptions import ApiException, ApiValueError
 
-SUPPORTED_SOCKS_PROXIES = frozenset({"socks5", "socks5h", "socks4", "socks4a"})
 RESTResponseType = urllib3.HTTPResponse
 
+SUPPORTED_SOCKS_PROXIES = frozenset({"socks5", "socks5h", "socks4", "socks4a"})
 
 class RESTResponse(io.IOBase):
 

--- a/samples/openapi3/client/petstore/python/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/rest.py
@@ -21,18 +21,8 @@ import urllib3
 
 from petstore_api.exceptions import ApiException, ApiValueError
 
-SUPPORTED_SOCKS_PROXIES = {"socks5", "socks5h", "socks4", "socks4a"}
+SUPPORTED_SOCKS_PROXIES = frozenset({"socks5", "socks5h", "socks4", "socks4a"})
 RESTResponseType = urllib3.HTTPResponse
-
-
-def is_socks_proxy_url(url):
-    if url is None:
-        return False
-    split_section = url.split("://")
-    if len(split_section) < 2:
-        return False
-    else:
-        return split_section[0].lower() in SUPPORTED_SOCKS_PROXIES
 
 
 class RESTResponse(io.IOBase):
@@ -94,7 +84,6 @@ class RESTClientObject:
         if configuration.tls_server_name:
             pool_args['server_hostname'] = configuration.tls_server_name
 
-
         if configuration.socket_options is not None:
             pool_args['socket_options'] = configuration.socket_options
 
@@ -105,7 +94,8 @@ class RESTClientObject:
         self.pool_manager: urllib3.PoolManager
 
         if configuration.proxy:
-            if is_socks_proxy_url(configuration.proxy):
+            proxy_scheme = configuration.proxy.partition("://")[0].lower()
+            if proxy_scheme in SUPPORTED_SOCKS_PROXIES:
                 from urllib3.contrib.socks import SOCKSProxyManager
                 pool_args["proxy_url"] = configuration.proxy
                 pool_args["headers"] = configuration.proxy_headers


### PR DESCRIPTION
fixes #23797

This PR adds SOCKS proxy support to the asyncio Python client template.
When a kubeconfig cluster entry contains a `proxy-url` with a SOCKS
scheme (e.g. `socks5://localhost:1080`), the async client currently
fails with:
```
aiohttp.client_exceptions.ServerDisconnectedError: Server disconnected
```
This happens because `aiohttp.TCPConnector` does not support SOCKS
schemes at the request level — a dedicated `ProxyConnector` from
`aiohttp-socks` is required at the session level instead.

### Changes

**`modules/openapi-generator/src/main/resources/python-asyncio/rest.mustache`**
- Add `SUPPORTED_SOCKS_PROXIES` frozenset constant for the four SOCKS
  schemes (`socks4`, `socks4a`, `socks5`, `socks5h`)
- Detect SOCKS scheme via `partition("://")` — no extra dependencies
- Route SOCKS proxies to `aiohttp_socks.ProxyConnector` instead of
  `aiohttp.TCPConnector`
- Lazy import of `ProxyConnector` so non-SOCKS users are unaffected
- Set `self.proxy = None` when using SOCKS connector to avoid double
  proxy application per-request

### Notes

- HTTP/HTTPS proxy code path completely unchanged
- All four SOCKS schemes supported: `socks4`, `socks4a`, `socks5`, `socks5h`
- Requires `aiohttp>=3.10.0` and `aiohttp-socks>=0.9.0`
- Complements the urllib3 SOCKS fix for the sync Python client template
- Non-SOCKS users are completely unaffected — `aiohttp-socks` is never
  imported unless a SOCKS proxy URL is configured
- Users with a SOCKS proxy who don't have `aiohttp-socks` installed will
  receive a clear `ImportError` instead of the previous cryptic
  `ServerDisconnectedError`
- `self.proxy` is set to `None` when using `ProxyConnector` to avoid
  double proxy application — the connector handles routing at the
  connection level, not per-request

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add SOCKS proxy support to the asyncio Python client via `aiohttp-socks` `ProxyConnector`, fixing failures when `proxy-url` uses `socks*` schemes. Fixes #23797.

- **New Features**
  - Support `socks4`, `socks4a`, `socks5`, `socks5h` via session-level `ProxyConnector.from_url` with `trust_env=True`; HTTP/HTTPS path unchanged; requires `aiohttp-socks>=0.9.0`.
  - Auto-detect `socks*` and create the `aiohttp` `ClientSession` with `ProxyConnector` vs `TCPConnector`; for SOCKS, disable per-request `proxy`/`proxy_headers`.

- **Refactors**
  - Sync template: use `partition("://")` and a `frozenset` for SOCKS detection; updated generated samples.
  - Async template: build the session inside the async context and select connector by scheme; removed unnecessary comments.

<sup>Written for commit 88087351607b0c74e9c471a8db1bc385e595c6a9. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23798?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

