### PR TITLE
 [Java] [vertx] Allow PoolOptions configuration when vertx 5

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/ApiClient.mustache
@@ -34,6 +34,9 @@ import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
+{{#useVertx5}}
+import io.vertx.core.http.PoolOptions;
+{{/useVertx5}}
 
 {{#jsr310}}
 import java.time.OffsetDateTime;
@@ -56,6 +59,9 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     protected final Vertx vertx;
     protected final JsonObject config;
     protected final String identifier;
+{{#useVertx5}}
+    protected final JsonObject poolConfig;
+{{/useVertx5}}
 
     protected MultiMap defaultHeaders = MultiMap.caseInsensitiveMultiMap();
     protected MultiMap defaultCookies = MultiMap.caseInsensitiveMultiMap();
@@ -66,9 +72,18 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     protected String downloadsDir = "";
     protected int timeout = -1;
 
+{{#useVertx5}}
     public ApiClient(Vertx vertx, JsonObject config) {
+        this(vertx, config, new JsonObject());
+    }
+
+{{/useVertx5}}
+    public ApiClient(Vertx vertx, JsonObject config{{#useVertx5}}, JsonObject poolConfig{{/useVertx5}}) {
         Objects.requireNonNull(vertx, "Vertx must not be null");
         Objects.requireNonNull(config, "Config must not be null");
+        {{#useVertx5}}
+        Objects.requireNonNull(poolConfig, "PoolConfig must not be null");
+        {{/useVertx5}}
 
         this.vertx = vertx;
 
@@ -109,6 +124,9 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         this.config = config;
         this.identifier = UUID.randomUUID().toString();
         this.timeout = config.getInteger("timeout", -1);
+        {{#useVertx5}}
+        this.poolConfig = poolConfig;
+        {{/useVertx5}}
     }
 
     public Vertx getVertx() {
@@ -128,7 +146,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         String webClientIdentifier = "web-client-" + identifier;
         WebClient webClient = this.vertx.getOrCreateContext().get(webClientIdentifier);
         if (webClient == null) {
-            webClient = buildWebClient(vertx, config);
+            webClient = buildWebClient(vertx, config{{#useVertx5}}, poolConfig{{/useVertx5}});
             this.vertx.getOrCreateContext().put(webClientIdentifier, webClient);
         }
         return webClient;
@@ -707,13 +725,13 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
      * @param vertx Vertx
      * @return WebClient
      */
-    protected WebClient buildWebClient(Vertx vertx, JsonObject config) {
+    protected WebClient buildWebClient(Vertx vertx, JsonObject config{{#useVertx5}}, JsonObject poolConfig{{/useVertx5}}) {
 
         if (!config.containsKey("userAgent")) {
             config.put("userAgent", "{{{httpUserAgent}}}{{^httpUserAgent}}OpenAPI-Generator/{{{artifactVersion}}}/java{{/httpUserAgent}}");
         }
 
-        return WebClient.create(vertx, new WebClientOptions(config));
+        return WebClient.create(vertx, new WebClientOptions(config){{#useVertx5}}, new PoolOptions(poolConfig){{/useVertx5}});
     }
 
 

--- a/samples/client/petstore/java/vertx5-supportVertxFuture/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/vertx5-supportVertxFuture/src/main/java/org/openapitools/client/ApiClient.java
@@ -41,6 +41,7 @@ import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.core.http.PoolOptions;
 
 import java.time.OffsetDateTime;
 import java.text.DateFormat;
@@ -60,6 +61,7 @@ public class ApiClient extends JavaTimeFormatter {
     protected final Vertx vertx;
     protected final JsonObject config;
     protected final String identifier;
+    protected final JsonObject poolConfig;
 
     protected MultiMap defaultHeaders = MultiMap.caseInsensitiveMultiMap();
     protected MultiMap defaultCookies = MultiMap.caseInsensitiveMultiMap();
@@ -71,8 +73,13 @@ public class ApiClient extends JavaTimeFormatter {
     protected int timeout = -1;
 
     public ApiClient(Vertx vertx, JsonObject config) {
+        this(vertx, config, new JsonObject());
+    }
+
+    public ApiClient(Vertx vertx, JsonObject config, JsonObject poolConfig) {
         Objects.requireNonNull(vertx, "Vertx must not be null");
         Objects.requireNonNull(config, "Config must not be null");
+        Objects.requireNonNull(poolConfig, "PoolConfig must not be null");
 
         this.vertx = vertx;
 
@@ -112,6 +119,7 @@ public class ApiClient extends JavaTimeFormatter {
         this.config = config;
         this.identifier = UUID.randomUUID().toString();
         this.timeout = config.getInteger("timeout", -1);
+        this.poolConfig = poolConfig;
     }
 
     public Vertx getVertx() {
@@ -131,7 +139,7 @@ public class ApiClient extends JavaTimeFormatter {
         String webClientIdentifier = "web-client-" + identifier;
         WebClient webClient = this.vertx.getOrCreateContext().get(webClientIdentifier);
         if (webClient == null) {
-            webClient = buildWebClient(vertx, config);
+            webClient = buildWebClient(vertx, config, poolConfig);
             this.vertx.getOrCreateContext().put(webClientIdentifier, webClient);
         }
         return webClient;
@@ -650,13 +658,13 @@ public class ApiClient extends JavaTimeFormatter {
      * @param vertx Vertx
      * @return WebClient
      */
-    protected WebClient buildWebClient(Vertx vertx, JsonObject config) {
+    protected WebClient buildWebClient(Vertx vertx, JsonObject config, JsonObject poolConfig) {
 
         if (!config.containsKey("userAgent")) {
             config.put("userAgent", "OpenAPI-Generator/1.0.0/java");
         }
 
-        return WebClient.create(vertx, new WebClientOptions(config));
+        return WebClient.create(vertx, new WebClientOptions(config), new PoolOptions(poolConfig));
     }
 
 

--- a/samples/client/petstore/java/vertx5/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/vertx5/src/main/java/org/openapitools/client/ApiClient.java
@@ -41,6 +41,7 @@ import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.core.http.PoolOptions;
 
 import java.time.OffsetDateTime;
 import java.text.DateFormat;
@@ -60,6 +61,7 @@ public class ApiClient extends JavaTimeFormatter {
     protected final Vertx vertx;
     protected final JsonObject config;
     protected final String identifier;
+    protected final JsonObject poolConfig;
 
     protected MultiMap defaultHeaders = MultiMap.caseInsensitiveMultiMap();
     protected MultiMap defaultCookies = MultiMap.caseInsensitiveMultiMap();
@@ -71,8 +73,13 @@ public class ApiClient extends JavaTimeFormatter {
     protected int timeout = -1;
 
     public ApiClient(Vertx vertx, JsonObject config) {
+        this(vertx, config, new JsonObject());
+    }
+
+    public ApiClient(Vertx vertx, JsonObject config, JsonObject poolConfig) {
         Objects.requireNonNull(vertx, "Vertx must not be null");
         Objects.requireNonNull(config, "Config must not be null");
+        Objects.requireNonNull(poolConfig, "PoolConfig must not be null");
 
         this.vertx = vertx;
 
@@ -112,6 +119,7 @@ public class ApiClient extends JavaTimeFormatter {
         this.config = config;
         this.identifier = UUID.randomUUID().toString();
         this.timeout = config.getInteger("timeout", -1);
+        this.poolConfig = poolConfig;
     }
 
     public Vertx getVertx() {
@@ -131,7 +139,7 @@ public class ApiClient extends JavaTimeFormatter {
         String webClientIdentifier = "web-client-" + identifier;
         WebClient webClient = this.vertx.getOrCreateContext().get(webClientIdentifier);
         if (webClient == null) {
-            webClient = buildWebClient(vertx, config);
+            webClient = buildWebClient(vertx, config, poolConfig);
             this.vertx.getOrCreateContext().put(webClientIdentifier, webClient);
         }
         return webClient;
@@ -650,13 +658,13 @@ public class ApiClient extends JavaTimeFormatter {
      * @param vertx Vertx
      * @return WebClient
      */
-    protected WebClient buildWebClient(Vertx vertx, JsonObject config) {
+    protected WebClient buildWebClient(Vertx vertx, JsonObject config, JsonObject poolConfig) {
 
         if (!config.containsKey("userAgent")) {
             config.put("userAgent", "OpenAPI-Generator/1.0.0/java");
         }
 
-        return WebClient.create(vertx, new WebClientOptions(config));
+        return WebClient.create(vertx, new WebClientOptions(config), new PoolOptions(poolConfig));
     }
 
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Closes #23828

When `useVertx5` is enabled, the `ApiClient` will have an additional `poolConfig` field. That field is for storing the json that will eventually be mapped to the [`PoolOptions`](https://vertx.io/docs/apidocs/io/vertx/core/http/PoolOptions.html) that is passed into the [`WebClient` factory method](https://vertx.io/docs/apidocs/io/vertx/ext/web/client/WebClient.html#create(io.vertx.core.Vertx,io.vertx.ext.web.client.WebClientOptions,io.vertx.core.http.PoolOptions)) alongside the `WebClientOptions`.

We still generate a `ApiClient` constructor with two params (which will just forward to the main constructor, passing an empty json for the `poolConfig`) to maintain backwards compatibility.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable connection pool support for Vert.x 5 by introducing a `poolConfig` JSON in `ApiClient` and passing it to `WebClient.create` as `PoolOptions`. Closes #23828.

- **New Features**
  - When `useVertx5` is enabled, `ApiClient` includes a `poolConfig` field used to build `PoolOptions`.
  - Added `ApiClient(Vertx, JsonObject, JsonObject)`; the existing 2-arg constructor forwards with an empty JSON to keep compatibility.
  - `WebClient` is now created with both `WebClientOptions` and `PoolOptions` derived from `poolConfig`.

<sup>Written for commit bc890da6a513c649346a57d203819f725adaef3e. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23829?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

