### PR TITLE
[kotlin-server] Enable oneOf sealed interface generation

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinServerCodegen.java
@@ -121,6 +121,9 @@ public class KotlinServerCodegen extends AbstractKotlinCodegen implements BeanVa
         // Enable proper oneOf/anyOf discriminator handling for polymorphism
         legacyDiscriminatorBehavior = false;
 
+        // Generate sealed interfaces for oneOf schemas (mirrors KotlinSpringServerCodegen)
+        useOneOfInterfaces = true;
+
         modifyFeatureSet(features -> features
                 .includeDocumentationFeatures(DocumentationFeature.Readme)
                 .wireFormatFeatures(EnumSet.of(WireFormatFeature.JSON, WireFormatFeature.XML))
@@ -698,9 +701,11 @@ public class KotlinServerCodegen extends AbstractKotlinCodegen implements BeanVa
                                         childModel.getAllVars().add(discriminatorProp);
                                     }
 
-                                    // Set parent constructor args for the discriminator property
-                                    childModel.getVendorExtensions().put("x-parent-ctor-args",
-                                            discriminatorVarName + " = " + discriminatorVarName);
+                                    // Set parent constructor args only when parent is a sealed class (not interface)
+                                    if (!useOneOfInterfaces) {
+                                        childModel.getVendorExtensions().put("x-parent-ctor-args",
+                                                discriminatorVarName + " = " + discriminatorVarName);
+                                    }
                                 }
                             }
                         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinServerCodegen.java
@@ -620,6 +620,12 @@ public class KotlinServerCodegen extends AbstractKotlinCodegen implements BeanVa
                             owner.getRequiredVars().add(parentDiscriminatorProp);
                             owner.getAllVars().add(parentDiscriminatorProp);
 
+                            // Children are retyped to kotlin.String and marked inherited below, so they can
+                            // override an abstract declaration on the oneOf interface. Only then may the
+                            // interface declare the discriminator - see oneof_interface.mustache.
+                            owner.getVendorExtensions().put("x-one-of-interface-declares-discriminator", true);
+                            owner.getDiscriminator().getVendorExtensions().put("x-one-of-interface-declares-discriminator", true);
+
                             // Parent now has properties (just the discriminator)
                             hasParentProperties = true;
 

--- a/modules/openapi-generator/src/main/resources/kotlin-server/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/data_class.mustache
@@ -104,7 +104,7 @@ sealed class {{classname}}
 {{/-last}}{{/requiredVars}}{{#hasRequired}}{{#hasOptional}},
 {{/hasOptional}}{{/hasRequired}}{{#optionalVars}}{{>data_class_opt_var}}{{^-last}},
 {{/-last}}{{/optionalVars}}
-){{#parent}} : {{{.}}}({{#vendorExtensions.x-parent-ctor-args}}{{{.}}}{{/vendorExtensions.x-parent-ctor-args}}){{/parent}}{{^parent}}{{^serializableModel}}{{#parcelizeModels}} : Parcelable{{/parcelizeModels}}{{/serializableModel}}{{^parcelizeModels}}{{#serializableModel}}: Serializable {{/serializableModel}}{{/parcelizeModels}}{{#parcelizeModels}}{{#serializableModel}} : Parcelable, Serializable {{/serializableModel}}{{/parcelizeModels}}{{/parent}}
+){{#parent}} : {{{.}}}{{#vendorExtensions.x-parent-ctor-args}}({{{.}}}){{/vendorExtensions.x-parent-ctor-args}}{{/parent}}{{^parent}}{{^serializableModel}}{{#parcelizeModels}} : Parcelable{{/parcelizeModels}}{{/serializableModel}}{{^parcelizeModels}}{{#serializableModel}}: Serializable {{/serializableModel}}{{/parcelizeModels}}{{#parcelizeModels}}{{#serializableModel}} : Parcelable, Serializable {{/serializableModel}}{{/parcelizeModels}}{{/parent}}
 {{#vendorExtensions.x-has-data-class-body}}
 {
 {{/vendorExtensions.x-has-data-class-body}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/data_class.mustache
@@ -104,7 +104,13 @@ sealed class {{classname}}
 {{/-last}}{{/requiredVars}}{{#hasRequired}}{{#hasOptional}},
 {{/hasOptional}}{{/hasRequired}}{{#optionalVars}}{{>data_class_opt_var}}{{^-last}},
 {{/-last}}{{/optionalVars}}
-){{#parent}} : {{{.}}}{{#vendorExtensions.x-parent-ctor-args}}({{{.}}}){{/vendorExtensions.x-parent-ctor-args}}{{/parent}}{{^parent}}{{^serializableModel}}{{#parcelizeModels}} : Parcelable{{/parcelizeModels}}{{/serializableModel}}{{^parcelizeModels}}{{#serializableModel}}: Serializable {{/serializableModel}}{{/parcelizeModels}}{{#parcelizeModels}}{{#serializableModel}} : Parcelable, Serializable {{/serializableModel}}{{/parcelizeModels}}{{/parent}}
+){{#parent}} : {{{.}}}{{#vendorExtensions.x-parent-ctor-args}}({{{.}}}){{/vendorExtensions.x-parent-ctor-args}}{{/parent}}{{^parent}}{{! no newline
+}}{{#vendorExtensions.x-implements}}{{! <- oneOf sealed interfaces this model is a member of
+    }}{{#-first}} : {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{! no newline
+    }}{{#-last}}{{#parcelizeModels}}, Parcelable{{/parcelizeModels}}{{#serializableModel}}, Serializable{{/serializableModel}}{{/-last}}{{! no newline
+}}{{/vendorExtensions.x-implements}}{{! no newline
+}}{{^vendorExtensions.x-implements}}{{^serializableModel}}{{#parcelizeModels}} : Parcelable{{/parcelizeModels}}{{/serializableModel}}{{^parcelizeModels}}{{#serializableModel}}: Serializable {{/serializableModel}}{{/parcelizeModels}}{{#parcelizeModels}}{{#serializableModel}} : Parcelable, Serializable {{/serializableModel}}{{/parcelizeModels}}{{/vendorExtensions.x-implements}}{{! no newline
+}}{{/parent}}
 {{#vendorExtensions.x-has-data-class-body}}
 {
 {{/vendorExtensions.x-has-data-class-body}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/data_class_opt_var.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/data_class_opt_var.mustache
@@ -3,4 +3,4 @@
 {{/description}}
 
     @JsonProperty("{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}")
-{{#useBeanValidation}}{{>beanValidation}}{{>beanValidationModel}}{{/useBeanValidation}}    {{>modelMutable}} {{{name}}}: {{#isEnum}}{{classname}}.{{nameInPascalCase}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}? = {{{defaultValue}}}{{^defaultValue}}null{{/defaultValue}}
+{{#useBeanValidation}}{{>beanValidation}}{{>beanValidationModel}}{{/useBeanValidation}}    {{#isInherited}}override {{/isInherited}}{{>modelMutable}} {{{name}}}: {{#isEnum}}{{classname}}.{{nameInPascalCase}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}? = {{{defaultValue}}}{{^defaultValue}}null{{/defaultValue}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/data_class_req_var.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/data_class_req_var.mustache
@@ -3,4 +3,4 @@
 {{/description}}
 
     @JsonProperty("{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}")
-{{#useBeanValidation}}{{>beanValidation}}{{>beanValidationModel}}{{/useBeanValidation}}    {{>modelMutable}} {{{name}}}: {{#isEnum}}{{classname}}.{{nameInPascalCase}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}
+{{#useBeanValidation}}{{>beanValidation}}{{>beanValidationModel}}{{/useBeanValidation}}    {{#isInherited}}override {{/isInherited}}{{>modelMutable}} {{{name}}}: {{#isEnum}}{{classname}}.{{nameInPascalCase}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/model.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/model.mustache
@@ -9,6 +9,6 @@ import {{javaxPackage}}.validation.Valid
 {{/useBeanValidation}}
 {{#models}}
 {{#model}}
-{{#isEnum}}{{>enum_class}}{{/isEnum}}{{^isEnum}}{{#oneOf}}{{>oneof_model}}{{/oneOf}}{{^oneOf}}{{#isAlias}}typealias {{classname}} = {{{dataType}}}{{/isAlias}}{{^isAlias}}{{>data_class}}{{/isAlias}}{{/oneOf}}{{/isEnum}}
+{{#isEnum}}{{>enum_class}}{{/isEnum}}{{^isEnum}}{{#vendorExtensions.x-is-one-of-interface}}{{>oneof_interface}}{{/vendorExtensions.x-is-one-of-interface}}{{^vendorExtensions.x-is-one-of-interface}}{{#oneOf}}{{>oneof_model}}{{/oneOf}}{{^oneOf}}{{#isAlias}}typealias {{classname}} = {{{dataType}}}{{/isAlias}}{{^isAlias}}{{>data_class}}{{/isAlias}}{{/oneOf}}{{/vendorExtensions.x-is-one-of-interface}}{{/isEnum}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/model.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/model.mustache
@@ -6,6 +6,6 @@ package {{modelPackage}}
 
 {{#models}}
 {{#model}}
-{{#isEnum}}{{>enum_class}}{{/isEnum}}{{^isEnum}}{{>data_class}}{{/isEnum}}
+{{#isEnum}}{{>enum_class}}{{/isEnum}}{{^isEnum}}{{#vendorExtensions.x-is-one-of-interface}}{{>oneof_interface}}{{/vendorExtensions.x-is-one-of-interface}}{{^vendorExtensions.x-is-one-of-interface}}{{>data_class}}{{/vendorExtensions.x-is-one-of-interface}}{{/isEnum}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/oneof_interface.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/oneof_interface.mustache
@@ -1,0 +1,17 @@
+/**
+ * {{{description}}}
+ */
+{{#discriminator}}
+{{>typeInfoAnnotation}}
+{{/discriminator}}
+{{#additionalModelTypeAnnotations}}
+{{{.}}}
+{{/additionalModelTypeAnnotations}}
+{{#vendorExtensions.x-class-extra-annotation}}
+{{{.}}}
+{{/vendorExtensions.x-class-extra-annotation}}
+sealed interface {{classname}}{{#vendorExtensions.x-kotlin-implements}}{{#-first}} : {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-kotlin-implements}} {
+{{#discriminator}}
+    val {{propertyName}}: {{{propertyType}}}
+{{/discriminator}}
+}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/oneof_interface.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/oneof_interface.mustache
@@ -12,6 +12,8 @@
 {{/vendorExtensions.x-class-extra-annotation}}
 sealed interface {{classname}}{{#vendorExtensions.x-kotlin-implements}}{{#-first}} : {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-kotlin-implements}} {
 {{#discriminator}}
+{{#vendorExtensions.x-one-of-interface-declares-discriminator}}
     val {{propertyName}}: {{{propertyType}}}
+{{/vendorExtensions.x-one-of-interface-declares-discriminator}}
 {{/discriminator}}
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinServerCodegenTest.java
@@ -325,7 +325,7 @@ public class KotlinServerCodegenTest {
     // ==================== Polymorphism and Discriminator Tests ====================
 
     @Test
-    public void oneOfWithDiscriminator_generatesSealedClassWithDiscriminatorProperty() throws IOException {
+    public void oneOfWithDiscriminator_generatesSealedInterfaceWithDiscriminatorProperty() throws IOException {
         File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
         output.deleteOnExit();
 
@@ -341,20 +341,20 @@ public class KotlinServerCodegenTest {
         String outputPath = output.getAbsolutePath() + "/src/main/kotlin/org/openapitools/server";
         Path petModel = Paths.get(outputPath + "/models/Pet.kt");
 
-        // Pet should be a sealed class with Jackson polymorphism annotations and discriminator property
+        // Pet should be a sealed interface with Jackson polymorphism annotations and discriminator property
         assertFileContains(
                 petModel,
-                "sealed class Pet(",
-                "open val petType: kotlin.String",
+                "sealed interface Pet",
+                "val petType:",
                 "@com.fasterxml.jackson.annotation.JsonTypeInfo",
                 "property = \"petType\"",
-                "visible = true",
                 "@com.fasterxml.jackson.annotation.JsonSubTypes"
         );
+        assertFileNotContains(petModel, "sealed class", "typealias");
     }
 
     @Test
-    public void oneOfWithDiscriminator_generatesChildrenWithOverrideDiscriminatorProperty() throws IOException {
+    public void oneOfWithDiscriminator_generatesChildrenImplementingInterface() throws IOException {
         File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
         output.deleteOnExit();
 
@@ -369,35 +369,14 @@ public class KotlinServerCodegenTest {
 
         String outputPath = output.getAbsolutePath() + "/src/main/kotlin/org/openapitools/server";
 
-        // Cat should have petType as overridden non-nullable String with default value
+        // Cat and Dog should be data classes (not typealias)
         Path catModel = Paths.get(outputPath + "/models/Cat.kt");
-        assertFileContains(
-                catModel,
-                "data class Cat(",
-                "override val petType: kotlin.String = \"cat\"",
-                ") : Pet(petType = petType)"
-        );
-        // Should NOT be nullable
-        assertFileNotContains(
-                catModel,
-                "petType: kotlin.String?",
-                "petType: kotlin.Any"
-        );
+        assertFileContains(catModel, "data class Cat(");
+        assertFileNotContains(catModel, "typealias", "kotlin.Any");
 
-        // Dog should have petType as overridden non-nullable String with default value
         Path dogModel = Paths.get(outputPath + "/models/Dog.kt");
-        assertFileContains(
-                dogModel,
-                "data class Dog(",
-                "override val petType: kotlin.String = \"dog\"",
-                ") : Pet(petType = petType)"
-        );
-        // Should NOT be nullable
-        assertFileNotContains(
-                dogModel,
-                "petType: kotlin.String?",
-                "petType: kotlin.Any"
-        );
+        assertFileContains(dogModel, "data class Dog(");
+        assertFileNotContains(dogModel, "typealias", "kotlin.Any");
     }
 
     @Test
@@ -466,7 +445,7 @@ public class KotlinServerCodegenTest {
     }
 
     @Test
-    public void polymorphismWithoutDiscriminator_generatesRegularDataClass() throws IOException {
+    public void polymorphismWithoutDiscriminator_generatesSealedInterface() throws IOException {
         File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
         output.deleteOnExit();
 
@@ -482,14 +461,12 @@ public class KotlinServerCodegenTest {
         String outputPath = output.getAbsolutePath() + "/src/main/kotlin/org/openapitools/server";
         Path petModel = Paths.get(outputPath + "/models/Pet.kt");
 
-        // Without discriminator, Pet should be a regular data class (not sealed)
-        assertFileContains(
-                petModel,
-                "data class Pet("
-        );
+        // Without discriminator, Pet should be a sealed interface (oneOf) without Jackson annotations
+        assertFileContains(petModel, "sealed interface Pet");
         assertFileNotContains(
                 petModel,
                 "sealed class",
+                "typealias",
                 "@com.fasterxml.jackson.annotation.JsonTypeInfo",
                 "@com.fasterxml.jackson.annotation.JsonSubTypes"
         );
@@ -513,12 +490,9 @@ public class KotlinServerCodegenTest {
         String outputPath = output.getAbsolutePath() + "/src/main/kotlin/org/openapitools/server";
         Path petModel = Paths.get(outputPath + "/models/Pet.kt");
 
-        // When fixJacksonJsonTypeInfoInheritance is false and parent has no properties,
-        // visible should be false for oneOf pattern
-        assertFileContains(
-                petModel,
-                "visible = false"
-        );
+        // With useOneOfInterfaces, Pet is a sealed interface.
+        // When fixJacksonJsonTypeInfoInheritance is false, visible should be false.
+        assertFileContains(petModel, "sealed interface Pet", "visible = false");
     }
 
     // ==================== useTags for JAXRS-SPEC ====================
@@ -826,5 +800,37 @@ public class KotlinServerCodegenTest {
         // All operations must still be reachable with their full paths
         assertFileContains(tagOneApi, "@Path(\"/foo/bar/one\")", "@Path(\"/foo/bar/two\")");
         assertFileContains(tagTwoApi, "@Path(\"/foo/bar/three\")", "@Path(\"/baz/bar/four\")");
+    }
+
+    @Test(description = "oneOf with discriminator generates sealed interface, not typealias")
+    public void testOneOfWithDiscriminatorGeneratesSealedInterface() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        KotlinServerCodegen codegen = new KotlinServerCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(LIBRARY, JAXRS_SPEC);
+
+        new DefaultGenerator().opts(new ClientOptInput()
+                        .openAPI(TestUtils.parseSpec("src/test/resources/3_1/polymorphism-and-discriminator.yaml"))
+                        .config(codegen))
+                .generate();
+
+        String outputPath = output.getAbsolutePath() + "/src/main/kotlin/org/openapitools/server/models";
+
+        // Pet must be a sealed interface with Jackson annotations, not a typealias
+        assertFileContains(Paths.get(outputPath + "/Pet.kt"),
+                "sealed interface Pet",
+                "@com.fasterxml.jackson.annotation.JsonTypeInfo",
+                "property = \"petType\"",
+                "@com.fasterxml.jackson.annotation.JsonSubTypes"
+        );
+        assertFileNotContains(Paths.get(outputPath + "/Pet.kt"), "typealias", "kotlin.Any");
+
+        // Subtypes must extend the sealed interface
+        assertFileContains(Paths.get(outputPath + "/Cat.kt"), "data class Cat");
+        assertFileNotContains(Paths.get(outputPath + "/Cat.kt"), "typealias", "kotlin.Any");
+        assertFileContains(Paths.get(outputPath + "/Dog.kt"), "data class Dog");
+        assertFileNotContains(Paths.get(outputPath + "/Dog.kt"), "typealias", "kotlin.Any");
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinServerCodegenTest.java
@@ -493,6 +493,14 @@ public class KotlinServerCodegenTest {
         // With useOneOfInterfaces, Pet is a sealed interface.
         // When fixJacksonJsonTypeInfoInheritance is false, visible should be false.
         assertFileContains(petModel, "sealed interface Pet", "visible = false");
+
+        // The interface must NOT declare the discriminator here: the children are only retyped to
+        // kotlin.String and marked inherited (i.e. rendered with `override`) when the Jackson fix is
+        // enabled. Declaring it anyway makes the subtypes fail to compile with
+        // "'petType' hides member of supertype 'Pet' and needs an 'override' modifier".
+        assertFileNotContains(petModel, "val petType");
+        assertFileNotContains(Paths.get(outputPath + "/models/Cat.kt"), "override val petType");
+        assertFileNotContains(Paths.get(outputPath + "/models/Dog.kt"), "override val petType");
     }
 
     // ==================== useTags for JAXRS-SPEC ====================
@@ -827,10 +835,33 @@ public class KotlinServerCodegenTest {
         );
         assertFileNotContains(Paths.get(outputPath + "/Pet.kt"), "typealias", "kotlin.Any");
 
-        // Subtypes must extend the sealed interface
-        assertFileContains(Paths.get(outputPath + "/Cat.kt"), "data class Cat");
+        // Subtypes must extend the sealed interface and override its discriminator
+        assertFileContains(Paths.get(outputPath + "/Cat.kt"), "data class Cat", ") : Pet", "override val petType");
         assertFileNotContains(Paths.get(outputPath + "/Cat.kt"), "typealias", "kotlin.Any");
-        assertFileContains(Paths.get(outputPath + "/Dog.kt"), "data class Dog");
+        assertFileContains(Paths.get(outputPath + "/Dog.kt"), "data class Dog", ") : Pet", "override val petType");
         assertFileNotContains(Paths.get(outputPath + "/Dog.kt"), "typealias", "kotlin.Any");
+    }
+
+    @Test(description = "oneOf without discriminator generates a sealed interface that subtypes implement")
+    public void testOneOfWithoutDiscriminatorSubtypesImplementInterface() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        KotlinServerCodegen codegen = new KotlinServerCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(LIBRARY, JAVALIN6);
+
+        new DefaultGenerator().opts(new ClientOptInput()
+                        .openAPI(TestUtils.parseSpec("src/test/resources/3_1/polymorphism.yaml"))
+                        .config(codegen))
+                .generate();
+
+        String outputPath = output.getAbsolutePath() + "/src/main/kotlin/org/openapitools/server/models";
+
+        // Without a discriminator the interface has no members, so it would be uninhabited unless the
+        // oneOf members declare it as a supertype via x-implements.
+        assertFileContains(Paths.get(outputPath + "/Pet.kt"), "sealed interface Pet");
+        assertFileContains(Paths.get(outputPath + "/Cat.kt"), "data class Cat", ") : Pet");
+        assertFileContains(Paths.get(outputPath + "/Dog.kt"), "data class Dog", ") : Pet");
     }
 }

--- a/samples/server/others/kotlin-server/polymorphism-and-discriminator-disabled-jackson-fix/src/main/kotlin/org/openapitools/server/models/Cat.kt
+++ b/samples/server/others/kotlin-server/polymorphism-and-discriminator-disabled-jackson-fix/src/main/kotlin/org/openapitools/server/models/Cat.kt
@@ -16,6 +16,7 @@ package org.openapitools.server.models
  * A pet cat
  * @param huntingSkill The measured skill for hunting
  * @param petType 
+ * @param name 
  */
 data class Cat(
     /* The measured skill for hunting */
@@ -25,7 +26,7 @@ data class Cat(
     
     @field:com.fasterxml.jackson.annotation.JsonProperty("petType")
     val petType: kotlin.Any? = null
-) : Pet()
+) : Pet
 {
     /**
     * The measured skill for hunting

--- a/samples/server/others/kotlin-server/polymorphism-and-discriminator-disabled-jackson-fix/src/main/kotlin/org/openapitools/server/models/Dog.kt
+++ b/samples/server/others/kotlin-server/polymorphism-and-discriminator-disabled-jackson-fix/src/main/kotlin/org/openapitools/server/models/Dog.kt
@@ -16,6 +16,7 @@ package org.openapitools.server.models
  * A pet dog
  * @param petType 
  * @param packSize the size of the pack the dog is from
+ * @param name 
  */
 data class Dog(
     
@@ -25,5 +26,5 @@ data class Dog(
     
     @field:com.fasterxml.jackson.annotation.JsonProperty("packSize")
     val packSize: kotlin.Int = 0
-) : Pet()
+) : Pet
 

--- a/samples/server/others/kotlin-server/polymorphism-and-discriminator-disabled-jackson-fix/src/main/kotlin/org/openapitools/server/models/Pet.kt
+++ b/samples/server/others/kotlin-server/polymorphism-and-discriminator-disabled-jackson-fix/src/main/kotlin/org/openapitools/server/models/Pet.kt
@@ -22,5 +22,7 @@ import org.openapitools.server.models.Dog
     com.fasterxml.jackson.annotation.JsonSubTypes.Type(value = Cat::class, name = "cat"),
     com.fasterxml.jackson.annotation.JsonSubTypes.Type(value = Dog::class, name = "dog")
 )
-sealed class Pet
+sealed interface Pet {
+    val petType: kotlin.String
+}
 

--- a/samples/server/others/kotlin-server/polymorphism-and-discriminator-disabled-jackson-fix/src/main/kotlin/org/openapitools/server/models/Pet.kt
+++ b/samples/server/others/kotlin-server/polymorphism-and-discriminator-disabled-jackson-fix/src/main/kotlin/org/openapitools/server/models/Pet.kt
@@ -23,6 +23,5 @@ import org.openapitools.server.models.Dog
     com.fasterxml.jackson.annotation.JsonSubTypes.Type(value = Dog::class, name = "dog")
 )
 sealed interface Pet {
-    val petType: kotlin.String
 }
 

--- a/samples/server/others/kotlin-server/polymorphism-and-discriminator/src/main/kotlin/org/openapitools/server/models/Cat.kt
+++ b/samples/server/others/kotlin-server/polymorphism-and-discriminator/src/main/kotlin/org/openapitools/server/models/Cat.kt
@@ -16,6 +16,7 @@ package org.openapitools.server.models
  * A pet cat
  * @param huntingSkill The measured skill for hunting
  * @param petType 
+ * @param name 
  */
 data class Cat(
     /* The measured skill for hunting */
@@ -26,7 +27,7 @@ data class Cat(
     @field:com.fasterxml.jackson.annotation.JsonProperty("petType")
     override val petType: kotlin.String = "cat",
 
-) : Pet(petType = petType)
+) : Pet
 {
     /**
     * The measured skill for hunting

--- a/samples/server/others/kotlin-server/polymorphism-and-discriminator/src/main/kotlin/org/openapitools/server/models/Dog.kt
+++ b/samples/server/others/kotlin-server/polymorphism-and-discriminator/src/main/kotlin/org/openapitools/server/models/Dog.kt
@@ -16,6 +16,7 @@ package org.openapitools.server.models
  * A pet dog
  * @param petType 
  * @param packSize the size of the pack the dog is from
+ * @param name 
  */
 data class Dog(
     
@@ -25,5 +26,5 @@ data class Dog(
     
     @field:com.fasterxml.jackson.annotation.JsonProperty("packSize")
     val packSize: kotlin.Int = 0
-) : Pet(petType = petType)
+) : Pet
 

--- a/samples/server/others/kotlin-server/polymorphism-and-discriminator/src/main/kotlin/org/openapitools/server/models/Pet.kt
+++ b/samples/server/others/kotlin-server/polymorphism-and-discriminator/src/main/kotlin/org/openapitools/server/models/Pet.kt
@@ -16,17 +16,13 @@ import org.openapitools.server.models.Dog
 
 /**
  * A pet
- * @param petType 
  */
 @com.fasterxml.jackson.annotation.JsonTypeInfo(use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME, include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY, property = "petType", visible = true)
 @com.fasterxml.jackson.annotation.JsonSubTypes(
     com.fasterxml.jackson.annotation.JsonSubTypes.Type(value = Cat::class, name = "cat"),
     com.fasterxml.jackson.annotation.JsonSubTypes.Type(value = Dog::class, name = "dog")
 )
-sealed class Pet(
-    
-    @field:com.fasterxml.jackson.annotation.JsonProperty("petType")
-    open val petType: kotlin.String
-
-)
+sealed interface Pet {
+    val petType: kotlin.String
+}
 

--- a/samples/server/others/kotlin-server/polymorphism/src/main/kotlin/org/openapitools/server/models/Cat.kt
+++ b/samples/server/others/kotlin-server/polymorphism/src/main/kotlin/org/openapitools/server/models/Cat.kt
@@ -16,6 +16,7 @@ package org.openapitools.server.models
  * A pet cat
  * @param huntingSkill The measured skill for hunting
  * @param petType 
+ * @param name 
  */
 data class Cat(
     /* The measured skill for hunting */

--- a/samples/server/others/kotlin-server/polymorphism/src/main/kotlin/org/openapitools/server/models/Cat.kt
+++ b/samples/server/others/kotlin-server/polymorphism/src/main/kotlin/org/openapitools/server/models/Cat.kt
@@ -26,7 +26,7 @@ data class Cat(
     
     @field:com.fasterxml.jackson.annotation.JsonProperty("petType")
     val petType: kotlin.Any? = null
-)
+) : Pet
 {
     /**
     * The measured skill for hunting

--- a/samples/server/others/kotlin-server/polymorphism/src/main/kotlin/org/openapitools/server/models/Dog.kt
+++ b/samples/server/others/kotlin-server/polymorphism/src/main/kotlin/org/openapitools/server/models/Dog.kt
@@ -16,6 +16,7 @@ package org.openapitools.server.models
  * A pet dog
  * @param packSize the size of the pack the dog is from
  * @param petType 
+ * @param name 
  */
 data class Dog(
     /* the size of the pack the dog is from */

--- a/samples/server/others/kotlin-server/polymorphism/src/main/kotlin/org/openapitools/server/models/Dog.kt
+++ b/samples/server/others/kotlin-server/polymorphism/src/main/kotlin/org/openapitools/server/models/Dog.kt
@@ -26,5 +26,5 @@ data class Dog(
     
     @field:com.fasterxml.jackson.annotation.JsonProperty("petType")
     val petType: kotlin.Any? = null
-)
+) : Pet
 

--- a/samples/server/others/kotlin-server/polymorphism/src/main/kotlin/org/openapitools/server/models/Pet.kt
+++ b/samples/server/others/kotlin-server/polymorphism/src/main/kotlin/org/openapitools/server/models/Pet.kt
@@ -16,37 +16,7 @@ import org.openapitools.server.models.Dog
 
 /**
  * 
- * @param name 
- * @param petType 
- * @param huntingSkill The measured skill for hunting
- * @param packSize the size of the pack the dog is from
  */
-data class Pet(
-    
-    @field:com.fasterxml.jackson.annotation.JsonProperty("name")
-    val name: kotlin.String,
-    
-    @field:com.fasterxml.jackson.annotation.JsonProperty("petType")
-    val petType: kotlin.Any?,
-    /* The measured skill for hunting */
-    
-    @field:com.fasterxml.jackson.annotation.JsonProperty("huntingSkill")
-    val huntingSkill: Pet.HuntingSkill,
-    /* the size of the pack the dog is from */
-    
-    @field:com.fasterxml.jackson.annotation.JsonProperty("packSize")
-    val packSize: kotlin.Int = 0
-)
-{
-    /**
-    * The measured skill for hunting
-    * Values: clueless,lazy,adventurous,aggressive
-    */
-    enum class HuntingSkill(val value: kotlin.String){
-        clueless("clueless"),
-        lazy("lazy"),
-        adventurous("adventurous"),
-        aggressive("aggressive");
-    }
+sealed interface Pet {
 }
 


### PR DESCRIPTION
## Summary

The `kotlin-server` generator produces `typealias Foo = Any` for `oneOf` schemas with discriminators instead of a sealed interface. This causes compile errors when subtypes (generated via `allOf`) try to extend the parent type.

**Reproducer**: any OpenAPI 3.1.x spec with `oneOf` + `discriminator` + `allOf` subtype pattern (e.g. `src/test/resources/3_1/polymorphism-and-discriminator.yaml`) generates:

```kotlin
typealias Pet = Any
```

instead of:

```kotlin
sealed interface Pet { ... }
```

Subtypes then fail to compile because `Any` has a constructor that cannot be delegated to.

**Root cause**: `KotlinServerCodegen` declares `SchemaSupportFeature.oneOf` and `SchemaSupportFeature.Polymorphism` but does not set `useOneOfInterfaces = true`, so the codegen pipeline never produces the `x-is-one-of-interface` vendor extension. The `model.mustache` template also lacks the routing to a `oneof_interface` template.

## Fix

Mirrors #23574 (kotlin-spring):

1. Set `useOneOfInterfaces = true` in `KotlinServerCodegen` constructor
2. Add `oneof_interface.mustache` template for `kotlin-server` (sealed interface with Jackson `@JsonTypeInfo` / `@JsonSubTypes` annotations)
3. Update `model.mustache` to route `x-is-one-of-interface` models to the new template

## Related issues

- #22013 — [BUG][KOTLIN] oneOf does not generate type hierarchy correctly
- #19928 — [BUG][Kotlin] discriminator pattern data classes don't implement the Interface
- #20260 — [BUG] Discriminator classes don't implement parent interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generate sealed interfaces for `oneOf` schemas in `kotlin-server` instead of `typealias Any`, fixing polymorphism and compile errors. Discriminators are declared on the interface only when subtypes override them, and `oneOf` members now implement the interface even without a discriminator.

- **Bug Fixes**
  - Enable `useOneOfInterfaces = true` in `KotlinServerCodegen`; add `oneof_interface.mustache` and route via `model.mustache` and `libraries/jaxrs-spec/model.mustache`.
  - Render sealed interfaces with Jackson annotations and declare the discriminator only when `fixJacksonJsonTypeInfoInheritance` makes subtypes `override` it.
  - Ensure `oneOf` members implement the sealed interface via `x-implements`, including discriminator-less `oneOf`.
  - Only emit parent constructor args for sealed classes; skip `x-parent-ctor-args` for interfaces in `data_class.mustache`.
  - In `libraries/jaxrs-spec` var templates, emit `override` for inherited properties; update tests and samples to expect sealed interfaces (no `typealias`).

<sup>Written for commit 9056b41248497e6e6db124365416a1ecac49d3c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

