### PR TITLE
Feat/normalizer default propagation

### DIFF
--- a/docs/default-resolution-strategy.md
+++ b/docs/default-resolution-strategy.md
@@ -160,6 +160,98 @@ define.
 | Variant | Selected candidate | Result | Log emitted |
 |---|---|---|---|
 | A (Root has `default: "root"`) | `{value="root", depth=0}` | **`"root"`** | `DEBUG`: 2 branch defaults ignored |
+
+---
+
+## How defaults are surfaced at codegen time
+
+The OpenAPI Normalizer wires `DefaultResolutionStrategy` into two complementary mechanisms.
+Both operate on the spec model **before** any generator runs, so every generator benefits —
+including the ~60 generators that override `toDefaultValue(Schema)` and do not call `super`.
+
+### Always-on: `$ref` default propagation
+
+When a property is a plain `$ref` (e.g. `$ref: '#/components/schemas/Status'`) and the
+referenced schema defines a `default:`, the Normalizer automatically copies that default onto
+the outer property schema. No configuration is required.
+
+Under the hood:
+
+1. The Normalizer reads `resolved.getDefault()` from the target schema.
+2. It copies the value to `property.setDefault(...)` on the `$ref`-holding wrapper.
+3. The existing `normalizeReferenceSchema` step detects the `$ref`-with-sibling-fields pattern
+   and rewrites it as `{ allOf: [{$ref: ...}], default: "..." }`, making the default visible
+   as `schema.getDefault()` on the outer schema.
+
+**Example:**
+
+```yaml
+# Before normalization
+components:
+  schemas:
+    Status:
+      type: string
+      default: "active"
+    Item:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/Status'   # no explicit default
+
+# After normalization (effective view — stored in the spec model)
+    Item:
+      type: object
+      properties:
+        status:
+          allOf:
+            - $ref: '#/components/schemas/Status'
+          default: "active"   # ← propagated from Status
+```
+
+### Opt-in: `RESOLVE_SCHEMA_DEFAULTS` normalizer rule
+
+For `allOf`-composed schemas, default resolution is **opt-in** because it requires choosing a
+strategy. Activate it via:
+
+```properties
+# In your generator config (generatorName, additionalProperties, etc.)
+openapiNormalizer=RESOLVE_SCHEMA_DEFAULTS=LAST_WINS
+```
+
+Valid strategy values (case-insensitive): `LAST_WINS`, `NEAREST_WINS`, `ROOT_WINS`, `STRICT`.
+
+When enabled, the Normalizer runs `ModelUtils.resolveDefault(openAPI, schema, strategy)` on
+every component schema and every property schema that has `getDefault() == null` after normal
+normalization. If a non-null result is returned, it is written back via `schema.setDefault(result)`.
+
+**Example:**
+
+```yaml
+# YAML spec
+components:
+  schemas:
+    BaseStatus:
+      type: string
+      enum: [active, inactive]
+      default: "active"
+    OrderStatus:
+      allOf:
+        - $ref: '#/components/schemas/BaseStatus'
+      # no direct default
+
+# With RESOLVE_SCHEMA_DEFAULTS=LAST_WINS:
+# OrderStatus.getDefault() → "active"   (resolved from the allOf branch)
+```
+
+| Rule value | Behaviour |
+|---|---|
+| `LAST_WINS` | Post-order DFS winner — root's own `default:` wins if present, otherwise the deepest/last branch wins |
+| `NEAREST_WINS` | Shallowest `default:` wins; warns on conflicting values |
+| `ROOT_WINS` | Only the root schema's direct `default:` is used; nested branch defaults are ignored |
+| `STRICT` | Returns `null` and logs `WARN` when more than one distinct default value exists |
+
+See the strategy sections above for a full description and worked examples.
+
 | B (no root default) | _(none at depth 0)_ | **`null`** | `DEBUG`: 2 branch defaults ignored |
 
 ---

--- a/docs/default-resolution-strategy.md
+++ b/docs/default-resolution-strategy.md
@@ -165,28 +165,34 @@ define.
 
 ## How defaults are surfaced at codegen time
 
-The OpenAPI Normalizer wires `DefaultResolutionStrategy` into two complementary mechanisms.
-Both operate on the spec model **before** any generator runs, so every generator benefits —
-including the ~60 generators that override `toDefaultValue(Schema)` and do not call `super`.
+Two complementary mechanisms wire `DefaultResolutionStrategy` into the code-generation pipeline.
+Both benefit all ~60+ generators without any generator-specific code.
 
-### Always-on: `$ref` default propagation
+### Always-on: `$ref` default propagation (codegen layer)
 
 When a property is a plain `$ref` (e.g. `$ref: '#/components/schemas/Status'`) and the
-referenced schema defines a `default:`, the Normalizer automatically copies that default onto
-the outer property schema. No configuration is required.
+referenced schema defines a `default:`, the default is **automatically propagated at codegen
+time** — no configuration is required.
 
-Under the hood:
+Under the hood, `DefaultCodegen.fromProperty` resolves the `$ref` chain before calling
+`toDefaultValue`, so generators always receive a fully-typed concrete schema:
 
-1. The Normalizer reads `resolved.getDefault()` from the target schema.
-2. It copies the value to `property.setDefault(...)` on the `$ref`-holding wrapper.
-3. The existing `normalizeReferenceSchema` step detects the `$ref`-with-sibling-fields pattern
-   and rewrites it as `{ allOf: [{$ref: ...}], default: "..." }`, making the default visible
-   as `schema.getDefault()` on the outer schema.
+```
+fromProperty("status", {$ref: '#/components/schemas/Status'})
+  ↓ loop: getReferencedSchema until no more $ref
+  → {type: string, default: "active"}
+  ↓ toDefaultValue(property, resolvedSchema)
+  → "active"
+```
+
+The loop handles arbitrarily deep chains (`A → $ref: B → $ref: C → {type: string, default: x}`).
+The spec model is **not mutated** — the `$ref` property schema remains unchanged in memory.
+Because the fix is in the base class (`DefaultCodegen`), all generators that override only
+`toDefaultValue(Schema)` inherit the behaviour automatically.
 
 **Example:**
 
 ```yaml
-# Before normalization
 components:
   schemas:
     Status:
@@ -197,16 +203,10 @@ components:
       properties:
         status:
           $ref: '#/components/schemas/Status'   # no explicit default
-
-# After normalization (effective view — stored in the spec model)
-    Item:
-      type: object
-      properties:
-        status:
-          allOf:
-            - $ref: '#/components/schemas/Status'
-          default: "active"   # ← propagated from Status
 ```
+
+After `fromProperty("status", ...)` the generated `CodegenProperty.defaultValue` will be
+`"active"` in every generator.
 
 ### Opt-in: `RESOLVE_SCHEMA_DEFAULTS` normalizer rule
 
@@ -221,8 +221,11 @@ openapiNormalizer=RESOLVE_SCHEMA_DEFAULTS=LAST_WINS
 Valid strategy values (case-insensitive): `LAST_WINS`, `NEAREST_WINS`, `ROOT_WINS`, `STRICT`.
 
 When enabled, the Normalizer runs `ModelUtils.resolveDefault(openAPI, schema, strategy)` on
-every component schema and every property schema that has `getDefault() == null` after normal
-normalization. If a non-null result is returned, it is written back via `schema.setDefault(result)`.
+every component schema and every **non-`$ref`** property schema that has `getDefault() == null`
+after normal normalization. Pure `$ref` property schemas are skipped — their defaults are
+resolved by `DefaultCodegen.fromProperty` at codegen time to avoid creating invalid OAS 3.0
+`$ref`-with-sibling-`default` constructs.
+If a non-null result is returned, it is written back via `schema.setDefault(result)`.
 
 **Example:**
 

--- a/docs/default-resolution-strategy.md
+++ b/docs/default-resolution-strategy.md
@@ -1,0 +1,225 @@
+# DefaultResolutionStrategy — how `default` values are resolved in `allOf` schemas
+
+OpenAPI does not define precedence rules for `default` values that appear in multiple
+branches of an `allOf` composition. `ModelUtils.resolveDefault()` fills that gap with a
+configurable **`DefaultResolutionStrategy`** enum. This document explains the four
+strategies using a concrete nested schema so you can choose the one that best matches your
+needs.
+
+---
+
+## Background: the collection phase
+
+Before any strategy is applied, `ModelUtils` runs a single **post-order DFS** traversal of
+the fully-resolved schema tree (all `$ref`s expanded, all `allOf` levels recursively
+flattened). The traversal produces an ordered list of **`DefaultCandidate`** objects, one
+for every schema node that carries a non-null `default:`. Each candidate records:
+
+| Field | Meaning |
+|---|---|
+| `value` | The raw default value found on that schema node |
+| `depth` | `0` for the root schema, `1` for its direct `allOf` items, `2` for their `allOf` items, … |
+| `visitOrder` | Monotonically increasing post-order DFS index (children before parent, so the root's own `default:` is **always last**) |
+
+Each strategy below is a pure **selector** over that candidate list; the collection phase is
+identical for all of them.
+
+---
+
+## Canonical example schema
+
+The following three-schema chain is used throughout this document.
+
+```yaml
+components:
+  schemas:
+
+    Base:
+      type: string
+      default: "base"        # depth 2 when reached from Root
+
+    Middle:
+      allOf:
+        - $ref: '#/components/schemas/Base'
+      default: "middle"      # depth 1 when reached from Root
+
+    Root:
+      allOf:
+        - $ref: '#/components/schemas/Middle'
+      default: "root"        # depth 0 — the root schema passed to resolveDefault
+```
+
+A second **"no-root-default" / "conflict"** variant is also used to show how strategies
+diverge when `Root` has no direct default:
+
+```yaml
+    # Same as above but Root carries NO default:
+    RootNoDefault:
+      allOf:
+        - $ref: '#/components/schemas/Middle'
+        #  ↑ Middle itself contains Base, which has default "base"
+        #  ↑ Middle also has default "middle"
+        # Root itself has no default here
+```
+
+---
+
+## DFS candidate walk
+
+### Variant A — Root has a direct `default: "root"`
+
+When `resolveDefault(openAPI, Root, strategy)` is called, the DFS visits:
+
+| Step | Schema visited | depth | Own `default:` | visitOrder assigned |
+|------|---------------|-------|----------------|---------------------|
+| 1    | `Base` (leaf, reached via Middle's allOf) | 2 | `"base"` | 0 |
+| 2    | `Middle` (after its allOf child) | 1 | `"middle"` | 1 |
+| 3    | `Root` (after its allOf child Middle) | 0 | `"root"` | 2 |
+
+**Candidate list (post-order):**
+
+```
+[ {value="base",   depth=2, visitOrder=0},
+  {value="middle", depth=1, visitOrder=1},
+  {value="root",   depth=0, visitOrder=2} ]
+```
+
+> The root schema's own `default:` is always appended **last** (highest `visitOrder`)
+> because the traversal is post-order (children before parent).
+
+### Variant B — Root has **no** direct `default:`
+
+| Step | Schema visited | depth | Own `default:` | visitOrder assigned |
+|------|---------------|-------|----------------|---------------------|
+| 1    | `Base` | 2 | `"base"` | 0 |
+| 2    | `Middle` | 1 | `"middle"` | 1 |
+| 3    | `RootNoDefault` | 0 | _(none)_ | _(not added)_ |
+
+**Candidate list (post-order):**
+
+```
+[ {value="base",   depth=2, visitOrder=0},
+  {value="middle", depth=1, visitOrder=1} ]
+```
+
+---
+
+## Strategies
+
+### `LAST_WINS` *(backward-compatible default)*
+
+> **Rule:** pick the candidate with the **highest `visitOrder`**.
+
+Because the root's own `default:` is always assigned the highest `visitOrder` in the
+post-order traversal, a direct root default always wins when present. When the root has no
+direct default, the **last `allOf` branch** (recursively resolved) wins.
+
+| Variant | Selected candidate | Result |
+|---|---|---|
+| A (Root has `default: "root"`) | `{value="root", visitOrder=2}` — highest | **`"root"`** |
+| B (no root default) | `{value="middle", visitOrder=1}` — highest remaining | **`"middle"`** |
+
+This strategy is used by the zero-argument
+`ModelUtils.resolveDefault(openAPI, schema)` overload for backward compatibility.
+
+---
+
+### `NEAREST_WINS`
+
+> **Rule:** pick the candidate with the **smallest `depth`**; break ties by smallest
+> `visitOrder` (leftmost at the same depth).
+>
+> Emits `LOGGER.warn` when more than one distinct value is found.
+
+"Nearest to the consumer" is treated as "most specific". A root direct default (depth 0)
+therefore always wins when present. If the root has no direct default, the leftmost
+`allOf` item at depth 1 is chosen over anything deeper.
+
+| Variant | Selected candidate | Result | Warning logged? |
+|---|---|---|---|
+| A (Root has `default: "root"`) | `{value="root", depth=0}` — shallowest | **`"root"`** | Yes (3 distinct-ish values) |
+| B (no root default) | `{value="middle", depth=1}` — shallowest remaining | **`"middle"`** | Yes (`"base"` vs `"middle"`) |
+
+Compare with `LAST_WINS` for Variant B: both return `"middle"` here, but would diverge
+if `Middle` listed `Base` **after** another sibling with a different default, because
+`NEAREST_WINS` picks the *leftmost* sibling while `LAST_WINS` picks the *rightmost*.
+
+---
+
+### `ROOT_WINS`
+
+> **Rule:** only `depth == 0` candidates count; all nested defaults are ignored.
+> Returns `null` when the root schema has no direct `default:`.
+>
+> Emits `LOGGER.debug` when `allOf`-branch defaults are being ignored.
+
+This is the most conservative heuristic. It intentionally discards everything inherited
+from `allOf` branches, making the generator's output independent of what base schemas
+define.
+
+| Variant | Selected candidate | Result | Log emitted |
+|---|---|---|---|
+| A (Root has `default: "root"`) | `{value="root", depth=0}` | **`"root"`** | `DEBUG`: 2 branch defaults ignored |
+| B (no root default) | _(none at depth 0)_ | **`null`** | `DEBUG`: 2 branch defaults ignored |
+
+---
+
+### `STRICT`
+
+> **Rule:** if there are **2 or more distinct values** in the candidate list, log a `WARN`
+> and return `null`. Otherwise return the single unambiguous value.
+>
+> Identical duplicates across branches are **not** a conflict — they resolve safely.
+
+`STRICT` is the most spec-faithful mode. OpenAPI itself provides no precedence rule for
+`default` in `allOf`, so `STRICT` refuses to silently choose a winner. Use it when you
+want to detect ambiguity early and fix the spec rather than rely on a heuristic.
+
+| Variant | Distinct values | Result | Warning logged? |
+|---|---|---|---|
+| A (Root has `default: "root"`) | 3 (`"base"`, `"middle"`, `"root"`) | **`null`** | Yes — lists all conflicting values |
+| B (no root default) | 2 (`"base"`, `"middle"`) | **`null`** | Yes |
+| All branches share the same value (e.g. every node says `"shared"`) | 1 | **`"shared"`** | No |
+
+---
+
+## Quick-reference comparison
+
+The table below summarises all four strategies applied to both variants of the example
+schema:
+
+| Strategy | Variant A result (`Root` has `default: "root"`) | Variant B result (no root default) | Conflict logged? |
+|---|---|---|---|
+| `LAST_WINS` | `"root"` | `"middle"` | No |
+| `NEAREST_WINS` | `"root"` | `"middle"` | Yes (`WARN`) |
+| `ROOT_WINS` | `"root"` | `null` | No (`DEBUG` only) |
+| `STRICT` | `null` | `null` | Yes (`WARN`) |
+
+> **When there is only one distinct default value** across the entire candidate list, all
+> four strategies agree and return that value.
+
+---
+
+## Choosing a strategy
+
+| Goal | Recommended strategy |
+|---|---|
+| Keep existing generator behaviour | `LAST_WINS` *(default)* |
+| "Most specific wins" — root overrides base, leftmost sibling wins ties | `NEAREST_WINS` |
+| Ignore inherited defaults entirely; only trust an explicit root `default:` | `ROOT_WINS` |
+| Fail fast on any ambiguity; enforce a single source of truth in the spec | `STRICT` |
+
+---
+
+## API
+
+```java
+// Default (LAST_WINS) — backward-compatible overload
+Object value = ModelUtils.resolveDefault(openAPI, schema);
+
+// Explicit strategy
+Object value = ModelUtils.resolveDefault(openAPI, schema, DefaultResolutionStrategy.STRICT);
+```
+
+Source: [`DefaultResolutionStrategy.java`](../modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/DefaultResolutionStrategy.java),
+[`ModelUtils.java`](../modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java)

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4316,11 +4316,11 @@ public class DefaultCodegen implements CodegenConfig {
 
         // set the default value
         // Fully resolve $ref chain before asking generators for the default value.
-        // ModelUtils.getReferencedSchema is single-level, so loop until stable.
+        // ModelUtils.getReferencedSchema returns the input unchanged when a ref cannot be
+        // resolved, so "referenced == pForDefault" is the natural termination condition.
+        // Circular $ref chains are invalid OpenAPI and do not need a separate guard.
         Schema pForDefault = p;
-        Schema prevSchema = null;
-        while (pForDefault != null && pForDefault.get$ref() != null && pForDefault != prevSchema) {
-            prevSchema = pForDefault;
+        while (pForDefault != null && pForDefault.get$ref() != null) {
             Schema referenced = ModelUtils.getReferencedSchema(openAPI, pForDefault);
             if (referenced == null || referenced == pForDefault) break;
             pForDefault = referenced;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4315,7 +4315,17 @@ public class DefaultCodegen implements CodegenConfig {
         }
 
         // set the default value
-        property.defaultValue = toDefaultValue(property, p);
+        // Fully resolve $ref chain before asking generators for the default value.
+        // ModelUtils.getReferencedSchema is single-level, so loop until stable.
+        Schema pForDefault = p;
+        Schema prevSchema = null;
+        while (pForDefault != null && pForDefault.get$ref() != null && pForDefault != prevSchema) {
+            prevSchema = pForDefault;
+            Schema referenced = ModelUtils.getReferencedSchema(openAPI, pForDefault);
+            if (referenced == null || referenced == pForDefault) break;
+            pForDefault = referenced;
+        }
+        property.defaultValue = toDefaultValue(property, pForDefault);
         property.defaultValueWithParam = toDefaultValueWithParam(name, p);
 
         LOGGER.debug("debugging from property return: {}", property);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -29,6 +29,7 @@ import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.utils.ModelUtils;
+import org.openapitools.codegen.utils.DefaultResolutionStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -159,6 +160,13 @@ public class OpenAPINormalizer {
     // when set to true, sort model properties by name to ensure deterministic output
     final String SORT_MODEL_PROPERTIES = "SORT_MODEL_PROPERTIES";
 
+    // when set to a strategy name (LAST_WINS, NEAREST_WINS, ROOT_WINS, STRICT), resolve
+    // `default` values in allOf-composed schemas and write the result back to the schema.
+    // This makes the resolved default available to all generators via schema.getDefault().
+    // Example: RESOLVE_SCHEMA_DEFAULTS=LAST_WINS
+    final String RESOLVE_SCHEMA_DEFAULTS = "RESOLVE_SCHEMA_DEFAULTS";
+    DefaultResolutionStrategy resolveSchemaDefaultsStrategy;
+
     // ============= end of rules =============
 
     /**
@@ -219,6 +227,7 @@ public class OpenAPINormalizer {
         ruleNames.add(REMOVE_PROPERTIES_FROM_TYPE_OTHER_THAN_OBJECT);
         ruleNames.add(SORT_MODEL_PROPERTIES);
         ruleNames.add(REPLACE_ONE_OF_BY_DISCRIMINATOR_MAPPING);
+        ruleNames.add(RESOLVE_SCHEMA_DEFAULTS);
 
         // rules that are default to true
         rules.put(SIMPLIFY_ONEOF_ANYOF, true);
@@ -328,6 +337,16 @@ public class OpenAPINormalizer {
         bearerAuthSecuritySchemeName = inputRules.get(SET_BEARER_AUTH_FOR_NAME);
         if (bearerAuthSecuritySchemeName != null) {
             rules.put(SET_BEARER_AUTH_FOR_NAME, true);
+        }
+
+        String resolveSchemaDefaultsValue = inputRules.get(RESOLVE_SCHEMA_DEFAULTS);
+        if (resolveSchemaDefaultsValue != null) {
+            try {
+                resolveSchemaDefaultsStrategy = DefaultResolutionStrategy.valueOf(resolveSchemaDefaultsValue.trim().toUpperCase(java.util.Locale.ROOT));
+                rules.put(RESOLVE_SCHEMA_DEFAULTS, true);
+            } catch (IllegalArgumentException e) {
+                LOGGER.error("RESOLVE_SCHEMA_DEFAULTS rule must be one of LAST_WINS, NEAREST_WINS, ROOT_WINS, STRICT. Got: {}", resolveSchemaDefaultsValue);
+            }
         }
     }
 
@@ -643,7 +662,17 @@ public class OpenAPINormalizer {
                 fixSelfReferenceSchema(schemaName, schema);
 
                 // normalize the schemas
-                schemas.put(schemaName, normalizeSchema(schema, new HashSet<>()));
+                Schema normalizedSchema = normalizeSchema(schema, new HashSet<>());
+                schemas.put(schemaName, normalizedSchema);
+
+                // if RESOLVE_SCHEMA_DEFAULTS is enabled, compute and write back the effective
+                // default for allOf-composed component schemas that have no direct default.
+                if (getRule(RESOLVE_SCHEMA_DEFAULTS) && normalizedSchema.getDefault() == null) {
+                    Object resolved = ModelUtils.resolveDefault(openAPI, normalizedSchema, resolveSchemaDefaultsStrategy);
+                    if (resolved != null) {
+                        normalizedSchema.setDefault(resolved);
+                    }
+                }
 
                 if (getRule(REPLACE_ONE_OF_BY_DISCRIMINATOR_MAPPING)) {
                     ensureInheritanceForDiscriminatorMappings(schema, schemaName);
@@ -930,7 +959,24 @@ public class OpenAPINormalizer {
                     property.getExtensions().remove(X_INTERNAL);
                 }
             }
+            // Propagate `default` from a pure $ref target before normalizeSchema runs.
+            // normalizeReferenceSchema will then promote it via allOf wrapping, making the
+            // default visible to all generators as schema.getDefault() on the outer schema.
+            if (property.get$ref() != null && property.getDefault() == null) {
+                Schema<?> resolved = ModelUtils.getReferencedSchema(openAPI, property);
+                if (resolved != null && resolved.getDefault() != null) {
+                    property.setDefault(resolved.getDefault());
+                }
+            }
             Schema newProperty = normalizeSchema(property, new HashSet<>());
+            // if RESOLVE_SCHEMA_DEFAULTS is enabled, write back the effective default for
+            // allOf-composed property schemas that still have no direct default after normalization.
+            if (getRule(RESOLVE_SCHEMA_DEFAULTS) && newProperty.getDefault() == null) {
+                Object resolved = ModelUtils.resolveDefault(openAPI, newProperty, resolveSchemaDefaultsStrategy);
+                if (resolved != null) {
+                    newProperty.setDefault(resolved);
+                }
+            }
             propertiesEntry.setValue(newProperty);
         }
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -959,19 +959,13 @@ public class OpenAPINormalizer {
                     property.getExtensions().remove(X_INTERNAL);
                 }
             }
-            // Propagate `default` from a pure $ref target before normalizeSchema runs.
-            // normalizeReferenceSchema will then promote it via allOf wrapping, making the
-            // default visible to all generators as schema.getDefault() on the outer schema.
-            if (property.get$ref() != null && property.getDefault() == null) {
-                Schema<?> resolved = ModelUtils.getReferencedSchema(openAPI, property);
-                if (resolved != null && resolved.getDefault() != null) {
-                    property.setDefault(resolved.getDefault());
-                }
-            }
             Schema newProperty = normalizeSchema(property, new HashSet<>());
             // if RESOLVE_SCHEMA_DEFAULTS is enabled, write back the effective default for
             // allOf-composed property schemas that still have no direct default after normalization.
-            if (getRule(RESOLVE_SCHEMA_DEFAULTS) && newProperty.getDefault() == null) {
+            // Skip pure $ref schemas — their defaults are resolved by DefaultCodegen.fromProperty
+            // at codegen time, avoiding invalid OAS 3.0 $ref-with-sibling-default constructs.
+            if (getRule(RESOLVE_SCHEMA_DEFAULTS) && newProperty.getDefault() == null
+                    && newProperty.get$ref() == null) {
                 Object resolved = ModelUtils.resolveDefault(openAPI, newProperty, resolveSchemaDefaultsStrategy);
                 if (resolved != null) {
                     newProperty.setDefault(resolved);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1375,7 +1375,6 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     @Override
     public String toDefaultValue(CodegenProperty cp, Schema schema) {
-        schema = ModelUtils.getReferencedSchema(this.openAPI, schema);
         if (ModelUtils.isArraySchema(schema)) {
             if (defaultToEmptyContainer) {
                 // if default to empty container option is set, respect the default values provided in the spec

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -1198,7 +1198,6 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
 
     @Override
     public String toDefaultValue(CodegenProperty cp, Schema schema) {
-        schema = ModelUtils.getReferencedSchema(this.openAPI, schema);
         if (ModelUtils.isBooleanSchema(schema)) {
             if (schema.getDefault() != null) {
                 return schema.getDefault().toString();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -175,18 +175,6 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
      */
     @Override
     public String toDefaultValue(Schema p) {
-        // If the Schema is a $ref, get the default value from the reference.
-        String ref = ModelUtils.getSimpleRef(p.get$ref());
-        if (ref != null) {
-            Schema referencedSchema = ModelUtils.getSchemas(this.openAPI).get(ref);
-            if (referencedSchema != null) {
-                String defaultValue = toDefaultValue(referencedSchema);
-                if (defaultValue != null) {
-                    return defaultValue;
-                }
-                // No default was found for the $ref, so see if one has been defined locally.
-            }
-        }
         if (ModelUtils.isBooleanSchema(p)) {
             if (p.getDefault() != null) {
                 if (!Boolean.valueOf(p.getDefault().toString()))

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -175,6 +175,20 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
      */
     @Override
     public String toDefaultValue(Schema p) {
+        // toDefaultValue(Schema) may be called directly (e.g. from fromOperation) with a $ref
+        // schema that has not been pre-resolved. Follow the ref so callers outside fromProperty
+        // can still obtain the default from the referenced schema.
+        String ref = ModelUtils.getSimpleRef(p.get$ref());
+        if (ref != null) {
+            Schema referencedSchema = ModelUtils.getSchemas(this.openAPI).get(ref);
+            if (referencedSchema != null) {
+                String defaultValue = toDefaultValue(referencedSchema);
+                if (defaultValue != null) {
+                    return defaultValue;
+                }
+                // No default was found for the $ref, so see if one has been defined locally.
+            }
+        }
         if (ModelUtils.isBooleanSchema(p)) {
             if (p.getDefault() != null) {
                 if (!Boolean.valueOf(p.getDefault().toString()))

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppHttplibServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppHttplibServerCodegen.java
@@ -1363,7 +1363,10 @@ public class CppHttplibServerCodegen extends AbstractCppCodegen {
             }
             if (var.isModel) {
                 var.vendorExtensions.put("isModel", true);
-                if (var.defaultValue != null && var.defaultValue.startsWith("std::make_shared<")) {
+                if (var.defaultValue == null) {
+                    // fromProperty pre-resolves $ref before calling toDefaultValue, so model
+                    // properties with no OAS default arrive here as null. Set C++ value-type
+                    // construction so the member appears in the initializer list.
                     var.defaultValue = var.datatypeWithEnum + "()";
                 }
             }
@@ -1779,10 +1782,6 @@ public class CppHttplibServerCodegen extends AbstractCppCodegen {
         if (ModelUtils.isMapSchema(p)) {
             String inner = getTypeDeclaration(ModelUtils.getAdditionalProperties(p));
             return "std::map<std::string, " + inner + ">()";
-        }
-        if (p.get$ref() != null && !p.get$ref().isEmpty()) {
-            // Model references as shared pointers - create instance with make_shared
-            return "std::make_shared<" + toModelName(ModelUtils.getSimpleRef(p.get$ref())) + ">()";
         }
         // Unknown type - skip initialization, let default constructor handle it
         return null;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppTinyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppTinyClientCodegen.java
@@ -21,6 +21,7 @@ import io.swagger.v3.parser.util.SchemaTypeUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.CliOption;
 import org.openapitools.codegen.CodegenConfig;
+import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.CodegenType;
 import org.openapitools.codegen.SupportingFile;
 import org.openapitools.codegen.meta.GeneratorMetadata;
@@ -351,6 +352,16 @@ public class CppTinyClientCodegen extends AbstractCppCodegen implements CodegenC
     }
 
     @Override
+    public String toDefaultValue(CodegenProperty cp, Schema schema) {
+        if (cp != null && cp.isModel) {
+            // Object model members must be default-constructed in C++ regardless of whether
+            // the OAS schema declares an explicit default. Use the resolved type name.
+            return cp.dataType + "()";
+        }
+        return toDefaultValue(schema);
+    }
+
+    @Override
     public String toDefaultValue(Schema p) {
         if (ModelUtils.isBooleanSchema(p)) {
             return "bool(false)";
@@ -363,8 +374,6 @@ public class CppTinyClientCodegen extends AbstractCppCodegen implements CodegenC
             return "int(0)";
         } else if (ModelUtils.isArraySchema(p)) {
             return "std::list";
-        } else if (!StringUtils.isEmpty(p.get$ref())) {
-            return toModelName(ModelUtils.getSimpleRef(p.get$ref())) + "()";
         } else if (ModelUtils.isDateSchema(p) || ModelUtils.isDateTimeSchema(p)) {
             return "std::string()";
         } else if (ModelUtils.isStringSchema(p)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppTizenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppTizenClientCodegen.java
@@ -21,6 +21,7 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.parser.util.SchemaTypeUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.CodegenConfig;
+import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.CodegenType;
 import org.openapitools.codegen.SupportingFile;
 import org.openapitools.codegen.meta.features.*;
@@ -235,6 +236,16 @@ public class CppTizenClientCodegen extends AbstractCppCodegen implements Codegen
 
     //Might not be needed
     @Override
+    public String toDefaultValue(CodegenProperty cp, Schema schema) {
+        if (cp != null && cp.isModel) {
+            // Object model members use heap-allocated default construction in C++ regardless
+            // of whether the OAS schema declares an explicit default.
+            return "new " + cp.dataType + "()";
+        }
+        return toDefaultValue(schema);
+    }
+
+    @Override
     public String toDefaultValue(Schema p) {
         if (ModelUtils.isBooleanSchema(p)) {
             return "bool(false)";
@@ -253,8 +264,6 @@ public class CppTizenClientCodegen extends AbstractCppCodegen implements Codegen
             return "new std::map()";
         } else if (ModelUtils.isArraySchema(p)) {
             return "new std::list()";
-        } else if (!StringUtils.isEmpty(p.get$ref())) {
-            return "new " + toModelName(ModelUtils.getSimpleRef(p.get$ref())) + "()";
         } else if (ModelUtils.isDateSchema(p) || ModelUtils.isDateTimeSchema(p)) {
             return "null";
         } else if (ModelUtils.isStringSchema(p)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/DefaultResolutionStrategy.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/DefaultResolutionStrategy.java
@@ -1,0 +1,84 @@
+package org.openapitools.codegen.utils;
+
+/**
+ * Defines the strategy used by {@link ModelUtils#resolveDefault(io.swagger.v3.oas.models.OpenAPI,
+ * io.swagger.v3.oas.models.media.Schema, DefaultResolutionStrategy)} when an OpenAPI schema
+ * composed with {@code allOf} carries {@code default} values in more than one branch.
+ *
+ * <p>OpenAPI does not specify precedence rules for {@code default} in {@code allOf} compositions,
+ * so any single strategy is a generator-level convention rather than a spec guarantee.
+ * Callers that need reproducible, portable behaviour should prefer {@link #STRICT} to detect
+ * ambiguity early, and fall back to an explicit heuristic mode only when the spec cannot be
+ * improved.</p>
+ *
+ * <h3>How candidates are collected</h3>
+ * <p>Internally, a single <em>post-order DFS</em> traversal of the fully-resolved schema tree
+ * (including {@code $ref} expansion and recursive {@code allOf} flattening) produces an ordered
+ * list of {@link ModelUtils.DefaultCandidate} objects. Each candidate records:
+ * <ul>
+ *   <li>{@code value} — the raw default value found on that schema node</li>
+ *   <li>{@code depth} — 0 for the root schema, 1 for its {@code allOf} items, and so on</li>
+ *   <li>{@code visitOrder} — monotonically increasing post-order DFS index; the root schema's
+ *       direct {@code default:} (if any) is always appended <em>last</em>, giving it the highest
+ *       {@code visitOrder} among all candidates</li>
+ * </ul>
+ * Each strategy below is then a pure selector over that list.</p>
+ */
+public enum DefaultResolutionStrategy {
+
+    /**
+     * Spec-faithful strict mode: never silently resolve conflicts.
+     *
+     * <ul>
+     *   <li>0 candidates → {@code null}</li>
+     *   <li>1 distinct value → return it</li>
+     *   <li>2+ distinct values → emit {@code LOGGER.warn} with a human-readable conflict message
+     *       and return {@code null}</li>
+     * </ul>
+     *
+     * <p>This is the most honest interpretation of the OpenAPI specification. Use it when
+     * consistency across generators is more important than silently choosing a winner.</p>
+     */
+    STRICT,
+
+    /**
+     * Heuristic mode: the schema node <em>closest</em> (shallowest) to the root property
+     * definition wins.
+     *
+     * <p>Selection rule: {@code min(depth), then min(visitOrder)} among all candidates.
+     * A direct {@code default:} on the root schema (depth 0) therefore always wins; if the root
+     * has no direct default, the leftmost {@code allOf} item at depth 1 is tried next, and so
+     * on. This strategy treats "nearest to the consumer" as "most specific".</p>
+     *
+     * <p>Emits a {@code LOGGER.warn} when more than one distinct value is found.</p>
+     */
+    NEAREST_WINS,
+
+    /**
+     * Heuristic mode (current default behaviour): the last non-null default encountered in the
+     * post-order DFS traversal wins.
+     *
+     * <p>Selection rule: {@code max(visitOrder)}. Because the post-order traversal appends each
+     * schema's direct {@code default:} <em>after</em> its children, the root schema's direct
+     * default always has the highest {@code visitOrder} and therefore always wins when present.
+     * When the root has no direct default, the last {@code allOf} branch (recursively resolved)
+     * wins.</p>
+     *
+     * <p>This is the strategy used by the zero-argument
+     * {@link ModelUtils#resolveDefault(io.swagger.v3.oas.models.OpenAPI,
+     * io.swagger.v3.oas.models.media.Schema)} overload for backward compatibility.</p>
+     */
+    LAST_WINS,
+
+    /**
+     * Heuristic mode: only the outermost schema's direct {@code default:} counts.
+     *
+     * <p>Selection rule: filter candidates to {@code depth == 0} and return the first (and only
+     * possible) match. No {@code allOf} traversal result is used. Returns {@code null} when the
+     * root schema has no direct {@code default:}, regardless of what nested branches define.</p>
+     *
+     * <p>Emits a {@code LOGGER.debug} when {@code allOf} branches carry defaults that are being
+     * ignored.</p>
+     */
+    ROOT_WINS
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -852,6 +852,240 @@ public class ModelUtils {
                 );
     }
 
+    /**
+     * A single {@code default} value candidate collected during the post-order DFS traversal
+     * of a composed schema tree.
+     *
+     * <p>Instances are produced by
+     * {@link ModelUtils#collectDefaultCandidates(OpenAPI, Schema, int, int[], List)} and
+     * consumed by {@link ModelUtils#selectDefault(List, DefaultResolutionStrategy)}.</p>
+     */
+    public static final class DefaultCandidate {
+
+        /** The raw default value found on this schema node (never {@code null}). */
+        public final Object value;
+
+        /**
+         * Nesting depth: {@code 0} for the root schema passed to {@code resolveDefault},
+         * {@code 1} for its direct {@code allOf} items, {@code 2} for their {@code allOf}
+         * items, and so on.
+         */
+        public final int depth;
+
+        /**
+         * Monotonically increasing post-order DFS index.  Because the traversal appends a
+         * schema's own {@code default:} <em>after</em> recursing into its children, the root
+         * schema's direct {@code default:} (depth&nbsp;0) always receives the highest
+         * {@code visitOrder} among all candidates, making it the natural winner for
+         * {@link DefaultResolutionStrategy#LAST_WINS}.
+         */
+        public final int visitOrder;
+
+        DefaultCandidate(Object value, int depth, int visitOrder) {
+            this.value = value;
+            this.depth = depth;
+            this.visitOrder = visitOrder;
+        }
+    }
+
+    /**
+     * Returns the effective {@code default} for the given schema using
+     * {@link DefaultResolutionStrategy#LAST_WINS} semantics (current default behaviour,
+     * preserved for backward compatibility).
+     *
+     * <p>Equivalent to {@code resolveDefault(openAPI, schema, DefaultResolutionStrategy.LAST_WINS)}.
+     * See {@link #resolveDefault(OpenAPI, Schema, DefaultResolutionStrategy)} for the full
+     * algorithm description and available strategies.</p>
+     *
+     * <h3>Example (LAST_WINS)</h3>
+     * <pre>{@code
+     * # Base1: default = "base_1"
+     * # Base2: default = "base_2"
+     * #
+     * # Intermediate:
+     * #   allOf: [$ref Base1, $ref Base2]
+     * #   → resolves to "base_2"  (Base2 is last in post-order, wins)
+     * #
+     * # Final:
+     * #   allOf:
+     * #     - $ref: Intermediate    → candidate = "base_2"
+     * #     - default: "final"      → candidate = "final"  (root wins in post-order)
+     * #   → resolves to "final"
+     * }</pre>
+     *
+     * @param openAPI the OpenAPI document used to resolve {@code $ref}s
+     * @param schema  the schema to inspect
+     * @return the effective default value, or {@code null} if none is defined
+     */
+    public static Object resolveDefault(OpenAPI openAPI, Schema<?> schema) {
+        return resolveDefault(openAPI, schema, DefaultResolutionStrategy.LAST_WINS);
+    }
+
+    /**
+     * Returns the effective {@code default} for the given schema using the specified
+     * {@link DefaultResolutionStrategy}.
+     *
+     * <h3>Collection phase</h3>
+     * <p>A single <em>post-order DFS</em> traversal (children before parent) builds a
+     * {@link List}&lt;{@link DefaultCandidate}&gt; that captures every {@code default:}
+     * value reachable through {@code $ref} expansion and recursive {@code allOf} flattening.
+     * Each candidate records its nesting {@code depth} (0 = root) and a monotonically
+     * increasing {@code visitOrder} index.  The root schema's direct {@code default:} is
+     * always appended last, giving it the highest {@code visitOrder}.</p>
+     *
+     * <h3>Selection phase</h3>
+     * <table border="1">
+     *   <caption>Strategy selection rules</caption>
+     *   <tr><th>Strategy</th><th>Selection rule</th></tr>
+     *   <tr><td>{@link DefaultResolutionStrategy#LAST_WINS}</td>
+     *       <td>{@code max(visitOrder)} — root direct default wins if present</td></tr>
+     *   <tr><td>{@link DefaultResolutionStrategy#NEAREST_WINS}</td>
+     *       <td>{@code min(depth), then min(visitOrder)} — shallowest, then leftmost</td></tr>
+     *   <tr><td>{@link DefaultResolutionStrategy#ROOT_WINS}</td>
+     *       <td>filter to {@code depth == 0}, return first (or {@code null})</td></tr>
+     *   <tr><td>{@link DefaultResolutionStrategy#STRICT}</td>
+     *       <td>if distinct values &gt; 1 → log {@code WARN} + return {@code null}</td></tr>
+     * </table>
+     *
+     * @param openAPI  the OpenAPI document used to resolve {@code $ref}s
+     * @param schema   the schema to inspect
+     * @param strategy the resolution strategy to apply
+     * @return the effective default value, or {@code null} if none is defined or the strategy
+     *         determines the result is ambiguous
+     */
+    public static Object resolveDefault(OpenAPI openAPI, Schema<?> schema,
+                                        DefaultResolutionStrategy strategy) {
+        if (schema == null) return null;
+        List<DefaultCandidate> candidates = new ArrayList<>();
+        collectDefaultCandidates(openAPI, schema, 0, new int[]{0}, candidates);
+        return selectDefault(candidates, strategy);
+    }
+
+    /**
+     * Post-order DFS traversal that collects all {@code default:} values found in the
+     * fully-resolved schema tree into {@code out}.  Children (allOf items) are visited
+     * before the parent schema's own direct default, so the root schema's default always
+     * receives the highest {@code visitOrder}.
+     */
+    private static void collectDefaultCandidates(OpenAPI openAPI, Schema<?> schema,
+                                                 int depth, int[] counter,
+                                                 List<DefaultCandidate> out) {
+        schema = getReferencedSchema(openAPI, schema);
+        if (schema == null) return;
+
+        // Post-order: recurse into allOf children first.
+        if (hasAllOf(schema)) {
+            for (Schema<?> item : schema.getAllOf()) {
+                collectDefaultCandidates(openAPI, item, depth + 1, counter, out);
+            }
+        }
+
+        // Then record this schema's own direct default (if any).
+        Object def = schema.getDefault();
+        if (def != null) {
+            out.add(new DefaultCandidate(def, depth, counter[0]++));
+        }
+    }
+
+    /**
+     * Selects a single default value from a list of {@link DefaultCandidate}s according to
+     * the given {@link DefaultResolutionStrategy}.
+     *
+     * @param candidates the candidates produced by {@link #collectDefaultCandidates}
+     * @param strategy   the strategy to apply
+     * @return the selected default value, or {@code null} if the list is empty or the
+     *         strategy determines the result is ambiguous
+     */
+    private static Object selectDefault(List<DefaultCandidate> candidates,
+                                        DefaultResolutionStrategy strategy) {
+        if (candidates.isEmpty()) return null;
+
+        switch (strategy) {
+
+            case LAST_WINS:
+                // max(visitOrder) — root's direct default has the highest visitOrder
+                return candidates.stream()
+                        .max(Comparator.comparingInt(c -> c.visitOrder))
+                        .map(c -> c.value)
+                        .orElse(null);
+
+            case NEAREST_WINS: {
+                // min(depth), break ties by min(visitOrder)
+                Comparator<DefaultCandidate> cmp =
+                        Comparator.comparingInt((DefaultCandidate c) -> c.depth)
+                                  .thenComparingInt(c -> c.visitOrder);
+                Object result = candidates.stream().min(cmp).map(c -> c.value).orElse(null);
+                long distinctCount = candidates.stream().map(c -> c.value).distinct().count();
+                if (distinctCount > 1) {
+                    LOGGER.warn("Conflicting default values detected across composed allOf schemas. "
+                            + "OpenAPI does not define precedence. Applying NEAREST_WINS heuristic: "
+                            + "using '{}'. Consider consolidating to a single source of truth.",
+                            result);
+                }
+                return result;
+            }
+
+            case ROOT_WINS: {
+                // Only depth-0 candidates count (root schema's direct default).
+                Optional<DefaultCandidate> rootCandidate = candidates.stream()
+                        .filter(c -> c.depth == 0)
+                        .findFirst();
+                if (!rootCandidate.isPresent()) {
+                    boolean hasNested = candidates.stream().anyMatch(c -> c.depth > 0);
+                    if (hasNested) {
+                        LOGGER.debug("ROOT_WINS strategy: ignoring {} allOf-branch default(s) "
+                                + "because the root schema has no direct default.", candidates.size());
+                    }
+                    return null;
+                }
+                long ignoredCount = candidates.stream().filter(c -> c.depth > 0).count();
+                if (ignoredCount > 0) {
+                    LOGGER.debug("ROOT_WINS strategy: ignoring {} allOf-branch default(s) "
+                            + "in favour of root default '{}'.", ignoredCount, rootCandidate.get().value);
+                }
+                return rootCandidate.get().value;
+            }
+
+            case STRICT: {
+                long distinctCount = candidates.stream().map(c -> c.value).distinct().count();
+                if (distinctCount > 1) {
+                    List<Object> distinctValues = candidates.stream()
+                            .map(c -> c.value)
+                            .distinct()
+                            .collect(Collectors.toList());
+                    LOGGER.warn("Conflicting default values {} detected in composed allOf schemas. "
+                            + "OpenAPI does not define precedence for defaults in allOf. "
+                            + "Returning null. Consider consolidating to a single source of truth.",
+                            distinctValues);
+                    return null;
+                }
+                // 0 or 1 distinct value — safe to return
+                return candidates.get(0).value;
+            }
+
+            default:
+                throw new IllegalArgumentException("Unknown DefaultResolutionStrategy: " + strategy);
+        }
+    }
+
+    /**
+     * Public accessor to the default-candidate collection phase, intended for use by linting
+     * tools (e.g. {@code OpenApiSchemaValidations}).
+     *
+     * <p>Returns all {@link DefaultCandidate}s reachable from the given schema by post-order
+     * DFS, including {@code $ref} expansion and recursive {@code allOf} flattening.</p>
+     *
+     * @param openAPI the OpenAPI document used to resolve {@code $ref}s
+     * @param schema  the root schema to inspect
+     * @return mutable list of candidates in post-order DFS visit order (never {@code null})
+     */
+    public static List<DefaultCandidate> collectDefaultCandidatesForLinting(
+            OpenAPI openAPI, Schema<?> schema) {
+        List<DefaultCandidate> out = new ArrayList<>();
+        collectDefaultCandidates(openAPI, schema, 0, new int[]{0}, out);
+        return out;
+    }
+
     public static boolean hasValidation(Schema sc) {
         return (
                 sc.getMaxItems() != null ||

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
@@ -7,6 +7,7 @@ import org.openapitools.codegen.validation.GenericValidator;
 import org.openapitools.codegen.validation.ValidationRule;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * A standalone instance for evaluating rules and recommendations related to OAS {@link Schema}
@@ -43,6 +44,27 @@ class OpenApiSchemaValidations extends GenericValidator<SchemaWrapper> {
                         OpenApiSchemaValidations::checkInvalidType
                 ));
             }
+        }
+        if (ruleConfiguration.isEnableAllOfConflictingDefaultsRecommendation()) {
+            rules.add(ValidationRule.warn(
+                    "Schema has conflicting default values across allOf branches.",
+                    "Conflicting default values detected in allOf composed schema. OpenAPI does not define precedence for defaults in allOf. Consider consolidating to a single source of truth.",
+                    OpenApiSchemaValidations::checkAllOfConflictingDefaults
+            ));
+        }
+        if (ruleConfiguration.isEnableAllOfShadowedDefaultsRecommendation()) {
+            rules.add(ValidationRule.warn(
+                    "Schema has a root-level default that shadows allOf branch defaults.",
+                    "A root-level 'default' is defined alongside 'allOf'. Defaults in allOf branches are shadowed and will be ignored by most generators. Remove redundant nested defaults or move the default to a single location.",
+                    OpenApiSchemaValidations::checkAllOfShadowedDefaults
+            ));
+        }
+        if (ruleConfiguration.isEnableAllOfRedundantDefaultsRecommendation()) {
+            rules.add(ValidationRule.warn(
+                    "Schema has redundant identical default values across allOf branches.",
+                    "Identical default values are repeated in multiple allOf branches. This adds noise without adding clarity. Consider defining the default only once.",
+                    OpenApiSchemaValidations::checkAllOfRedundantDefaults
+            ));
         }
     }
 
@@ -159,5 +181,101 @@ class OpenApiSchemaValidations extends GenericValidator<SchemaWrapper> {
             return result;
         }
         return result;
+    }
+
+    /**
+     * Checks whether the schema has conflicting (2+ distinct) {@code default} values across its
+     * {@code allOf} tree.  OpenAPI does not define precedence for defaults in {@code allOf}, so
+     * any conflict is a spec smell.
+     *
+     * @param schemaWrapper the schema to validate
+     * @return {@link ValidationRule.Pass} if no conflict exists, otherwise {@link ValidationRule.Fail}
+     */
+    private static ValidationRule.Result checkAllOfConflictingDefaults(SchemaWrapper schemaWrapper) {
+        if (!ModelUtils.isComposedSchema(schemaWrapper.getSchema()) ||
+                !ModelUtils.hasAllOf(schemaWrapper.getSchema())) {
+            return ValidationRule.Pass.empty();
+        }
+
+        List<ModelUtils.DefaultCandidate> candidates = collectCandidates(schemaWrapper);
+        long distinctCount = candidates.stream().map(c -> c.value).distinct().count();
+        if (distinctCount > 1) {
+            List<Object> distinctValues = candidates.stream()
+                    .map(c -> c.value)
+                    .distinct()
+                    .collect(Collectors.toList());
+            ValidationRule.Fail fail = new ValidationRule.Fail();
+            fail.setDetails(String.format(Locale.ROOT,
+                    "Schema '%s' has conflicting default values %s across allOf branches.",
+                    nameOf(schemaWrapper.getSchema()), distinctValues));
+            return fail;
+        }
+        return ValidationRule.Pass.empty();
+    }
+
+    /**
+     * Checks whether the schema has a root-level {@code default:} alongside {@code allOf} items
+     * that also carry defaults.  The root default shadows (and effectively overwrites) any nested
+     * defaults, which may be unintentional.
+     *
+     * @param schemaWrapper the schema to validate
+     * @return {@link ValidationRule.Pass} if no shadowing exists, otherwise {@link ValidationRule.Fail}
+     */
+    private static ValidationRule.Result checkAllOfShadowedDefaults(SchemaWrapper schemaWrapper) {
+        Schema<?> schema = schemaWrapper.getSchema();
+        if (!ModelUtils.hasAllOf(schema) || schema.getDefault() == null) {
+            return ValidationRule.Pass.empty();
+        }
+
+        List<ModelUtils.DefaultCandidate> candidates = collectCandidates(schemaWrapper);
+        boolean hasNestedDefaults = candidates.stream().anyMatch(c -> c.depth > 0);
+        if (hasNestedDefaults) {
+            ValidationRule.Fail fail = new ValidationRule.Fail();
+            fail.setDetails(String.format(Locale.ROOT,
+                    "Schema '%s' has a root-level 'default: %s' that shadows defaults in allOf branches.",
+                    nameOf(schema), schema.getDefault()));
+            return fail;
+        }
+        return ValidationRule.Pass.empty();
+    }
+
+    /**
+     * Checks whether the schema has the same {@code default} value repeated in multiple
+     * {@code allOf} branches.  Redundant identical defaults add maintenance noise without
+     * adding clarity.
+     *
+     * @param schemaWrapper the schema to validate
+     * @return {@link ValidationRule.Pass} if no redundancy exists, otherwise {@link ValidationRule.Fail}
+     */
+    private static ValidationRule.Result checkAllOfRedundantDefaults(SchemaWrapper schemaWrapper) {
+        if (!ModelUtils.isComposedSchema(schemaWrapper.getSchema()) ||
+                !ModelUtils.hasAllOf(schemaWrapper.getSchema())) {
+            return ValidationRule.Pass.empty();
+        }
+
+        List<ModelUtils.DefaultCandidate> candidates = collectCandidates(schemaWrapper);
+        if (candidates.size() < 2) return ValidationRule.Pass.empty();
+
+        // Only flag when there is exactly ONE distinct value but MORE than one candidate
+        // (i.e., the same value is repeated — not a conflict, but redundant).
+        long distinctCount = candidates.stream().map(c -> c.value).distinct().count();
+        if (distinctCount == 1 && candidates.size() > 1) {
+            ValidationRule.Fail fail = new ValidationRule.Fail();
+            fail.setDetails(String.format(Locale.ROOT,
+                    "Schema '%s' has the default value '%s' repeated in %d allOf branches. "
+                            + "Consider defining it only once.",
+                    nameOf(schemaWrapper.getSchema()), candidates.get(0).value, candidates.size()));
+            return fail;
+        }
+        return ValidationRule.Pass.empty();
+    }
+
+    /** Collects default candidates for a schema, tolerating a null OpenAPI document. */
+    private static List<ModelUtils.DefaultCandidate> collectCandidates(SchemaWrapper schemaWrapper) {
+        io.swagger.v3.oas.models.OpenAPI openAPI = schemaWrapper.getOpenAPI();
+        if (openAPI == null) {
+            openAPI = new io.swagger.v3.oas.models.OpenAPI();
+        }
+        return ModelUtils.collectDefaultCandidatesForLinting(openAPI, schemaWrapper.getSchema());
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/RuleConfiguration.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/RuleConfiguration.java
@@ -128,6 +128,50 @@ public class RuleConfiguration {
 
     /**
      * -- GETTER --
+     * Gets whether the recommendation check for conflicting {@code default} values in {@code allOf}
+     * composed schemas is enabled.
+     * <p>
+     * OpenAPI does not define precedence for {@code default} values in {@code allOf}.
+     * When two or more distinct defaults exist across composed branches, the effective value
+     * is tool-dependent and therefore unreliable.
+     *
+     * @return <code>true</code> if enabled, <code>false</code> if disabled
+     * -- SETTER --
+     * Enable or Disable the recommendation check for conflicting defaults in {@code allOf} schemas.
+     * @param enableAllOfConflictingDefaultsRecommendation <code>true</code> to enable, <code>false</code> to disable
+     */
+    private boolean enableAllOfConflictingDefaultsRecommendation = defaultedBoolean(propertyPrefix + ".allof-conflicting-defaults", true);
+
+    /**
+     * -- GETTER --
+     * Gets whether the recommendation check for shadowed {@code default} values is enabled.
+     * <p>
+     * A root-level {@code default:} alongside {@code allOf} shadows any defaults defined
+     * inside the {@code allOf} branches, which may be unintentional.
+     *
+     * @return <code>true</code> if enabled, <code>false</code> if disabled
+     * -- SETTER --
+     * Enable or Disable the recommendation check for shadowed defaults in {@code allOf} schemas.
+     * @param enableAllOfShadowedDefaultsRecommendation <code>true</code> to enable, <code>false</code> to disable
+     */
+    private boolean enableAllOfShadowedDefaultsRecommendation = defaultedBoolean(propertyPrefix + ".allof-shadowed-defaults", true);
+
+    /**
+     * -- GETTER --
+     * Gets whether the recommendation check for redundant {@code default} values is enabled.
+     * <p>
+     * Identical defaults appearing in multiple {@code allOf} branches add noise without adding
+     * clarity and may indicate copy-paste maintenance issues.
+     *
+     * @return <code>true</code> if enabled, <code>false</code> if disabled
+     * -- SETTER --
+     * Enable or Disable the recommendation check for redundant defaults in {@code allOf} schemas.
+     * @param enableAllOfRedundantDefaultsRecommendation <code>true</code> to enable, <code>false</code> to disable
+     */
+    private boolean enableAllOfRedundantDefaultsRecommendation = defaultedBoolean(propertyPrefix + ".allof-redundant-defaults", true);
+
+    /**
+     * -- GETTER --
      * Gets whether we will raise awareness a GET or HEAD operation is defined with body.
      *
      * @return <code>true</code> if enabled, <code>false</code> if disabled

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -5150,6 +5150,42 @@ public class DefaultCodegenTest {
         assertTrue(openIdScheme.isOpenId);
     }
 
+    @Test
+    public void testFromPropertyRefDefaultPropagation() {
+        // fromProperty should resolve $ref chains and propagate the default from the referenced schema.
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        // Bar is a string schema with a default value.
+        openAPI.getComponents().addSchemas("Bar", new StringSchema()._default("active"));
+        // Item has a `status` property that is a pure $ref to Bar.
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        Schema statusRef = new Schema<>().$ref("#/components/schemas/Bar");
+        CodegenProperty cp = codegen.fromProperty("status", statusRef);
+
+        assertEquals("active", cp.defaultValue,
+                "fromProperty must propagate default from $ref target for a pure $ref property");
+    }
+
+    @Test
+    public void testFromPropertyRefChainDefaultPropagation() {
+        // fromProperty must follow multi-level $ref chains to find the default.
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        // Base is the concrete string schema with the default.
+        openAPI.getComponents().addSchemas("Base", new StringSchema()._default("pending"));
+        // Middle is a $ref to Base.
+        openAPI.getComponents().addSchemas("Middle", new Schema<>().$ref("#/components/schemas/Base"));
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        // The property schema points to Middle, which transitively has default "pending" via Base.
+        Schema middleRef = new Schema<>().$ref("#/components/schemas/Middle");
+        CodegenProperty cp = codegen.fromProperty("status", middleRef);
+
+        assertEquals("pending", cp.defaultValue,
+                "fromProperty must follow a $ref chain to find the default from the concrete schema");
+    }
+
     private List<String> getRequiredVars(CodegenModel model) {
         return getNames(model.getRequiredVars());
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -1545,4 +1545,60 @@ public class OpenAPINormalizerTest {
         assertNotNull(payload.getOneOf());
     }
 
+    @Test
+    public void testRefDefaultPropagation() {
+        // Change 1 (always-on): a property referencing a $ref whose target has a default should
+        // receive that default value on the outer schema after normalization.
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/normalizer_ref_default_propagation.yaml");
+        OpenAPINormalizer normalizer = new OpenAPINormalizer(openAPI, Map.of());
+        normalizer.normalize();
+
+        Schema itemSchema = openAPI.getComponents().getSchemas().get("Item");
+        assertNotNull(itemSchema);
+
+        // The `status` property is a pure $ref to Status which has default "active".
+        // After normalization it must expose that default (via allOf wrapping or inline).
+        Schema statusProp = (Schema) itemSchema.getProperties().get("status");
+        assertNotNull(statusProp, "status property must exist");
+        assertEquals(statusProp.getDefault(), "active",
+                "default should be propagated from $ref target to the outer property schema");
+    }
+
+    @Test
+    public void testResolveSchemaDefaultsRule_lastWins() {
+        // Change 2 (opt-in): with RESOLVE_SCHEMA_DEFAULTS=LAST_WINS a component schema that
+        // composes via allOf and has no direct default should receive the resolved default.
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/normalizer_resolve_schema_defaults.yaml");
+        Map<String, String> inputRules = Map.of("RESOLVE_SCHEMA_DEFAULTS", "LAST_WINS");
+        OpenAPINormalizer normalizer = new OpenAPINormalizer(openAPI, inputRules);
+        normalizer.normalize();
+
+        // ChildNoDefault has no direct default — the LAST_WINS strategy should resolve
+        // the default from the allOf $ref target (BaseStatus has default "active").
+        Schema childNoDefault = openAPI.getComponents().getSchemas().get("ChildNoDefault");
+        assertNotNull(childNoDefault);
+        assertNotNull(childNoDefault.getAllOf(), "ChildNoDefault should still have allOf after normalization");
+        assertEquals(childNoDefault.getDefault(), "active",
+                "RESOLVE_SCHEMA_DEFAULTS should propagate default from allOf base to child with no own default");
+
+        // ChildWithOwnDefault already has default "inactive" — it must NOT be overwritten.
+        Schema childWithOwnDefault = openAPI.getComponents().getSchemas().get("ChildWithOwnDefault");
+        assertNotNull(childWithOwnDefault);
+        assertEquals(childWithOwnDefault.getDefault(), "inactive",
+                "RESOLVE_SCHEMA_DEFAULTS must not overwrite an existing direct default");
+    }
+
+    @Test
+    public void testResolveSchemaDefaultsRule_disabled() {
+        // Without the rule, allOf schemas must NOT have defaults injected automatically.
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/normalizer_resolve_schema_defaults.yaml");
+        OpenAPINormalizer normalizer = new OpenAPINormalizer(openAPI, Map.of());
+        normalizer.normalize();
+
+        Schema childNoDefault = openAPI.getComponents().getSchemas().get("ChildNoDefault");
+        assertNotNull(childNoDefault);
+        assertNull(childNoDefault.getDefault(),
+                "Without RESOLVE_SCHEMA_DEFAULTS rule, no default should be injected");
+    }
+
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -1546,9 +1546,10 @@ public class OpenAPINormalizerTest {
     }
 
     @Test
-    public void testRefDefaultPropagation() {
-        // Change 1 (always-on): a property referencing a $ref whose target has a default should
-        // receive that default value on the outer schema after normalization.
+    public void testRefDefaultNotPropagatedByNormalizer() {
+        // Change 1 (normalizer $ref default copy) was removed.
+        // Pure $ref properties must NOT have their defaults injected by the normalizer — the
+        // default is resolved later by DefaultCodegen.fromProperty at codegen time.
         OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/normalizer_ref_default_propagation.yaml");
         OpenAPINormalizer normalizer = new OpenAPINormalizer(openAPI, Map.of());
         normalizer.normalize();
@@ -1557,11 +1558,13 @@ public class OpenAPINormalizerTest {
         assertNotNull(itemSchema);
 
         // The `status` property is a pure $ref to Status which has default "active".
-        // After normalization it must expose that default (via allOf wrapping or inline).
+        // After normalization the property must remain a pure $ref — no allOf wrapping and
+        // no default set on the outer schema (that is handled by DefaultCodegen.fromProperty).
         Schema statusProp = (Schema) itemSchema.getProperties().get("status");
         assertNotNull(statusProp, "status property must exist");
-        assertEquals(statusProp.getDefault(), "active",
-                "default should be propagated from $ref target to the outer property schema");
+        assertNotNull(statusProp.get$ref(), "status property must remain a pure $ref after normalization");
+        assertNull(statusProp.getDefault(),
+                "normalizer must NOT inject default onto a pure $ref property");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -23,6 +23,7 @@ import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import org.openapitools.codegen.TestUtils;
+import org.openapitools.codegen.utils.DefaultResolutionStrategy;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -756,5 +757,410 @@ public class ModelUtilsTest {
         Map<String, Schema> allSchemas = openAPI.getComponents().getSchemas();
         Schema composedSchema = allSchemas.get("RandomAnimalsResponse_animals_inner");
         assertNull(ModelUtils.getParentName(composedSchema, allSchemas));
+    }
+    // -------------------------------------------------------------------------
+    // resolveDefault
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void resolveDefault_nullSchema_returnsNull() {
+        assertNull(ModelUtils.resolveDefault(new OpenAPI(), null));
+    }
+
+    @Test
+    public void resolveDefault_noDefaultDefined_returnsNull() {
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        assertNull(ModelUtils.resolveDefault(openAPI, new IntegerSchema()));
+    }
+
+    @Test
+    public void resolveDefault_inlineDefault_returnsIt() {
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        Schema<?> schema = new IntegerSchema();
+        schema.setDefault(10);
+        assertEquals(ModelUtils.resolveDefault(openAPI, schema), 10);
+    }
+
+    @Test
+    public void resolveDefault_refToSchemaWithDefault_resolvesRef() {
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        Schema<?> refTarget = new IntegerSchema();
+        refTarget.setDefault(0);
+        openAPI.getComponents().addSchemas("MyInt", refTarget);
+
+        Schema<?> ref = new Schema<>().$ref("#/components/schemas/MyInt");
+        assertEquals(ModelUtils.resolveDefault(openAPI, ref), 0);
+    }
+
+    @Test
+    public void resolveDefault_allOfItemHasDefault_returnsIt() {
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        Schema<?> allOfItem = new IntegerSchema();
+        allOfItem.setDefault(20);
+        openAPI.getComponents().addSchemas("Base", allOfItem);
+
+        // Inline schema has no default; allOf item has default=20
+        Schema<?> schema = new Schema<>().allOf(List.of(new Schema<>().$ref("#/components/schemas/Base")));
+        assertEquals(ModelUtils.resolveDefault(openAPI, schema), 20);
+    }
+
+    @Test
+    public void resolveDefault_inlineDefaultTakesPrecedenceOverAllOf() {
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        Schema<?> allOfItem = new IntegerSchema();
+        allOfItem.setDefault(99);
+        openAPI.getComponents().addSchemas("Base", allOfItem);
+
+        // Inline schema default=5 should win over allOf item default=99
+        Schema<?> schema = new IntegerSchema();
+        schema.setDefault(5);
+        schema.setAllOf(List.of(new Schema<>().$ref("#/components/schemas/Base")));
+        assertEquals(ModelUtils.resolveDefault(openAPI, schema), 5);
+    }
+
+    @Test
+    public void resolveDefault_allOfItemsNoDefault_returnsNull() {
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        openAPI.getComponents().addSchemas("Base", new IntegerSchema()); // no default
+
+        Schema<?> schema = new Schema<>().allOf(List.of(new Schema<>().$ref("#/components/schemas/Base")));
+        assertNull(ModelUtils.resolveDefault(openAPI, schema));
+    }
+
+    @Test
+    public void resolveDefault_stringDefault_returnsIt() {
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        Schema<?> schema = new StringSchema();
+        schema.setDefault("hello");
+        assertEquals(ModelUtils.resolveDefault(openAPI, schema), "hello");
+    }
+
+    @Test
+    public void resolveDefault_nestedAllOf_findsDefaultInNestedItem() {
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        // base has default=99; mid allOf ΓåÆ base; top allOf ΓåÆ mid
+        Schema<?> base = new IntegerSchema();
+        base.setDefault(99);
+        openAPI.getComponents().addSchemas("Base", base);
+
+        Schema<?> mid = new Schema<>().allOf(List.of(new Schema<>().$ref("#/components/schemas/Base")));
+        openAPI.getComponents().addSchemas("Mid", mid);
+
+        Schema<?> top = new Schema<>().allOf(List.of(new Schema<>().$ref("#/components/schemas/Mid")));
+
+        assertEquals(ModelUtils.resolveDefault(openAPI, top), 99);
+    }
+
+    @Test
+    public void resolveDefault_allOf_lastDefaultWins() {
+        // allOf: [Base1(default="base_1"), Base2(default="base_2")]
+        // Base2 is last ΓåÆ wins
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        Schema<?> base1 = new StringSchema();
+        base1.setDefault("base_1");
+        openAPI.getComponents().addSchemas("Base1", base1);
+
+        Schema<?> base2 = new StringSchema();
+        base2.setDefault("base_2");
+        openAPI.getComponents().addSchemas("Base2", base2);
+
+        Schema<?> schema = new Schema<>().allOf(List.of(
+                new Schema<>().$ref("#/components/schemas/Base1"),
+                new Schema<>().$ref("#/components/schemas/Base2")
+        ));
+        assertEquals(ModelUtils.resolveDefault(openAPI, schema), "base_2");
+    }
+
+    @Test
+    public void resolveDefault_allOf_lastNonNullDefaultWins() {
+        // allOf: [Base1(default="base_1"), NoDefault] ΓÇö trailing null item does not clear candidate
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        Schema<?> base1 = new StringSchema();
+        base1.setDefault("base_1");
+        openAPI.getComponents().addSchemas("Base1", base1);
+
+        Schema<?> schema = new Schema<>().allOf(List.of(
+                new Schema<>().$ref("#/components/schemas/Base1"),
+                new StringSchema() // no default
+        ));
+        assertEquals(ModelUtils.resolveDefault(openAPI, schema), "base_1");
+    }
+
+    @Test
+    public void resolveDefault_fullChain_lastWriterWins() {
+        // Mirrors the documented resolution example:
+        //   Base1: default="base_1"
+        //   Base2: default="base_2"
+        //   Intermediate: allOf: [Base1, Base2]  ΓåÆ resolves to "base_2" (Base2 is last)
+        //   Final: allOf: [Intermediate, {default:"final"}]  ΓåÆ resolves to "final" (inline patch is last)
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+
+        Schema<?> base1 = new StringSchema();
+        base1.setDefault("base_1");
+        openAPI.getComponents().addSchemas("Base1", base1);
+
+        Schema<?> base2 = new StringSchema();
+        base2.setDefault("base_2");
+        openAPI.getComponents().addSchemas("Base2", base2);
+
+        Schema<?> intermediate = new Schema<>().allOf(List.of(
+                new Schema<>().$ref("#/components/schemas/Base1"),
+                new Schema<>().$ref("#/components/schemas/Base2")
+        ));
+        openAPI.getComponents().addSchemas("Intermediate", intermediate);
+
+        Schema<?> inlinePatch = new StringSchema();
+        inlinePatch.setDefault("final");
+        Schema<?> finalSchema = new Schema<>().allOf(List.of(
+                new Schema<>().$ref("#/components/schemas/Intermediate"),
+                inlinePatch
+        ));
+
+        // Intermediate alone resolves to "base_2"
+        assertEquals(ModelUtils.resolveDefault(openAPI, new Schema<>().$ref("#/components/schemas/Intermediate")), "base_2");
+        // Full chain resolves to "final"
+        assertEquals(ModelUtils.resolveDefault(openAPI, finalSchema), "final");
+    }
+
+    // -------------------------------------------------------------------------
+    // resolveDefault with explicit strategies
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void resolveDefault_strategy_nullSchema_returnsNull() {
+        for (DefaultResolutionStrategy strategy : DefaultResolutionStrategy.values()) {
+            assertNull(ModelUtils.resolveDefault(new OpenAPI(), null, strategy),
+                    "Expected null for null schema with strategy " + strategy);
+        }
+    }
+
+    @Test
+    public void resolveDefault_strategy_noDefault_allStrategiesReturnNull() {
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        Schema<?> schema = new StringSchema(); // no default
+        for (DefaultResolutionStrategy strategy : DefaultResolutionStrategy.values()) {
+            assertNull(ModelUtils.resolveDefault(openAPI, schema, strategy),
+                    "Expected null when no default exists, strategy=" + strategy);
+        }
+    }
+
+    @Test
+    public void resolveDefault_strategy_singleDefault_allStrategiesReturnIt() {
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        Schema<?> schema = new StringSchema();
+        schema.setDefault("only");
+        for (DefaultResolutionStrategy strategy : DefaultResolutionStrategy.values()) {
+            assertEquals(ModelUtils.resolveDefault(openAPI, schema, strategy), "only",
+                    "Expected 'only' with strategy=" + strategy);
+        }
+    }
+
+    // -- LAST_WINS (explicit) --
+
+    @Test
+    public void resolveDefault_lastWins_rootDefaultWins() {
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        Schema<?> base = new StringSchema();
+        base.setDefault("from_base");
+        openAPI.getComponents().addSchemas("Base", base);
+
+        Schema<?> schema = new StringSchema();
+        schema.setDefault("root");
+        schema.setAllOf(List.of(new Schema<>().$ref("#/components/schemas/Base")));
+
+        assertEquals(ModelUtils.resolveDefault(openAPI, schema, DefaultResolutionStrategy.LAST_WINS),
+                "root");
+    }
+
+    @Test
+    public void resolveDefault_lastWins_lastAllOfBranchWins() {
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        Schema<?> base1 = new StringSchema();
+        base1.setDefault("first");
+        openAPI.getComponents().addSchemas("First", base1);
+
+        Schema<?> base2 = new StringSchema();
+        base2.setDefault("last");
+        openAPI.getComponents().addSchemas("Last", base2);
+
+        Schema<?> schema = new Schema<>().allOf(List.of(
+                new Schema<>().$ref("#/components/schemas/First"),
+                new Schema<>().$ref("#/components/schemas/Last")
+        ));
+        assertEquals(ModelUtils.resolveDefault(openAPI, schema, DefaultResolutionStrategy.LAST_WINS),
+                "last");
+    }
+
+    // -- NEAREST_WINS --
+
+    @Test
+    public void resolveDefault_nearestWins_rootDefaultWins() {
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        Schema<?> base = new StringSchema();
+        base.setDefault("deep");
+        openAPI.getComponents().addSchemas("Deep", base);
+
+        Schema<?> schema = new StringSchema();
+        schema.setDefault("root");
+        schema.setAllOf(List.of(new Schema<>().$ref("#/components/schemas/Deep")));
+
+        assertEquals(ModelUtils.resolveDefault(openAPI, schema, DefaultResolutionStrategy.NEAREST_WINS),
+                "root");
+    }
+
+    @Test
+    public void resolveDefault_nearestWins_noRootDefault_firstAllOfBranchWins() {
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        Schema<?> first = new StringSchema();
+        first.setDefault("first_branch");
+        openAPI.getComponents().addSchemas("First", first);
+
+        Schema<?> second = new StringSchema();
+        second.setDefault("second_branch");
+        openAPI.getComponents().addSchemas("Second", second);
+
+        // No root default ΓÇö NEAREST_WINS picks the shallowest (depth 1) leftmost candidate
+        Schema<?> schema = new Schema<>().allOf(List.of(
+                new Schema<>().$ref("#/components/schemas/First"),
+                new Schema<>().$ref("#/components/schemas/Second")
+        ));
+        assertEquals(ModelUtils.resolveDefault(openAPI, schema, DefaultResolutionStrategy.NEAREST_WINS),
+                "first_branch");
+    }
+
+    @Test
+    public void resolveDefault_nearestWins_depthPrecedence() {
+        // depth-1 branch wins over depth-2 even if depth-2 would win under LAST_WINS
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+
+        Schema<?> deepBase = new StringSchema();
+        deepBase.setDefault("deep_value");
+        openAPI.getComponents().addSchemas("DeepBase", deepBase);
+
+        // Mid: allOf ΓåÆ DeepBase  (no own default)
+        Schema<?> mid = new Schema<>().allOf(List.of(new Schema<>().$ref("#/components/schemas/DeepBase")));
+        openAPI.getComponents().addSchemas("Mid", mid);
+
+        Schema<?> shallow = new StringSchema();
+        shallow.setDefault("shallow_value");
+        openAPI.getComponents().addSchemas("Shallow", shallow);
+
+        // Root allOf: [Mid (depth-2 leaf), Shallow (depth-1)]
+        Schema<?> schema = new Schema<>().allOf(List.of(
+                new Schema<>().$ref("#/components/schemas/Mid"),
+                new Schema<>().$ref("#/components/schemas/Shallow")
+        ));
+
+        // LAST_WINS would pick "shallow_value" (last in post-order among depth-1 siblings)
+        // NEAREST_WINS should also pick "shallow_value" because depth-1 < depth-2
+        assertEquals(ModelUtils.resolveDefault(openAPI, schema, DefaultResolutionStrategy.NEAREST_WINS),
+                "shallow_value");
+    }
+
+    // -- ROOT_WINS --
+
+    @Test
+    public void resolveDefault_rootWins_directDefaultReturned() {
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        Schema<?> base = new StringSchema();
+        base.setDefault("ignored");
+        openAPI.getComponents().addSchemas("Base", base);
+
+        Schema<?> schema = new StringSchema();
+        schema.setDefault("winner");
+        schema.setAllOf(List.of(new Schema<>().$ref("#/components/schemas/Base")));
+
+        assertEquals(ModelUtils.resolveDefault(openAPI, schema, DefaultResolutionStrategy.ROOT_WINS),
+                "winner");
+    }
+
+    @Test
+    public void resolveDefault_rootWins_noDirectDefault_returnsNull() {
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        Schema<?> base = new StringSchema();
+        base.setDefault("nested");
+        openAPI.getComponents().addSchemas("Base", base);
+
+        // Root has no direct default ΓÇö ROOT_WINS must return null
+        Schema<?> schema = new Schema<>().allOf(List.of(new Schema<>().$ref("#/components/schemas/Base")));
+        assertNull(ModelUtils.resolveDefault(openAPI, schema, DefaultResolutionStrategy.ROOT_WINS));
+    }
+
+    // -- STRICT --
+
+    @Test
+    public void resolveDefault_strict_singleDefault_returnsIt() {
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        Schema<?> base = new StringSchema();
+        base.setDefault("unique");
+        openAPI.getComponents().addSchemas("Base", base);
+
+        Schema<?> schema = new Schema<>().allOf(List.of(new Schema<>().$ref("#/components/schemas/Base")));
+        assertEquals(ModelUtils.resolveDefault(openAPI, schema, DefaultResolutionStrategy.STRICT),
+                "unique");
+    }
+
+    @Test
+    public void resolveDefault_strict_conflictingDefaults_returnsNull() {
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        Schema<?> base1 = new StringSchema();
+        base1.setDefault("value_a");
+        openAPI.getComponents().addSchemas("Base1", base1);
+
+        Schema<?> base2 = new StringSchema();
+        base2.setDefault("value_b");
+        openAPI.getComponents().addSchemas("Base2", base2);
+
+        Schema<?> schema = new Schema<>().allOf(List.of(
+                new Schema<>().$ref("#/components/schemas/Base1"),
+                new Schema<>().$ref("#/components/schemas/Base2")
+        ));
+        assertNull(ModelUtils.resolveDefault(openAPI, schema, DefaultResolutionStrategy.STRICT),
+                "STRICT should return null on conflicting defaults");
+    }
+
+    @Test
+    public void resolveDefault_strict_identicalDefaults_returnsValue() {
+        // Same value in two branches ΓÇö not a conflict
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        Schema<?> base1 = new StringSchema();
+        base1.setDefault("same");
+        openAPI.getComponents().addSchemas("Base1", base1);
+
+        Schema<?> base2 = new StringSchema();
+        base2.setDefault("same");
+        openAPI.getComponents().addSchemas("Base2", base2);
+
+        Schema<?> schema = new Schema<>().allOf(List.of(
+                new Schema<>().$ref("#/components/schemas/Base1"),
+                new Schema<>().$ref("#/components/schemas/Base2")
+        ));
+        assertEquals(ModelUtils.resolveDefault(openAPI, schema, DefaultResolutionStrategy.STRICT),
+                "same");
+    }
+
+    // -- Determinism --
+
+    @Test
+    public void resolveDefault_deterministic_sameInputSameOutput() {
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        Schema<?> base1 = new StringSchema();
+        base1.setDefault("alpha");
+        openAPI.getComponents().addSchemas("A", base1);
+
+        Schema<?> base2 = new StringSchema();
+        base2.setDefault("beta");
+        openAPI.getComponents().addSchemas("B", base2);
+
+        Schema<?> schema = new Schema<>().allOf(List.of(
+                new Schema<>().$ref("#/components/schemas/A"),
+                new Schema<>().$ref("#/components/schemas/B")
+        ));
+
+        for (DefaultResolutionStrategy strategy : DefaultResolutionStrategy.values()) {
+            Object first = ModelUtils.resolveDefault(openAPI, schema, strategy);
+            Object second = ModelUtils.resolveDefault(openAPI, schema, strategy);
+            assertEquals(first, second, "Strategy " + strategy + " must be deterministic");
+        }
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidationsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidationsTest.java
@@ -128,4 +128,251 @@ public class OpenApiSchemaValidationsTest {
 
         return schema;
     }
+
+    // -------------------------------------------------------------------------
+    // allOf conflicting defaults lint rule
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void checkAllOfConflictingDefaults_distinctDefaults_firesWarning() {
+        RuleConfiguration config = new RuleConfiguration();
+        config.setEnableAllOfConflictingDefaultsRecommendation(true);
+        OpenApiSchemaValidations validator = new OpenApiSchemaValidations(config);
+
+        StringSchema branch1 = new StringSchema();
+        branch1.setDefault("alpha");
+        StringSchema branch2 = new StringSchema();
+        branch2.setDefault("beta");
+
+        ComposedSchema schema = new ComposedSchema();
+        schema.allOf(Arrays.asList(branch1, branch2));
+
+        ValidationResult result = validator.validate(new SchemaWrapper(null, schema));
+        List<Invalid> warnings = warningsForRule(result, "Schema has conflicting default values across allOf branches.");
+        Assert.assertEquals(warnings.size(), 1, "Expected conflicting-defaults warning to fire.");
+    }
+
+    @Test
+    public void checkAllOfConflictingDefaults_identicalDefaults_doesNotFireConflict() {
+        RuleConfiguration config = new RuleConfiguration();
+        config.setEnableAllOfConflictingDefaultsRecommendation(true);
+        OpenApiSchemaValidations validator = new OpenApiSchemaValidations(config);
+
+        StringSchema branch1 = new StringSchema();
+        branch1.setDefault("same");
+        StringSchema branch2 = new StringSchema();
+        branch2.setDefault("same");
+
+        ComposedSchema schema = new ComposedSchema();
+        schema.allOf(Arrays.asList(branch1, branch2));
+
+        ValidationResult result = validator.validate(new SchemaWrapper(null, schema));
+        List<Invalid> warnings = warningsForRule(result, "Schema has conflicting default values across allOf branches.");
+        Assert.assertEquals(warnings.size(), 0, "Identical defaults must not fire the conflict rule.");
+    }
+
+    @Test
+    public void checkAllOfConflictingDefaults_disabled_doesNotFire() {
+        RuleConfiguration config = new RuleConfiguration();
+        config.setEnableAllOfConflictingDefaultsRecommendation(false);
+        OpenApiSchemaValidations validator = new OpenApiSchemaValidations(config);
+
+        StringSchema branch1 = new StringSchema();
+        branch1.setDefault("alpha");
+        StringSchema branch2 = new StringSchema();
+        branch2.setDefault("beta");
+
+        ComposedSchema schema = new ComposedSchema();
+        schema.allOf(Arrays.asList(branch1, branch2));
+
+        ValidationResult result = validator.validate(new SchemaWrapper(null, schema));
+        List<Invalid> warnings = warningsForRule(result, "Schema has conflicting default values across allOf branches.");
+        Assert.assertEquals(warnings.size(), 0, "Rule must be suppressed when disabled.");
+    }
+
+    @Test
+    public void checkAllOfConflictingDefaults_noAllOf_doesNotFire() {
+        RuleConfiguration config = new RuleConfiguration();
+        config.setEnableAllOfConflictingDefaultsRecommendation(true);
+        OpenApiSchemaValidations validator = new OpenApiSchemaValidations(config);
+
+        StringSchema schema = new StringSchema();
+        schema.setDefault("only");
+
+        ValidationResult result = validator.validate(new SchemaWrapper(null, schema));
+        List<Invalid> warnings = warningsForRule(result, "Schema has conflicting default values across allOf branches.");
+        Assert.assertEquals(warnings.size(), 0, "Plain schema must not trigger allOf rule.");
+    }
+
+    // -------------------------------------------------------------------------
+    // allOf shadowed defaults lint rule
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void checkAllOfShadowedDefaults_rootAndBranchDefault_firesWarning() {
+        RuleConfiguration config = new RuleConfiguration();
+        config.setEnableAllOfShadowedDefaultsRecommendation(true);
+        OpenApiSchemaValidations validator = new OpenApiSchemaValidations(config);
+
+        StringSchema branch = new StringSchema();
+        branch.setDefault("nested");
+
+        ComposedSchema schema = new ComposedSchema();
+        schema.setDefault("root");
+        schema.allOf(Arrays.asList(branch));
+
+        ValidationResult result = validator.validate(new SchemaWrapper(null, schema));
+        List<Invalid> warnings = warningsForRule(result, "Schema has a root-level default that shadows allOf branch defaults.");
+        Assert.assertEquals(warnings.size(), 1, "Expected shadowed-defaults warning to fire.");
+    }
+
+    @Test
+    public void checkAllOfShadowedDefaults_onlyRootDefault_doesNotFire() {
+        RuleConfiguration config = new RuleConfiguration();
+        config.setEnableAllOfShadowedDefaultsRecommendation(true);
+        OpenApiSchemaValidations validator = new OpenApiSchemaValidations(config);
+
+        StringSchema branch = new StringSchema(); // no default in branch
+
+        ComposedSchema schema = new ComposedSchema();
+        schema.setDefault("root");
+        schema.allOf(Arrays.asList(branch));
+
+        ValidationResult result = validator.validate(new SchemaWrapper(null, schema));
+        List<Invalid> warnings = warningsForRule(result, "Schema has a root-level default that shadows allOf branch defaults.");
+        Assert.assertEquals(warnings.size(), 0, "No shadowing when branch has no default.");
+    }
+
+    @Test
+    public void checkAllOfShadowedDefaults_disabled_doesNotFire() {
+        RuleConfiguration config = new RuleConfiguration();
+        config.setEnableAllOfShadowedDefaultsRecommendation(false);
+        OpenApiSchemaValidations validator = new OpenApiSchemaValidations(config);
+
+        StringSchema branch = new StringSchema();
+        branch.setDefault("nested");
+
+        ComposedSchema schema = new ComposedSchema();
+        schema.setDefault("root");
+        schema.allOf(Arrays.asList(branch));
+
+        ValidationResult result = validator.validate(new SchemaWrapper(null, schema));
+        List<Invalid> warnings = warningsForRule(result, "Schema has a root-level default that shadows allOf branch defaults.");
+        Assert.assertEquals(warnings.size(), 0, "Rule must be suppressed when disabled.");
+    }
+
+    // -------------------------------------------------------------------------
+    // allOf redundant defaults lint rule
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void checkAllOfRedundantDefaults_identicalDefaults_firesWarning() {
+        RuleConfiguration config = new RuleConfiguration();
+        config.setEnableAllOfRedundantDefaultsRecommendation(true);
+        OpenApiSchemaValidations validator = new OpenApiSchemaValidations(config);
+
+        StringSchema branch1 = new StringSchema();
+        branch1.setDefault("same");
+        StringSchema branch2 = new StringSchema();
+        branch2.setDefault("same");
+
+        ComposedSchema schema = new ComposedSchema();
+        schema.allOf(Arrays.asList(branch1, branch2));
+
+        ValidationResult result = validator.validate(new SchemaWrapper(null, schema));
+        List<Invalid> warnings = warningsForRule(result, "Schema has redundant identical default values across allOf branches.");
+        Assert.assertEquals(warnings.size(), 1, "Expected redundant-defaults warning to fire.");
+    }
+
+    @Test
+    public void checkAllOfRedundantDefaults_distinctDefaults_doesNotFireRedundant() {
+        RuleConfiguration config = new RuleConfiguration();
+        config.setEnableAllOfRedundantDefaultsRecommendation(true);
+        OpenApiSchemaValidations validator = new OpenApiSchemaValidations(config);
+
+        StringSchema branch1 = new StringSchema();
+        branch1.setDefault("alpha");
+        StringSchema branch2 = new StringSchema();
+        branch2.setDefault("beta");
+
+        ComposedSchema schema = new ComposedSchema();
+        schema.allOf(Arrays.asList(branch1, branch2));
+
+        ValidationResult result = validator.validate(new SchemaWrapper(null, schema));
+        List<Invalid> warnings = warningsForRule(result, "Schema has redundant identical default values across allOf branches.");
+        Assert.assertEquals(warnings.size(), 0, "Distinct defaults must not fire the redundant rule.");
+    }
+
+    @Test
+    public void checkAllOfRedundantDefaults_disabled_doesNotFire() {
+        RuleConfiguration config = new RuleConfiguration();
+        config.setEnableAllOfRedundantDefaultsRecommendation(false);
+        OpenApiSchemaValidations validator = new OpenApiSchemaValidations(config);
+
+        StringSchema branch1 = new StringSchema();
+        branch1.setDefault("same");
+        StringSchema branch2 = new StringSchema();
+        branch2.setDefault("same");
+
+        ComposedSchema schema = new ComposedSchema();
+        schema.allOf(Arrays.asList(branch1, branch2));
+
+        ValidationResult result = validator.validate(new SchemaWrapper(null, schema));
+        List<Invalid> warnings = warningsForRule(result, "Schema has redundant identical default values across allOf branches.");
+        Assert.assertEquals(warnings.size(), 0, "Rule must be suppressed when disabled.");
+    }
+
+    @Test
+    public void checkAllOfRedundantDefaults_singleBranchDefault_doesNotFire() {
+        RuleConfiguration config = new RuleConfiguration();
+        config.setEnableAllOfRedundantDefaultsRecommendation(true);
+        OpenApiSchemaValidations validator = new OpenApiSchemaValidations(config);
+
+        StringSchema branch1 = new StringSchema();
+        branch1.setDefault("only_one");
+        StringSchema branch2 = new StringSchema(); // no default
+
+        ComposedSchema schema = new ComposedSchema();
+        schema.allOf(Arrays.asList(branch1, branch2));
+
+        ValidationResult result = validator.validate(new SchemaWrapper(null, schema));
+        List<Invalid> warnings = warningsForRule(result, "Schema has redundant identical default values across allOf branches.");
+        Assert.assertEquals(warnings.size(), 0, "Single default cannot be redundant.");
+    }
+
+    // -------------------------------------------------------------------------
+    // Clean schema — no warnings from any allOf default rule
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void allOfDefaultRules_cleanSchema_noWarnings() {
+        RuleConfiguration config = new RuleConfiguration();
+        config.setEnableAllOfConflictingDefaultsRecommendation(true);
+        config.setEnableAllOfShadowedDefaultsRecommendation(true);
+        config.setEnableAllOfRedundantDefaultsRecommendation(true);
+        OpenApiSchemaValidations validator = new OpenApiSchemaValidations(config);
+
+        // Clean: allOf with one branch that has a default, root has no default
+        StringSchema branch = new StringSchema();
+        branch.setDefault("clean");
+        ComposedSchema schema = new ComposedSchema();
+        schema.allOf(Arrays.asList(branch));
+
+        ValidationResult result = validator.validate(new SchemaWrapper(null, schema));
+        List<Invalid> allOfWarnings = result.getWarnings().stream()
+                .filter(w -> w.getRule().getDescription() != null
+                        && w.getRule().getDescription().contains("allOf"))
+                .collect(Collectors.toList());
+        Assert.assertEquals(allOfWarnings.size(), 0, "Clean schema should not fire any allOf default warnings.");
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper
+    // -------------------------------------------------------------------------
+
+    private List<Invalid> warningsForRule(ValidationResult result, String ruleDescription) {
+        return result.getWarnings().stream()
+                .filter(w -> ruleDescription.equals(w.getRule().getDescription()))
+                .collect(Collectors.toList());
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/normalizer_ref_default_propagation.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/normalizer_ref_default_propagation.yaml
@@ -1,0 +1,18 @@
+openapi: "3.0.0"
+info:
+  version: "1.0.0"
+  title: "Test $ref default propagation"
+paths: {}
+components:
+  schemas:
+    Status:
+      type: string
+      default: "active"
+    Item:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/Status'
+        explicitDefault:
+          $ref: '#/components/schemas/Status'
+          # would be invalid in strict OAS3, but we test that an explicit default is NOT overwritten

--- a/modules/openapi-generator/src/test/resources/3_0/normalizer_resolve_schema_defaults.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/normalizer_resolve_schema_defaults.yaml
@@ -1,0 +1,18 @@
+openapi: "3.0.0"
+info:
+  version: "1.0.0"
+  title: "Test RESOLVE_SCHEMA_DEFAULTS normalizer rule"
+paths: {}
+components:
+  schemas:
+    BaseStatus:
+      type: string
+      enum: [active, inactive]
+      default: "active"
+    ChildNoDefault:
+      allOf:
+        - $ref: '#/components/schemas/BaseStatus'
+    ChildWithOwnDefault:
+      allOf:
+        - $ref: '#/components/schemas/BaseStatus'
+      default: "inactive"

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/docs/models/EnumTest.md
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/docs/models/EnumTest.md
@@ -10,9 +10,9 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **EnumString** | **string** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -39,9 +39,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber</param>
         /// <param name="enumString">enumString</param>
         /// <param name="outerEnum">outerEnum</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue</param>
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed)</param>
         /// <param name="outerEnumInteger">outerEnumInteger</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0)</param>
         [JsonConstructor]
         public EnumTest(EnumStringRequiredEnum enumStringRequired, Option<EnumIntegerEnum?> enumInteger = default, Option<EnumIntegerOnlyEnum?> enumIntegerOnly = default, Option<EnumNumberEnum?> enumNumber = default, Option<EnumStringEnum?> enumString = default, Option<OuterEnum?> outerEnum = default, Option<OuterEnumDefaultValue?> outerEnumDefaultValue = default, Option<OuterEnumInteger?> outerEnumInteger = default, Option<OuterEnumIntegerDefaultValue?> outerEnumIntegerDefaultValue = default)
         {

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/docs/apis/FakeApi.md
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/docs/apis/FakeApi.md
@@ -495,7 +495,7 @@ To test enum parameters
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **enumFormString** | **TestEnumParametersRequestEnumFormString** |  | [optional]  |
-| **enumFormStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Form parameter enum test (string array) | [optional]  |
+| **enumFormStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Form parameter enum test (string array) | [optional] [default to $] |
 | **enumHeaderString** | **TestEnumParametersEnumHeaderStringParameter** | Header parameter enum test (string) | [optional]  |
 | **enumHeaderStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Header parameter enum test (string array) | [optional]  |
 | **enumQueryDouble** | **TestEnumParametersEnumQueryDoubleParameter** | Query parameter enum test (double) | [optional]  |

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/docs/models/ChildCat.md
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/docs/models/ChildCat.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**PetType** | **ChildCatAllOfPetType** |  | 
 **Name** | **string** |  | [optional] 
+**PetType** | **ChildCatAllOfPetType** |  | [default to ChildCatAllOfPetType.ChildCat]
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/docs/models/EnumTest.md
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/docs/models/EnumTest.md
@@ -10,9 +10,9 @@ Name | Type | Description | Notes
 **EnumNumber** | **TestEnumParametersEnumQueryDoubleParameter** |  | [optional] 
 **EnumString** | **EnumTestEnumString** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -364,7 +364,7 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="enumFormString"> (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
         /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
         /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
@@ -382,7 +382,7 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters
         /// </remarks>
         /// <param name="enumFormString"> (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
         /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
         /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
@@ -4549,7 +4549,7 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters To test enum parameters
         /// </summary>
         /// <param name="enumFormString"> (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
         /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
         /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
@@ -4575,7 +4575,7 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="enumFormString"> (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
         /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
         /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -36,19 +36,12 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ChildCat(Option<string> name = default) : base()
         {
-            PetType = (ChildCatAllOfPetType)Enum.Parse(typeof(ChildCatAllOfPetType), this.GetType().Name);
             NameOption = name;
+            PetType = (ChildCatAllOfPetType)Enum.Parse(typeof(ChildCatAllOfPetType), this.GetType().Name);
             OnCreated();
         }
 
         partial void OnCreated();
-
-        /// <summary>
-        /// The discriminator
-        /// </summary>
-        [JsonIgnore]
-        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public new ChildCatAllOfPetType PetType { get; }
 
         /// <summary>
         /// Used to track the state of Name
@@ -62,6 +55,13 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("name")]
         public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
+
+        /// <summary>
+        /// The discriminator
+        /// </summary>
+        [JsonIgnore]
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public new ChildCatAllOfPetType PetType { get; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -100,8 +100,8 @@ namespace Org.OpenAPITools.Model
 
             JsonTokenType startingTokenType = utf8JsonReader.TokenType;
 
-            Option<ChildCatAllOfPetType?> petType = default;
             Option<string> name = default;
+            Option<ChildCatAllOfPetType?> petType = default;
 
             while (utf8JsonReader.Read())
             {
@@ -118,13 +118,13 @@ namespace Org.OpenAPITools.Model
 
                     switch (localVarJsonPropertyName)
                     {
+                        case "name":
+                            name = new Option<string>(utf8JsonReader.GetString());
+                            break;
                         case "pet_type":
                             string petTypeRawValue = utf8JsonReader.GetString();
                             if (petTypeRawValue != null)
                                 petType = new Option<ChildCatAllOfPetType?>(ChildCatAllOfPetTypeValueConverter.FromStringOrDefault(petTypeRawValue));
-                            break;
-                        case "name":
-                            name = new Option<string>(utf8JsonReader.GetString());
                             break;
                         default:
                             break;
@@ -135,11 +135,11 @@ namespace Org.OpenAPITools.Model
             if (!petType.IsSet)
                 throw new ArgumentException("Property is required for class ChildCat.", nameof(petType));
 
-            if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
-
             if (name.IsSet && name.Value == null)
                 throw new ArgumentNullException(nameof(name), "Property is not nullable for class ChildCat.");
+
+            if (petType.IsSet && petType.Value == null)
+                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
 
             return new ChildCat(name);
         }
@@ -171,10 +171,10 @@ namespace Org.OpenAPITools.Model
             if (childCat.NameOption.IsSet && childCat.Name == null)
                 throw new ArgumentNullException(nameof(childCat.Name), "Property is required for class ChildCat.");
 
-            writer.WriteString("pet_type", ChildCatAllOfPetTypeValueConverter.ToJsonValue(childCat.PetType));
-
             if (childCat.NameOption.IsSet)
                 writer.WriteString("name", childCat.Name);
+
+            writer.WriteString("pet_type", ChildCatAllOfPetTypeValueConverter.ToJsonValue(childCat.PetType));
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -38,9 +38,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber</param>
         /// <param name="enumString">enumString</param>
         /// <param name="outerEnum">outerEnum</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue</param>
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed)</param>
         /// <param name="outerEnumInteger">outerEnumInteger</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0)</param>
         [JsonConstructor]
         public EnumTest(EnumTestEnumString enumStringRequired, Option<EnumTestEnumInteger?> enumInteger = default, Option<EnumTestEnumIntegerOnly?> enumIntegerOnly = default, Option<TestEnumParametersEnumQueryDoubleParameter?> enumNumber = default, Option<EnumTestEnumString?> enumString = default, Option<OuterEnum?> outerEnum = default, Option<OuterEnumDefaultValue?> outerEnumDefaultValue = default, Option<OuterEnumInteger?> outerEnumInteger = default, Option<OuterEnumIntegerDefaultValue?> outerEnumIntegerDefaultValue = default)
         {

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/docs/models/EnumTest.md
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/docs/models/EnumTest.md
@@ -10,9 +10,9 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **EnumString** | **string** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -40,9 +40,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber</param>
         /// <param name="enumString">enumString</param>
         /// <param name="outerEnum">outerEnum</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue</param>
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed)</param>
         /// <param name="outerEnumInteger">outerEnumInteger</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0)</param>
         [JsonConstructor]
         public EnumTest(EnumStringRequiredEnum enumStringRequired, Option<EnumIntegerEnum?> enumInteger = default, Option<EnumIntegerOnlyEnum?> enumIntegerOnly = default, Option<EnumNumberEnum?> enumNumber = default, Option<EnumStringEnum?> enumString = default, Option<OuterEnum?> outerEnum = default, Option<OuterEnumDefaultValue?> outerEnumDefaultValue = default, Option<OuterEnumInteger?> outerEnumInteger = default, Option<OuterEnumIntegerDefaultValue?> outerEnumIntegerDefaultValue = default)
         {

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/docs/models/EnumTest.md
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/docs/models/EnumTest.md
@@ -10,9 +10,9 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **EnumString** | **string** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -38,9 +38,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber</param>
         /// <param name="enumString">enumString</param>
         /// <param name="outerEnum">outerEnum</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue</param>
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed)</param>
         /// <param name="outerEnumInteger">outerEnumInteger</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0)</param>
         [JsonConstructor]
         public EnumTest(EnumStringRequiredEnum enumStringRequired, Option<EnumIntegerEnum?> enumInteger = default, Option<EnumIntegerOnlyEnum?> enumIntegerOnly = default, Option<EnumNumberEnum?> enumNumber = default, Option<EnumStringEnum?> enumString = default, Option<OuterEnum?> outerEnum = default, Option<OuterEnumDefaultValue?> outerEnumDefaultValue = default, Option<OuterEnumInteger?> outerEnumInteger = default, Option<OuterEnumIntegerDefaultValue?> outerEnumIntegerDefaultValue = default)
         {

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/docs/models/EnumTest.md
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/docs/models/EnumTest.md
@@ -10,9 +10,9 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **EnumString** | **string** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -41,9 +41,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber</param>
         /// <param name="enumString">enumString</param>
         /// <param name="outerEnum">outerEnum</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue</param>
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed)</param>
         /// <param name="outerEnumInteger">outerEnumInteger</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0)</param>
         [JsonConstructor]
         public EnumTest(EnumStringRequiredEnum enumStringRequired, Option<EnumIntegerEnum?> enumInteger = default, Option<EnumIntegerOnlyEnum?> enumIntegerOnly = default, Option<EnumNumberEnum?> enumNumber = default, Option<EnumStringEnum?> enumString = default, Option<OuterEnum?> outerEnum = default, Option<OuterEnumDefaultValue?> outerEnumDefaultValue = default, Option<OuterEnumInteger?> outerEnumInteger = default, Option<OuterEnumIntegerDefaultValue?> outerEnumIntegerDefaultValue = default)
         {

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/docs/apis/FakeApi.md
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/docs/apis/FakeApi.md
@@ -495,7 +495,7 @@ To test enum parameters
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **enumFormString** | **TestEnumParametersRequestEnumFormString** |  | [optional]  |
-| **enumFormStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Form parameter enum test (string array) | [optional]  |
+| **enumFormStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Form parameter enum test (string array) | [optional] [default to $] |
 | **enumHeaderString** | **TestEnumParametersEnumHeaderStringParameter** | Header parameter enum test (string) | [optional]  |
 | **enumHeaderStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Header parameter enum test (string array) | [optional]  |
 | **enumQueryDouble** | **TestEnumParametersEnumQueryDoubleParameter** | Query parameter enum test (double) | [optional]  |

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/docs/models/ChildCat.md
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/docs/models/ChildCat.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**PetType** | **ChildCatAllOfPetType** |  | 
 **Name** | **string** |  | [optional] 
+**PetType** | **ChildCatAllOfPetType** |  | [default to ChildCatAllOfPetType.ChildCat]
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/docs/models/EnumTest.md
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/docs/models/EnumTest.md
@@ -10,9 +10,9 @@ Name | Type | Description | Notes
 **EnumNumber** | **TestEnumParametersEnumQueryDoubleParameter** |  | [optional] 
 **EnumString** | **EnumTestEnumString** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -364,7 +364,7 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="enumFormString"> (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
         /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
         /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
@@ -382,7 +382,7 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters
         /// </remarks>
         /// <param name="enumFormString"> (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
         /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
         /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
@@ -4540,7 +4540,7 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters To test enum parameters
         /// </summary>
         /// <param name="enumFormString"> (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
         /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
         /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
@@ -4566,7 +4566,7 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="enumFormString"> (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
         /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
         /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -36,19 +36,12 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ChildCat(Option<string> name = default) : base()
         {
-            PetType = (ChildCatAllOfPetType)Enum.Parse(typeof(ChildCatAllOfPetType), this.GetType().Name);
             NameOption = name;
+            PetType = (ChildCatAllOfPetType)Enum.Parse(typeof(ChildCatAllOfPetType), this.GetType().Name);
             OnCreated();
         }
 
         partial void OnCreated();
-
-        /// <summary>
-        /// The discriminator
-        /// </summary>
-        [JsonIgnore]
-        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public new ChildCatAllOfPetType PetType { get; }
 
         /// <summary>
         /// Used to track the state of Name
@@ -62,6 +55,13 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("name")]
         public string Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<string>(value); } }
+
+        /// <summary>
+        /// The discriminator
+        /// </summary>
+        [JsonIgnore]
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public new ChildCatAllOfPetType PetType { get; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -100,8 +100,8 @@ namespace Org.OpenAPITools.Model
 
             JsonTokenType startingTokenType = utf8JsonReader.TokenType;
 
-            Option<ChildCatAllOfPetType?> petType = default;
             Option<string> name = default;
+            Option<ChildCatAllOfPetType?> petType = default;
 
             while (utf8JsonReader.Read())
             {
@@ -118,13 +118,13 @@ namespace Org.OpenAPITools.Model
 
                     switch (localVarJsonPropertyName)
                     {
+                        case "name":
+                            name = new Option<string>(utf8JsonReader.GetString());
+                            break;
                         case "pet_type":
                             string petTypeRawValue = utf8JsonReader.GetString();
                             if (petTypeRawValue != null)
                                 petType = new Option<ChildCatAllOfPetType?>(ChildCatAllOfPetTypeValueConverter.FromStringOrDefault(petTypeRawValue));
-                            break;
-                        case "name":
-                            name = new Option<string>(utf8JsonReader.GetString());
                             break;
                         default:
                             break;
@@ -135,11 +135,11 @@ namespace Org.OpenAPITools.Model
             if (!petType.IsSet)
                 throw new ArgumentException("Property is required for class ChildCat.", nameof(petType));
 
-            if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
-
             if (name.IsSet && name.Value == null)
                 throw new ArgumentNullException(nameof(name), "Property is not nullable for class ChildCat.");
+
+            if (petType.IsSet && petType.Value == null)
+                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
 
             return new ChildCat(name);
         }
@@ -171,10 +171,10 @@ namespace Org.OpenAPITools.Model
             if (childCat.NameOption.IsSet && childCat.Name == null)
                 throw new ArgumentNullException(nameof(childCat.Name), "Property is required for class ChildCat.");
 
-            writer.WriteString("pet_type", ChildCatAllOfPetTypeValueConverter.ToJsonValue(childCat.PetType));
-
             if (childCat.NameOption.IsSet)
                 writer.WriteString("name", childCat.Name);
+
+            writer.WriteString("pet_type", ChildCatAllOfPetTypeValueConverter.ToJsonValue(childCat.PetType));
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -38,9 +38,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber</param>
         /// <param name="enumString">enumString</param>
         /// <param name="outerEnum">outerEnum</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue</param>
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed)</param>
         /// <param name="outerEnumInteger">outerEnumInteger</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0)</param>
         [JsonConstructor]
         public EnumTest(EnumTestEnumString enumStringRequired, Option<EnumTestEnumInteger?> enumInteger = default, Option<EnumTestEnumIntegerOnly?> enumIntegerOnly = default, Option<TestEnumParametersEnumQueryDoubleParameter?> enumNumber = default, Option<EnumTestEnumString?> enumString = default, Option<OuterEnum?> outerEnum = default, Option<OuterEnumDefaultValue?> outerEnumDefaultValue = default, Option<OuterEnumInteger?> outerEnumInteger = default, Option<OuterEnumIntegerDefaultValue?> outerEnumIntegerDefaultValue = default)
         {

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/docs/models/EnumTest.md
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/docs/models/EnumTest.md
@@ -10,9 +10,9 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **EnumString** | **string** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -38,9 +38,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber</param>
         /// <param name="enumString">enumString</param>
         /// <param name="outerEnum">outerEnum</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue</param>
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed)</param>
         /// <param name="outerEnumInteger">outerEnumInteger</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0)</param>
         [JsonConstructor]
         public EnumTest(EnumStringRequiredEnum enumStringRequired, Option<EnumIntegerEnum?> enumInteger = default, Option<EnumIntegerOnlyEnum?> enumIntegerOnly = default, Option<EnumNumberEnum?> enumNumber = default, Option<EnumStringEnum?> enumString = default, Option<OuterEnum?> outerEnum = default, Option<OuterEnumDefaultValue?> outerEnumDefaultValue = default, Option<OuterEnumInteger?> outerEnumInteger = default, Option<OuterEnumIntegerDefaultValue?> outerEnumIntegerDefaultValue = default)
         {

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/docs/apis/FakeApi.md
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/docs/apis/FakeApi.md
@@ -495,7 +495,7 @@ To test enum parameters
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **enumFormString** | **TestEnumParametersRequestEnumFormString** |  | [optional]  |
-| **enumFormStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Form parameter enum test (string array) | [optional]  |
+| **enumFormStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Form parameter enum test (string array) | [optional] [default to $] |
 | **enumHeaderString** | **TestEnumParametersEnumHeaderStringParameter** | Header parameter enum test (string) | [optional]  |
 | **enumHeaderStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Header parameter enum test (string array) | [optional]  |
 | **enumQueryDouble** | **TestEnumParametersEnumQueryDoubleParameter** | Query parameter enum test (double) | [optional]  |

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/docs/models/ChildCat.md
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/docs/models/ChildCat.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**PetType** | **ChildCatAllOfPetType** |  | 
 **Name** | **string** |  | [optional] 
+**PetType** | **ChildCatAllOfPetType** |  | [default to ChildCatAllOfPetType.ChildCat]
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/docs/models/EnumTest.md
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/docs/models/EnumTest.md
@@ -10,9 +10,9 @@ Name | Type | Description | Notes
 **EnumNumber** | **TestEnumParametersEnumQueryDoubleParameter** |  | [optional] 
 **EnumString** | **EnumTestEnumString** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -364,7 +364,7 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="enumFormString"> (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
         /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
         /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
@@ -382,7 +382,7 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters
         /// </remarks>
         /// <param name="enumFormString"> (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
         /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
         /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
@@ -4540,7 +4540,7 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters To test enum parameters
         /// </summary>
         /// <param name="enumFormString"> (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
         /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
         /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
@@ -4566,7 +4566,7 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="enumFormString"> (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
         /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
         /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -36,19 +36,12 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ChildCat(Option<string> name = default) : base()
         {
-            PetType = (ChildCatAllOfPetType)Enum.Parse(typeof(ChildCatAllOfPetType), this.GetType().Name);
             NameOption = name;
+            PetType = (ChildCatAllOfPetType)Enum.Parse(typeof(ChildCatAllOfPetType), this.GetType().Name);
             OnCreated();
         }
 
         partial void OnCreated();
-
-        /// <summary>
-        /// The discriminator
-        /// </summary>
-        [JsonIgnore]
-        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public new ChildCatAllOfPetType PetType { get; }
 
         /// <summary>
         /// Used to track the state of Name
@@ -62,6 +55,13 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("name")]
         public string Name { get { return this.NameOption.Value; } set { this.NameOption = new Option<string>(value); } }
+
+        /// <summary>
+        /// The discriminator
+        /// </summary>
+        [JsonIgnore]
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public new ChildCatAllOfPetType PetType { get; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -100,8 +100,8 @@ namespace Org.OpenAPITools.Model
 
             JsonTokenType startingTokenType = utf8JsonReader.TokenType;
 
-            Option<ChildCatAllOfPetType?> petType = default;
             Option<string> name = default;
+            Option<ChildCatAllOfPetType?> petType = default;
 
             while (utf8JsonReader.Read())
             {
@@ -118,13 +118,13 @@ namespace Org.OpenAPITools.Model
 
                     switch (localVarJsonPropertyName)
                     {
+                        case "name":
+                            name = new Option<string>(utf8JsonReader.GetString());
+                            break;
                         case "pet_type":
                             string petTypeRawValue = utf8JsonReader.GetString();
                             if (petTypeRawValue != null)
                                 petType = new Option<ChildCatAllOfPetType?>(ChildCatAllOfPetTypeValueConverter.FromStringOrDefault(petTypeRawValue));
-                            break;
-                        case "name":
-                            name = new Option<string>(utf8JsonReader.GetString());
                             break;
                         default:
                             break;
@@ -135,11 +135,11 @@ namespace Org.OpenAPITools.Model
             if (!petType.IsSet)
                 throw new ArgumentException("Property is required for class ChildCat.", nameof(petType));
 
-            if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
-
             if (name.IsSet && name.Value == null)
                 throw new ArgumentNullException(nameof(name), "Property is not nullable for class ChildCat.");
+
+            if (petType.IsSet && petType.Value == null)
+                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
 
             return new ChildCat(name);
         }
@@ -171,10 +171,10 @@ namespace Org.OpenAPITools.Model
             if (childCat.NameOption.IsSet && childCat.Name == null)
                 throw new ArgumentNullException(nameof(childCat.Name), "Property is required for class ChildCat.");
 
-            writer.WriteString("pet_type", ChildCatAllOfPetTypeValueConverter.ToJsonValue(childCat.PetType));
-
             if (childCat.NameOption.IsSet)
                 writer.WriteString("name", childCat.Name);
+
+            writer.WriteString("pet_type", ChildCatAllOfPetTypeValueConverter.ToJsonValue(childCat.PetType));
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -38,9 +38,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber</param>
         /// <param name="enumString">enumString</param>
         /// <param name="outerEnum">outerEnum</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue</param>
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed)</param>
         /// <param name="outerEnumInteger">outerEnumInteger</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0)</param>
         [JsonConstructor]
         public EnumTest(EnumTestEnumString enumStringRequired, Option<EnumTestEnumInteger?> enumInteger = default, Option<EnumTestEnumIntegerOnly?> enumIntegerOnly = default, Option<TestEnumParametersEnumQueryDoubleParameter?> enumNumber = default, Option<EnumTestEnumString?> enumString = default, Option<OuterEnum?> outerEnum = default, Option<OuterEnumDefaultValue?> outerEnumDefaultValue = default, Option<OuterEnumInteger?> outerEnumInteger = default, Option<OuterEnumIntegerDefaultValue?> outerEnumIntegerDefaultValue = default)
         {

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/docs/models/EnumTest.md
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/docs/models/EnumTest.md
@@ -10,9 +10,9 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **EnumString** | **string** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -38,9 +38,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber</param>
         /// <param name="enumString">enumString</param>
         /// <param name="outerEnum">outerEnum</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue</param>
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed)</param>
         /// <param name="outerEnumInteger">outerEnumInteger</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0)</param>
         [JsonConstructor]
         public EnumTest(EnumStringRequiredEnum enumStringRequired, Option<EnumIntegerEnum?> enumInteger = default, Option<EnumIntegerOnlyEnum?> enumIntegerOnly = default, Option<EnumNumberEnum?> enumNumber = default, Option<EnumStringEnum?> enumString = default, Option<OuterEnum?> outerEnum = default, Option<OuterEnumDefaultValue?> outerEnumDefaultValue = default, Option<OuterEnumInteger?> outerEnumInteger = default, Option<OuterEnumIntegerDefaultValue?> outerEnumIntegerDefaultValue = default)
         {

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/docs/apis/FakeApi.md
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/docs/apis/FakeApi.md
@@ -495,7 +495,7 @@ To test enum parameters
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **enumFormString** | **TestEnumParametersRequestEnumFormString** |  | [optional]  |
-| **enumFormStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Form parameter enum test (string array) | [optional]  |
+| **enumFormStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Form parameter enum test (string array) | [optional] [default to $] |
 | **enumHeaderString** | **TestEnumParametersEnumHeaderStringParameter** | Header parameter enum test (string) | [optional]  |
 | **enumHeaderStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Header parameter enum test (string array) | [optional]  |
 | **enumQueryDouble** | **TestEnumParametersEnumQueryDoubleParameter** | Query parameter enum test (double) | [optional]  |

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/docs/models/ChildCat.md
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/docs/models/ChildCat.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**PetType** | **ChildCatAllOfPetType** |  | 
 **Name** | **string** |  | [optional] 
+**PetType** | **ChildCatAllOfPetType** |  | [default to ChildCatAllOfPetType.ChildCat]
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/docs/models/EnumTest.md
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/docs/models/EnumTest.md
@@ -10,9 +10,9 @@ Name | Type | Description | Notes
 **EnumNumber** | **TestEnumParametersEnumQueryDoubleParameter** |  | [optional] 
 **EnumString** | **EnumTestEnumString** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -364,7 +364,7 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="enumFormString"> (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
         /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
         /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
@@ -382,7 +382,7 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters
         /// </remarks>
         /// <param name="enumFormString"> (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
         /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
         /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
@@ -4549,7 +4549,7 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters To test enum parameters
         /// </summary>
         /// <param name="enumFormString"> (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
         /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
         /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
@@ -4575,7 +4575,7 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="enumFormString"> (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
         /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
         /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -36,19 +36,12 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ChildCat(Option<string> name = default) : base()
         {
-            PetType = (ChildCatAllOfPetType)Enum.Parse(typeof(ChildCatAllOfPetType), this.GetType().Name);
             NameOption = name;
+            PetType = (ChildCatAllOfPetType)Enum.Parse(typeof(ChildCatAllOfPetType), this.GetType().Name);
             OnCreated();
         }
 
         partial void OnCreated();
-
-        /// <summary>
-        /// The discriminator
-        /// </summary>
-        [JsonIgnore]
-        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public new ChildCatAllOfPetType PetType { get; }
 
         /// <summary>
         /// Used to track the state of Name
@@ -62,6 +55,13 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("name")]
         public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
+
+        /// <summary>
+        /// The discriminator
+        /// </summary>
+        [JsonIgnore]
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public new ChildCatAllOfPetType PetType { get; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -100,8 +100,8 @@ namespace Org.OpenAPITools.Model
 
             JsonTokenType startingTokenType = utf8JsonReader.TokenType;
 
-            Option<ChildCatAllOfPetType?> petType = default;
             Option<string> name = default;
+            Option<ChildCatAllOfPetType?> petType = default;
 
             while (utf8JsonReader.Read())
             {
@@ -118,13 +118,13 @@ namespace Org.OpenAPITools.Model
 
                     switch (localVarJsonPropertyName)
                     {
+                        case "name":
+                            name = new Option<string>(utf8JsonReader.GetString());
+                            break;
                         case "pet_type":
                             string petTypeRawValue = utf8JsonReader.GetString();
                             if (petTypeRawValue != null)
                                 petType = new Option<ChildCatAllOfPetType?>(ChildCatAllOfPetTypeValueConverter.FromStringOrDefault(petTypeRawValue));
-                            break;
-                        case "name":
-                            name = new Option<string>(utf8JsonReader.GetString());
                             break;
                         default:
                             break;
@@ -135,11 +135,11 @@ namespace Org.OpenAPITools.Model
             if (!petType.IsSet)
                 throw new ArgumentException("Property is required for class ChildCat.", nameof(petType));
 
-            if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
-
             if (name.IsSet && name.Value == null)
                 throw new ArgumentNullException(nameof(name), "Property is not nullable for class ChildCat.");
+
+            if (petType.IsSet && petType.Value == null)
+                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
 
             return new ChildCat(name);
         }
@@ -171,10 +171,10 @@ namespace Org.OpenAPITools.Model
             if (childCat.NameOption.IsSet && childCat.Name == null)
                 throw new ArgumentNullException(nameof(childCat.Name), "Property is required for class ChildCat.");
 
-            writer.WriteString("pet_type", ChildCatAllOfPetTypeValueConverter.ToJsonValue(childCat.PetType));
-
             if (childCat.NameOption.IsSet)
                 writer.WriteString("name", childCat.Name);
+
+            writer.WriteString("pet_type", ChildCatAllOfPetTypeValueConverter.ToJsonValue(childCat.PetType));
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -38,9 +38,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber</param>
         /// <param name="enumString">enumString</param>
         /// <param name="outerEnum">outerEnum</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue</param>
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed)</param>
         /// <param name="outerEnumInteger">outerEnumInteger</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0)</param>
         [JsonConstructor]
         public EnumTest(EnumTestEnumString enumStringRequired, Option<EnumTestEnumInteger?> enumInteger = default, Option<EnumTestEnumIntegerOnly?> enumIntegerOnly = default, Option<TestEnumParametersEnumQueryDoubleParameter?> enumNumber = default, Option<EnumTestEnumString?> enumString = default, Option<OuterEnum?> outerEnum = default, Option<OuterEnumDefaultValue?> outerEnumDefaultValue = default, Option<OuterEnumInteger?> outerEnumInteger = default, Option<OuterEnumIntegerDefaultValue?> outerEnumIntegerDefaultValue = default)
         {

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/docs/models/EnumTest.md
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/docs/models/EnumTest.md
@@ -10,9 +10,9 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **EnumString** | **string** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -40,9 +40,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber</param>
         /// <param name="enumString">enumString</param>
         /// <param name="outerEnum">outerEnum</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue</param>
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed)</param>
         /// <param name="outerEnumInteger">outerEnumInteger</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0)</param>
         [JsonConstructor]
         public EnumTest(EnumStringRequiredEnum enumStringRequired, Option<EnumIntegerEnum?> enumInteger = default, Option<EnumIntegerOnlyEnum?> enumIntegerOnly = default, Option<EnumNumberEnum?> enumNumber = default, Option<EnumStringEnum?> enumString = default, Option<OuterEnum?> outerEnum = default, Option<OuterEnumDefaultValue?> outerEnumDefaultValue = default, Option<OuterEnumInteger?> outerEnumInteger = default, Option<OuterEnumIntegerDefaultValue?> outerEnumIntegerDefaultValue = default)
         {

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/docs/models/EnumTest.md
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/docs/models/EnumTest.md
@@ -10,9 +10,9 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **EnumString** | **string** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -38,9 +38,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber</param>
         /// <param name="enumString">enumString</param>
         /// <param name="outerEnum">outerEnum</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue</param>
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed)</param>
         /// <param name="outerEnumInteger">outerEnumInteger</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0)</param>
         [JsonConstructor]
         public EnumTest(EnumStringRequiredEnum enumStringRequired, Option<EnumIntegerEnum?> enumInteger = default, Option<EnumIntegerOnlyEnum?> enumIntegerOnly = default, Option<EnumNumberEnum?> enumNumber = default, Option<EnumStringEnum?> enumString = default, Option<OuterEnum?> outerEnum = default, Option<OuterEnumDefaultValue?> outerEnumDefaultValue = default, Option<OuterEnumInteger?> outerEnumInteger = default, Option<OuterEnumIntegerDefaultValue?> outerEnumIntegerDefaultValue = default)
         {

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/docs/models/EnumTest.md
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/docs/models/EnumTest.md
@@ -10,9 +10,9 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **EnumString** | **string** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -41,9 +41,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber</param>
         /// <param name="enumString">enumString</param>
         /// <param name="outerEnum">outerEnum</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue</param>
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed)</param>
         /// <param name="outerEnumInteger">outerEnumInteger</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0)</param>
         [JsonConstructor]
         public EnumTest(EnumStringRequiredEnum enumStringRequired, Option<EnumIntegerEnum?> enumInteger = default, Option<EnumIntegerOnlyEnum?> enumIntegerOnly = default, Option<EnumNumberEnum?> enumNumber = default, Option<EnumStringEnum?> enumString = default, Option<OuterEnum?> outerEnum = default, Option<OuterEnumDefaultValue?> outerEnumDefaultValue = default, Option<OuterEnumInteger?> outerEnumInteger = default, Option<OuterEnumIntegerDefaultValue?> outerEnumIntegerDefaultValue = default)
         {

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/docs/apis/FakeApi.md
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/docs/apis/FakeApi.md
@@ -495,7 +495,7 @@ To test enum parameters
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **enumFormString** | **TestEnumParametersRequestEnumFormString** |  | [optional]  |
-| **enumFormStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Form parameter enum test (string array) | [optional]  |
+| **enumFormStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Form parameter enum test (string array) | [optional] [default to $] |
 | **enumHeaderString** | **TestEnumParametersEnumHeaderStringParameter** | Header parameter enum test (string) | [optional]  |
 | **enumHeaderStringArray** | [**List&lt;TestEnumParametersRequestEnumFormStringArrayInner&gt;**](TestEnumParametersRequestEnumFormStringArrayInner.md) | Header parameter enum test (string array) | [optional]  |
 | **enumQueryDouble** | **TestEnumParametersEnumQueryDoubleParameter** | Query parameter enum test (double) | [optional]  |

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/docs/models/ChildCat.md
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/docs/models/ChildCat.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**PetType** | **ChildCatAllOfPetType** |  | 
 **Name** | **string** |  | [optional] 
+**PetType** | **ChildCatAllOfPetType** |  | [default to ChildCatAllOfPetType.ChildCat]
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/docs/models/EnumTest.md
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/docs/models/EnumTest.md
@@ -10,9 +10,9 @@ Name | Type | Description | Notes
 **EnumNumber** | **TestEnumParametersEnumQueryDoubleParameter** |  | [optional] 
 **EnumString** | **EnumTestEnumString** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -364,7 +364,7 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="enumFormString"> (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
         /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
         /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
@@ -382,7 +382,7 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters
         /// </remarks>
         /// <param name="enumFormString"> (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
         /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
         /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
@@ -4549,7 +4549,7 @@ namespace Org.OpenAPITools.Api
         /// To test enum parameters To test enum parameters
         /// </summary>
         /// <param name="enumFormString"> (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
         /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
         /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>
@@ -4575,7 +4575,7 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="enumFormString"> (optional)</param>
-        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional)</param>
+        /// <param name="enumFormStringArray">Form parameter enum test (string array) (optional, default to $)</param>
         /// <param name="enumHeaderString">Header parameter enum test (string) (optional)</param>
         /// <param name="enumHeaderStringArray">Header parameter enum test (string array) (optional)</param>
         /// <param name="enumQueryDouble">Query parameter enum test (double) (optional)</param>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -36,19 +36,12 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ChildCat(Option<string> name = default) : base()
         {
-            PetType = (ChildCatAllOfPetType)Enum.Parse(typeof(ChildCatAllOfPetType), this.GetType().Name);
             NameOption = name;
+            PetType = (ChildCatAllOfPetType)Enum.Parse(typeof(ChildCatAllOfPetType), this.GetType().Name);
             OnCreated();
         }
 
         partial void OnCreated();
-
-        /// <summary>
-        /// The discriminator
-        /// </summary>
-        [JsonIgnore]
-        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public new ChildCatAllOfPetType PetType { get; }
 
         /// <summary>
         /// Used to track the state of Name
@@ -62,6 +55,13 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("name")]
         public string Name { get { return this.NameOption.Value; } set { this.NameOption = new(value); } }
+
+        /// <summary>
+        /// The discriminator
+        /// </summary>
+        [JsonIgnore]
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public new ChildCatAllOfPetType PetType { get; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -100,8 +100,8 @@ namespace Org.OpenAPITools.Model
 
             JsonTokenType startingTokenType = utf8JsonReader.TokenType;
 
-            Option<ChildCatAllOfPetType?> petType = default;
             Option<string> name = default;
+            Option<ChildCatAllOfPetType?> petType = default;
 
             while (utf8JsonReader.Read())
             {
@@ -118,13 +118,13 @@ namespace Org.OpenAPITools.Model
 
                     switch (localVarJsonPropertyName)
                     {
+                        case "name":
+                            name = new Option<string>(utf8JsonReader.GetString());
+                            break;
                         case "pet_type":
                             string petTypeRawValue = utf8JsonReader.GetString();
                             if (petTypeRawValue != null)
                                 petType = new Option<ChildCatAllOfPetType?>(ChildCatAllOfPetTypeValueConverter.FromStringOrDefault(petTypeRawValue));
-                            break;
-                        case "name":
-                            name = new Option<string>(utf8JsonReader.GetString());
                             break;
                         default:
                             break;
@@ -135,11 +135,11 @@ namespace Org.OpenAPITools.Model
             if (!petType.IsSet)
                 throw new ArgumentException("Property is required for class ChildCat.", nameof(petType));
 
-            if (petType.IsSet && petType.Value == null)
-                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
-
             if (name.IsSet && name.Value == null)
                 throw new ArgumentNullException(nameof(name), "Property is not nullable for class ChildCat.");
+
+            if (petType.IsSet && petType.Value == null)
+                throw new ArgumentNullException(nameof(petType), "Property is not nullable for class ChildCat.");
 
             return new ChildCat(name);
         }
@@ -171,10 +171,10 @@ namespace Org.OpenAPITools.Model
             if (childCat.NameOption.IsSet && childCat.Name == null)
                 throw new ArgumentNullException(nameof(childCat.Name), "Property is required for class ChildCat.");
 
-            writer.WriteString("pet_type", ChildCatAllOfPetTypeValueConverter.ToJsonValue(childCat.PetType));
-
             if (childCat.NameOption.IsSet)
                 writer.WriteString("name", childCat.Name);
+
+            writer.WriteString("pet_type", ChildCatAllOfPetTypeValueConverter.ToJsonValue(childCat.PetType));
         }
     }
 }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -38,9 +38,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber</param>
         /// <param name="enumString">enumString</param>
         /// <param name="outerEnum">outerEnum</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue</param>
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed)</param>
         /// <param name="outerEnumInteger">outerEnumInteger</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0)</param>
         [JsonConstructor]
         public EnumTest(EnumTestEnumString enumStringRequired, Option<EnumTestEnumInteger?> enumInteger = default, Option<EnumTestEnumIntegerOnly?> enumIntegerOnly = default, Option<TestEnumParametersEnumQueryDoubleParameter?> enumNumber = default, Option<EnumTestEnumString?> enumString = default, Option<OuterEnum?> outerEnum = default, Option<OuterEnumDefaultValue?> outerEnumDefaultValue = default, Option<OuterEnumInteger?> outerEnumInteger = default, Option<OuterEnumIntegerDefaultValue?> outerEnumIntegerDefaultValue = default)
         {

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/docs/models/EnumTest.md
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/docs/models/EnumTest.md
@@ -10,9 +10,9 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **EnumString** | **string** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -40,9 +40,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber</param>
         /// <param name="enumString">enumString</param>
         /// <param name="outerEnum">outerEnum</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue</param>
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed)</param>
         /// <param name="outerEnumInteger">outerEnumInteger</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0)</param>
         [JsonConstructor]
         public EnumTest(EnumStringRequiredEnum enumStringRequired, Option<EnumIntegerEnum?> enumInteger = default, Option<EnumIntegerOnlyEnum?> enumIntegerOnly = default, Option<EnumNumberEnum?> enumNumber = default, Option<EnumStringEnum?> enumString = default, Option<OuterEnum?> outerEnum = default, Option<OuterEnumDefaultValue?> outerEnumDefaultValue = default, Option<OuterEnumInteger?> outerEnumInteger = default, Option<OuterEnumIntegerDefaultValue?> outerEnumIntegerDefaultValue = default)
         {

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/docs/models/EnumTest.md
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/docs/models/EnumTest.md
@@ -10,9 +10,9 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **EnumString** | **string** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -38,9 +38,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber</param>
         /// <param name="enumString">enumString</param>
         /// <param name="outerEnum">outerEnum</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue</param>
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed)</param>
         /// <param name="outerEnumInteger">outerEnumInteger</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0)</param>
         [JsonConstructor]
         public EnumTest(EnumStringRequiredEnum enumStringRequired, Option<EnumIntegerEnum?> enumInteger = default, Option<EnumIntegerOnlyEnum?> enumIntegerOnly = default, Option<EnumNumberEnum?> enumNumber = default, Option<EnumStringEnum?> enumString = default, Option<OuterEnum?> outerEnum = default, Option<OuterEnumDefaultValue?> outerEnumDefaultValue = default, Option<OuterEnumInteger?> outerEnumInteger = default, Option<OuterEnumIntegerDefaultValue?> outerEnumIntegerDefaultValue = default)
         {

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/docs/models/EnumTest.md
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/docs/models/EnumTest.md
@@ -10,9 +10,9 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **EnumString** | **string** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -41,9 +41,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber</param>
         /// <param name="enumString">enumString</param>
         /// <param name="outerEnum">outerEnum</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue</param>
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed)</param>
         /// <param name="outerEnumInteger">outerEnumInteger</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0)</param>
         [JsonConstructor]
         public EnumTest(EnumStringRequiredEnum enumStringRequired, Option<EnumIntegerEnum?> enumInteger = default, Option<EnumIntegerOnlyEnum?> enumIntegerOnly = default, Option<EnumNumberEnum?> enumNumber = default, Option<EnumStringEnum?> enumString = default, Option<OuterEnum?> outerEnum = default, Option<OuterEnumDefaultValue?> outerEnumDefaultValue = default, Option<OuterEnumInteger?> outerEnumInteger = default, Option<OuterEnumIntegerDefaultValue?> outerEnumIntegerDefaultValue = default)
         {

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/docs/models/EnumTest.md
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/docs/models/EnumTest.md
@@ -10,9 +10,9 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **EnumString** | **string** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -38,9 +38,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber</param>
         /// <param name="enumString">enumString</param>
         /// <param name="outerEnum">outerEnum</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue</param>
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed)</param>
         /// <param name="outerEnumInteger">outerEnumInteger</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0)</param>
         [JsonConstructor]
         public EnumTest(EnumStringRequiredEnum enumStringRequired, Option<EnumIntegerEnum?> enumInteger = default, Option<EnumIntegerOnlyEnum?> enumIntegerOnly = default, Option<EnumNumberEnum?> enumNumber = default, Option<EnumStringEnum?> enumString = default, Option<OuterEnum?> outerEnum = default, Option<OuterEnumDefaultValue?> outerEnumDefaultValue = default, Option<OuterEnumInteger?> outerEnumInteger = default, Option<OuterEnumIntegerDefaultValue?> outerEnumIntegerDefaultValue = default)
         {

--- a/samples/client/petstore/csharp/httpclient/net10/Petstore/docs/EnumTest.md
+++ b/samples/client/petstore/csharp/httpclient/net10/Petstore/docs/EnumTest.md
@@ -11,8 +11,8 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/httpclient/net10/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/httpclient/net10/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -266,9 +266,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber.</param>
         /// <param name="outerEnum">outerEnum.</param>
         /// <param name="outerEnumInteger">outerEnumInteger.</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = default, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default)
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed).</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0).</param>
+        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = OuterEnumDefaultValue.Placed, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue.NUMBER_0)
         {
             this.EnumStringRequired = enumStringRequired;
             this.EnumString = enumString;

--- a/samples/client/petstore/csharp/httpclient/net9/Petstore/docs/EnumTest.md
+++ b/samples/client/petstore/csharp/httpclient/net9/Petstore/docs/EnumTest.md
@@ -11,8 +11,8 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/httpclient/net9/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/httpclient/net9/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -266,9 +266,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber.</param>
         /// <param name="outerEnum">outerEnum.</param>
         /// <param name="outerEnumInteger">outerEnumInteger.</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = default, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default)
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed).</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0).</param>
+        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = OuterEnumDefaultValue.Placed, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue.NUMBER_0)
         {
             this.EnumStringRequired = enumStringRequired;
             this.EnumString = enumString;

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/docs/EnumTest.md
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/docs/EnumTest.md
@@ -11,8 +11,8 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -266,9 +266,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber.</param>
         /// <param name="outerEnum">outerEnum.</param>
         /// <param name="outerEnumInteger">outerEnumInteger.</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = default, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default)
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed).</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0).</param>
+        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = OuterEnumDefaultValue.Placed, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue.NUMBER_0)
         {
             this.EnumStringRequired = enumStringRequired;
             this.EnumString = enumString;

--- a/samples/client/petstore/csharp/restsharp/net10/Petstore/docs/EnumTest.md
+++ b/samples/client/petstore/csharp/restsharp/net10/Petstore/docs/EnumTest.md
@@ -11,8 +11,8 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net10/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/restsharp/net10/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -265,9 +265,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber.</param>
         /// <param name="outerEnum">outerEnum.</param>
         /// <param name="outerEnumInteger">outerEnumInteger.</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = default, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default)
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed).</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0).</param>
+        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = OuterEnumDefaultValue.Placed, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue.NUMBER_0)
         {
             this.EnumStringRequired = enumStringRequired;
             this.EnumString = enumString;

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/docs/EnumTest.md
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/docs/EnumTest.md
@@ -11,8 +11,8 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -265,9 +265,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber.</param>
         /// <param name="outerEnum">outerEnum.</param>
         /// <param name="outerEnumInteger">outerEnumInteger.</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = default, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default)
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed).</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0).</param>
+        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = OuterEnumDefaultValue.Placed, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue.NUMBER_0)
         {
             this.EnumStringRequired = enumStringRequired;
             this.EnumString = enumString;

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/docs/EnumTest.md
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/docs/EnumTest.md
@@ -11,8 +11,8 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -265,9 +265,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber.</param>
         /// <param name="outerEnum">outerEnum.</param>
         /// <param name="outerEnumInteger">outerEnumInteger.</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = default, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default)
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed).</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0).</param>
+        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = OuterEnumDefaultValue.Placed, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue.NUMBER_0)
         {
             this.EnumStringRequired = enumStringRequired;
             this.EnumString = enumString;

--- a/samples/client/petstore/csharp/restsharp/net8/EnumMappings/docs/EnumTest.md
+++ b/samples/client/petstore/csharp/restsharp/net8/EnumMappings/docs/EnumTest.md
@@ -11,8 +11,8 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net8/EnumMappings/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/restsharp/net8/EnumMappings/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -265,9 +265,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber.</param>
         /// <param name="outerEnum">outerEnum.</param>
         /// <param name="outerEnumInteger">outerEnumInteger.</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = default, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default)
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed).</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0).</param>
+        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = OuterEnumDefaultValue.Placed, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue.NUMBER_0)
         {
             this.EnumStringRequired = enumStringRequired;
             this.EnumString = enumString;

--- a/samples/client/petstore/csharp/restsharp/net8/Petstore/docs/EnumTest.md
+++ b/samples/client/petstore/csharp/restsharp/net8/Petstore/docs/EnumTest.md
@@ -11,8 +11,8 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net8/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/restsharp/net8/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -262,9 +262,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber.</param>
         /// <param name="outerEnum">outerEnum.</param>
         /// <param name="outerEnumInteger">outerEnumInteger.</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = default, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default)
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed).</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0).</param>
+        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = OuterEnumDefaultValue.Placed, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue.NUMBER_0)
         {
             this.EnumStringRequired = enumStringRequired;
             this.EnumString = enumString;

--- a/samples/client/petstore/csharp/restsharp/net9/EnumMappings/docs/EnumTest.md
+++ b/samples/client/petstore/csharp/restsharp/net9/EnumMappings/docs/EnumTest.md
@@ -11,8 +11,8 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net9/EnumMappings/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/restsharp/net9/EnumMappings/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -265,9 +265,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber.</param>
         /// <param name="outerEnum">outerEnum.</param>
         /// <param name="outerEnumInteger">outerEnumInteger.</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = default, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default)
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed).</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0).</param>
+        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = OuterEnumDefaultValue.Placed, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue.NUMBER_0)
         {
             this.EnumStringRequired = enumStringRequired;
             this.EnumString = enumString;

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/docs/EnumTest.md
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/docs/EnumTest.md
@@ -11,8 +11,8 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -445,9 +445,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber.</param>
         /// <param name="outerEnum">outerEnum.</param>
         /// <param name="outerEnumInteger">outerEnumInteger.</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = default, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default)
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed).</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0).</param>
+        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = OuterEnumDefaultValue.Placed, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue.NUMBER_0)
         {
             this._EnumStringRequired = enumStringRequired;
             this._EnumString = enumString;
@@ -479,16 +479,6 @@ namespace Org.OpenAPITools.Model
             if (this.OuterEnumInteger != null)
             {
                 this._flagOuterEnumInteger = true;
-            }
-            this._OuterEnumDefaultValue = outerEnumDefaultValue;
-            if (this.OuterEnumDefaultValue != null)
-            {
-                this._flagOuterEnumDefaultValue = true;
-            }
-            this._OuterEnumIntegerDefaultValue = outerEnumIntegerDefaultValue;
-            if (this.OuterEnumIntegerDefaultValue != null)
-            {
-                this._flagOuterEnumIntegerDefaultValue = true;
             }
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/docs/EnumTest.md
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/docs/EnumTest.md
@@ -11,8 +11,8 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -265,9 +265,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber.</param>
         /// <param name="outerEnum">outerEnum.</param>
         /// <param name="outerEnumInteger">outerEnumInteger.</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = default, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default)
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed).</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0).</param>
+        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = OuterEnumDefaultValue.Placed, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue.NUMBER_0)
         {
             this.EnumStringRequired = enumStringRequired;
             this.EnumString = enumString;

--- a/samples/client/petstore/csharp/unityWebRequest/net10/Petstore/docs/EnumTest.md
+++ b/samples/client/petstore/csharp/unityWebRequest/net10/Petstore/docs/EnumTest.md
@@ -11,8 +11,8 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/unityWebRequest/net10/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/net10/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -260,9 +260,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber.</param>
         /// <param name="outerEnum">outerEnum.</param>
         /// <param name="outerEnumInteger">outerEnumInteger.</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = default, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default)
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed).</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0).</param>
+        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = OuterEnumDefaultValue.Placed, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue.NUMBER_0)
         {
             this.EnumStringRequired = enumStringRequired;
             this.EnumString = enumString;

--- a/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/docs/EnumTest.md
+++ b/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/docs/EnumTest.md
@@ -11,8 +11,8 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -260,9 +260,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber.</param>
         /// <param name="outerEnum">outerEnum.</param>
         /// <param name="outerEnumInteger">outerEnumInteger.</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = default, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default)
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed).</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0).</param>
+        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = OuterEnumDefaultValue.Placed, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue.NUMBER_0)
         {
             this.EnumStringRequired = enumStringRequired;
             this.EnumString = enumString;

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/docs/EnumTest.md
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/docs/EnumTest.md
@@ -11,8 +11,8 @@ Name | Type | Description | Notes
 **EnumNumber** | **double** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] [default to OuterEnumDefaultValue.Placed]
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] [default to OuterEnumIntegerDefaultValue.NUMBER_0]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -260,9 +260,9 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumNumber">enumNumber.</param>
         /// <param name="outerEnum">outerEnum.</param>
         /// <param name="outerEnumInteger">outerEnumInteger.</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = default, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default)
+        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue (default to OuterEnumDefaultValue.Placed).</param>
+        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue (default to OuterEnumIntegerDefaultValue.NUMBER_0).</param>
+        public EnumTest(EnumStringEnum? enumString = default, EnumStringRequiredEnum enumStringRequired = default, EnumIntegerEnum? enumInteger = default, EnumIntegerOnlyEnum? enumIntegerOnly = default, EnumNumberEnum? enumNumber = default, OuterEnum? outerEnum = default, OuterEnumInteger? outerEnumInteger = default, OuterEnumDefaultValue? outerEnumDefaultValue = OuterEnumDefaultValue.Placed, OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue.NUMBER_0)
         {
             this.EnumStringRequired = enumStringRequired;
             this.EnumString = enumString;

--- a/samples/client/petstore/javascript-apollo/docs/EnumTest.md
+++ b/samples/client/petstore/javascript-apollo/docs/EnumTest.md
@@ -10,8 +10,8 @@ Name | Type | Description | Notes
 **enumNumber** | **Number** |  | [optional] 
 **outerEnum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
 **outerEnumInteger** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] 
-**outerEnumDefaultValue** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] 
-**outerEnumIntegerDefaultValue** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] 
+**outerEnumDefaultValue** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] [default to &#39;placed&#39;]
+**outerEnumIntegerDefaultValue** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] [default to OuterEnumIntegerDefaultValue.0]
 
 
 

--- a/samples/client/petstore/javascript-apollo/src/model/EnumTest.js
+++ b/samples/client/petstore/javascript-apollo/src/model/EnumTest.js
@@ -40,6 +40,8 @@ class EnumTest {
      */
     static initialize(obj, enumStringRequired) { 
         obj['enum_string_required'] = enumStringRequired;
+        obj['outerEnumDefaultValue'] = 'placed';
+        obj['outerEnumIntegerDefaultValue'] = OuterEnumIntegerDefaultValue.0;
     }
 
     /**
@@ -142,13 +144,15 @@ EnumTest.prototype['outerEnumInteger'] = undefined;
 
 /**
  * @member {module:model/OuterEnumDefaultValue} outerEnumDefaultValue
+ * @default 'placed'
  */
-EnumTest.prototype['outerEnumDefaultValue'] = undefined;
+EnumTest.prototype['outerEnumDefaultValue'] = 'placed';
 
 /**
  * @member {module:model/OuterEnumIntegerDefaultValue} outerEnumIntegerDefaultValue
+ * @default OuterEnumIntegerDefaultValue.0
  */
-EnumTest.prototype['outerEnumIntegerDefaultValue'] = undefined;
+EnumTest.prototype['outerEnumIntegerDefaultValue'] = OuterEnumIntegerDefaultValue.0;
 
 
 

--- a/samples/client/petstore/javascript-es6/docs/EnumTest.md
+++ b/samples/client/petstore/javascript-es6/docs/EnumTest.md
@@ -10,8 +10,8 @@ Name | Type | Description | Notes
 **enumNumber** | **Number** |  | [optional] 
 **outerEnum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
 **outerEnumInteger** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] 
-**outerEnumDefaultValue** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] 
-**outerEnumIntegerDefaultValue** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] 
+**outerEnumDefaultValue** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] [default to &#39;placed&#39;]
+**outerEnumIntegerDefaultValue** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] [default to OuterEnumIntegerDefaultValue.0]
 
 
 

--- a/samples/client/petstore/javascript-es6/src/model/EnumTest.js
+++ b/samples/client/petstore/javascript-es6/src/model/EnumTest.js
@@ -40,6 +40,8 @@ class EnumTest {
      */
     static initialize(obj, enumStringRequired) { 
         obj['enum_string_required'] = enumStringRequired;
+        obj['outerEnumDefaultValue'] = 'placed';
+        obj['outerEnumIntegerDefaultValue'] = OuterEnumIntegerDefaultValue.0;
     }
 
     /**
@@ -142,13 +144,15 @@ EnumTest.prototype['outerEnumInteger'] = undefined;
 
 /**
  * @member {module:model/OuterEnumDefaultValue} outerEnumDefaultValue
+ * @default 'placed'
  */
-EnumTest.prototype['outerEnumDefaultValue'] = undefined;
+EnumTest.prototype['outerEnumDefaultValue'] = 'placed';
 
 /**
  * @member {module:model/OuterEnumIntegerDefaultValue} outerEnumIntegerDefaultValue
+ * @default OuterEnumIntegerDefaultValue.0
  */
-EnumTest.prototype['outerEnumIntegerDefaultValue'] = undefined;
+EnumTest.prototype['outerEnumIntegerDefaultValue'] = OuterEnumIntegerDefaultValue.0;
 
 
 

--- a/samples/client/petstore/javascript-promise-es6/docs/EnumTest.md
+++ b/samples/client/petstore/javascript-promise-es6/docs/EnumTest.md
@@ -10,8 +10,8 @@ Name | Type | Description | Notes
 **enumNumber** | **Number** |  | [optional] 
 **outerEnum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
 **outerEnumInteger** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] 
-**outerEnumDefaultValue** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] 
-**outerEnumIntegerDefaultValue** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] 
+**outerEnumDefaultValue** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] [default to &#39;placed&#39;]
+**outerEnumIntegerDefaultValue** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] [default to OuterEnumIntegerDefaultValue.0]
 
 
 

--- a/samples/client/petstore/javascript-promise-es6/src/model/EnumTest.js
+++ b/samples/client/petstore/javascript-promise-es6/src/model/EnumTest.js
@@ -40,6 +40,8 @@ class EnumTest {
      */
     static initialize(obj, enumStringRequired) { 
         obj['enum_string_required'] = enumStringRequired;
+        obj['outerEnumDefaultValue'] = 'placed';
+        obj['outerEnumIntegerDefaultValue'] = OuterEnumIntegerDefaultValue.0;
     }
 
     /**
@@ -142,13 +144,15 @@ EnumTest.prototype['outerEnumInteger'] = undefined;
 
 /**
  * @member {module:model/OuterEnumDefaultValue} outerEnumDefaultValue
+ * @default 'placed'
  */
-EnumTest.prototype['outerEnumDefaultValue'] = undefined;
+EnumTest.prototype['outerEnumDefaultValue'] = 'placed';
 
 /**
  * @member {module:model/OuterEnumIntegerDefaultValue} outerEnumIntegerDefaultValue
+ * @default OuterEnumIntegerDefaultValue.0
  */
-EnumTest.prototype['outerEnumIntegerDefaultValue'] = undefined;
+EnumTest.prototype['outerEnumIntegerDefaultValue'] = OuterEnumIntegerDefaultValue.0;
 
 
 

--- a/samples/client/petstore/perl/docs/EnumTest.md
+++ b/samples/client/petstore/perl/docs/EnumTest.md
@@ -14,8 +14,8 @@ Name | Type | Description | Notes
 **enum_number** | **double** |  | [optional] 
 **outer_enum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
 **outer_enum_integer** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] 
-**outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] 
-**outer_enum_integer_default_value** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] 
+**outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] [default to &#39;placed&#39;]
+**outer_enum_integer_default_value** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] [default to 0]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/docs/Api/FakeApi.md
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/docs/Api/FakeApi.md
@@ -163,7 +163,7 @@ $apiInstance = new OpenAPI\Client\Api\FakeApi(
     new GuzzleHttp\Client()
 );
 $enum_class = new \OpenAPI\Client\Model\\OpenAPI\Client\Model\EnumClass(); // \OpenAPI\Client\Model\EnumClass | enum class parameter
-$enum_class_array = array(new \OpenAPI\Client\Model\\OpenAPI\Client\Model\EnumClass()); // \OpenAPI\Client\Model\EnumClass[] | enum class parameter
+$enum_class_array = ; // \OpenAPI\Client\Model\EnumClass[] | enum class parameter
 $enum_class_map = array('key' => new \OpenAPI\Client\Model\\OpenAPI\Client\Model\EnumClass()); // array<string,\OpenAPI\Client\Model\EnumClass> | enum class parameter
 
 try {
@@ -1251,7 +1251,7 @@ $enum_query_string_array = ['$']; // string[] | Query parameter enum test (strin
 $enum_query_string = '-efg'; // string | Query parameter enum test (string)
 $enum_query_integer = 56; // int | Query parameter enum test (double)
 $enum_query_double = 3.4; // float | Query parameter enum test (double)
-$enum_query_model_array = array(new \OpenAPI\Client\Model\\OpenAPI\Client\Model\EnumClass()); // \OpenAPI\Client\Model\EnumClass[]
+$enum_query_model_array = ; // \OpenAPI\Client\Model\EnumClass[]
 $enum_form_string_array = ['$']; // string[] | Form parameter enum test (string array)
 $enum_form_string = '-efg'; // string | Form parameter enum test (string)
 

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/docs/Model/EnumTest.md
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/docs/Model/EnumTest.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 **enum_number** | **float** |  | [optional]
 **outer_enum** | [**\OpenAPI\Client\Model\OuterEnum**](OuterEnum.md) |  | [optional]
 **outer_enum_integer** | [**\OpenAPI\Client\Model\OuterEnumInteger**](OuterEnumInteger.md) |  | [optional]
-**outer_enum_default_value** | [**\OpenAPI\Client\Model\OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional]
-**outer_enum_integer_default_value** | [**\OpenAPI\Client\Model\OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional]
+**outer_enum_default_value** | [**\OpenAPI\Client\Model\OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] [default to OuterEnumDefaultValue::PLACED]
+**outer_enum_integer_default_value** | [**\OpenAPI\Client\Model\OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] [default to 0]
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumTest.php
@@ -335,8 +335,8 @@ class EnumTest implements ModelInterface, ArrayAccess, JsonSerializable
         $this->setIfExists('enum_number', $data ?? [], null);
         $this->setIfExists('outer_enum', $data ?? [], null);
         $this->setIfExists('outer_enum_integer', $data ?? [], null);
-        $this->setIfExists('outer_enum_default_value', $data ?? [], null);
-        $this->setIfExists('outer_enum_integer_default_value', $data ?? [], null);
+        $this->setIfExists('outer_enum_default_value', $data ?? [], OuterEnumDefaultValue::PLACED);
+        $this->setIfExists('outer_enum_integer_default_value', $data ?? [], 0);
     }
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Model/EnumTest.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Model/EnumTest.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 **enum_number** | **float** |  | [optional]
 **outer_enum** | [**\OpenAPI\Client\Model\OuterEnum**](OuterEnum.md) |  | [optional]
 **outer_enum_integer** | [**\OpenAPI\Client\Model\OuterEnumInteger**](OuterEnumInteger.md) |  | [optional]
-**outer_enum_default_value** | [**\OpenAPI\Client\Model\OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional]
-**outer_enum_integer_default_value** | [**\OpenAPI\Client\Model\OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional]
+**outer_enum_default_value** | [**\OpenAPI\Client\Model\OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] [default to OuterEnumDefaultValue::PLACED]
+**outer_enum_integer_default_value** | [**\OpenAPI\Client\Model\OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] [default to 0]
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
@@ -356,8 +356,8 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
         $this->setIfExists('enum_number', $data ?? [], null);
         $this->setIfExists('outer_enum', $data ?? [], null);
         $this->setIfExists('outer_enum_integer', $data ?? [], null);
-        $this->setIfExists('outer_enum_default_value', $data ?? [], null);
-        $this->setIfExists('outer_enum_integer_default_value', $data ?? [], null);
+        $this->setIfExists('outer_enum_default_value', $data ?? [], OuterEnumDefaultValue::PLACED);
+        $this->setIfExists('outer_enum_integer_default_value', $data ?? [], 0);
     }
 
     /**

--- a/samples/client/petstore/php/psr-18/docs/Model/EnumTest.md
+++ b/samples/client/petstore/php/psr-18/docs/Model/EnumTest.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 **enum_number** | **float** |  | [optional]
 **outer_enum** | [**\OpenAPI\Client\Model\OuterEnum**](OuterEnum.md) |  | [optional]
 **outer_enum_integer** | [**\OpenAPI\Client\Model\OuterEnumInteger**](OuterEnumInteger.md) |  | [optional]
-**outer_enum_default_value** | [**\OpenAPI\Client\Model\OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional]
-**outer_enum_integer_default_value** | [**\OpenAPI\Client\Model\OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional]
+**outer_enum_default_value** | [**\OpenAPI\Client\Model\OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] [default to OuterEnumDefaultValue::PLACED]
+**outer_enum_integer_default_value** | [**\OpenAPI\Client\Model\OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] [default to 0]
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/samples/client/petstore/php/psr-18/lib/Model/EnumTest.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/EnumTest.php
@@ -356,8 +356,8 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
         $this->setIfExists('enum_number', $data ?? [], null);
         $this->setIfExists('outer_enum', $data ?? [], null);
         $this->setIfExists('outer_enum_integer', $data ?? [], null);
-        $this->setIfExists('outer_enum_default_value', $data ?? [], null);
-        $this->setIfExists('outer_enum_integer_default_value', $data ?? [], null);
+        $this->setIfExists('outer_enum_default_value', $data ?? [], OuterEnumDefaultValue::PLACED);
+        $this->setIfExists('outer_enum_integer_default_value', $data ?? [], 0);
     }
 
     /**

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/docs/EnumTest.md
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/docs/EnumTest.md
@@ -12,8 +12,8 @@ Name | Type | Description | Notes
 **enum_number** | **number** |  | [optional] [default to undefined]
 **outerEnum** | [**OuterEnum**](OuterEnum.md) |  | [optional] [default to undefined]
 **outerEnumInteger** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] [default to undefined]
-**outerEnumDefaultValue** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] [default to undefined]
-**outerEnumIntegerDefaultValue** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] [default to undefined]
+**outerEnumDefaultValue** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] [default to OuterEnumDefaultValue_Placed]
+**outerEnumIntegerDefaultValue** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] [default to OuterEnumIntegerDefaultValue_NUMBER_0]
 
 ## Example
 

--- a/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/docs/EnumTest.md
+++ b/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/docs/EnumTest.md
@@ -11,8 +11,8 @@ Name | Type | Description | Notes
 **enum_number** | **number** |  | [optional] [default to undefined]
 **outerEnum** | [**OuterEnum**](OuterEnum.md) |  | [optional] [default to undefined]
 **outerEnumInteger** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] [default to undefined]
-**outerEnumDefaultValue** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] [default to undefined]
-**outerEnumIntegerDefaultValue** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] [default to undefined]
+**outerEnumDefaultValue** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] [default to OuterEnumDefaultValue_Placed]
+**outerEnumIntegerDefaultValue** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] [default to OuterEnumIntegerDefaultValue_NUMBER_0]
 
 ## Example
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/doc/EnumTest.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/doc/EnumTest.md
@@ -14,8 +14,8 @@ Name | Type | Description | Notes
 **enumNumber** | **double** |  | [optional] 
 **outerEnum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
 **outerEnumInteger** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] 
-**outerEnumDefaultValue** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] 
-**outerEnumIntegerDefaultValue** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] 
+**outerEnumDefaultValue** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] [default to 'placed']
+**outerEnumIntegerDefaultValue** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] [default to OuterEnumIntegerDefaultValue.number0]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/enum_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/enum_test.dart
@@ -36,9 +36,9 @@ class EnumTest {
 
      this.outerEnumInteger,
 
-     this.outerEnumDefaultValue,
+     this.outerEnumDefaultValue = 'placed',
 
-     this.outerEnumIntegerDefaultValue,
+     this.outerEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue.number0,
   });
 
   @JsonKey(
@@ -120,7 +120,7 @@ class EnumTest {
 
 
   @JsonKey(
-    
+    defaultValue: 'placed',
     name: r'outerEnumDefaultValue',
     required: false,
     includeIfNull: false,
@@ -133,7 +133,7 @@ class EnumTest {
 
 
   @JsonKey(
-    
+    defaultValue: OuterEnumIntegerDefaultValue.number0,
     name: r'outerEnumIntegerDefaultValue',
     required: false,
     includeIfNull: false,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/EnumTest.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/EnumTest.md
@@ -14,8 +14,8 @@ Name | Type | Description | Notes
 **enumNumber** | **double** |  | [optional] 
 **outerEnum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
 **outerEnumInteger** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] 
-**outerEnumDefaultValue** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] 
-**outerEnumIntegerDefaultValue** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] 
+**outerEnumDefaultValue** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] [default to 'placed']
+**outerEnumIntegerDefaultValue** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] [default to OuterEnumIntegerDefaultValue.number0]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/enum_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/enum_test.dart
@@ -63,7 +63,9 @@ abstract class EnumTest implements Built<EnumTest, EnumTestBuilder> {
   factory EnumTest([void updates(EnumTestBuilder b)]) = _$EnumTest;
 
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults(EnumTestBuilder b) => b;
+  static void _defaults(EnumTestBuilder b) => b
+      ..outerEnumDefaultValue = 'placed'
+      ..outerEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue.number0;
 
   @BuiltValueSerializer(custom: true)
   static Serializer<EnumTest> get serializer => _$EnumTestSerializer();

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/doc/EnumTest.md
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/doc/EnumTest.md
@@ -14,8 +14,8 @@ Name | Type | Description | Notes
 **enumNumber** | **double** |  | [optional] 
 **outerEnum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
 **outerEnumInteger** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] 
-**outerEnumDefaultValue** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] 
-**outerEnumIntegerDefaultValue** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] 
+**outerEnumDefaultValue** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] [default to 'placed']
+**outerEnumIntegerDefaultValue** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] [default to OuterEnumIntegerDefaultValue.number0]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_test.dart
@@ -19,8 +19,8 @@ class EnumTest {
     this.enumNumber,
     this.outerEnum,
     this.outerEnumInteger,
-    this.outerEnumDefaultValue,
-    this.outerEnumIntegerDefaultValue,
+    this.outerEnumDefaultValue = 'placed',
+    this.outerEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue.number0,
   });
 
   EnumTestEnumStringEnum? enumString;
@@ -41,21 +41,9 @@ class EnumTest {
   ///
   OuterEnumInteger? outerEnumInteger;
 
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  OuterEnumDefaultValue? outerEnumDefaultValue;
+  OuterEnumDefaultValue outerEnumDefaultValue;
 
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue;
+  OuterEnumIntegerDefaultValue outerEnumIntegerDefaultValue;
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is EnumTest &&
@@ -77,8 +65,8 @@ class EnumTest {
     (enumNumber == null ? 0 : enumNumber!.hashCode) +
     (outerEnum == null ? 0 : outerEnum!.hashCode) +
     (outerEnumInteger == null ? 0 : outerEnumInteger!.hashCode) +
-    (outerEnumDefaultValue == null ? 0 : outerEnumDefaultValue!.hashCode) +
-    (outerEnumIntegerDefaultValue == null ? 0 : outerEnumIntegerDefaultValue!.hashCode);
+    (outerEnumDefaultValue.hashCode) +
+    (outerEnumIntegerDefaultValue.hashCode);
 
   @override
   String toString() => 'EnumTest[enumString=$enumString, enumStringRequired=$enumStringRequired, enumInteger=$enumInteger, enumNumber=$enumNumber, outerEnum=$outerEnum, outerEnumInteger=$outerEnumInteger, outerEnumDefaultValue=$outerEnumDefaultValue, outerEnumIntegerDefaultValue=$outerEnumIntegerDefaultValue]';
@@ -111,16 +99,8 @@ class EnumTest {
     } else {
       json[r'outerEnumInteger'] = null;
     }
-    if (this.outerEnumDefaultValue != null) {
       json[r'outerEnumDefaultValue'] = this.outerEnumDefaultValue;
-    } else {
-      json[r'outerEnumDefaultValue'] = null;
-    }
-    if (this.outerEnumIntegerDefaultValue != null) {
       json[r'outerEnumIntegerDefaultValue'] = this.outerEnumIntegerDefaultValue;
-    } else {
-      json[r'outerEnumIntegerDefaultValue'] = null;
-    }
     return json;
   }
 
@@ -147,8 +127,8 @@ class EnumTest {
         enumNumber: EnumTestEnumNumberEnum.fromJson(json[r'enum_number']),
         outerEnum: OuterEnum.fromJson(json[r'outerEnum']),
         outerEnumInteger: OuterEnumInteger.fromJson(json[r'outerEnumInteger']),
-        outerEnumDefaultValue: OuterEnumDefaultValue.fromJson(json[r'outerEnumDefaultValue']),
-        outerEnumIntegerDefaultValue: OuterEnumIntegerDefaultValue.fromJson(json[r'outerEnumIntegerDefaultValue']),
+        outerEnumDefaultValue: OuterEnumDefaultValue.fromJson(json[r'outerEnumDefaultValue']) ?? 'placed',
+        outerEnumIntegerDefaultValue: OuterEnumIntegerDefaultValue.fromJson(json[r'outerEnumIntegerDefaultValue']) ?? OuterEnumIntegerDefaultValue.number0,
       );
     }
     return null;

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/docs/EnumRefWithDefaultValue.md
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/docs/EnumRefWithDefaultValue.md
@@ -4,7 +4,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**report_format** | [**DataOutputFormat**](DataOutputFormat.md) |  | [optional] 
+**report_format** | [**DataOutputFormat**](DataOutputFormat.md) |  | [optional] [default to 'JSON']
 
 ## Example
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/docs/EnumTest.md
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/docs/EnumTest.md
@@ -13,8 +13,8 @@ Name | Type | Description | Notes
 **enum_integer_single_member** | **int** |  | [optional] 
 **outer_enum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
 **outer_enum_integer** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] 
-**outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] 
-**outer_enum_integer_default_value** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] 
+**outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] [default to 'placed']
+**outer_enum_integer_default_value** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] [default to 0]
 **enum_number_vendor_ext** | [**EnumNumberVendorExt**](EnumNumberVendorExt.md) |  | [optional] 
 **enum_string_vendor_ext** | [**EnumStringVendorExt**](EnumStringVendorExt.md) |  | [optional] 
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/docs/TestModelWithEnumDefault.md
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/docs/TestModelWithEnumDefault.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **test_enum** | [**TestEnum**](TestEnum.md) |  | 
 **test_string** | **str** |  | [optional] 
-**test_enum_with_default** | [**TestEnumWithDefault**](TestEnumWithDefault.md) |  | [optional] 
+**test_enum_with_default** | [**TestEnumWithDefault**](TestEnumWithDefault.md) |  | [optional] [default to 'ZWEI']
 **test_string_with_default** | **str** |  | [optional] [default to 'ahoy matey']
 **test_inline_defined_enum_with_default** | **str** |  | [optional] [default to 'B']
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/enum_ref_with_default_value.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/enum_ref_with_default_value.py
@@ -26,7 +26,7 @@ class EnumRefWithDefaultValue(BaseModel):
     """
     EnumRefWithDefaultValue
     """
-    report_format: Optional[DataOutputFormat] = None
+    report_format: Optional[DataOutputFormat] = 'JSON'
     __properties = ["report_format"]
 
     class Config:
@@ -65,7 +65,7 @@ class EnumRefWithDefaultValue(BaseModel):
             return EnumRefWithDefaultValue.parse_obj(obj)
 
         _obj = EnumRefWithDefaultValue.parse_obj({
-            "report_format": obj.get("report_format")
+            "report_format": obj.get("report_format") if obj.get("report_format") is not None else 'JSON'
         })
         return _obj
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/enum_test.py
@@ -40,8 +40,8 @@ class EnumTest(BaseModel):
     enum_integer_single_member: Optional[StrictInt] = None
     outer_enum: Optional[OuterEnum] = Field(default=None, alias="outerEnum")
     outer_enum_integer: Optional[OuterEnumInteger] = Field(default=None, alias="outerEnumInteger")
-    outer_enum_default_value: Optional[OuterEnumDefaultValue] = Field(default=None, alias="outerEnumDefaultValue")
-    outer_enum_integer_default_value: Optional[OuterEnumIntegerDefaultValue] = Field(default=None, alias="outerEnumIntegerDefaultValue")
+    outer_enum_default_value: Optional[OuterEnumDefaultValue] = Field(default='placed', alias="outerEnumDefaultValue")
+    outer_enum_integer_default_value: Optional[OuterEnumIntegerDefaultValue] = Field(default=0, alias="outerEnumIntegerDefaultValue")
     enum_number_vendor_ext: Optional[EnumNumberVendorExt] = Field(default=None, alias="enumNumberVendorExt")
     enum_string_vendor_ext: Optional[EnumStringVendorExt] = Field(default=None, alias="enumStringVendorExt")
     __properties = ["enum_string", "enum_string_required", "enum_integer_default", "enum_integer", "enum_number", "enum_string_single_member", "enum_integer_single_member", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue", "enumNumberVendorExt", "enumStringVendorExt"]
@@ -163,8 +163,8 @@ class EnumTest(BaseModel):
             "enum_integer_single_member": obj.get("enum_integer_single_member"),
             "outer_enum": obj.get("outerEnum"),
             "outer_enum_integer": obj.get("outerEnumInteger"),
-            "outer_enum_default_value": obj.get("outerEnumDefaultValue"),
-            "outer_enum_integer_default_value": obj.get("outerEnumIntegerDefaultValue"),
+            "outer_enum_default_value": obj.get("outerEnumDefaultValue") if obj.get("outerEnumDefaultValue") is not None else 'placed',
+            "outer_enum_integer_default_value": obj.get("outerEnumIntegerDefaultValue") if obj.get("outerEnumIntegerDefaultValue") is not None else 0,
             "enum_number_vendor_ext": obj.get("enumNumberVendorExt"),
             "enum_string_vendor_ext": obj.get("enumStringVendorExt")
         })

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/test_model_with_enum_default.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/test_model_with_enum_default.py
@@ -29,7 +29,7 @@ class TestModelWithEnumDefault(BaseModel):
     """
     test_enum: TestEnum = Field(...)
     test_string: Optional[StrictStr] = None
-    test_enum_with_default: Optional[TestEnumWithDefault] = None
+    test_enum_with_default: Optional[TestEnumWithDefault] = 'ZWEI'
     test_string_with_default: Optional[StrictStr] = 'ahoy matey'
     test_inline_defined_enum_with_default: Optional[StrictStr] = 'B'
     __properties = ["test_enum", "test_string", "test_enum_with_default", "test_string_with_default", "test_inline_defined_enum_with_default"]
@@ -82,7 +82,7 @@ class TestModelWithEnumDefault(BaseModel):
         _obj = TestModelWithEnumDefault.parse_obj({
             "test_enum": obj.get("test_enum"),
             "test_string": obj.get("test_string"),
-            "test_enum_with_default": obj.get("test_enum_with_default"),
+            "test_enum_with_default": obj.get("test_enum_with_default") if obj.get("test_enum_with_default") is not None else 'ZWEI',
             "test_string_with_default": obj.get("test_string_with_default") if obj.get("test_string_with_default") is not None else 'ahoy matey',
             "test_inline_defined_enum_with_default": obj.get("test_inline_defined_enum_with_default") if obj.get("test_inline_defined_enum_with_default") is not None else 'B'
         })

--- a/samples/openapi3/client/petstore/python-pydantic-v1/docs/EnumRefWithDefaultValue.md
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/docs/EnumRefWithDefaultValue.md
@@ -4,7 +4,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**report_format** | [**DataOutputFormat**](DataOutputFormat.md) |  | [optional] 
+**report_format** | [**DataOutputFormat**](DataOutputFormat.md) |  | [optional] [default to 'JSON']
 
 ## Example
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/docs/EnumTest.md
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/docs/EnumTest.md
@@ -13,8 +13,8 @@ Name | Type | Description | Notes
 **enum_integer_single_member** | **int** |  | [optional] 
 **outer_enum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
 **outer_enum_integer** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] 
-**outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] 
-**outer_enum_integer_default_value** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] 
+**outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] [default to 'placed']
+**outer_enum_integer_default_value** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] [default to 0]
 **enum_number_vendor_ext** | [**EnumNumberVendorExt**](EnumNumberVendorExt.md) |  | [optional] 
 **enum_string_vendor_ext** | [**EnumStringVendorExt**](EnumStringVendorExt.md) |  | [optional] 
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/docs/TestModelWithEnumDefault.md
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/docs/TestModelWithEnumDefault.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **test_enum** | [**TestEnum**](TestEnum.md) |  | 
 **test_string** | **str** |  | [optional] 
-**test_enum_with_default** | [**TestEnumWithDefault**](TestEnumWithDefault.md) |  | [optional] 
+**test_enum_with_default** | [**TestEnumWithDefault**](TestEnumWithDefault.md) |  | [optional] [default to 'ZWEI']
 **test_string_with_default** | **str** |  | [optional] [default to 'ahoy matey']
 **test_inline_defined_enum_with_default** | **str** |  | [optional] [default to 'B']
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/enum_ref_with_default_value.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/enum_ref_with_default_value.py
@@ -26,7 +26,7 @@ class EnumRefWithDefaultValue(BaseModel):
     """
     EnumRefWithDefaultValue
     """
-    report_format: Optional[DataOutputFormat] = None
+    report_format: Optional[DataOutputFormat] = 'JSON'
     additional_properties: Dict[str, Any] = {}
     __properties = ["report_format"]
 
@@ -72,7 +72,7 @@ class EnumRefWithDefaultValue(BaseModel):
             return EnumRefWithDefaultValue.parse_obj(obj)
 
         _obj = EnumRefWithDefaultValue.parse_obj({
-            "report_format": obj.get("report_format")
+            "report_format": obj.get("report_format") if obj.get("report_format") is not None else 'JSON'
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/enum_test.py
@@ -40,8 +40,8 @@ class EnumTest(BaseModel):
     enum_integer_single_member: Optional[StrictInt] = None
     outer_enum: Optional[OuterEnum] = Field(default=None, alias="outerEnum")
     outer_enum_integer: Optional[OuterEnumInteger] = Field(default=None, alias="outerEnumInteger")
-    outer_enum_default_value: Optional[OuterEnumDefaultValue] = Field(default=None, alias="outerEnumDefaultValue")
-    outer_enum_integer_default_value: Optional[OuterEnumIntegerDefaultValue] = Field(default=None, alias="outerEnumIntegerDefaultValue")
+    outer_enum_default_value: Optional[OuterEnumDefaultValue] = Field(default='placed', alias="outerEnumDefaultValue")
+    outer_enum_integer_default_value: Optional[OuterEnumIntegerDefaultValue] = Field(default=0, alias="outerEnumIntegerDefaultValue")
     enum_number_vendor_ext: Optional[EnumNumberVendorExt] = Field(default=None, alias="enumNumberVendorExt")
     enum_string_vendor_ext: Optional[EnumStringVendorExt] = Field(default=None, alias="enumStringVendorExt")
     additional_properties: Dict[str, Any] = {}
@@ -170,8 +170,8 @@ class EnumTest(BaseModel):
             "enum_integer_single_member": obj.get("enum_integer_single_member"),
             "outer_enum": obj.get("outerEnum"),
             "outer_enum_integer": obj.get("outerEnumInteger"),
-            "outer_enum_default_value": obj.get("outerEnumDefaultValue"),
-            "outer_enum_integer_default_value": obj.get("outerEnumIntegerDefaultValue"),
+            "outer_enum_default_value": obj.get("outerEnumDefaultValue") if obj.get("outerEnumDefaultValue") is not None else 'placed',
+            "outer_enum_integer_default_value": obj.get("outerEnumIntegerDefaultValue") if obj.get("outerEnumIntegerDefaultValue") is not None else 0,
             "enum_number_vendor_ext": obj.get("enumNumberVendorExt"),
             "enum_string_vendor_ext": obj.get("enumStringVendorExt")
         })

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/test_model_with_enum_default.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/test_model_with_enum_default.py
@@ -29,7 +29,7 @@ class TestModelWithEnumDefault(BaseModel):
     """
     test_enum: TestEnum = Field(...)
     test_string: Optional[StrictStr] = None
-    test_enum_with_default: Optional[TestEnumWithDefault] = None
+    test_enum_with_default: Optional[TestEnumWithDefault] = 'ZWEI'
     test_string_with_default: Optional[StrictStr] = 'ahoy matey'
     test_inline_defined_enum_with_default: Optional[StrictStr] = 'B'
     additional_properties: Dict[str, Any] = {}
@@ -89,7 +89,7 @@ class TestModelWithEnumDefault(BaseModel):
         _obj = TestModelWithEnumDefault.parse_obj({
             "test_enum": obj.get("test_enum"),
             "test_string": obj.get("test_string"),
-            "test_enum_with_default": obj.get("test_enum_with_default"),
+            "test_enum_with_default": obj.get("test_enum_with_default") if obj.get("test_enum_with_default") is not None else 'ZWEI',
             "test_string_with_default": obj.get("test_string_with_default") if obj.get("test_string_with_default") is not None else 'ahoy matey',
             "test_inline_defined_enum_with_default": obj.get("test_inline_defined_enum_with_default") if obj.get("test_inline_defined_enum_with_default") is not None else 'B'
         })

--- a/samples/schema/petstore/mysql/mysql_schema.sql
+++ b/samples/schema/petstore/mysql/mysql_schema.sql
@@ -175,8 +175,8 @@ CREATE TABLE IF NOT EXISTS `Enum_Test` (
   `enum_number` ENUM('1.1', '-1.2') DEFAULT NULL,
   `outerEnum` TEXT DEFAULT NULL,
   `outerEnumInteger` TEXT DEFAULT NULL,
-  `outerEnumDefaultValue` TEXT DEFAULT NULL,
-  `outerEnumIntegerDefaultValue` TEXT DEFAULT NULL
+  `outerEnumDefaultValue` TEXT,
+  `outerEnumIntegerDefaultValue` TEXT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 --

--- a/samples/server/petstore/cpp-restbed/generated/3_0/model/Enum_Test.h
+++ b/samples/server/petstore/cpp-restbed/generated/3_0/model/Enum_Test.h
@@ -115,10 +115,10 @@ protected:
     std::string m_Enum_string_required = "";
     int32_t m_Enum_integer = 0;
     double m_Enum_number = 0.0;
-    OuterEnum m_OuterEnum = OuterEnum{};
-    OuterEnumInteger m_OuterEnumInteger = OuterEnumInteger{};
-    OuterEnumDefaultValue m_OuterEnumDefaultValue = OuterEnumDefaultValue{};
-    OuterEnumIntegerDefaultValue m_OuterEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue{};
+    OuterEnum m_OuterEnum = "";
+    OuterEnumInteger m_OuterEnumInteger = 0;
+    OuterEnumDefaultValue m_OuterEnumDefaultValue = "placed";
+    OuterEnumIntegerDefaultValue m_OuterEnumIntegerDefaultValue = 0;
 };
 
 std::vector<Enum_Test> createEnum_TestVectorFromJsonString(const std::string& json);

--- a/samples/server/petstore/cpp-restbed/generated/3_0/model/OuterObjectWithEnumProperty.h
+++ b/samples/server/petstore/cpp-restbed/generated/3_0/model/OuterObjectWithEnumProperty.h
@@ -65,7 +65,7 @@ public:
     void setValue(OuterEnumInteger value);
 
 protected:
-    OuterEnumInteger m_Value = OuterEnumInteger{};
+    OuterEnumInteger m_Value = 0;
 };
 
 std::vector<OuterObjectWithEnumProperty> createOuterObjectWithEnumPropertyVectorFromJsonString(const std::string& json);

--- a/samples/server/petstore/php-laravel/Model/EnumTest.php
+++ b/samples/server/petstore/php-laravel/Model/EnumTest.php
@@ -65,8 +65,8 @@ class EnumTest
         public \OpenAPI\Server\Model\EnumTestEnumInteger $enumInteger,
         public \OpenAPI\Server\Model\TestEnumParametersEnumQueryDoubleParameter $enumNumber,
         public \OpenAPI\Server\Model\OuterEnumInteger $outerEnumInteger,
-        public \OpenAPI\Server\Model\OuterEnumDefaultValue $outerEnumDefaultValue,
-        public \OpenAPI\Server\Model\OuterEnumIntegerDefaultValue $outerEnumIntegerDefaultValue,
+        public \OpenAPI\Server\Model\OuterEnumDefaultValue $outerEnumDefaultValue = OuterEnumDefaultValue::PLACED,
+        public \OpenAPI\Server\Model\OuterEnumIntegerDefaultValue $outerEnumIntegerDefaultValue = 0,
         public ?\OpenAPI\Server\Model\OuterEnum $outerEnum = null,
     ) {}
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a configurable `DefaultResolutionStrategy` to resolve `default` values in `allOf` schemas and makes `$ref` defaults reliably visible to generators by pre-resolving refs in `DefaultCodegen.fromProperty`. Also adds an opt-in normalizer rule `RESOLVE_SCHEMA_DEFAULTS` to write resolved defaults back to schemas.

- **New Features**
  - `ModelUtils.resolveDefault()` with strategies: `LAST_WINS`, `NEAREST_WINS`, `ROOT_WINS`, `STRICT` (see `docs/default-resolution-strategy.md`).
  - Normalizer flag `RESOLVE_SCHEMA_DEFAULTS=<strategy>` resolves and applies `default` to component/property schemas; skips pure `$ref` to keep OAS validity.
  - Lint recommendations for `allOf` conflicts and shadowed defaults in `OpenApiSchemaValidations`.

- **Refactors**
  - `$ref` default propagation moved to `DefaultCodegen.fromProperty` (deep `$ref` traversal); removed redundant ref resolution in `AbstractJavaCodegen`/`AbstractKotlinCodegen`; restored follow-ref in `AbstractPythonCodegen.toDefaultValue(Schema)` for direct calls.
  - C++: ensure model members are default-constructed (`CppHttplibServerCodegen`, `CppTinyClientCodegen`, `CppTizenClientCodegen`).
  - Added tests and refreshed samples; generated C# docs now display enum defaults.

<sup>Written for commit 6177051989f24d0a9346bd54711655d71f8c7c49. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23821?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

