### PR TITLE
[kotlin-client] Add decodeOrNull helper for Jackson enums, fix decode KDoc

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
@@ -108,10 +108,10 @@ import kotlinx.serialization.encoding.Encoder
          */
         {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}fun encode(data: kotlin.Any?): kotlin.String? = if (data is {{classname}}) "$data" else null
 
+{{^jackson}}
         /**
          * Returns a valid [{{classname}}] for [data], null otherwise.
          */
-{{^jackson}}
         {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}fun decode(data: kotlin.Any?): {{classname}}? = data?.let {
           val normalizedData = "$it".lowercase()
           entries.firstOrNull { value ->
@@ -120,6 +120,12 @@ import kotlinx.serialization.encoding.Encoder
         }
 {{/jackson}}
 {{#jackson}}
+        /**
+         * Returns a valid [{{classname}}] for [data].{{^isNullable}}{{^enumUnknownDefaultCase}}
+         *
+         * Throws [IllegalArgumentException] when [data] is null or does not match a known value.
+         * For lenient lookup that returns null on unknown values, see [decodeOrNull].{{/enumUnknownDefaultCase}}{{/isNullable}}
+         */
         @JvmStatic
         @JsonCreator
         {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}fun decode(data: kotlin.Any?): {{classname}}{{#isNullable}}?{{/isNullable}} {
@@ -137,6 +143,20 @@ import kotlinx.serialization.encoding.Encoder
           }{{#isNullable}}{{/isNullable}}{{^isNullable}}{{#enumUnknownDefaultCase}}
             ?: {{#allowableValues}}{{#enumVars}}{{#-last}}{{&name}}{{/-last}}{{/enumVars}}{{/allowableValues}}{{/enumUnknownDefaultCase}}{{^enumUnknownDefaultCase}}
             ?: throw IllegalArgumentException("Unknown {{classname}} value: $data"){{/enumUnknownDefaultCase}}{{/isNullable}}
+        }
+
+        /**
+         * Returns a valid [{{classname}}] for [data], or null when [data] is null or does not match a known value.
+         *
+         * Lenient counterpart to [decode], intended for direct calls from Kotlin code.
+         * Jackson deserialization uses [decode], which is strict.
+         */
+        @JvmStatic
+        {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}fun decodeOrNull(data: kotlin.Any?): {{classname}}? = data?.let {
+          val normalizedData = "$it".lowercase()
+          entries.firstOrNull { value ->
+            it == value || normalizedData == "$value".lowercase()
+          }
         }
 {{/jackson}}
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
@@ -820,6 +820,39 @@ public class KotlinClientCodegenModelTest {
   }
 
   @Test
+  public void testJacksonEnumsExposeDecodeOrNullHelper() throws IOException {
+      File output = Files.createTempDirectory("test").toFile();
+      output.deleteOnExit();
+
+      final CodegenConfigurator configurator = new CodegenConfigurator()
+              .setGeneratorName("kotlin")
+              .setLibrary("jvm-retrofit2")
+              .setAdditionalProperties(new HashMap<>() {{
+                put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
+                put(CodegenConstants.MODEL_PACKAGE, "model");
+              }})
+              .setInputSpec("src/test/resources/3_0/kotlin/issue22534-kotlin-numeric-enum.yaml")
+              .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+      final ClientOptInput clientOptInput = configurator.toClientOptInput();
+      DefaultGenerator generator = new DefaultGenerator();
+
+      generator.opts(clientOptInput).generate();
+
+      final Path enumKt = Paths.get(output + "/src/main/kotlin/model/ExampleNumericEnum.kt");
+
+      // decodeOrNull should always be generated alongside decode in the Jackson branch
+      // and must return null for unknown values without throwing.
+      TestUtils.assertFileContains(enumKt, "fun decodeOrNull(data: kotlin.Any?): ExampleNumericEnum?");
+      // decodeOrNull should not be annotated with @JsonCreator — only decode is the Jackson entry point.
+      // Verify by checking @JsonCreator appears exactly once in the file.
+      String content = new String(java.nio.file.Files.readAllBytes(enumKt), java.nio.charset.StandardCharsets.UTF_8);
+      int jsonCreatorCount = content.split("@JsonCreator", -1).length - 1;
+      Assert.assertEquals(jsonCreatorCount, 1,
+              "Expected exactly one @JsonCreator annotation in the generated enum, found " + jsonCreatorCount);
+  }
+
+  @Test
   public void testJacksonEnumsWithUnknownDefaultCase() throws IOException {
       File output = Files.createTempDirectory("test").toFile();
       output.deleteOnExit();

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/StringEnumRef.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/StringEnumRef.kt
@@ -66,7 +66,7 @@ enum class StringEnumRef(@get:JsonValue val value: kotlin.String) {
         fun encode(data: kotlin.Any?): kotlin.String? = if (data is StringEnumRef) "$data" else null
 
         /**
-         * Returns a valid [StringEnumRef] for [data], null otherwise.
+         * Returns a valid [StringEnumRef] for [data].
          */
         @JvmStatic
         @JsonCreator
@@ -79,6 +79,20 @@ enum class StringEnumRef(@get:JsonValue val value: kotlin.String) {
             data == value || normalizedData == "$value".lowercase()
           }
             ?: unknown_default_open_api
+        }
+
+        /**
+         * Returns a valid [StringEnumRef] for [data], or null when [data] is null or does not match a known value.
+         *
+         * Lenient counterpart to [decode], intended for direct calls from Kotlin code.
+         * Jackson deserialization uses [decode], which is strict.
+         */
+        @JvmStatic
+        fun decodeOrNull(data: kotlin.Any?): StringEnumRef? = data?.let {
+          val normalizedData = "$it".lowercase()
+          entries.firstOrNull { value ->
+            it == value || normalizedData == "$value".lowercase()
+          }
         }
     }
 }

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/StringEnumRef.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/StringEnumRef.kt
@@ -66,7 +66,7 @@ enum class StringEnumRef(@get:JsonValue val value: kotlin.String) {
         fun encode(data: kotlin.Any?): kotlin.String? = if (data is StringEnumRef) "$data" else null
 
         /**
-         * Returns a valid [StringEnumRef] for [data], null otherwise.
+         * Returns a valid [StringEnumRef] for [data].
          */
         @JvmStatic
         @JsonCreator
@@ -79,6 +79,20 @@ enum class StringEnumRef(@get:JsonValue val value: kotlin.String) {
             data == value || normalizedData == "$value".lowercase()
           }
             ?: unknown_default_open_api
+        }
+
+        /**
+         * Returns a valid [StringEnumRef] for [data], or null when [data] is null or does not match a known value.
+         *
+         * Lenient counterpart to [decode], intended for direct calls from Kotlin code.
+         * Jackson deserialization uses [decode], which is strict.
+         */
+        @JvmStatic
+        fun decodeOrNull(data: kotlin.Any?): StringEnumRef? = data?.let {
+          val normalizedData = "$it".lowercase()
+          entries.firstOrNull { value ->
+            it == value || normalizedData == "$value".lowercase()
+          }
         }
     }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ```
  Only the Jackson-using Kotlin client samples that actually contain `@JsonCreator` enums were affected (the two echo-api samples). All other generators produce identical output. No docs changed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks).
- [x] References issue using GitHub linking syntax.
- [x] @-mention Kotlin technical committee: @karismann @Zomzog @andrewemery @4brunu @yutaka0m @stefankoppier @e5l

## Summary

Follow-up to #22663 (which fixed the 7.18.0 silent-null regression in Jackson deserialization of Kotlin enums). Addresses concerns raised in #23791.

PR #22535 (7.18.0) tied two contracts together by adding `@JsonCreator` to the existing `decode()` helper:

1. **`decode()` as a standalone function** — historically nullable-returning, KDoc said "null otherwise."
2. **Jackson deserialization** — pre-7.18.0 it used Jackson's default handling, which throws on unknown values.

PR #22663 (7.19.0) restored the Jackson throwing behavior, but as a side effect changed `decode()`'s direct-call contract for non-nullable enums (it now throws instead of returning null).

This PR cleanly separates the two contracts by **adding `decodeOrNull()`** alongside `decode()` in the Jackson branch:

- `decode()` — strict, `@JsonCreator` entry point (unchanged from 7.19.0)
- `decodeOrNull()` — lenient helper for manual callers; always returns null on unknown values or null input

This follows idiomatic Kotlin conventions (`toIntOrNull`, `firstOrNull`, etc.) and gives anyone affected by the 7.19.0 change a trivial one-line migration: `MyEnum.decode(x)` → `MyEnum.decodeOrNull(x)`.

Also corrects the KDoc on `decode()` which still claimed "null otherwise" even though the function now throws.

## Changes

- `modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache`: adds `decodeOrNull()` in the Jackson branch; updates the `decode()` KDoc so it no longer says "null otherwise" when the function may throw.
- `KotlinClientCodegenModelTest.java`: new unit test `testJacksonEnumsExposeDecodeOrNullHelper` verifying `decodeOrNull` is generated and `@JsonCreator` is still applied only to `decode`.
- Regenerated affected Kotlin samples (`kotlin-jvm-spring-3-restclient` and `kotlin-jvm-spring-3-webclient` echo-api samples — the only samples containing Jackson-annotated Kotlin enums).

## Validation

```
./mvnw -pl modules/openapi-generator test -Dtest='KotlinClientCodegenModelTest'
# Tests run: 45, Failures: 0, Errors: 0, Skipped: 0
```

Resolves #23791

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add decodeOrNull() to Kotlin Jackson enums to restore a lenient, null-returning lookup for manual calls, while keeping decode() as the strict @JsonCreator entry point. Also fixes decode() KDoc and adds a test; regenerated the affected echo-api Kotlin samples.

- New Features
  - Added decodeOrNull() in the Jackson enum template; returns null for unknown or null input.
  - decode() remains strict (@JsonCreator) and throws on unknown values; Jackson uses this path.
  - Added a unit test to verify decodeOrNull() generation and that only decode() has @JsonCreator.
  - Regenerated echo-api Kotlin samples (Spring 3 RestClient/WebClient).

- Bug Fixes
  - Corrected decode() KDoc to reflect its throwing behavior.

<sup>Written for commit ec18c9e3754bde422911075c66dae411ce004a89. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23823?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

