### PR TITLE
feat(kotlin-client): support dynamic auth credentials for okhttp client (#23835)

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/api_doc.mustache
@@ -73,20 +73,24 @@ Configure {{name}} statically:
 ApiClient.username = ""
 ApiClient.password = ""
 ```
+{{#jvm-okhttp}}
 Configure {{name}} dynamically:
 ```kotlin
-{{{classname}}}().userCredentialProvider = { "user" to "pass" }
+apiInstance.userCredentialProvider = { "user" to "pass" }
 ```
+{{/jvm-okhttp}}
 {{/isBasicBasic}}
 {{#isBasicBearer}}
 Configure {{name}} statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
+{{#jvm-okhttp}}
 Configure {{name}} dynamically:
 ```kotlin
-{{{classname}}}().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
+{{/jvm-okhttp}}
 {{/isBasicBearer}}
 {{/isBasic}}
 {{#isOAuth}}
@@ -94,10 +98,12 @@ Configure {{name}} statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
+{{#jvm-okhttp}}
 Configure {{name}} dynamically:
 ```kotlin
-{{{classname}}}().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
+{{/jvm-okhttp}}
 {{/isOAuth}}
 {{/authMethods}}
 

--- a/modules/openapi-generator/src/main/resources/kotlin-client/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/api_doc.mustache
@@ -68,18 +68,36 @@ Configure {{name}}:
 {{/isApiKey}}
 {{#isBasic}}
 {{#isBasicBasic}}
-Configure {{name}}:
-    ApiClient.username = ""
-    ApiClient.password = ""
+Configure {{name}} statically:
+```kotlin
+ApiClient.username = ""
+ApiClient.password = ""
+```
+Configure {{name}} dynamically:
+```kotlin
+{{{classname}}}().userCredentialProvider = { "user" to "pass" }
+```
 {{/isBasicBasic}}
 {{#isBasicBearer}}
-Configure {{name}}:
-    ApiClient.accessToken = ""
+Configure {{name}} statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure {{name}} dynamically:
+```kotlin
+{{{classname}}}().accessTokenProvider = { "" }
+```
 {{/isBasicBearer}}
 {{/isBasic}}
 {{#isOAuth}}
-Configure {{name}}:
-    ApiClient.accessToken = ""
+Configure {{name}} statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure {{name}} dynamically:
+```kotlin
+{{{classname}}}().accessTokenProvider = { "" }
+```
 {{/isOAuth}}
 {{/authMethods}}
 

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
@@ -148,8 +148,8 @@ import com.squareup.moshi.adapter
         {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val accessTokenProvider: () -> String? = { accessToken }
+    {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
@@ -148,6 +148,9 @@ import com.squareup.moshi.adapter
         {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *
@@ -460,25 +463,26 @@ import com.squareup.moshi.adapter
         {{#isBasic}}
         {{#isBasicBasic}}
         if (requestConfig.headers[AUTHORIZATION].isNullOrEmpty()) {
-            username?.let { username ->
-                password?.let { password ->
-                    requestConfig.headers[AUTHORIZATION] = okhttp3.Credentials.basic(username, password)
+            val (user, passw) = userCredentialsProvider()
+            user?.let { user ->
+                passw?.let { passw ->
+                    requestConfig.headers[AUTHORIZATION] = okhttp3.Credentials.basic(user, passw)
                 }
             }
         }
         {{/isBasicBasic}}
         {{#isBasicBearer}}
         if (requestConfig.headers[AUTHORIZATION].isNullOrEmpty()) {
-            accessToken?.let { accessToken ->
-                requestConfig.headers[AUTHORIZATION] = "Bearer $accessToken"
+            accessTokenProvider()?.let { token ->
+                requestConfig.headers[AUTHORIZATION] = "Bearer $token"
             }
         }
         {{/isBasicBearer}}
         {{/isBasic}}
         {{#isOAuth}}
         if (requestConfig.headers[AUTHORIZATION].isNullOrEmpty()) {
-            accessToken?.let { accessToken ->
-                requestConfig.headers[AUTHORIZATION] = "Bearer $accessToken "
+            accessTokenProvider()?.let { token ->
+                requestConfig.headers[AUTHORIZATION] = "Bearer $token "
             }
         }
         {{/isOAuth}}

--- a/samples/client/echo_api/kotlin-jvm-okhttp/docs/AuthApi.md
+++ b/samples/client/echo_api/kotlin-jvm-okhttp/docs/AuthApi.md
@@ -52,7 +52,7 @@ ApiClient.password = ""
 ```
 Configure http_auth dynamically:
 ```kotlin
-AuthApi().userCredentialProvider = { "user" to "pass" }
+apiInstance.userCredentialProvider = { "user" to "pass" }
 ```
 
 ### HTTP request headers
@@ -103,7 +103,7 @@ ApiClient.accessToken = ""
 ```
 Configure http_bearer_auth dynamically:
 ```kotlin
-AuthApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/echo_api/kotlin-jvm-okhttp/docs/AuthApi.md
+++ b/samples/client/echo_api/kotlin-jvm-okhttp/docs/AuthApi.md
@@ -45,9 +45,15 @@ This endpoint does not need any parameter.
 ### Authorization
 
 
-Configure http_auth:
-    ApiClient.username = ""
-    ApiClient.password = ""
+Configure http_auth statically:
+```kotlin
+ApiClient.username = ""
+ApiClient.password = ""
+```
+Configure http_auth dynamically:
+```kotlin
+AuthApi().userCredentialProvider = { "user" to "pass" }
+```
 
 ### HTTP request headers
 
@@ -91,8 +97,14 @@ This endpoint does not need any parameter.
 ### Authorization
 
 
-Configure http_bearer_auth:
-    ApiClient.accessToken = ""
+Configure http_bearer_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure http_bearer_auth dynamically:
+```kotlin
+AuthApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,6 +119,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *
@@ -357,15 +360,16 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers[AUTHORIZATION].isNullOrEmpty()) {
-            username?.let { username ->
-                password?.let { password ->
-                    requestConfig.headers[AUTHORIZATION] = okhttp3.Credentials.basic(username, password)
+            val (user, passw) = userCredentialsProvider()
+            user?.let { user ->
+                passw?.let { passw ->
+                    requestConfig.headers[AUTHORIZATION] = okhttp3.Credentials.basic(user, passw)
                 }
             }
         }
         if (requestConfig.headers[AUTHORIZATION].isNullOrEmpty()) {
-            accessToken?.let { accessToken ->
-                requestConfig.headers[AUTHORIZATION] = "Bearer $accessToken"
+            accessTokenProvider()?.let { token ->
+                requestConfig.headers[AUTHORIZATION] = "Bearer $token"
             }
         }
     }

--- a/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,8 +119,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/docs/AuthApi.md
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/docs/AuthApi.md
@@ -45,9 +45,15 @@ This endpoint does not need any parameter.
 ### Authorization
 
 
-Configure http_auth:
-    ApiClient.username = ""
-    ApiClient.password = ""
+Configure http_auth statically:
+```kotlin
+ApiClient.username = ""
+ApiClient.password = ""
+```
+Configure http_auth dynamically:
+```kotlin
+AuthApi().userCredentialProvider = { "user" to "pass" }
+```
 
 ### HTTP request headers
 
@@ -91,8 +97,14 @@ This endpoint does not need any parameter.
 ### Authorization
 
 
-Configure http_bearer_auth:
-    ApiClient.accessToken = ""
+Configure http_bearer_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure http_bearer_auth dynamically:
+```kotlin
+AuthApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/docs/AuthApi.md
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/docs/AuthApi.md
@@ -50,10 +50,6 @@ Configure http_auth statically:
 ApiClient.username = ""
 ApiClient.password = ""
 ```
-Configure http_auth dynamically:
-```kotlin
-AuthApi().userCredentialProvider = { "user" to "pass" }
-```
 
 ### HTTP request headers
 
@@ -100,10 +96,6 @@ This endpoint does not need any parameter.
 Configure http_bearer_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure http_bearer_auth dynamically:
-```kotlin
-AuthApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/docs/AuthApi.md
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/docs/AuthApi.md
@@ -45,9 +45,15 @@ This endpoint does not need any parameter.
 ### Authorization
 
 
-Configure http_auth:
-    ApiClient.username = ""
-    ApiClient.password = ""
+Configure http_auth statically:
+```kotlin
+ApiClient.username = ""
+ApiClient.password = ""
+```
+Configure http_auth dynamically:
+```kotlin
+AuthApi().userCredentialProvider = { "user" to "pass" }
+```
 
 ### HTTP request headers
 
@@ -91,8 +97,14 @@ This endpoint does not need any parameter.
 ### Authorization
 
 
-Configure http_bearer_auth:
-    ApiClient.accessToken = ""
+Configure http_bearer_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure http_bearer_auth dynamically:
+```kotlin
+AuthApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/docs/AuthApi.md
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/docs/AuthApi.md
@@ -50,10 +50,6 @@ Configure http_auth statically:
 ApiClient.username = ""
 ApiClient.password = ""
 ```
-Configure http_auth dynamically:
-```kotlin
-AuthApi().userCredentialProvider = { "user" to "pass" }
-```
 
 ### HTTP request headers
 
@@ -100,10 +96,6 @@ This endpoint does not need any parameter.
 Configure http_bearer_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure http_bearer_auth dynamically:
-```kotlin
-AuthApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/others/kotlin-integer-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/others/kotlin-integer-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,6 +119,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *

--- a/samples/client/others/kotlin-integer-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/others/kotlin-integer-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,8 +119,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/docs/PetApi.md
+++ b/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/docs/PetApi.md
@@ -60,7 +60,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -115,7 +115,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -169,7 +169,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -223,7 +223,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -326,7 +326,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -383,7 +383,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -441,7 +441,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/docs/PetApi.md
+++ b/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/docs/PetApi.md
@@ -54,8 +54,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -103,8 +109,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -151,8 +163,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -199,8 +217,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -296,8 +320,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -347,8 +377,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -399,8 +435,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,6 +119,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *
@@ -357,8 +360,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers[AUTHORIZATION].isNullOrEmpty()) {
-            accessToken?.let { accessToken ->
-                requestConfig.headers[AUTHORIZATION] = "Bearer $accessToken "
+            accessTokenProvider()?.let { token ->
+                requestConfig.headers[AUTHORIZATION] = "Bearer $token "
             }
         }
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {

--- a/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,8 +119,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/others/kotlin-jvm-okhttp-parameter-tests/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-parameter-tests/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,6 +119,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *

--- a/samples/client/others/kotlin-jvm-okhttp-parameter-tests/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-parameter-tests/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,8 +119,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/others/kotlin-jvm-okhttp-path-comments/docs/StuffApi.md
+++ b/samples/client/others/kotlin-jvm-okhttp-path-comments/docs/StuffApi.md
@@ -44,8 +44,14 @@ This endpoint does not need any parameter.
 ### Authorization
 
 
-Configure bearerAuth:
-    ApiClient.accessToken = ""
+Configure bearerAuth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure bearerAuth dynamically:
+```kotlin
+StuffApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/others/kotlin-jvm-okhttp-path-comments/docs/StuffApi.md
+++ b/samples/client/others/kotlin-jvm-okhttp-path-comments/docs/StuffApi.md
@@ -50,7 +50,7 @@ ApiClient.accessToken = ""
 ```
 Configure bearerAuth dynamically:
 ```kotlin
-StuffApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/others/kotlin-jvm-okhttp-path-comments/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-path-comments/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,6 +119,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *
@@ -357,8 +360,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers[AUTHORIZATION].isNullOrEmpty()) {
-            accessToken?.let { accessToken ->
-                requestConfig.headers[AUTHORIZATION] = "Bearer $accessToken"
+            accessTokenProvider()?.let { token ->
+                requestConfig.headers[AUTHORIZATION] = "Bearer $token"
             }
         }
     }

--- a/samples/client/others/kotlin-jvm-okhttp-path-comments/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-path-comments/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,8 +119,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/petstore/kotlin-allOf-discriminator-kotlinx-serialization/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-allOf-discriminator-kotlinx-serialization/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -120,6 +120,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *

--- a/samples/client/petstore/kotlin-allOf-discriminator-kotlinx-serialization/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-allOf-discriminator-kotlinx-serialization/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -120,8 +120,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/petstore/kotlin-allOf-discriminator/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-allOf-discriminator/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,6 +119,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *

--- a/samples/client/petstore/kotlin-allOf-discriminator/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-allOf-discriminator/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,8 +119,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/petstore/kotlin-array-integer-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-array-integer-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,6 +119,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *

--- a/samples/client/petstore/kotlin-array-integer-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-array-integer-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,8 +119,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/petstore/kotlin-array-nullable-items/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-array-nullable-items/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,6 +119,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *

--- a/samples/client/petstore/kotlin-array-nullable-items/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-array-nullable-items/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,8 +119,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,6 +119,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,8 +119,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,6 +119,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *

--- a/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,8 +119,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,6 +119,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,8 +119,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,6 +119,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *

--- a/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,8 +119,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/petstore/kotlin-explicit/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-explicit/docs/PetApi.md
@@ -51,8 +51,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -98,8 +104,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -146,8 +158,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -194,8 +212,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -288,8 +312,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -337,8 +367,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -387,8 +423,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-explicit/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-explicit/docs/PetApi.md
@@ -57,7 +57,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -110,7 +110,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -164,7 +164,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -218,7 +218,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -318,7 +318,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -373,7 +373,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -429,7 +429,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,6 +119,9 @@ public open class ApiClient(public val baseUrl: String, public val client: Call.
         public val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    public val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    public val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *
@@ -357,8 +360,8 @@ public open class ApiClient(public val baseUrl: String, public val client: Call.
 
     protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers[AUTHORIZATION].isNullOrEmpty()) {
-            accessToken?.let { accessToken ->
-                requestConfig.headers[AUTHORIZATION] = "Bearer $accessToken "
+            accessTokenProvider()?.let { token ->
+                requestConfig.headers[AUTHORIZATION] = "Bearer $token "
             }
         }
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {

--- a/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,8 +119,8 @@ public open class ApiClient(public val baseUrl: String, public val client: Call.
         public val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    public val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    public val accessTokenProvider: () -> String? = { accessToken }
+    public var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    public var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/petstore/kotlin-gson/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-gson/docs/PetApi.md
@@ -60,7 +60,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -115,7 +115,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -169,7 +169,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -223,7 +223,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -326,7 +326,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -383,7 +383,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -441,7 +441,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin-gson/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-gson/docs/PetApi.md
@@ -54,8 +54,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -103,8 +109,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -151,8 +163,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -199,8 +217,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -296,8 +320,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -347,8 +377,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -399,8 +435,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,6 +119,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *
@@ -356,8 +359,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers[AUTHORIZATION].isNullOrEmpty()) {
-            accessToken?.let { accessToken ->
-                requestConfig.headers[AUTHORIZATION] = "Bearer $accessToken "
+            accessTokenProvider()?.let { token ->
+                requestConfig.headers[AUTHORIZATION] = "Bearer $token "
             }
         }
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,8 +119,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/petstore/kotlin-jackson/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jackson/docs/PetApi.md
@@ -51,8 +51,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -98,8 +104,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -146,8 +158,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -194,8 +212,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -288,8 +312,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -337,8 +367,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -387,8 +423,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-jackson/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jackson/docs/PetApi.md
@@ -57,7 +57,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -110,7 +110,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -164,7 +164,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -218,7 +218,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -318,7 +318,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -373,7 +373,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -429,7 +429,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,6 +119,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *
@@ -356,8 +359,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers[AUTHORIZATION].isNullOrEmpty()) {
-            accessToken?.let { accessToken ->
-                requestConfig.headers[AUTHORIZATION] = "Bearer $accessToken "
+            accessTokenProvider()?.let { token ->
+                requestConfig.headers[AUTHORIZATION] = "Bearer $token "
             }
         }
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,8 +119,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/petstore/kotlin-json-request-string/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-json-request-string/docs/PetApi.md
@@ -57,7 +57,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -110,7 +110,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -164,7 +164,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -216,7 +216,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -316,7 +316,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -371,7 +371,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -427,7 +427,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin-json-request-string/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-json-request-string/docs/PetApi.md
@@ -51,8 +51,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -98,8 +104,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -146,8 +158,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -192,8 +210,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -286,8 +310,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -335,8 +365,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -385,8 +421,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -121,8 +121,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -121,6 +121,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *
@@ -364,8 +367,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers[AUTHORIZATION].isNullOrEmpty()) {
-            accessToken?.let { accessToken ->
-                requestConfig.headers[AUTHORIZATION] = "Bearer $accessToken "
+            accessTokenProvider()?.let { token ->
+                requestConfig.headers[AUTHORIZATION] = "Bearer $token "
             }
         }
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/docs/FakeApi.md
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/docs/FakeApi.md
@@ -100,10 +100,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-FakeApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/docs/FakeApi.md
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/docs/FakeApi.md
@@ -96,8 +96,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+FakeApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/docs/PetApi.md
@@ -58,10 +58,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -113,10 +109,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -167,10 +159,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -220,10 +208,6 @@ try {
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -324,10 +308,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -380,10 +360,6 @@ null (empty response body)
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -438,10 +414,6 @@ try {
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/docs/PetApi.md
@@ -54,8 +54,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -103,8 +109,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -151,8 +163,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -199,8 +217,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -296,8 +320,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -347,8 +377,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -399,8 +435,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/docs/PetApi.md
@@ -51,8 +51,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -98,8 +104,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -146,8 +158,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -194,8 +212,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -288,8 +312,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -337,8 +367,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -387,8 +423,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/docs/PetApi.md
@@ -55,10 +55,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -107,10 +103,6 @@ null (empty response body)
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -162,10 +154,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -215,10 +203,6 @@ try {
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -316,10 +300,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -370,10 +350,6 @@ null (empty response body)
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -426,10 +402,6 @@ try {
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/docs/PetApi.md
@@ -58,10 +58,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -113,10 +109,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -167,10 +159,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -220,10 +208,6 @@ try {
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -324,10 +308,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -380,10 +360,6 @@ null (empty response body)
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -438,10 +414,6 @@ try {
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/docs/PetApi.md
@@ -54,8 +54,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -103,8 +109,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -151,8 +163,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -199,8 +217,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -296,8 +320,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -347,8 +377,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -399,8 +435,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/docs/PetApi.md
@@ -51,8 +51,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -98,8 +104,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -146,8 +158,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -194,8 +212,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -288,8 +312,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -337,8 +367,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -387,8 +423,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/docs/PetApi.md
@@ -57,7 +57,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -110,7 +110,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -164,7 +164,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -218,7 +218,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -318,7 +318,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -373,7 +373,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -429,7 +429,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -122,8 +122,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -122,6 +122,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *
@@ -359,8 +362,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers[AUTHORIZATION].isNullOrEmpty()) {
-            accessToken?.let { accessToken ->
-                requestConfig.headers[AUTHORIZATION] = "Bearer $accessToken "
+            accessTokenProvider()?.let { token ->
+                requestConfig.headers[AUTHORIZATION] = "Bearer $token "
             }
         }
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/docs/PetApi.md
@@ -58,10 +58,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -113,10 +109,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -167,10 +159,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -220,10 +208,6 @@ try {
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -324,10 +308,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -380,10 +360,6 @@ null (empty response body)
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -438,10 +414,6 @@ try {
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/docs/PetApi.md
@@ -54,8 +54,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -103,8 +109,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -151,8 +163,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -199,8 +217,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -296,8 +320,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -347,8 +377,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -399,8 +435,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/docs/PetApi.md
@@ -58,10 +58,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -113,10 +109,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -167,10 +159,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -220,10 +208,6 @@ try {
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -324,10 +308,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -380,10 +360,6 @@ null (empty response body)
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -438,10 +414,6 @@ try {
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/docs/PetApi.md
@@ -54,8 +54,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -103,8 +109,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -151,8 +163,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -199,8 +217,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -296,8 +320,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -347,8 +377,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -399,8 +435,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/docs/PetApi.md
@@ -58,10 +58,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -113,10 +109,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -167,10 +159,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -220,10 +208,6 @@ try {
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -324,10 +308,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -380,10 +360,6 @@ null (empty response body)
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -438,10 +414,6 @@ try {
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/docs/PetApi.md
@@ -54,8 +54,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -103,8 +109,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -151,8 +163,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -199,8 +217,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -296,8 +320,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -347,8 +377,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -399,8 +435,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-jvm-vertx-gson/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-vertx-gson/docs/PetApi.md
@@ -58,10 +58,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -113,10 +109,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -167,10 +159,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -220,10 +208,6 @@ try {
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -324,10 +308,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -380,10 +360,6 @@ null (empty response body)
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -438,10 +414,6 @@ try {
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin-jvm-vertx-gson/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-vertx-gson/docs/PetApi.md
@@ -54,8 +54,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -103,8 +109,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -151,8 +163,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -199,8 +217,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -296,8 +320,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -347,8 +377,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -399,8 +435,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/docs/PetApi.md
@@ -58,10 +58,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -113,10 +109,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -167,10 +159,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -220,10 +208,6 @@ try {
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -324,10 +308,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -380,10 +360,6 @@ null (empty response body)
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -438,10 +414,6 @@ try {
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/docs/PetApi.md
@@ -54,8 +54,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -103,8 +109,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -151,8 +163,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -199,8 +217,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -296,8 +320,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -347,8 +377,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -399,8 +435,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson/docs/PetApi.md
@@ -58,10 +58,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -113,10 +109,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -167,10 +159,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -220,10 +208,6 @@ try {
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -324,10 +308,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -380,10 +360,6 @@ null (empty response body)
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -438,10 +414,6 @@ try {
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson/docs/PetApi.md
@@ -54,8 +54,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -103,8 +109,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -151,8 +163,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -199,8 +217,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -296,8 +320,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -347,8 +377,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -399,8 +435,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-jvm-vertx-moshi/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-vertx-moshi/docs/PetApi.md
@@ -58,10 +58,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -113,10 +109,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -167,10 +159,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -220,10 +208,6 @@ try {
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -324,10 +308,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -380,10 +360,6 @@ null (empty response body)
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -438,10 +414,6 @@ try {
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin-jvm-vertx-moshi/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-jvm-vertx-moshi/docs/PetApi.md
@@ -54,8 +54,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -103,8 +109,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -151,8 +163,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -199,8 +217,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -296,8 +320,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -347,8 +377,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -399,8 +435,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-kotlinx-datetime/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-kotlinx-datetime/docs/PetApi.md
@@ -51,8 +51,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -98,8 +104,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -146,8 +158,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -194,8 +212,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -288,8 +312,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -337,8 +367,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -387,8 +423,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-kotlinx-datetime/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-kotlinx-datetime/docs/PetApi.md
@@ -57,7 +57,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -110,7 +110,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -164,7 +164,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -218,7 +218,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -318,7 +318,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -373,7 +373,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -429,7 +429,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,6 +119,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *
@@ -357,8 +360,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers[AUTHORIZATION].isNullOrEmpty()) {
-            accessToken?.let { accessToken ->
-                requestConfig.headers[AUTHORIZATION] = "Bearer $accessToken "
+            accessTokenProvider()?.let { token ->
+                requestConfig.headers[AUTHORIZATION] = "Bearer $token "
             }
         }
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {

--- a/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,8 +119,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/petstore/kotlin-modelMutable/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-modelMutable/docs/PetApi.md
@@ -51,8 +51,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -98,8 +104,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -146,8 +158,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -194,8 +212,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -288,8 +312,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -337,8 +367,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -387,8 +423,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-modelMutable/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-modelMutable/docs/PetApi.md
@@ -57,7 +57,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -110,7 +110,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -164,7 +164,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -218,7 +218,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -318,7 +318,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -373,7 +373,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -429,7 +429,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,6 +119,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *
@@ -357,8 +360,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers[AUTHORIZATION].isNullOrEmpty()) {
-            accessToken?.let { accessToken ->
-                requestConfig.headers[AUTHORIZATION] = "Bearer $accessToken "
+            accessTokenProvider()?.let { token ->
+                requestConfig.headers[AUTHORIZATION] = "Bearer $token "
             }
         }
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,8 +119,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/petstore/kotlin-moshi-codegen/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-moshi-codegen/docs/PetApi.md
@@ -51,8 +51,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -98,8 +104,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -146,8 +158,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -194,8 +212,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -288,8 +312,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -337,8 +367,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -387,8 +423,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-moshi-codegen/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-moshi-codegen/docs/PetApi.md
@@ -57,7 +57,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -110,7 +110,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -164,7 +164,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -218,7 +218,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -318,7 +318,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -373,7 +373,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -429,7 +429,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,6 +119,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *
@@ -357,8 +360,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers[AUTHORIZATION].isNullOrEmpty()) {
-            accessToken?.let { accessToken ->
-                requestConfig.headers[AUTHORIZATION] = "Bearer $accessToken "
+            accessTokenProvider()?.let { token ->
+                requestConfig.headers[AUTHORIZATION] = "Bearer $token "
             }
         }
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,8 +119,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/docs/PetApi.md
@@ -51,8 +51,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -98,8 +104,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -146,8 +158,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -194,8 +212,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -288,8 +312,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -337,8 +367,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -387,8 +423,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/docs/PetApi.md
@@ -55,10 +55,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -107,10 +103,6 @@ null (empty response body)
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -162,10 +154,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -215,10 +203,6 @@ try {
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -316,10 +300,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -370,10 +350,6 @@ null (empty response body)
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -426,10 +402,6 @@ try {
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin-multiplatform/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-multiplatform/docs/PetApi.md
@@ -51,8 +51,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -98,8 +104,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -146,8 +158,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -194,8 +212,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -288,8 +312,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -337,8 +367,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -387,8 +423,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-multiplatform/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-multiplatform/docs/PetApi.md
@@ -55,10 +55,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -107,10 +103,6 @@ null (empty response body)
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -162,10 +154,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -215,10 +203,6 @@ try {
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -316,10 +300,6 @@ Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
 ```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
-```
 
 ### HTTP request headers
 
@@ -370,10 +350,6 @@ null (empty response body)
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -426,10 +402,6 @@ try {
 Configure petstore_auth statically:
 ```kotlin
 ApiClient.accessToken = ""
-```
-Configure petstore_auth dynamically:
-```kotlin
-PetApi().accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin-name-parameter-mappings/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-name-parameter-mappings/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,6 +119,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *

--- a/samples/client/petstore/kotlin-name-parameter-mappings/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-name-parameter-mappings/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,8 +119,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/petstore/kotlin-nonpublic/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-nonpublic/docs/PetApi.md
@@ -51,8 +51,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -98,8 +104,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -146,8 +158,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -194,8 +212,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -288,8 +312,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -337,8 +367,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -387,8 +423,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-nonpublic/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-nonpublic/docs/PetApi.md
@@ -57,7 +57,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -110,7 +110,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -164,7 +164,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -218,7 +218,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -318,7 +318,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -373,7 +373,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -429,7 +429,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,6 +119,9 @@ internal open class ApiClient(val baseUrl: String, val client: Call.Factory = de
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *
@@ -357,8 +360,8 @@ internal open class ApiClient(val baseUrl: String, val client: Call.Factory = de
 
     protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers[AUTHORIZATION].isNullOrEmpty()) {
-            accessToken?.let { accessToken ->
-                requestConfig.headers[AUTHORIZATION] = "Bearer $accessToken "
+            accessTokenProvider()?.let { token ->
+                requestConfig.headers[AUTHORIZATION] = "Bearer $token "
             }
         }
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,8 +119,8 @@ internal open class ApiClient(val baseUrl: String, val client: Call.Factory = de
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/petstore/kotlin-nullable/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-nullable/docs/PetApi.md
@@ -51,8 +51,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -98,8 +104,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -146,8 +158,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -194,8 +212,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -288,8 +312,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -337,8 +367,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -387,8 +423,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-nullable/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-nullable/docs/PetApi.md
@@ -57,7 +57,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -110,7 +110,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -164,7 +164,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -218,7 +218,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -318,7 +318,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -373,7 +373,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -429,7 +429,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,6 +119,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *
@@ -357,8 +360,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers[AUTHORIZATION].isNullOrEmpty()) {
-            accessToken?.let { accessToken ->
-                requestConfig.headers[AUTHORIZATION] = "Bearer $accessToken "
+            accessTokenProvider()?.let { token ->
+                requestConfig.headers[AUTHORIZATION] = "Bearer $token "
             }
         }
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,8 +119,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/petstore/kotlin-string/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-string/docs/PetApi.md
@@ -51,8 +51,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -98,8 +104,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -146,8 +158,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -194,8 +212,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -288,8 +312,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -337,8 +367,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -387,8 +423,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-string/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-string/docs/PetApi.md
@@ -57,7 +57,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -110,7 +110,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -164,7 +164,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -218,7 +218,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -318,7 +318,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -373,7 +373,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -429,7 +429,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,6 +119,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *
@@ -357,8 +360,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers[AUTHORIZATION].isNullOrEmpty()) {
-            accessToken?.let { accessToken ->
-                requestConfig.headers[AUTHORIZATION] = "Bearer $accessToken "
+            accessTokenProvider()?.let { token ->
+                requestConfig.headers[AUTHORIZATION] = "Bearer $token "
             }
         }
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,8 +119,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/petstore/kotlin-threetenbp/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-threetenbp/docs/PetApi.md
@@ -51,8 +51,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -98,8 +104,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -146,8 +158,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -194,8 +212,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -288,8 +312,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -337,8 +367,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -387,8 +423,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin-threetenbp/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-threetenbp/docs/PetApi.md
@@ -57,7 +57,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -110,7 +110,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -164,7 +164,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -218,7 +218,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -318,7 +318,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -373,7 +373,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -429,7 +429,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,6 +119,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *
@@ -357,8 +360,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers[AUTHORIZATION].isNullOrEmpty()) {
-            accessToken?.let { accessToken ->
-                requestConfig.headers[AUTHORIZATION] = "Bearer $accessToken "
+            accessTokenProvider()?.let { token ->
+                requestConfig.headers[AUTHORIZATION] = "Bearer $token "
             }
         }
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,8 +119,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -120,6 +120,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -120,8 +120,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").

--- a/samples/client/petstore/kotlin/docs/PetApi.md
+++ b/samples/client/petstore/kotlin/docs/PetApi.md
@@ -51,8 +51,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -98,8 +104,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -146,8 +158,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -194,8 +212,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -288,8 +312,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -337,8 +367,14 @@ null (empty response body)
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 
@@ -387,8 +423,14 @@ try {
 ### Authorization
 
 
-Configure petstore_auth:
-    ApiClient.accessToken = ""
+Configure petstore_auth statically:
+```kotlin
+ApiClient.accessToken = ""
+```
+Configure petstore_auth dynamically:
+```kotlin
+PetApi().accessTokenProvider = { "" }
+```
 
 ### HTTP request headers
 

--- a/samples/client/petstore/kotlin/docs/PetApi.md
+++ b/samples/client/petstore/kotlin/docs/PetApi.md
@@ -57,7 +57,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -110,7 +110,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -164,7 +164,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -218,7 +218,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -318,7 +318,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -373,7 +373,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers
@@ -429,7 +429,7 @@ ApiClient.accessToken = ""
 ```
 Configure petstore_auth dynamically:
 ```kotlin
-PetApi().accessTokenProvider = { "" }
+apiInstance.accessTokenProvider = { "" }
 ```
 
 ### HTTP request headers

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,6 +119,9 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
+    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    val accessTokenProvider: () -> String? = { accessToken }
+
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").
      *
@@ -357,8 +360,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
 
     protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers[AUTHORIZATION].isNullOrEmpty()) {
-            accessToken?.let { accessToken ->
-                requestConfig.headers[AUTHORIZATION] = "Bearer $accessToken "
+            accessTokenProvider()?.let { token ->
+                requestConfig.headers[AUTHORIZATION] = "Bearer $token "
             }
         }
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -119,8 +119,8 @@ open class ApiClient(val baseUrl: String, val client: Call.Factory = defaultClie
         val builder: OkHttpClient.Builder = OkHttpClient.Builder()
     }
 
-    val userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
-    val accessTokenProvider: () -> String? = { accessToken }
+    var userCredentialsProvider: () -> Pair<String?, String?> = { username to password }
+    var accessTokenProvider: () -> String? = { accessToken }
 
     /**
      * Guess Content-Type header from the given byteArray (defaults to "application/octet-stream").


### PR DESCRIPTION
resolves #23835

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This change adds dynamic credential/token provider support to Kotlin jvm-okhttp clients so auth values can be resolved at request time (instead of only using static ApiClient fields).

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Kotlin comittee:
@karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06) @e5l (2024/10) @dennisameling (2026/02)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds dynamic auth providers to Kotlin JVM `okhttp` clients so credentials/tokens are resolved per request. Enables rotating tokens and multi-tenant auth without rebuilding the client.

- **New Features**
  - Added `userCredentialsProvider` and `accessTokenProvider` on `ApiClient` (assignable per instance); invoked at request time if `Authorization` is missing.
  - Supports Basic, Bearer, and OAuth schemes.
  - Backwards compatible: providers default to existing static fields.
  - Updated docs/samples to show static and dynamic setup (dynamic shown for JVM `okhttp`); fixed formatting and consistency.

<sup>Written for commit 9f56ca8e5832a48a027340bbb1b37321a706a947. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23836?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

