### PR TITLE
[scala-sttp4-jsoniter] add generic Option and Seq codecs for jsoniter-scala

### DIFF
--- a/modules/openapi-generator/src/main/resources/scala-sttp4-jsoniter/jsonSupport.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp4-jsoniter/jsonSupport.mustache
@@ -12,6 +12,9 @@ import com.github.plokhotnyuk.jsoniter_scala.circe.JsoniterScalaCodec.*
 object JsonSupport extends AdditionalTypeSerializers:
   inline given CodecMakerConfig = CodecMakerConfig.withAllowRecursiveTypes(true)
 
+  given [A](using JsonValueCodec[A]): JsonValueCodec[Option[A]] = deriveJsonCodec
+  given [A](using JsonValueCodec[A]): JsonValueCodec[Seq[A]] = deriveJsonCodec
+
   inline def deriveJsonCodec[A](using inline config: CodecMakerConfig): JsonValueCodec[A] =
     JsonCodecMaker.make(config)
 

--- a/samples/client/petstore/scala-sttp4-jsoniter/src/main/scala/org/openapitools/client/core/JsonSupport.scala
+++ b/samples/client/petstore/scala-sttp4-jsoniter/src/main/scala/org/openapitools/client/core/JsonSupport.scala
@@ -20,6 +20,9 @@ import com.github.plokhotnyuk.jsoniter_scala.circe.JsoniterScalaCodec.*
 object JsonSupport extends AdditionalTypeSerializers:
   inline given CodecMakerConfig = CodecMakerConfig.withAllowRecursiveTypes(true)
 
+  given [A](using JsonValueCodec[A]): JsonValueCodec[Option[A]] = deriveJsonCodec
+  given [A](using JsonValueCodec[A]): JsonValueCodec[Seq[A]] = deriveJsonCodec
+
   inline def deriveJsonCodec[A](using inline config: CodecMakerConfig): JsonValueCodec[A] =
     JsonCodecMaker.make(config)
 


### PR DESCRIPTION
Add generic `JsonValueCodec` instances for `Option[A]` and `Seq[A]` directly
in `JsonSupport`, derived via `deriveJsonCodec`. Without these, the generated
code that wraps types in `Option` or `Seq` fails to compile because no implicit
codec is in scope at the call site.

@lbialy @flsh86

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add generic `JsonValueCodec` for `Option[A]` and `Seq[A]` in `JsonSupport` for `scala-sttp4-jsoniter`. This fixes compile errors in generated clients when optional or sequence fields are present.

- **Bug Fixes**
  - Provide `given` instances for `JsonValueCodec[Option[A]]` and `JsonValueCodec[Seq[A]]` via `deriveJsonCodec`, ensuring required implicits are always in scope.

<sup>Written for commit 8e59584dc6002a5e8adda17a326c7f273637e1d7. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23800?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

