### PR TITLE
fix(typescript-fetch): support non-default file names

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/ApiEntitiesRecord.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/ApiEntitiesRecord.mustache
@@ -5,7 +5,7 @@ import { Map, Record, RecordOf } from 'immutable';
 {{#isEntity}}
 import {
     {{classname}}RecordEntity,
-} from "./models/{{classname}}Record{{importFileExtension}}"
+} from "./models/{{classFileName}}Record{{importFileExtension}}"
 {{/isEntity}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/ApiEntitiesRecord.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/ApiEntitiesRecord.mustache
@@ -4,7 +4,7 @@ import { Map, Record, RecordOf } from 'immutable';
 {{#model}}
 {{#isEntity}}
 import {
-    {{classname}}RecordEntity,
+    {{className}}RecordEntity,
 } from "./models/{{classFileName}}Record{{importFileExtension}}"
 {{/isEntity}}
 {{/model}}
@@ -15,7 +15,7 @@ export const ApiEntitiesRecordProps = {
 {{#models}}
 {{#model}}
 {{#isEntity}}
-    {{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}: ({{classname}}RecordEntity(), Map<string, {{classname}}RecordEntity>()),
+    {{#lambda.camelcase}}{{className}}{{/lambda.camelcase}}: ({{className}}RecordEntity(), Map<string, {{className}}RecordEntity>()),
 {{/isEntity}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/README.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/README.mustache
@@ -26,12 +26,12 @@ All URIs are relative to *{{basePath}}*
 
 | Class | Method | HTTP request | Description
 | ----- | ------ | ------------ | -------------
-{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}*{{classname}}* | [**{{operationId}}**]({{apiDocPath}}/{{classname}}.md#{{operationIdLowerCase}}) | **{{httpMethod}}** {{path}} | {{summary}}
+{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}*{{className}}* | [**{{operationId}}**]({{apiDocPath}}/{{className}}.md#{{operationIdLowerCase}}) | **{{httpMethod}}** {{path}} | {{summary}}
 {{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
 
 ### Models
 
-{{#models}}{{#model}}- [{{{classname}}}]({{modelDocPath}}/{{{classname}}}.md){{/model}}
+{{#models}}{{#model}}- [{{{className}}}]({{modelDocPath}}/{{{className}}}.md){{/model}}
 {{/models}}
 
 ### Authorization

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/api_doc.mustache
@@ -1,4 +1,4 @@
-# {{classname}}{{#description}}
+# {{className}}{{#description}}
 
 {{.}}{{/description}}
 
@@ -6,7 +6,7 @@ All URIs are relative to *{{basePath}}*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
-{{#operations}}{{#operation}}| [**{{operationId}}**]({{classname}}.md#{{operationIdLowerCase}}) | **{{httpMethod}}** {{commonPath}}{{path}} | {{summary}} |
+{{#operations}}{{#operation}}| [**{{operationId}}**]({{className}}.md#{{operationIdLowerCase}}) | **{{httpMethod}}** {{commonPath}}{{path}} | {{summary}} |
 {{/operation}}{{/operations}}
 
 {{#operations}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/api_example.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/api_example.mustache
@@ -1,6 +1,6 @@
 import {
   Configuration,
-  {{classname}},
+  {{className}},
 } from '{{npmName}}';
 import type { {{operationIdCamelCase}}Request } from '{{npmName}}';
 
@@ -21,7 +21,7 @@ async function example() {
     headers: { "YOUR HEADER NAME": "YOUR SIGNATURE" },{{/isHttpSignature}}{{/authMethods}}
   });
   {{/hasAuthMethods}}
-  const api = new {{classname}}({{#hasAuthMethods}}config{{/hasAuthMethods}});
+  const api = new {{className}}({{#hasAuthMethods}}config{{/hasAuthMethods}});
 
   {{#hasParams}}
   const body = {

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -23,7 +23,7 @@ import {
 {{#operations}}
 {{#operation}}
 {{#allParams.0}}
-export interface {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request {
+export interface {{#prefixParameterInterfaces}}{{className}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request {
 {{#allParams}}
     {{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{#hasReadOnly}}Omit<{{{dataType}}}, {{#readOnlyVars}}'{{baseName}}'{{^-last}}|{{/-last}}{{/readOnlyVars}}>{{/hasReadOnly}}{{^hasReadOnly}}{{{dataType}}}{{/hasReadOnly}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}};
 {{/allParams}}
@@ -35,12 +35,12 @@ export interface {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterIn
 {{#withInterfaces}}
 {{#operations}}
 /**
- * {{classname}} - interface
+ * {{className}} - interface
  * {{#lambda.indented_1}}{{{unescapedDescription}}}{{/lambda.indented_1}}
  * @export
- * @interface {{classname}}Interface
+ * @interface {{className}}Interface
  */
-export interface {{classname}}Interface {
+export interface {{className}}Interface {
 {{#operation}}
     {{#withRequestOptsInInterface}}
     /**
@@ -52,9 +52,9 @@ export interface {{classname}}Interface {
      * @deprecated
     {{/isDeprecated}}
      * @throws {RequiredError}
-     * @memberof {{classname}}Interface
+     * @memberof {{className}}Interface
      */
-    {{nickname}}RequestOpts({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request{{/allParams.0}}): Promise<runtime.RequestOpts>;
+    {{nickname}}RequestOpts({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{className}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request{{/allParams.0}}): Promise<runtime.RequestOpts>;
 
     {{/withRequestOptsInInterface}}
     /**
@@ -70,9 +70,9 @@ export interface {{classname}}Interface {
      * @deprecated
     {{/isDeprecated}}
      * @throws {RequiredError}
-     * @memberof {{classname}}Interface
+     * @memberof {{className}}Interface
      */
-    {{nickname}}Raw({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request, {{/allParams.0}}initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{{{returnType}}}{{^returnType}}void{{/returnType}}>>;
+    {{nickname}}Raw({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{className}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request, {{/allParams.0}}initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{{{returnType}}}{{^returnType}}void{{/returnType}}>>;
 
     /**
      {{#notes}}
@@ -89,7 +89,7 @@ export interface {{classname}}Interface {
     {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}}, {{/allParams}}initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{{{returnType}}}{{#returnType}}{{#isResponseOptional}} | null | undefined {{/isResponseOptional}}{{/returnType}}{{^returnType}}void{{/returnType}}>;
     {{/useSingleRequestParameter}}
     {{#useSingleRequestParameter}}
-    {{nickname}}({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request, {{/allParams.0}}initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{{{returnType}}}{{#returnType}}{{#isResponseOptional}} | null | undefined {{/isResponseOptional}}{{/returnType}}{{^returnType}}void{{/returnType}}>;
+    {{nickname}}({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{className}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request, {{/allParams.0}}initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{{{returnType}}}{{#returnType}}{{#isResponseOptional}} | null | undefined {{/isResponseOptional}}{{/returnType}}{{^returnType}}void{{/returnType}}>;
     {{/useSingleRequestParameter}}
 
 {{/operation}}
@@ -102,10 +102,10 @@ export interface {{classname}}Interface {
  * {{#lambda.indented_star_1}}{{{unescapedDescription}}}{{/lambda.indented_star_1}}
  */
 {{#withInterfaces}}
-export class {{classname}} extends runtime.BaseAPI implements {{classname}}Interface {
+export class {{className}} extends runtime.BaseAPI implements {{className}}Interface {
 {{/withInterfaces}}
 {{^withInterfaces}}
-export class {{classname}} extends runtime.BaseAPI {
+export class {{className}} extends runtime.BaseAPI {
 {{/withInterfaces}}
 
     {{#operation}}
@@ -115,7 +115,7 @@ export class {{classname}} extends runtime.BaseAPI {
      * @deprecated
      {{/isDeprecated}}
      */
-    async {{nickname}}RequestOpts({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request{{/allParams.0}}): Promise<runtime.RequestOpts> {
+    async {{nickname}}RequestOpts({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{className}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request{{/allParams.0}}): Promise<runtime.RequestOpts> {
         {{#allParams}}
         {{#required}}
         if (requestParameters['{{paramName}}'] == null) {
@@ -366,7 +366,7 @@ export class {{classname}} extends runtime.BaseAPI {
      * @deprecated
      {{/isDeprecated}}
      */
-    async {{nickname}}Raw({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request, {{/allParams.0}}initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{{{returnType}}}{{^returnType}}void{{/returnType}}>> {
+    async {{nickname}}Raw({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{className}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request, {{/allParams.0}}initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{{{returnType}}}{{^returnType}}void{{/returnType}}>> {
         const requestOptions = await this.{{nickname}}RequestOpts({{#allParams.0}}requestParameters{{/allParams.0}});
         const response = await this.request(requestOptions, initOverrides);
 
@@ -447,7 +447,7 @@ export class {{classname}} extends runtime.BaseAPI {
     }
     {{/useSingleRequestParameter}}
     {{#useSingleRequestParameter}}
-    async {{nickname}}({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request{{^hasRequiredParams}} = {}{{/hasRequiredParams}}, {{/allParams.0}}initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{{{returnType}}}{{#returnType}}{{#isResponseOptional}} | null | undefined {{/isResponseOptional}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
+    async {{nickname}}({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{className}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request{{^hasRequiredParams}} = {}{{/hasRequiredParams}}, {{/allParams.0}}initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{{{returnType}}}{{#returnType}}{{#isResponseOptional}} | null | undefined {{/isResponseOptional}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
         {{#returnType}}
         const response = await this.{{nickname}}Raw({{#allParams.0}}requestParameters, {{/allParams.0}}initOverrides);
         {{#isResponseOptional}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -16,7 +16,7 @@ import {
     type {{className}},
     {{className}}FromJSON,
     {{className}}ToJSON,
-} from '../models/{{className}}{{importFileExtension}}';
+} from '../models/{{classFileName}}{{importFileExtension}}';
 {{/imports}}
 {{/withoutRuntimeChecks}}
 

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
@@ -1,9 +1,9 @@
 {{>modelEnumInterfaces}}
 
-export function instanceOf{{classname}}(value: any): boolean {
-    for (const key in {{classname}}) {
-        if (Object.prototype.hasOwnProperty.call({{classname}}, key)) {
-            if ({{classname}}[key as keyof typeof {{classname}}] === value) {
+export function instanceOf{{className}}(value: any): boolean {
+    for (const key in {{className}}) {
+        if (Object.prototype.hasOwnProperty.call({{className}}, key)) {
+            if ({{className}}[key as keyof typeof {{className}}] === value) {
                 return true;
             }
         }
@@ -11,18 +11,18 @@ export function instanceOf{{classname}}(value: any): boolean {
     return false;
 }
 
-export function {{classname}}FromJSON(json: any): {{classname}} {
-    return {{classname}}FromJSONTyped(json, false);
+export function {{className}}FromJSON(json: any): {{className}} {
+    return {{className}}FromJSONTyped(json, false);
 }
 
-export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boolean): {{classname}} {
-    return json as {{classname}};
+export function {{className}}FromJSONTyped(json: any, ignoreDiscriminator: boolean): {{className}} {
+    return json as {{className}};
 }
 
-export function {{classname}}ToJSON(value?: {{classname}} | null): any {
+export function {{className}}ToJSON(value?: {{className}} | null): any {
     return value as any;
 }
 
-export function {{classname}}ToJSONTyped(value: any, ignoreDiscriminator: boolean): {{classname}} {
-    return value as {{classname}};
+export function {{className}}ToJSONTyped(value: any, ignoreDiscriminator: boolean): {{className}} {
+    return value as {{className}};
 }

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnumInterfaces.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnumInterfaces.mustache
@@ -4,7 +4,7 @@
  * @export
  * @enum {string}
  */
-export enum {{classname}} {
+export enum {{className}} {
 {{#allowableValues}}
 {{#enumVars}}
     {{#enumDescription}}
@@ -21,7 +21,7 @@ export enum {{classname}} {
  * {{#lambda.indented_star_1}}{{{unescapedDescription}}}{{/lambda.indented_star_1}}
  * @export
  */
-export const {{classname}} = {
+export const {{className}} = {
 {{#allowableValues}}
 {{#enumVars}}
     {{#enumDescription}}
@@ -33,5 +33,5 @@ export const {{classname}} = {
 {{/enumVars}}
 {{/allowableValues}}
 } as const;
-export type {{classname}} = typeof {{classname}}[keyof typeof {{classname}}];
+export type {{className}} = typeof {{className}}[keyof typeof {{className}}];
 {{/stringEnums}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -1,12 +1,12 @@
 import { mapValues } from '../runtime{{importFileExtension}}';
 {{#hasImports}}
 {{#tsImports}}
-import type { {{{classname}}} } from './{{filename}}{{importFileExtension}}';
+import type { {{{className}}} } from './{{filename}}{{importFileExtension}}';
 import {
-    {{classname}}FromJSON,
-    {{classname}}FromJSONTyped,
-    {{classname}}ToJSON,
-    {{classname}}ToJSONTyped,
+    {{className}}FromJSON,
+    {{className}}FromJSONTyped,
+    {{className}}ToJSON,
+    {{className}}ToJSONTyped,
 } from './{{filename}}{{importFileExtension}}';
 {{/tsImports}}
 
@@ -20,9 +20,9 @@ import { type {{modelName}}, {{modelName}}FromJSONTyped, {{modelName}}ToJSON, {{
 
 
 /**
- * Check if a given object implements the {{classname}} interface.
+ * Check if a given object implements the {{className}} interface.
  */
-export function instanceOf{{classname}}(value: object): value is {{classname}} {
+export function instanceOf{{className}}(value: object): value is {{className}} {
     {{#vars}}
     {{#required}}
     {{#hasSanitizedName}}
@@ -54,11 +54,11 @@ export function instanceOf{{classname}}(value: object): value is {{classname}} {
     return true;
 }
 
-export function {{classname}}FromJSON(json: any): {{classname}} {
-    return {{classname}}FromJSONTyped(json, false);
+export function {{className}}FromJSON(json: any): {{className}} {
+    return {{className}}FromJSONTyped(json, false);
 }
 
-export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boolean): {{classname}} {
+export function {{className}}FromJSONTyped(json: any, ignoreDiscriminator: boolean): {{className}} {
     {{#hasVars}}
     if (json == null) {
         return json;
@@ -138,11 +138,11 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
     {{/hasVars}}
 }
 
-export function {{classname}}ToJSON(json: any): {{classname}} {
-    return {{classname}}ToJSONTyped(json, false);
+export function {{className}}ToJSON(json: any): {{className}} {
+    return {{className}}ToJSONTyped(json, false);
 }
 
-export function {{classname}}ToJSONTyped(value?: {{#hasReadOnly}}Omit<{{classname}}, {{#readOnlyVars}}'{{baseName}}'{{^-last}}|{{/-last}}{{/readOnlyVars}}>{{/hasReadOnly}}{{^hasReadOnly}}{{classname}}{{/hasReadOnly}} | null, ignoreDiscriminator: boolean = false): any {
+export function {{className}}ToJSONTyped(value?: {{#hasReadOnly}}Omit<{{className}}, {{#readOnlyVars}}'{{baseName}}'{{^-last}}|{{/-last}}{{/readOnlyVars}}>{{/hasReadOnly}}{{^hasReadOnly}}{{className}}{{/hasReadOnly}} | null, ignoreDiscriminator: boolean = false): any {
     {{#hasVars}}
     if (value == null) {
         return value;

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGenericInterfaces.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGenericInterfaces.mustache
@@ -2,13 +2,13 @@
  * {{#lambda.indented_star_1}}{{{unescapedDescription}}}{{/lambda.indented_star_1}}
  * @export
 {{^parentIsOneOf}}
- * @interface {{classname}}
+ * @interface {{className}}
  */
-export interface {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
+export interface {{className}} {{#parent}}extends {{{.}}} {{/parent}}{
 {{/parentIsOneOf}}
 {{#parentIsOneOf}}
  */
-export type {{classname}} = {{{parent}}} & {
+export type {{className}} = {{{parent}}} & {
 {{/parentIsOneOf}}
 {{#additionalPropertiesType}}
     [key: string]: {{{additionalPropertiesType}}}{{#hasVars}} | any{{/hasVars}};
@@ -17,7 +17,7 @@ export type {{classname}} = {{{parent}}} & {
     /**
      * {{#lambda.indented_star_4}}{{{unescapedDescription}}}{{/lambda.indented_star_4}}
      * @type {{=<% %>=}}{<%&datatypeWithEnum%>}<%={{ }}=%>
-     * @memberof {{classname}}
+     * @memberof {{className}}
     {{#deprecated}}
      * @deprecated
     {{/deprecated}}
@@ -33,7 +33,7 @@ export type {{classname}} = {{{parent}}} & {
 * @export
 * @enum {string}
 */
-export enum {{classname}}{{enumName}} {
+export enum {{className}}{{enumName}} {
 {{#allowableValues}}
     {{#enumVars}}
     {{{name}}} = {{{value}}}{{^-last}},{{/-last}}
@@ -44,13 +44,13 @@ export enum {{classname}}{{enumName}} {
 /**
  * @export
  */
-export const {{classname}}{{enumName}} = {
+export const {{className}}{{enumName}} = {
 {{#allowableValues}}
     {{#enumVars}}
     {{{name}}}: {{{value}}}{{^-last}},{{/-last}}
     {{/enumVars}}
 {{/allowableValues}}
 } as const;
-export type {{classname}}{{enumName}} = typeof {{classname}}{{enumName}}[keyof typeof {{classname}}{{enumName}}];
+export type {{className}}{{enumName}} = typeof {{className}}{{enumName}}[keyof typeof {{className}}{{enumName}}];
 {{/stringEnums}}
 {{/isEnum}}{{/vars}}{{/hasEnums}}{{>validationAttributes}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
@@ -22,11 +22,11 @@ import {
 {{>modelOneOfInterfaces}}
 
 
-export function {{classname}}FromJSON(json: any): {{classname}} {
-    return {{classname}}FromJSONTyped(json, false);
+export function {{className}}FromJSON(json: any): {{className}} {
+    return {{className}}FromJSONTyped(json, false);
 }
 
-export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boolean): {{classname}} {
+export function {{className}}FromJSONTyped(json: any, ignoreDiscriminator: boolean): {{className}} {
     if (json == null) {
         return json;
     }
@@ -147,11 +147,11 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
 {{/discriminator}}
 }
 
-export function {{classname}}ToJSON(json: any): any {
-    return {{classname}}ToJSONTyped(json, false);
+export function {{className}}ToJSON(json: any): any {
+    return {{className}}ToJSONTyped(json, false);
 }
 
-export function {{classname}}ToJSONTyped(value?: {{classname}} | null, ignoreDiscriminator: boolean = false): any {
+export function {{className}}ToJSONTyped(value?: {{className}} | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOfInterfaces.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOfInterfaces.mustache
@@ -1,6 +1,6 @@
 /**
- * @type {{classname}}
+ * @type {{className}}
  * {{#lambda.indented_star_1}}{{{unescapedDescription}}}{{/lambda.indented_star_1}}
  * @export
  */
-export type {{classname}} = {{#discriminator}}{{#mappedModels}}{ {{discriminator.propertyName}}: '{{mappingName}}' } & {{modelName}}{{^-last}} | {{/-last}}{{/mappedModels}}{{/discriminator}}{{^discriminator}}{{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}}{{/discriminator}};
+export type {{className}} = {{#discriminator}}{{#mappedModels}}{ {{discriminator.propertyName}}: '{{mappingName}}' } & {{modelName}}{{^-last}} | {{/-last}}{{/mappedModels}}{{/discriminator}}{{^discriminator}}{{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}}{{/discriminator}};

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/model_doc.mustache
@@ -1,5 +1,5 @@
 {{#models}}{{#model}}
-# {{classname}}
+# {{className}}
 
 {{#description}}{{&description}}
 {{/description}}
@@ -15,14 +15,14 @@ Name | Type
 ## Example
 
 ```typescript
-import type { {{classname}} } from '{{npmName}}'
+import type { {{className}} } from '{{npmName}}'
 
 // TODO: Update the object below with actual values
 const example = {
 {{#vars}}
   "{{name}}": {{{example}}},
 {{/vars}}
-} satisfies {{classname}}
+} satisfies {{className}}
 
 console.log(example)
 
@@ -31,7 +31,7 @@ const exampleJSON: string = JSON.stringify(example)
 console.log(exampleJSON)
 
 // Parse the JSON string back to an object
-const exampleParsed = JSON.parse(exampleJSON) as {{classname}}
+const exampleParsed = JSON.parse(exampleJSON) as {{className}}
 console.log(exampleParsed)
 ```
 {{/withoutRuntimeChecks}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/recordGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/recordGeneric.mustache
@@ -5,10 +5,10 @@ import { Schema, schema, NormalizedSchema } from "normalizr";
 import { select, call } from "redux-saga/effects";
 
 import {
-    {{classname}},
+    {{className}},
 {{#vars}}
 {{#isEnum}}
-    {{classname}}{{enumName}},
+    {{className}}{{enumName}},
 {{/isEnum}}
 {{/vars}}
 } from './{{classFileName}}{{importFileExtension}}';
@@ -26,8 +26,8 @@ import {
 } from './{{{.}}}Record{{importFileExtension}}';
 {{/modelImports}}
 
-export const {{classname}}RecordProps = {
-    recType: "{{classname}}ApiRecord" as "{{classname}}ApiRecord",
+export const {{className}}RecordProps = {
+    recType: "{{className}}ApiRecord" as "{{className}}ApiRecord",
 {{#vars}}
     {{#isArray}}
     {{#items.isModel}}
@@ -58,16 +58,16 @@ export const {{classname}}RecordProps = {
 {{/vars}}
 };
 
-export type {{classname}}RecordPropsType = typeof {{classname}}RecordProps;
-export const {{classname}}Record = Record({{classname}}RecordProps, {{classname}}RecordProps.recType);
-export type {{classname}}Record = RecordOf<{{classname}}RecordPropsType>;
+export type {{className}}RecordPropsType = typeof {{className}}RecordProps;
+export const {{className}}Record = Record({{className}}RecordProps, {{className}}RecordProps.recType);
+export type {{className}}Record = RecordOf<{{className}}RecordPropsType>;
 
-knownRecordFactories.set({{classname}}RecordProps.recType, {{classname}}Record);
+knownRecordFactories.set({{className}}RecordProps.recType, {{className}}Record);
 
 {{#isEntity}}
-export const {{classname}}RecordEntityProps = {
-    ...{{classname}}RecordProps,
-    recType: "{{classname}}ApiRecordEntity" as "{{classname}}ApiRecordEntity",
+export const {{className}}RecordEntityProps = {
+    ...{{className}}RecordProps,
+    recType: "{{className}}ApiRecordEntity" as "{{className}}ApiRecordEntity",
 {{#vars}}
     {{#isEntity}}
     {{^keepAsJSObject}}
@@ -84,16 +84,16 @@ export const {{classname}}RecordEntityProps = {
 {{/vars}}
 };
 
-export type {{classname}}RecordEntityPropsType = typeof {{classname}}RecordEntityProps;
-export const {{classname}}RecordEntity = Record({{classname}}RecordEntityProps, {{classname}}RecordEntityProps.recType);
-export type {{classname}}RecordEntity = RecordOf<{{classname}}RecordEntityPropsType>;
+export type {{className}}RecordEntityPropsType = typeof {{className}}RecordEntityProps;
+export const {{className}}RecordEntity = Record({{className}}RecordEntityProps, {{className}}RecordEntityProps.recType);
+export type {{className}}RecordEntity = RecordOf<{{className}}RecordEntityPropsType>;
 
-knownRecordFactories.set({{classname}}RecordEntityProps.recType, {{classname}}RecordEntity);
+knownRecordFactories.set({{className}}RecordEntityProps.recType, {{className}}RecordEntity);
 {{/isEntity}}
 
-class {{classname}}RecordUtils extends ApiRecordUtils<{{classname}}, {{classname}}Record> {
-    public normalize(apiObject: {{classname}}, asEntity?: boolean): {{classname}} {
-        (apiObject as any).recType = {{#isEntity}}asEntity ? {{classname}}RecordEntityProps.recType : {{/isEntity}}{{classname}}RecordProps.recType;
+class {{className}}RecordUtils extends ApiRecordUtils<{{className}}, {{className}}Record> {
+    public normalize(apiObject: {{className}}, asEntity?: boolean): {{className}} {
+        (apiObject as any).recType = {{#isEntity}}asEntity ? {{className}}RecordEntityProps.recType : {{/isEntity}}{{className}}RecordProps.recType;
 {{#vars}}
         {{#isUniqueId}}
         {{#isArray}}
@@ -124,7 +124,7 @@ class {{classname}}RecordUtils extends ApiRecordUtils<{{classname}}, {{classname
 {{#isEntity}}
 
     public getSchema(): Schema {
-        return new schema.Entity("{{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}", {
+        return new schema.Entity("{{#lambda.camelcase}}{{className}}{{/lambda.camelcase}}", {
 {{#vars}}
             {{#isEntity}}
             {{^keepAsJSObject}}
@@ -145,7 +145,7 @@ class {{classname}}RecordUtils extends ApiRecordUtils<{{classname}}, {{classname
     public *toInlined(entityId?: string | null) {
         if (!entityId) {return undefined; }
         // @ts-ignore
-        const entity = yield select(apiEntity{{classname}}Selector, {id: entityId});
+        const entity = yield select(apiEntity{{className}}Selector, {id: entityId});
         if (!entity) {return undefined; }
 
         const {
@@ -186,7 +186,7 @@ class {{classname}}RecordUtils extends ApiRecordUtils<{{classname}}, {{classname
 {{/vars}}
         }
 
-        return {{classname}}Record({
+        return {{className}}Record({
             ...unchangedProperties,
             ...entityProperties
         });
@@ -194,7 +194,7 @@ class {{classname}}RecordUtils extends ApiRecordUtils<{{classname}}, {{classname
 
     public *toInlinedArray(entityIds: List<string> | null) {
         if (!entityIds) {return null; }
-        let entities = List<{{classname}}Record>();
+        let entities = List<{{className}}Record>();
         for (let entityIndex = 0; entityIndex < entityIds.count(); entityIndex++) {
             // @ts-ignore
             const entity = yield call(this.toInlined, entityIds.get(entityIndex));
@@ -206,7 +206,7 @@ class {{classname}}RecordUtils extends ApiRecordUtils<{{classname}}, {{classname
     }
 {{/isEntity}}
 
-    public toApi(record: {{classname}}Record): {{classname}} {
+    public toApi(record: {{className}}Record): {{className}} {
         const apiObject = super.toApi(record);
 {{#vars}}
         {{#isUniqueId}}
@@ -238,7 +238,7 @@ class {{classname}}RecordUtils extends ApiRecordUtils<{{classname}}, {{classname
 {{#returnPassthrough}}
 {{#vars.1}}
 
-    public fromApiPassthrough(apiObject: {{classname}}): {{{dataTypeAlternate}}} {
+    public fromApiPassthrough(apiObject: {{className}}): {{{dataTypeAlternate}}} {
     {{#isModel}}
         if (!apiObject.{{{returnPassthrough}}}) {return {{{defaultValue}}}; }
         const normalizedApiObject = {{#lambda.camelcase}}{{{dataTypeAlternate}}}{{/lambda.camelcase}}Utils.normalize(apiObject.{{{returnPassthrough}}});
@@ -261,7 +261,7 @@ class {{classname}}RecordUtils extends ApiRecordUtils<{{classname}}, {{classname
     {{/isModel}}
     }
 
-    public fromApiPassthroughAsEntities(apiObject: {{classname}}): NormalizedRecordEntities {
+    public fromApiPassthroughAsEntities(apiObject: {{className}}): NormalizedRecordEntities {
     {{#isEntity}}
         if (!apiObject.{{{returnPassthrough}}}) {return {entities: {}, result: List<string>()}; }
         return ApiRecordUtils.toNormalizedRecordEntities({{#lambda.camelcase}}{{{dataTypeAlternate}}}{{/lambda.camelcase}}Utils.normalizeArrayAsEntities([apiObject.{{{returnPassthrough}}}]), true);
@@ -287,9 +287,9 @@ class {{classname}}RecordUtils extends ApiRecordUtils<{{classname}}, {{classname
 {{/returnPassthrough}}
 }
 
-export const {{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}RecordUtils = new {{classname}}RecordUtils();
+export const {{#lambda.camelcase}}{{className}}{{/lambda.camelcase}}RecordUtils = new {{className}}RecordUtils();
 
 {{#isEntity}}
-export const apiEntities{{classname}}Selector = (state: any) => getApiEntitiesState(state).{{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}} as Map<string, {{classname}}RecordEntity>;
-export const apiEntity{{classname}}Selector = (state: any, {id}: {id?: string | null}) => id ? apiEntities{{classname}}Selector(state).get(id) : undefined;
+export const apiEntities{{className}}Selector = (state: any) => getApiEntitiesState(state).{{#lambda.camelcase}}{{className}}{{/lambda.camelcase}} as Map<string, {{className}}RecordEntity>;
+export const apiEntity{{className}}Selector = (state: any, {id}: {id?: string | null}) => id ? apiEntities{{className}}Selector(state).get(id) : undefined;
 {{/isEntity}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/recordGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/recordGeneric.mustache
@@ -11,7 +11,7 @@ import {
     {{classname}}{{enumName}},
 {{/isEnum}}
 {{/vars}}
-} from './{{classname}}{{importFileExtension}}';
+} from './{{classFileName}}{{importFileExtension}}';
 
 {{#imports}}
 import {

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/sagas.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/sagas.mustache
@@ -14,7 +14,7 @@ import {
 } from '../models/{{classFileName}}{{importFileExtension}}';
 import {
     {{className}}Record,
-    {{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}RecordUtils,
+    {{#lambda.camelcase}}{{className}}{{/lambda.camelcase}}RecordUtils,
 } from '../models/{{classFileName}}Record{{importFileExtension}}';
 {{/imports}}
 {{#passthroughImports}}
@@ -37,9 +37,9 @@ import {
 {{/operations}}
 {{/hasEnums}}
 
-const createSagaAction = <T>(type: string) => originalCreateSagaAction<T>(type, {namespace: "api_{{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}"});
+const createSagaAction = <T>(type: string) => originalCreateSagaAction<T>(type, {namespace: "api_{{#lambda.camelcase}}{{className}}{{/lambda.camelcase}}"});
 
-export const {{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}SagaMap = new Map<string, () => Generator<any, any, any>>([
+export const {{#lambda.camelcase}}{{className}}{{/lambda.camelcase}}SagaMap = new Map<string, () => Generator<any, any, any>>([
 {{#operations}}
     {{#operation}}
         ["{{nickname}}", {{nickname}}Saga],
@@ -48,8 +48,8 @@ export const {{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}SagaMap = ne
     ]
 );
 
-export function *{{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}AllSagas() {
-    yield all([...{{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}SagaMap.values()].map(actionSaga => fork(actionSaga)));
+export function *{{#lambda.camelcase}}{{className}}{{/lambda.camelcase}}AllSagas() {
+    yield all([...{{#lambda.camelcase}}{{className}}{{/lambda.camelcase}}SagaMap.values()].map(actionSaga => fork(actionSaga)));
 }
 
 {{#operations}}
@@ -107,7 +107,7 @@ export function *{{nickname}}SagaImp(_action_: Action<Payload{{#lambda.titlecase
 
         yield put({{nickname}}Request({{#allParams.0}}{{#returnTypeSupportsEntities}}requestPayload{{/returnTypeSupportsEntities}}{{^returnTypeSupportsEntities}}_action_.payload{{/returnTypeSupportsEntities}}{{/allParams.0}}));
 
-        const response{{#returnType}}: Required<{{{returnType}}}>{{/returnType}} = yield apiCall(Api.{{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}, Api.{{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}['{{nickname}}'],
+        const response{{#returnType}}: Required<{{{returnType}}}>{{/returnType}} = yield apiCall(Api.{{#lambda.camelcase}}{{className}}{{/lambda.camelcase}}, Api.{{#lambda.camelcase}}{{className}}{{/lambda.camelcase}}['{{nickname}}'],
 {{#allParams.0}}
 {{#allParams}}
 {{#isUniqueId}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/sagas.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/sagas.mustache
@@ -11,11 +11,11 @@ import { Action } from "redux-ts-simple";
 {{#imports}}
 import {
     {{className}},
-} from '../models/{{className}}{{importFileExtension}}';
+} from '../models/{{classFileName}}{{importFileExtension}}';
 import {
     {{className}}Record,
     {{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}RecordUtils,
-} from '../models/{{className}}Record{{importFileExtension}}';
+} from '../models/{{classFileName}}Record{{importFileExtension}}';
 {{/imports}}
 {{#passthroughImports}}
 import {
@@ -30,7 +30,7 @@ import {
 
 import {
     {{operationIdCamelCase}}{{enumName}},
-} from './{{classname}}{{importFileExtension}}';
+} from './{{classFileName}}{{importFileExtension}}';
 {{/isEnum}}
 {{/allParams}}
 {{/operation}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/validationAttributes.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/validationAttributes.mustache
@@ -1,6 +1,6 @@
 {{#validationAttributes}}
 
-export const {{classname}}PropertyValidationAttributesMap: {
+export const {{className}}PropertyValidationAttributesMap: {
     [property: string]: {
         maxLength?: number,
         minLength?: number,
@@ -53,7 +53,7 @@ export const {{classname}}PropertyValidationAttributesMap: {
 }
 {{#isAdditionalPropertiesTrue}}
 
-export const {{classname}}AdditionalPropertiesValidationAttributes: { maxProperties?: number, minProperties?: number } = {
+export const {{className}}AdditionalPropertiesValidationAttributes: { maxProperties?: number, minProperties?: number } = {
     {{#maxProperties}}
     maxProperties: {{maxProperties}},
     {{/maxProperties}}


### PR DESCRIPTION
files generated with non-default (e.g. `"fileNaming": "kebab-case"`) have their import path set with the default file name. this PR fixes the non-barrel imports by using the parsed file name instead of simply the class name.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `typescript-fetch` generator to work with non-default model file names. Imports, helpers, and docs now resolve correctly when file names differ from class names.

- **Bug Fixes**
  - Use `classFileName` for all import paths (models, records, sagas, examples, docs).
  - Normalize identifiers to `className` (replacing legacy `classname`) in APIs, models, enums, and validation helpers.
  - Correct saga namespaces and selectors to use the proper casing.
  - Prevents broken imports and docs when custom file naming is enabled.

<sup>Written for commit c029bfb9e8b09ffc5ed50ec82b3b7c1ce01270d7. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23839?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

