### PR TITLE
[scala-http4s] Preserve underscores in enum names

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractScalaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractScalaCodegen.java
@@ -551,6 +551,21 @@ public abstract class AbstractScalaCodegen extends DefaultCodegen {
 
         return escapeReservedWord(identifier);
     }
+    protected String formatEnumIdentifier(String name) {
+        if (specialCharReplacements.containsKey(name)) {
+            name = specialCharReplacements.get(name);
+        }
+
+        String sanitized = sanitizeName(name);
+
+        // Preserve already-valid Scala identifiers
+        if (sanitized.matches("[A-Za-z_][A-Za-z0-9_]*")
+                && !isReservedWord(sanitized)) {
+            return sanitized;
+        }
+
+        return escapeReservedWord(sanitized);
+    }
 
     protected String stripPackageName(String input) {
         if (!stripPackageName || StringUtils.isEmpty(input) || input.lastIndexOf(".") < 0)

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractScalaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractScalaCodegen.java
@@ -551,21 +551,6 @@ public abstract class AbstractScalaCodegen extends DefaultCodegen {
 
         return escapeReservedWord(identifier);
     }
-    protected String formatEnumIdentifier(String name) {
-        if (specialCharReplacements.containsKey(name)) {
-            name = specialCharReplacements.get(name);
-        }
-
-        String sanitized = sanitizeName(name);
-
-        // Preserve already-valid Scala identifiers
-        if (sanitized.matches("[A-Za-z_][A-Za-z0-9_]*")
-                && !isReservedWord(sanitized)) {
-            return sanitized;
-        }
-
-        return escapeReservedWord(sanitized);
-    }
 
     protected String stripPackageName(String input) {
         if (!stripPackageName || StringUtils.isEmpty(input) || input.lastIndexOf(".") < 0)

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaHttp4sClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaHttp4sClientCodegen.java
@@ -628,7 +628,7 @@ public class ScalaHttp4sClientCodegen extends AbstractScalaCodegen implements Co
     private class EnumEntryLambda extends CustomLambda {
         @Override
         public String formatFragment(String fragment) {
-            return formatIdentifier(fragment, true);
+            return formatEnumIdentifier(fragment);
         }
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaHttp4sClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaHttp4sClientCodegen.java
@@ -624,11 +624,24 @@ public class ScalaHttp4sClientCodegen extends AbstractScalaCodegen implements Co
         }
     }
 
+    @Override
+    public String toEnumVarName(String value, String datatype) {
+        String sanitized = sanitizeName(value);
+
+        // Preserve SCREAMING_SNAKE_CASE values
+        if (sanitized.matches("^[A-Z][A-Z0-9_]*$")
+                && !isReservedWord(sanitized)) {
+            return sanitized;
+        }
+
+        return super.formatIdentifier(sanitized, true);
+
+    }
 
     private class EnumEntryLambda extends CustomLambda {
         @Override
         public String formatFragment(String fragment) {
-            return formatEnumIdentifier(fragment);
+            return toEnumVarName(fragment, "string");
         }
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/ScalaHttp4sClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/ScalaHttp4sClientCodegenTest.java
@@ -145,6 +145,42 @@ public class ScalaHttp4sClientCodegenTest {
     }
 
     @Test
+    public void preserveScreamingSnakeCaseEnumNames() {
+        ScalaHttp4sClientCodegen codegen = new ScalaHttp4sClientCodegen();
+
+        assertEquals(
+                codegen.toEnumVarName("ACTIVE_STATUS", "string"),
+                "ACTIVE_STATUS"
+        );
+
+        assertEquals(
+                codegen.toEnumVarName("INACTIVE_STATUS", "string"),
+                "INACTIVE_STATUS"
+        );
+
+        assertEquals(
+                codegen.toEnumVarName("USER_123_STATUS", "string"),
+                "USER_123_STATUS"
+        );
+    }
+
+    @Test
+    public void formatRegularEnumNames() {
+        ScalaHttp4sClientCodegen codegen = new ScalaHttp4sClientCodegen();
+
+        assertEquals(
+                codegen.toEnumVarName("available", "string"),
+                "Available"
+        );
+
+        assertEquals(
+                codegen.toEnumVarName("pending_status", "string"),
+                "PendingStatus"
+        );
+
+    }
+
+    @Test
     public void encodePath() {
         ScalaHttp4sClientCodegen codegen = new ScalaHttp4sClientCodegen();
         assertEquals(codegen.encodePath("{user_name}"), "${userName}");


### PR DESCRIPTION
## Summary

This fixes an issue in the `scala-http4s` generator where enum entries containing underscores are incorrectly camelized during generation.

For example:

```yaml id="fnhg0h"
enum:
  - ACTIVE_STATUS
```

was previously generated as:

```scala id="qv57ep"
ActiveStatus
```

instead of preserving the valid Scala identifier:

```scala id="g4g6ae"
ACTIVE_STATUS
```

## Root Cause

`EnumEntryLambda` currently calls:

```java id="5dpc2v"
formatIdentifier(fragment, true)
```

which delegates to `camelize()` and removes underscores.

This behavior is appropriate for general identifiers, but not for enum entries that are already valid Scala identifiers.

## Fix

Added a dedicated `formatEnumIdentifier()` helper in `AbstractScalaCodegen` which:

* preserves valid Scala identifiers unchanged
* avoids camelization for enum entries
* still applies reserved-word escaping when needed

`ScalaHttp4sClientCodegen.EnumEntryLambda` now uses this helper instead of `formatIdentifier()`.

## Verification

Generated models using:

```yaml id="s2vj2e"
enum:
  - ACTIVE_STATUS
  - INACTIVE_STATUS
```

now correctly produce:

```scala id="h8d67o"
case ACTIVE_STATUS extends MyStatus("ACTIVE_STATUS")
case INACTIVE_STATUS extends MyStatus("INACTIVE_STATUS")
```

Fixes #23841

---

### PR checklist

* [x] Read the contribution guidelines.
* [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work.
* [ ] Run the full sample regeneration scripts.
* [x] File the PR against the `master` branch.
* [x] Reference the reported issue using GitHub linking syntax.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves SCREAMING_SNAKE_CASE enum entry names in the `scala-http4s` generator by avoiding camelization of underscores. Names are sanitized and reserved words are still escaped.

- **Bug Fixes**
  - Overrode `toEnumVarName()` in `ScalaHttp4sClientCodegen` to return SCREAMING_SNAKE_CASE identifiers as-is when not reserved; otherwise sanitize and format via `formatIdentifier()`.
  - Updated `EnumEntryLambda` to use `toEnumVarName()` and added tests for preserving SCREAMING_SNAKE_CASE and formatting regular/underscored names.

<sup>Written for commit b748b14027ae9c8208b52d6bf9440e8d70726baa. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23842?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

