### PR TITLE
Update spring boot starter parent version to 3.5.14

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-http-interface/httpInterfacesConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-http-interface/httpInterfacesConfiguration.mustache
@@ -35,7 +35,7 @@ public abstract class HttpInterfacesAbstractConfigurator {
     @Bean(name = "{{configPackage}}.HttpInterfacesAbstractConfigurator.{{classVarName}}")
     {{classname}} {{classVarName}}HttpProxy() {
     {{#reactive}}
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(WebClientAdapter.forClient(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
     {{/reactive}}
     {{^reactive}}
         HttpServiceProxyFactory factory = HttpServiceProxyFactory.builderFor(RestClientAdapter.create(client)).build();

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-http-interface/httpInterfacesConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-http-interface/httpInterfacesConfiguration.mustache
@@ -35,7 +35,7 @@ public abstract class HttpInterfacesAbstractConfigurator {
     @Bean(name = "{{configPackage}}.HttpInterfacesAbstractConfigurator.{{classVarName}}")
     {{classname}} {{classVarName}}HttpProxy() {
     {{#reactive}}
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder().exchangeAdapter(WebClientAdapter.create(client)).build();
     {{/reactive}}
     {{^reactive}}
         HttpServiceProxyFactory factory = HttpServiceProxyFactory.builderFor(RestClientAdapter.create(client)).build();

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-http-interface/pom-sb3.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-http-interface/pom-sb3.mustache
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.13</version>
+        <version>3.5.14</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 {{/parentOverridden}}

--- a/samples/client/petstore/spring-http-interface-bean-validation/pom.xml
+++ b/samples/client/petstore/spring-http-interface-bean-validation/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.13</version>
+        <version>3.5.14</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/pom.xml
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.13</version>
+        <version>3.5.14</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/samples/client/petstore/spring-http-interface-reactive-bean-validation/pom.xml
+++ b/samples/client/petstore/spring-http-interface-reactive-bean-validation/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.13</version>
+        <version>3.5.14</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
+++ b/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
@@ -27,37 +27,37 @@ public abstract class HttpInterfacesAbstractConfigurator {
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.anotherFake")
     AnotherFakeApi anotherFakeHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(WebClientAdapter.forClient(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
         return factory.createClient(AnotherFakeApi.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.fake")
     FakeApi fakeHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(WebClientAdapter.forClient(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
         return factory.createClient(FakeApi.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.fakeClassnameTags123")
     FakeClassnameTags123Api fakeClassnameTags123HttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(WebClientAdapter.forClient(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
         return factory.createClient(FakeClassnameTags123Api.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.pet")
     PetApi petHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(WebClientAdapter.forClient(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
         return factory.createClient(PetApi.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.store")
     StoreApi storeHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(WebClientAdapter.forClient(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
         return factory.createClient(StoreApi.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.user")
     UserApi userHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(WebClientAdapter.forClient(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
         return factory.createClient(UserApi.class);
     }
 

--- a/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
+++ b/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
@@ -27,37 +27,37 @@ public abstract class HttpInterfacesAbstractConfigurator {
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.anotherFake")
     AnotherFakeApi anotherFakeHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder().exchangeAdapter(WebClientAdapter.create(client)).build();
         return factory.createClient(AnotherFakeApi.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.fake")
     FakeApi fakeHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder().exchangeAdapter(WebClientAdapter.create(client)).build();
         return factory.createClient(FakeApi.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.fakeClassnameTags123")
     FakeClassnameTags123Api fakeClassnameTags123HttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder().exchangeAdapter(WebClientAdapter.create(client)).build();
         return factory.createClient(FakeClassnameTags123Api.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.pet")
     PetApi petHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder().exchangeAdapter(WebClientAdapter.create(client)).build();
         return factory.createClient(PetApi.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.store")
     StoreApi storeHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder().exchangeAdapter(WebClientAdapter.create(client)).build();
         return factory.createClient(StoreApi.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.user")
     UserApi userHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder().exchangeAdapter(WebClientAdapter.create(client)).build();
         return factory.createClient(UserApi.class);
     }
 

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/pom.xml
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.13</version>
+        <version>3.5.14</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
@@ -27,37 +27,37 @@ public abstract class HttpInterfacesAbstractConfigurator {
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.anotherFake")
     AnotherFakeApi anotherFakeHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(WebClientAdapter.forClient(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
         return factory.createClient(AnotherFakeApi.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.fake")
     FakeApi fakeHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(WebClientAdapter.forClient(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
         return factory.createClient(FakeApi.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.fakeClassnameTags123")
     FakeClassnameTags123Api fakeClassnameTags123HttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(WebClientAdapter.forClient(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
         return factory.createClient(FakeClassnameTags123Api.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.pet")
     PetApi petHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(WebClientAdapter.forClient(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
         return factory.createClient(PetApi.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.store")
     StoreApi storeHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(WebClientAdapter.forClient(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
         return factory.createClient(StoreApi.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.user")
     UserApi userHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(WebClientAdapter.forClient(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
         return factory.createClient(UserApi.class);
     }
 

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
@@ -27,37 +27,37 @@ public abstract class HttpInterfacesAbstractConfigurator {
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.anotherFake")
     AnotherFakeApi anotherFakeHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder().exchangeAdapter(WebClientAdapter.create(client)).build();
         return factory.createClient(AnotherFakeApi.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.fake")
     FakeApi fakeHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder().exchangeAdapter(WebClientAdapter.create(client)).build();
         return factory.createClient(FakeApi.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.fakeClassnameTags123")
     FakeClassnameTags123Api fakeClassnameTags123HttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder().exchangeAdapter(WebClientAdapter.create(client)).build();
         return factory.createClient(FakeClassnameTags123Api.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.pet")
     PetApi petHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder().exchangeAdapter(WebClientAdapter.create(client)).build();
         return factory.createClient(PetApi.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.store")
     StoreApi storeHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder().exchangeAdapter(WebClientAdapter.create(client)).build();
         return factory.createClient(StoreApi.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.user")
     UserApi userHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder().exchangeAdapter(WebClientAdapter.create(client)).build();
         return factory.createClient(UserApi.class);
     }
 

--- a/samples/client/petstore/spring-http-interface-reactive/pom.xml
+++ b/samples/client/petstore/spring-http-interface-reactive/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.13</version>
+        <version>3.5.14</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
@@ -27,37 +27,37 @@ public abstract class HttpInterfacesAbstractConfigurator {
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.anotherFake")
     AnotherFakeApi anotherFakeHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(WebClientAdapter.forClient(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
         return factory.createClient(AnotherFakeApi.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.fake")
     FakeApi fakeHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(WebClientAdapter.forClient(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
         return factory.createClient(FakeApi.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.fakeClassnameTags123")
     FakeClassnameTags123Api fakeClassnameTags123HttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(WebClientAdapter.forClient(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
         return factory.createClient(FakeClassnameTags123Api.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.pet")
     PetApi petHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(WebClientAdapter.forClient(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
         return factory.createClient(PetApi.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.store")
     StoreApi storeHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(WebClientAdapter.forClient(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
         return factory.createClient(StoreApi.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.user")
     UserApi userHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(WebClientAdapter.forClient(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
         return factory.createClient(UserApi.class);
     }
 

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/configuration/HttpInterfacesAbstractConfigurator.java
@@ -27,37 +27,37 @@ public abstract class HttpInterfacesAbstractConfigurator {
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.anotherFake")
     AnotherFakeApi anotherFakeHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder().exchangeAdapter(WebClientAdapter.create(client)).build();
         return factory.createClient(AnotherFakeApi.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.fake")
     FakeApi fakeHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder().exchangeAdapter(WebClientAdapter.create(client)).build();
         return factory.createClient(FakeApi.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.fakeClassnameTags123")
     FakeClassnameTags123Api fakeClassnameTags123HttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder().exchangeAdapter(WebClientAdapter.create(client)).build();
         return factory.createClient(FakeClassnameTags123Api.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.pet")
     PetApi petHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder().exchangeAdapter(WebClientAdapter.create(client)).build();
         return factory.createClient(PetApi.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.store")
     StoreApi storeHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder().exchangeAdapter(WebClientAdapter.create(client)).build();
         return factory.createClient(StoreApi.class);
     }
 
     @Bean(name = "org.openapitools.configuration.HttpInterfacesAbstractConfigurator.user")
     UserApi userHttpProxy() {
-        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(new WebClientAdapter(client)).build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder().exchangeAdapter(WebClientAdapter.create(client)).build();
         return factory.createClient(UserApi.class);
     }
 

--- a/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/pom.xml
+++ b/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.13</version>
+        <version>3.5.14</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/samples/client/petstore/spring-http-interface/pom.xml
+++ b/samples/client/petstore/spring-http-interface/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.13</version>
+        <version>3.5.14</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
Update spring boot starter parent version to 3.5.14

@cachescrubber (2022/02) @welshm (2022/02) @MelleD (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02) @borsch (2022/02) @banlevente (2022/02) @Zomzog (2022/09) @martin-mfg (2023/08)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Spring Boot parent to 3.5.14 across the Spring HTTP Interface template and samples so generated clients use the 3.5 line. In reactive configs, replaced `HttpServiceProxyFactory.builder(WebClientAdapter.forClient(client))` with `HttpServiceProxyFactory.builder().exchangeAdapter(WebClientAdapter.create(client))` to match the latest `HttpServiceProxyFactory` API.

<sup>Written for commit 637a5977af0039f7e445b4d9272be13c6e79122d. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23809?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

