### PR TITLE
[scala-sttp4-jsoniter] extend Primitive type with UUID, LocalDate and OffsetDateTime

### DIFF
--- a/modules/openapi-generator/src/main/resources/scala-sttp4-jsoniter/helpers.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp4-jsoniter/helpers.mustache
@@ -4,10 +4,12 @@ package {{invokerPackage}}
 import scala.deriving.*
 import scala.compiletime.*
 import java.io.File
+import java.util.UUID
+import java.time.{LocalDate, OffsetDateTime}
+import java.time.format.DateTimeFormatter
 import com.github.plokhotnyuk.jsoniter_scala.core.{JsonValueCodec, writeToString}
 
-type Primitive = String | Short | Int | Long | Float | Double | BigDecimal |
-  Boolean
+type Primitive = String | Short | Int | Long | Float | Double | BigDecimal | Boolean | UUID | LocalDate | OffsetDateTime
 
 enum Authorization:
   case NoAuthorization
@@ -45,6 +47,12 @@ private inline def checkFields[T <: Tuple]: Unit =
         case _ => error("Cannot derive structure, structure must consist only of primitive fields")
   }
 
+extension (p: Primitive)
+  def asString: String = p match
+    case v: OffsetDateTime => DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(v)
+    case v: LocalDate      => DateTimeFormatter.ISO_LOCAL_DATE.format(v)
+    case _                 => p.toString
+   
 private val flattenKeyVals: Primitive | Option[Primitive] => Option[Primitive] = {
   case p: Primitive => Some(p)
   case opt: Option[Primitive] => opt
@@ -81,7 +89,7 @@ object FormSerializable:
             optArray.map(serializeArray(name, _, format, explode))
               .getOrElse(Seq.empty[(String, String)])
           case freeObj: Map[String, Primitive] =>
-            freeObj.map((key, value) => (key, value.toString)).toSeq
+            freeObj.map((key, value) => (key, value.asString)).toSeq
           case optObj: Option[t] =>
             inline summonInline[Mirror.Of[t]] match
               case mirror: Mirror.ProductOf[t] =>
@@ -115,7 +123,7 @@ object FormSerializable:
   ): Seq[(String, String)] = {
     inline format match
       case FormStyleFormat.FORM =>
-        Seq(paramName -> value.toString) // for primitve values explode does not change anything
+        Seq(paramName -> value.asString) // for primitve values explode does not change anything
       case FormStyleFormat.SPACEDELIMITED =>
         error("FormStyleFormat.SpaceDelimited does not support primitive values")
       case FormStyleFormat.PIPEDELIMITED =>
@@ -132,14 +140,14 @@ object FormSerializable:
   ): Seq[(String, String)] = {
     inline format match
       case FormStyleFormat.FORM =>
-        inline if explode then values.map(s => (paramName, s.toString))
-        else Seq(paramName -> values.mkString(","))
+        inline if explode then values.map(s => (paramName, s.asString))
+        else Seq(paramName -> values.map(_.asString).mkString(","))
       case FormStyleFormat.SPACEDELIMITED =>
-        inline if explode then values.map(s => (paramName, s.toString))
-        else Seq(paramName -> values.mkString(" ")) // Sttp will encode space as +, from https://swagger.io/docs/specification/v3_0/serialization/#query-parameters it is not clear if it should be + or %20
+        inline if explode then values.map(s => (paramName, s.asString))
+        else Seq(paramName -> values.map(_.asString).mkString(" ")) // Sttp will encode space as +, from https://swagger.io/docs/specification/v3_0/serialization/#query-parameters it is not clear if it should be + or %20
       case FormStyleFormat.PIPEDELIMITED =>
-        inline if explode then values.map(s => (paramName, s.toString))
-        else Seq(paramName -> values.mkString("|"))
+        inline if explode then values.map(s => (paramName, s.asString))
+        else Seq(paramName -> values.map(_.asString).mkString("|"))
       case FormStyleFormat.DEEPOBJECT =>
         error("FormStyleFormat.DeepObject does not support arrays")
   }
@@ -151,14 +159,14 @@ object FormSerializable:
   ): Seq[(String, String)] = {
     inline format match
       case FormStyleFormat.FORM =>
-        inline if explode then keyValPairs.map((key, value) => (key, value.toString))
-        else Seq(paramName -> keyValPairs.flatMap((key, value) => Seq(key, value.toString)).mkString(","))
+        inline if explode then keyValPairs.map((key, value) => (key, value.asString))
+        else Seq(paramName -> keyValPairs.flatMap((key, value) => Seq(key, value.asString)).mkString(","))
       case FormStyleFormat.SPACEDELIMITED =>
         error("FormStyleFormat.SpaceDelimited does not support objects")
       case FormStyleFormat.PIPEDELIMITED =>
         error("FormStyleFormat.PipeDelimited does not support objects")
       case FormStyleFormat.DEEPOBJECT =>
-        inline if explode then keyValPairs.map((key, value) => (s"$paramName[$key]", value.toString))
+        inline if explode then keyValPairs.map((key, value) => (s"$paramName[$key]", value.asString))
         else error("FormStyleFormat.DeepObject does not support explode=false")
   }
 end FormSerializable
@@ -179,11 +187,11 @@ object HeaderSerializable:
     summonFrom {
       case t: HeaderSerializable[T] => t.serialize(name, obj, explode)
       case _ => inline obj match
-        case primitive: Primitive => Map(name -> primitive.toString)
-        case optPrimitive: Option[Primitive] => optPrimitive.map(v => Map(name -> v.toString)).getOrElse(Map.empty[String, String])
-        case seqPrimitive: Seq[Primitive] => Map(name -> seqPrimitive.map(_.toString).mkString(","))
-        case optSeqPrimitive: Option[Seq[Primitive]] => optSeqPrimitive.map(v => Map(name -> v.map(_.toString).mkString(","))).getOrElse(Map.empty[String, String])
-        case mapPrimitive: Map[String, Primitive] => mapPrimitive.map((k, v) => (k, v.toString))
+        case primitive: Primitive => Map(name -> primitive.asString)
+        case optPrimitive: Option[Primitive] => optPrimitive.map(v => Map(name -> v.asString)).getOrElse(Map.empty[String, String])
+        case seqPrimitive: Seq[Primitive] => Map(name -> seqPrimitive.map(_.asString).mkString(","))
+        case optSeqPrimitive: Option[Seq[Primitive]] => optSeqPrimitive.map(v => Map(name -> v.map(_.asString).mkString(","))).getOrElse(Map.empty[String, String])
+        case mapPrimitive: Map[String, Primitive] => mapPrimitive.map((k, v) => (k, v.asString))
         case optObj: Option[t] =>
           inline summonInline[Mirror.Of[t]] match
             case mirror: Mirror.ProductOf[t] =>
@@ -192,7 +200,7 @@ object HeaderSerializable:
               optObj.map { obj =>
                   val keyVals = labels.zip(obj.asInstanceOf[Product].productIterator.toSeq.asInstanceOf[Seq[Primitive | Option[Primitive]]].map(flattenKeyVals))
                     .filter((_, v) => v.isDefined)
-                    .map((k, v) => (k, v.get.toString))
+                    .map((k, v) => (k, v.get.asString))
                   inline if explode then
                     Map(name ->keyVals.map((k, v) => s"$k=$v").mkString(","))
                   else
@@ -206,7 +214,7 @@ object HeaderSerializable:
               val labels = allLabels[mirror.MirroredElemLabels]
               val keyVals = labels.zip(obj.asInstanceOf[Product].productIterator.toSeq.asInstanceOf[Seq[Primitive | Option[Primitive]]].map(flattenKeyVals))
                 .filter((_, v) => v.isDefined)
-                .map((k, v) => (k, v.get.toString))
+                .map((k, v) => (k, v.get.asString))
               inline if explode then
                 Map(name ->keyVals.map((k, v) => s"$k=$v").mkString(","))
               else
@@ -235,7 +243,7 @@ object PathSerializable:
             optArray.map(serializeArray(name, _, style, explode))
               .getOrElse("")
           case freeObj: Map[String, Primitive] =>
-            serializeModel(name, freeObj.map((key, value) => (key, value.toString)).toSeq, style, explode)
+            serializeModel(name, freeObj.map((key, value) => (key, value.asString)).toSeq, style, explode)
           case optObj: Option[t] =>
             inline summonInline[Mirror.Of[t]] match
               case mirror: Mirror.ProductOf[t] =>
@@ -267,9 +275,9 @@ object PathSerializable:
       inline format: PathStyleFormat,
       inline explode: Boolean
   ): String = inline format match
-    case PathStyleFormat.SIMPLE => value.toString
-    case PathStyleFormat.LABEL => s".${value.toString}"
-    case PathStyleFormat.MATRIX => s";$paramName=${value.toString}"
+    case PathStyleFormat.SIMPLE => value.asString
+    case PathStyleFormat.LABEL => s".${value.asString}"
+    case PathStyleFormat.MATRIX => s";$paramName=${value.asString}"
 
   private inline def serializeArray(
       paramName: String,
@@ -277,9 +285,9 @@ object PathSerializable:
       inline format: PathStyleFormat,
       inline explode: Boolean
   ): String = inline format match
-    case PathStyleFormat.SIMPLE => values.map(_.toString).mkString(",")
-    case PathStyleFormat.LABEL => inline if explode then values.map(_.toString).mkString(".", ".", "") else values.map(_.toString).mkString(".", ",", "")
-    case PathStyleFormat.MATRIX => inline if explode then values.map(v => s";$paramName=${v.toString}").mkString else s";$paramName=" + values.map(_.toString).mkString(",")
+    case PathStyleFormat.SIMPLE => values.map(_.asString).mkString(",")
+    case PathStyleFormat.LABEL => inline if explode then values.map(_.asString).mkString(".", ".", "") else values.map(_.asString).mkString(".", ",", "")
+    case PathStyleFormat.MATRIX => inline if explode then values.map(v => s";$paramName=${v.asString}").mkString else s";$paramName=" + values.map(_.asString).mkString(",")
 
   private inline def serializeModel(
       paramName: String,
@@ -288,14 +296,14 @@ object PathSerializable:
       inline explode: Boolean
   ): String = inline format match
     case PathStyleFormat.SIMPLE =>
-      inline if explode then keyValPairs.map((k, v) => s"$k=${v.toString}").mkString(",")
-      else keyValPairs.map((k, v) => s"$k,${v.toString}").mkString(",")
+      inline if explode then keyValPairs.map((k, v) => s"$k=${v.asString}").mkString(",")
+      else keyValPairs.map((k, v) => s"$k,${v.asString}").mkString(",")
     case PathStyleFormat.LABEL =>
-      inline if explode then keyValPairs.map((k, v) => s"$k=${v.toString}").mkString(".", ".", "")
-      else keyValPairs.map((k, v) => s"$k,${v.toString}").mkString(".", ",", "")
+      inline if explode then keyValPairs.map((k, v) => s"$k=${v.asString}").mkString(".", ".", "")
+      else keyValPairs.map((k, v) => s"$k,${v.asString}").mkString(".", ",", "")
     case PathStyleFormat.MATRIX =>
-      inline if explode then keyValPairs.map((k, v) => s";$k=${v.toString}").mkString
-      else keyValPairs.map((k, v) => s"$k,${v.toString}").mkString(s";$paramName=", ",", "")
+      inline if explode then keyValPairs.map((k, v) => s";$k=${v.asString}").mkString
+      else keyValPairs.map((k, v) => s"$k,${v.asString}").mkString(s";$paramName=", ",", "")
 end PathSerializable
 
 trait CookieSerializable[T]:
@@ -326,7 +334,7 @@ object CookieSerializable:
             optArray.map(serializeArray(name, _, explode))
               .getOrElse(Seq.empty[(String, String)])
           case freeObj: Map[String, Primitive] =>
-            serializeModel(name, freeObj.map((key, value) => (key, value.toString)).toSeq, explode)
+            serializeModel(name, freeObj.map((key, value) => (key, value.asString)).toSeq, explode)
           case optObj: Option[t] =>
             inline summonInline[Mirror.Of[t]] match
               case mirror: Mirror.ProductOf[t] =>
@@ -356,7 +364,7 @@ object CookieSerializable:
       paramName: String,
       value: Primitive,
       inline explode: Boolean
-  ): Seq[(String, String)] =  Seq(paramName -> value.toString)
+  ): Seq[(String, String)] =  Seq(paramName -> value.asString)
 
   private inline def serializeArray(
       paramName: String,
@@ -364,7 +372,7 @@ object CookieSerializable:
       inline explode: Boolean
   ): Seq[(String, String)] =
     inline if explode then error("Not supported")
-    else Seq(paramName -> values.map(_.toString).mkString(","))
+    else Seq(paramName -> values.map(_.asString).mkString(","))
 
   private inline def serializeModel(
       paramName: String,
@@ -372,7 +380,7 @@ object CookieSerializable:
       inline explode: Boolean
   ): Seq[(String, String)] =
     inline if explode then error("Not supported")
-    else Seq(paramName -> keyValPairs.map((k, v) => s"$k,$v").mkString(","))
+    else Seq(paramName -> keyValPairs.map((k, v) => s"$k,${v.asString}").mkString(","))
 end CookieSerializable
 
 object Helpers:

--- a/samples/client/petstore/scala-sttp4-jsoniter/src/main/scala/org/openapitools/client/core/Helpers.scala
+++ b/samples/client/petstore/scala-sttp4-jsoniter/src/main/scala/org/openapitools/client/core/Helpers.scala
@@ -14,10 +14,12 @@ package org.openapitools.client.core
 import scala.deriving.*
 import scala.compiletime.*
 import java.io.File
+import java.util.UUID
+import java.time.{LocalDate, OffsetDateTime}
+import java.time.format.DateTimeFormatter
 import com.github.plokhotnyuk.jsoniter_scala.core.{JsonValueCodec, writeToString}
 
-type Primitive = String | Short | Int | Long | Float | Double | BigDecimal |
-  Boolean
+type Primitive = String | Short | Int | Long | Float | Double | BigDecimal | Boolean | UUID | LocalDate | OffsetDateTime
 
 enum Authorization:
   case NoAuthorization
@@ -55,6 +57,12 @@ private inline def checkFields[T <: Tuple]: Unit =
         case _ => error("Cannot derive structure, structure must consist only of primitive fields")
   }
 
+extension (p: Primitive)
+  def asString: String = p match
+    case v: OffsetDateTime => DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(v)
+    case v: LocalDate      => DateTimeFormatter.ISO_LOCAL_DATE.format(v)
+    case _                 => p.toString
+   
 private val flattenKeyVals: Primitive | Option[Primitive] => Option[Primitive] = {
   case p: Primitive => Some(p)
   case opt: Option[Primitive] => opt
@@ -91,7 +99,7 @@ object FormSerializable:
             optArray.map(serializeArray(name, _, format, explode))
               .getOrElse(Seq.empty[(String, String)])
           case freeObj: Map[String, Primitive] =>
-            freeObj.map((key, value) => (key, value.toString)).toSeq
+            freeObj.map((key, value) => (key, value.asString)).toSeq
           case optObj: Option[t] =>
             inline summonInline[Mirror.Of[t]] match
               case mirror: Mirror.ProductOf[t] =>
@@ -125,7 +133,7 @@ object FormSerializable:
   ): Seq[(String, String)] = {
     inline format match
       case FormStyleFormat.FORM =>
-        Seq(paramName -> value.toString) // for primitve values explode does not change anything
+        Seq(paramName -> value.asString) // for primitve values explode does not change anything
       case FormStyleFormat.SPACEDELIMITED =>
         error("FormStyleFormat.SpaceDelimited does not support primitive values")
       case FormStyleFormat.PIPEDELIMITED =>
@@ -142,14 +150,14 @@ object FormSerializable:
   ): Seq[(String, String)] = {
     inline format match
       case FormStyleFormat.FORM =>
-        inline if explode then values.map(s => (paramName, s.toString))
-        else Seq(paramName -> values.mkString(","))
+        inline if explode then values.map(s => (paramName, s.asString))
+        else Seq(paramName -> values.map(_.asString).mkString(","))
       case FormStyleFormat.SPACEDELIMITED =>
-        inline if explode then values.map(s => (paramName, s.toString))
-        else Seq(paramName -> values.mkString(" ")) // Sttp will encode space as +, from https://swagger.io/docs/specification/v3_0/serialization/#query-parameters it is not clear if it should be + or %20
+        inline if explode then values.map(s => (paramName, s.asString))
+        else Seq(paramName -> values.map(_.asString).mkString(" ")) // Sttp will encode space as +, from https://swagger.io/docs/specification/v3_0/serialization/#query-parameters it is not clear if it should be + or %20
       case FormStyleFormat.PIPEDELIMITED =>
-        inline if explode then values.map(s => (paramName, s.toString))
-        else Seq(paramName -> values.mkString("|"))
+        inline if explode then values.map(s => (paramName, s.asString))
+        else Seq(paramName -> values.map(_.asString).mkString("|"))
       case FormStyleFormat.DEEPOBJECT =>
         error("FormStyleFormat.DeepObject does not support arrays")
   }
@@ -161,14 +169,14 @@ object FormSerializable:
   ): Seq[(String, String)] = {
     inline format match
       case FormStyleFormat.FORM =>
-        inline if explode then keyValPairs.map((key, value) => (key, value.toString))
-        else Seq(paramName -> keyValPairs.flatMap((key, value) => Seq(key, value.toString)).mkString(","))
+        inline if explode then keyValPairs.map((key, value) => (key, value.asString))
+        else Seq(paramName -> keyValPairs.flatMap((key, value) => Seq(key, value.asString)).mkString(","))
       case FormStyleFormat.SPACEDELIMITED =>
         error("FormStyleFormat.SpaceDelimited does not support objects")
       case FormStyleFormat.PIPEDELIMITED =>
         error("FormStyleFormat.PipeDelimited does not support objects")
       case FormStyleFormat.DEEPOBJECT =>
-        inline if explode then keyValPairs.map((key, value) => (s"$paramName[$key]", value.toString))
+        inline if explode then keyValPairs.map((key, value) => (s"$paramName[$key]", value.asString))
         else error("FormStyleFormat.DeepObject does not support explode=false")
   }
 end FormSerializable
@@ -189,11 +197,11 @@ object HeaderSerializable:
     summonFrom {
       case t: HeaderSerializable[T] => t.serialize(name, obj, explode)
       case _ => inline obj match
-        case primitive: Primitive => Map(name -> primitive.toString)
-        case optPrimitive: Option[Primitive] => optPrimitive.map(v => Map(name -> v.toString)).getOrElse(Map.empty[String, String])
-        case seqPrimitive: Seq[Primitive] => Map(name -> seqPrimitive.map(_.toString).mkString(","))
-        case optSeqPrimitive: Option[Seq[Primitive]] => optSeqPrimitive.map(v => Map(name -> v.map(_.toString).mkString(","))).getOrElse(Map.empty[String, String])
-        case mapPrimitive: Map[String, Primitive] => mapPrimitive.map((k, v) => (k, v.toString))
+        case primitive: Primitive => Map(name -> primitive.asString)
+        case optPrimitive: Option[Primitive] => optPrimitive.map(v => Map(name -> v.asString)).getOrElse(Map.empty[String, String])
+        case seqPrimitive: Seq[Primitive] => Map(name -> seqPrimitive.map(_.asString).mkString(","))
+        case optSeqPrimitive: Option[Seq[Primitive]] => optSeqPrimitive.map(v => Map(name -> v.map(_.asString).mkString(","))).getOrElse(Map.empty[String, String])
+        case mapPrimitive: Map[String, Primitive] => mapPrimitive.map((k, v) => (k, v.asString))
         case optObj: Option[t] =>
           inline summonInline[Mirror.Of[t]] match
             case mirror: Mirror.ProductOf[t] =>
@@ -202,7 +210,7 @@ object HeaderSerializable:
               optObj.map { obj =>
                   val keyVals = labels.zip(obj.asInstanceOf[Product].productIterator.toSeq.asInstanceOf[Seq[Primitive | Option[Primitive]]].map(flattenKeyVals))
                     .filter((_, v) => v.isDefined)
-                    .map((k, v) => (k, v.get.toString))
+                    .map((k, v) => (k, v.get.asString))
                   inline if explode then
                     Map(name ->keyVals.map((k, v) => s"$k=$v").mkString(","))
                   else
@@ -216,7 +224,7 @@ object HeaderSerializable:
               val labels = allLabels[mirror.MirroredElemLabels]
               val keyVals = labels.zip(obj.asInstanceOf[Product].productIterator.toSeq.asInstanceOf[Seq[Primitive | Option[Primitive]]].map(flattenKeyVals))
                 .filter((_, v) => v.isDefined)
-                .map((k, v) => (k, v.get.toString))
+                .map((k, v) => (k, v.get.asString))
               inline if explode then
                 Map(name ->keyVals.map((k, v) => s"$k=$v").mkString(","))
               else
@@ -245,7 +253,7 @@ object PathSerializable:
             optArray.map(serializeArray(name, _, style, explode))
               .getOrElse("")
           case freeObj: Map[String, Primitive] =>
-            serializeModel(name, freeObj.map((key, value) => (key, value.toString)).toSeq, style, explode)
+            serializeModel(name, freeObj.map((key, value) => (key, value.asString)).toSeq, style, explode)
           case optObj: Option[t] =>
             inline summonInline[Mirror.Of[t]] match
               case mirror: Mirror.ProductOf[t] =>
@@ -277,9 +285,9 @@ object PathSerializable:
       inline format: PathStyleFormat,
       inline explode: Boolean
   ): String = inline format match
-    case PathStyleFormat.SIMPLE => value.toString
-    case PathStyleFormat.LABEL => s".${value.toString}"
-    case PathStyleFormat.MATRIX => s";$paramName=${value.toString}"
+    case PathStyleFormat.SIMPLE => value.asString
+    case PathStyleFormat.LABEL => s".${value.asString}"
+    case PathStyleFormat.MATRIX => s";$paramName=${value.asString}"
 
   private inline def serializeArray(
       paramName: String,
@@ -287,9 +295,9 @@ object PathSerializable:
       inline format: PathStyleFormat,
       inline explode: Boolean
   ): String = inline format match
-    case PathStyleFormat.SIMPLE => values.map(_.toString).mkString(",")
-    case PathStyleFormat.LABEL => inline if explode then values.map(_.toString).mkString(".", ".", "") else values.map(_.toString).mkString(".", ",", "")
-    case PathStyleFormat.MATRIX => inline if explode then values.map(v => s";$paramName=${v.toString}").mkString else s";$paramName=" + values.map(_.toString).mkString(",")
+    case PathStyleFormat.SIMPLE => values.map(_.asString).mkString(",")
+    case PathStyleFormat.LABEL => inline if explode then values.map(_.asString).mkString(".", ".", "") else values.map(_.asString).mkString(".", ",", "")
+    case PathStyleFormat.MATRIX => inline if explode then values.map(v => s";$paramName=${v.asString}").mkString else s";$paramName=" + values.map(_.asString).mkString(",")
 
   private inline def serializeModel(
       paramName: String,
@@ -298,14 +306,14 @@ object PathSerializable:
       inline explode: Boolean
   ): String = inline format match
     case PathStyleFormat.SIMPLE =>
-      inline if explode then keyValPairs.map((k, v) => s"$k=${v.toString}").mkString(",")
-      else keyValPairs.map((k, v) => s"$k,${v.toString}").mkString(",")
+      inline if explode then keyValPairs.map((k, v) => s"$k=${v.asString}").mkString(",")
+      else keyValPairs.map((k, v) => s"$k,${v.asString}").mkString(",")
     case PathStyleFormat.LABEL =>
-      inline if explode then keyValPairs.map((k, v) => s"$k=${v.toString}").mkString(".", ".", "")
-      else keyValPairs.map((k, v) => s"$k,${v.toString}").mkString(".", ",", "")
+      inline if explode then keyValPairs.map((k, v) => s"$k=${v.asString}").mkString(".", ".", "")
+      else keyValPairs.map((k, v) => s"$k,${v.asString}").mkString(".", ",", "")
     case PathStyleFormat.MATRIX =>
-      inline if explode then keyValPairs.map((k, v) => s";$k=${v.toString}").mkString
-      else keyValPairs.map((k, v) => s"$k,${v.toString}").mkString(s";$paramName=", ",", "")
+      inline if explode then keyValPairs.map((k, v) => s";$k=${v.asString}").mkString
+      else keyValPairs.map((k, v) => s"$k,${v.asString}").mkString(s";$paramName=", ",", "")
 end PathSerializable
 
 trait CookieSerializable[T]:
@@ -336,7 +344,7 @@ object CookieSerializable:
             optArray.map(serializeArray(name, _, explode))
               .getOrElse(Seq.empty[(String, String)])
           case freeObj: Map[String, Primitive] =>
-            serializeModel(name, freeObj.map((key, value) => (key, value.toString)).toSeq, explode)
+            serializeModel(name, freeObj.map((key, value) => (key, value.asString)).toSeq, explode)
           case optObj: Option[t] =>
             inline summonInline[Mirror.Of[t]] match
               case mirror: Mirror.ProductOf[t] =>
@@ -366,7 +374,7 @@ object CookieSerializable:
       paramName: String,
       value: Primitive,
       inline explode: Boolean
-  ): Seq[(String, String)] =  Seq(paramName -> value.toString)
+  ): Seq[(String, String)] =  Seq(paramName -> value.asString)
 
   private inline def serializeArray(
       paramName: String,
@@ -374,7 +382,7 @@ object CookieSerializable:
       inline explode: Boolean
   ): Seq[(String, String)] =
     inline if explode then error("Not supported")
-    else Seq(paramName -> values.map(_.toString).mkString(","))
+    else Seq(paramName -> values.map(_.asString).mkString(","))
 
   private inline def serializeModel(
       paramName: String,
@@ -382,7 +390,7 @@ object CookieSerializable:
       inline explode: Boolean
   ): Seq[(String, String)] =
     inline if explode then error("Not supported")
-    else Seq(paramName -> keyValPairs.map((k, v) => s"$k,$v").mkString(","))
+    else Seq(paramName -> keyValPairs.map((k, v) => s"$k,${v.asString}").mkString(","))
 end CookieSerializable
 
 object Helpers:


### PR DESCRIPTION
Extend the `Primitive` union type in `helpers.mustache` with `UUID`,
`LocalDate`, and `OffsetDateTime` so that path, query, header, cookie, and
form parameters typed with these formats serialize via `.toString()` on the
fast primitive path. Without this, fields generated from `format: uuid`,
`format: date`, and `format: date-time` fall through to the Mirror-based
object path and fail at compile time because they are not products or sums.

Add an `asString` extension method on `Primitive`.A bare `.toString` is
correct for UUID and the numeric/boolean/string primitives, but produces the
wrong representation for Java's default LocalDate/
OffsetDateTime as `toString` on these does not match the expected wire format. `asString`
formats `OffsetDateTime` with `DateTimeFormatter.ISO_OFFSET_DATE_TIME` and `LocalDate`
with `ISO_LOCAL_DATE`, falling back to `.toString` for everything else, so `date`
and `date-time`  parameters are emitted as `ISO-8601` strings.


@lbialy @flsh86
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extended `Primitive` in `scala-sttp4-jsoniter` to include `UUID`, `LocalDate`, and `OffsetDateTime`, and added ISO string formatting via a new `asString` fast path across all parameter serializers. This removes the Mirror fallback and fixes compile errors in generated clients.

- **Bug Fixes**
  - Path, query, header, cookie, and form params with these formats now serialize as primitives using ISO/RFC 3339 strings and compile.
  - Updated petstore sample to reflect the new `Primitive` union and formatting.

<sup>Written for commit 03a7f9bd59260ea6e19761f6cbe4f88ac3e2e3e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

