### PR TITLE
[scala-sttp4-jsoniter] bump Scala to 3.3.7, sttp4 to 4.0.23, jsoniter-scala to 2.38.12

### DIFF
--- a/docs/generators/scala-sttp4-jsoniter.md
+++ b/docs/generators/scala-sttp4-jsoniter.md
@@ -23,7 +23,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |disallowAdditionalPropertiesIfNotPresent|If false, the 'additionalProperties' implementation (set to true by default) is compliant with the OAS and JSON schema specifications. If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.|<dl><dt>**false**</dt><dd>The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.</dd><dt>**true**</dt><dd>Keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.</dd></dl>|true|
 |ensureUniqueParams|Whether to ensure parameter names are unique in an operation (rename parameters that are not).| |true|
 |enumUnknownDefaultCase|If the server adds new enum cases, that are unknown by an old spec/client, the client will fail to parse the network response. With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the server sends an enum case that is not known by the client/spec, they can safely fallback to this case.|<dl><dt>**false**</dt><dd>No changes to the enums are made, this is the default option.</dd><dt>**true**</dt><dd>With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the enum case sent by the server is not known by the client/spec, can safely be decoded to this case.</dd></dl>|false|
-|jsoniterVersion|The version of jsoniter-scala library| |2.31.1|
+|jsoniterVersion|The version of jsoniter-scala library| |2.38.12|
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
 |mainPackage|Top-level package name, which defines 'apiPackage', 'modelPackage', 'invokerPackage'| |org.openapitools.client|
 |modelPackage|package for generated models| |null|
@@ -33,7 +33,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |null|
-|sttpClientVersion|The version of sttp client| |4.0.0-RC1|
+|sttpClientVersion|The version of sttp client| |4.0.23|
 
 ## IMPORT MAPPING
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaSttp4JsoniterClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaSttp4JsoniterClientCodegen.java
@@ -47,7 +47,7 @@ public class ScalaSttp4JsoniterClientCodegen extends AbstractScalaCodegen implem
     private static final StringProperty STTP_CLIENT_VERSION = new StringProperty("sttpClientVersion",
             "The version of " +
                     "sttp client",
-            "4.0.0-RC1");
+            "4.0.23");
     private static final BooleanProperty USE_SEPARATE_ERROR_CHANNEL = new BooleanProperty("separateErrorChannel",
             "Whether to return response as " +
                     "F[Either[ResponseError[ErrorType], ReturnType]]] or to flatten " +
@@ -56,7 +56,7 @@ public class ScalaSttp4JsoniterClientCodegen extends AbstractScalaCodegen implem
     private static final StringProperty JSONITER_VERSION = new StringProperty("jsoniterVersion",
             "The version of jsoniter-scala " +
                     "library",
-            "2.31.1");
+            "2.38.12");
 
     public static final String DEFAULT_PACKAGE_NAME = "org.openapitools.client";
     private static final PackageProperty PACKAGE_PROPERTY = new PackageProperty();

--- a/modules/openapi-generator/src/main/resources/scala-sttp4-jsoniter/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp4-jsoniter/build.sbt.mustache
@@ -2,7 +2,7 @@ version := "{{artifactVersion}}"
 name := "{{artifactId}}"
 organization := "{{groupId}}"
 
-scalaVersion := "3.3.4"
+scalaVersion := "3.3.7"
 
 libraryDependencies ++= Seq(
   "com.softwaremill.sttp.client4" %% "core"                          % "{{sttpClientVersion}}",

--- a/samples/client/petstore/scala-sttp4-jsoniter/build.sbt
+++ b/samples/client/petstore/scala-sttp4-jsoniter/build.sbt
@@ -2,14 +2,14 @@ version := "1.0.0"
 name := "openapi-client"
 organization := "org.openapitools"
 
-scalaVersion := "3.3.4"
+scalaVersion := "3.3.7"
 
 libraryDependencies ++= Seq(
-  "com.softwaremill.sttp.client4" %% "core"                          % "4.0.0-RC1",
-  "com.softwaremill.sttp.client4" %% "jsoniter"                      % "4.0.0-RC1",
-  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % "2.31.1",
-  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.31.1" % "compile-internal",
-  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-circe"  % "2.31.1"
+  "com.softwaremill.sttp.client4" %% "core"                          % "4.0.23",
+  "com.softwaremill.sttp.client4" %% "jsoniter"                      % "4.0.23",
+  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % "2.38.12",
+  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.38.12" % "compile-internal",
+  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-circe"  % "2.38.12"
 )
 
 scalacOptions := Seq(


### PR DESCRIPTION
Bump default dependency versions for the `scala-sttp4-jsoniter` generator:
- Scala: 3.3.4 → 3.3.7
- sttp client 4: 4.0.0-RC1 → 4.0.23 (RC → GA stable)
- jsoniter-scala: 2.31.1 → 2.38.12

The sttp client bump is the most impactful — moving off the release candidate
to a stable GA release line. Scala and jsoniter-scala bumps pick up bug fixes
within their LTS / minor lines and remain source-compatible.

@lbialy
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped default dependencies for the `scala-sttp4-jsoniter` generator to latest stable and updated docs and sample. Moves `sttp.client4` off RC to GA; pulls in bug fixes with source-compatible changes.

- **Dependencies**
  - Scala: 3.3.4 → 3.3.7
  - `sttp.client4`: 4.0.0-RC1 → 4.0.23
  - `jsoniter-scala`: 2.31.1 → 2.38.12

<sup>Written for commit fae2be85e29ada3c0a1a0969914d81f5749afc79. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23802?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

