### PR TITLE
regression: restore dateSerializers in scala sttp 4 client gen

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaSttp4ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaSttp4ClientCodegen.java
@@ -174,6 +174,7 @@ public class ScalaSttp4ClientCodegen extends AbstractScalaCodegen implements Cod
         supportingFiles.add(new SupportingFile("jsonSupport.mustache", invokerFolder, "JsonSupport.scala"));
         supportingFiles.add(new SupportingFile("additionalTypeSerializers.mustache", invokerFolder, "AdditionalTypeSerializers.scala"));
         supportingFiles.add(new SupportingFile("project/build.properties.mustache", "project", "build.properties"));
+        supportingFiles.add(new SupportingFile("dateSerializers.mustache", invokerFolder, "DateSerializers.scala"));
         supportingFiles.add(new SupportingFile("project/plugins.mustache", "project", "plugins.sbt"));
         supportingFiles.add(new SupportingFile("scalafmt.mustache", "", ".scalafmt.conf"));
     }

--- a/samples/client/petstore/scala-sttp4/.openapi-generator/FILES
+++ b/samples/client/petstore/scala-sttp4/.openapi-generator/FILES
@@ -7,6 +7,7 @@ src/main/scala/org/openapitools/client/api/PetApi.scala
 src/main/scala/org/openapitools/client/api/StoreApi.scala
 src/main/scala/org/openapitools/client/api/UserApi.scala
 src/main/scala/org/openapitools/client/core/AdditionalTypeSerializers.scala
+src/main/scala/org/openapitools/client/core/DateSerializers.scala
 src/main/scala/org/openapitools/client/core/JsonSupport.scala
 src/main/scala/org/openapitools/client/model/ApiResponse.scala
 src/main/scala/org/openapitools/client/model/Category.scala


### PR DESCRIPTION
to close https://github.com/OpenAPITools/sbt-openapi-generator/issues/87#issuecomment-4514169399

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores generation of `DateSerializers.scala` in the Scala STTP 4 client to fix a regression that removed date/time serializers. Updates samples so generated clients again provide JSON support for `java.time` types.

- **Bug Fixes**
  - Add `dateSerializers.mustache` to `ScalaSttp4ClientCodegen` supportingFiles to emit `DateSerializers.scala`; update sample file list.

<sup>Written for commit f69ed707cc05900ff8d1591aecc531a866c62493. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23845?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

