### PR TITLE
[python][asyncio] Expose ClientSession extension points (closes #23830)

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
@@ -7,7 +7,7 @@ import io
 import json
 import re
 import ssl
-from typing import Optional, Union
+from typing import Any, Dict, Optional, Union
 
 import aiohttp
 import aiohttp_retry
@@ -48,6 +48,10 @@ class RESTResponse(io.IOBase):
 class RESTClientObject:
 
     def __init__(self, configuration) -> None:
+
+        # Keep a reference so factory methods (_create_pool_manager / _create_connector)
+        # and subclasses can read extension fields like trace_configs.
+        self.configuration = configuration
 
         # maxsize is number of requests to host that are allowed in parallel
         self.maxsize = configuration.connection_pool_maxsize
@@ -91,6 +95,40 @@ class RESTClientObject:
             await self.pool_manager.close()
         if self.retry_client is not None:
             await self.retry_client.close()
+
+    def _create_connector(self) -> aiohttp.TCPConnector:
+        """Build the TCPConnector used by the ClientSession.
+
+        Override in a subclass to customize DNS resolver, keepalive, etc.
+        """
+        kwargs: Dict[str, Any] = {
+            "limit": self.maxsize,
+            "ssl": self.ssl_context,
+        }
+        limit_per_host = getattr(self.configuration, "tcp_connector_limit_per_host", None)
+        if limit_per_host is not None:
+            kwargs["limit_per_host"] = limit_per_host
+        return aiohttp.TCPConnector(**kwargs)
+
+    def _create_pool_manager(self) -> aiohttp.ClientSession:
+        """Build the aiohttp.ClientSession used as the connection pool.
+
+        Override in a subclass to fully customize the session (e.g. attach
+        aiohttp.TraceConfig, swap json_serialize, etc.). Typed Configuration
+        fields (trace_configs / client_session_kwargs) are read via getattr
+        so older Configuration objects remain compatible.
+        """
+        kwargs: Dict[str, Any] = {
+            "connector": self._create_connector(),
+            "trust_env": True,
+        }
+        trace_configs = getattr(self.configuration, "trace_configs", None)
+        if trace_configs is not None:
+            kwargs["trace_configs"] = trace_configs
+        extra = getattr(self.configuration, "client_session_kwargs", None)
+        if extra:
+            kwargs.update(extra)
+        return aiohttp.ClientSession(**kwargs)
 
     async def request(
         self,
@@ -200,10 +238,7 @@ class RESTClientObject:
 
         # https pool manager
         if self.pool_manager is None:
-            self.pool_manager = aiohttp.ClientSession(
-                connector=aiohttp.TCPConnector(limit=self.maxsize, ssl=self.ssl_context),
-                trust_env=True,
-            )
+            self.pool_manager = self._create_pool_manager()
         pool_manager = self.pool_manager
 
         if self._effective_retry_options is not None and method in ALLOW_RETRY_METHODS:

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -1,6 +1,7 @@
 {{>partial_header}}
 
 {{#asyncio}}
+import aiohttp
 import aiohttp_retry
 {{/asyncio}}
 {{#async}}
@@ -192,6 +193,13 @@ class Configuration:
       in PEM format.
 {{#asyncio}}
     :param retries: int | aiohttp_retry.RetryOptionsBase - Retry configuration.
+    :param trace_configs: list of aiohttp.TraceConfig instances forwarded to
+      aiohttp.ClientSession for tracing/instrumentation (e.g. OpenTelemetry).
+    :param tcp_connector_limit_per_host: Per-host concurrency cap forwarded to
+      aiohttp.TCPConnector(limit_per_host=...). None leaves aiohttp's default (0 = unlimited).
+    :param client_session_kwargs: Extra keyword arguments merged into
+      aiohttp.ClientSession(**kwargs) (e.g. json_serialize=orjson.dumps,
+      cookie_jar=aiohttp.DummyCookieJar()).
 {{/asyncio}}
 {{#httpx}}
     :param retries: int - Retry configuration.
@@ -320,6 +328,9 @@ conf = {{{packageName}}}.Configuration(
         ssl_ca_cert: Optional[str]=None,
 {{#asyncio}}
         retries: Optional[Union[int, aiohttp_retry.RetryOptionsBase]] = None,
+        trace_configs: Optional[List[aiohttp.TraceConfig]] = None,
+        tcp_connector_limit_per_host: Optional[int] = None,
+        client_session_kwargs: Optional[Dict[str, Any]] = None,
 {{/asyncio}}
 {{#httpx}}
         retries: Optional[int] = None,
@@ -470,6 +481,17 @@ conf = {{{packageName}}}.Configuration(
         self.retries = retries
         """Retry configuration
         """
+{{#asyncio}}
+        self.trace_configs = trace_configs
+        """aiohttp.TraceConfig list forwarded to ClientSession for tracing.
+        """
+        self.tcp_connector_limit_per_host = tcp_connector_limit_per_host
+        """Per-host concurrency cap forwarded to TCPConnector.
+        """
+        self.client_session_kwargs = client_session_kwargs
+        """Extra kwargs merged into aiohttp.ClientSession(**kwargs).
+        """
+{{/asyncio}}
         # Enable client side validation
         self.client_side_validation = client_side_validation
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/configuration.py
@@ -10,6 +10,7 @@
 """  # noqa: E501
 
 
+import aiohttp
 import aiohttp_retry
 import base64
 import copy
@@ -169,6 +170,13 @@ class Configuration:
     :param ssl_ca_cert: str - the path to a file of concatenated CA certificates
       in PEM format.
     :param retries: int | aiohttp_retry.RetryOptionsBase - Retry configuration.
+    :param trace_configs: list of aiohttp.TraceConfig instances forwarded to
+      aiohttp.ClientSession for tracing/instrumentation (e.g. OpenTelemetry).
+    :param tcp_connector_limit_per_host: Per-host concurrency cap forwarded to
+      aiohttp.TCPConnector(limit_per_host=...). None leaves aiohttp's default (0 = unlimited).
+    :param client_session_kwargs: Extra keyword arguments merged into
+      aiohttp.ClientSession(**kwargs) (e.g. json_serialize=orjson.dumps,
+      cookie_jar=aiohttp.DummyCookieJar()).
     :param ca_cert_data: verify the peer using concatenated CA certificate data
       in PEM (str) or DER (bytes) format.
     :param cert_file: the path to a client certificate file, for mTLS.
@@ -279,6 +287,9 @@ conf = petstore_api.Configuration(
         ignore_operation_servers: bool=False,
         ssl_ca_cert: Optional[str]=None,
         retries: Optional[Union[int, aiohttp_retry.RetryOptionsBase]] = None,
+        trace_configs: Optional[List[aiohttp.TraceConfig]] = None,
+        tcp_connector_limit_per_host: Optional[int] = None,
+        client_session_kwargs: Optional[Dict[str, Any]] = None,
         ca_cert_data: Optional[Union[str, bytes]] = None,
         cert_file: Optional[str]=None,
         key_file: Optional[str]=None,
@@ -408,6 +419,15 @@ conf = petstore_api.Configuration(
         """
         self.retries = retries
         """Retry configuration
+        """
+        self.trace_configs = trace_configs
+        """aiohttp.TraceConfig list forwarded to ClientSession for tracing.
+        """
+        self.tcp_connector_limit_per_host = tcp_connector_limit_per_host
+        """Per-host concurrency cap forwarded to TCPConnector.
+        """
+        self.client_session_kwargs = client_session_kwargs
+        """Extra kwargs merged into aiohttp.ClientSession(**kwargs).
         """
         # Enable client side validation
         self.client_side_validation = client_side_validation

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/rest.py
@@ -16,7 +16,7 @@ import io
 import json
 import re
 import ssl
-from typing import Optional, Union
+from typing import Any, Dict, Optional, Union
 
 import aiohttp
 import aiohttp_retry
@@ -57,6 +57,10 @@ class RESTResponse(io.IOBase):
 class RESTClientObject:
 
     def __init__(self, configuration) -> None:
+
+        # Keep a reference so factory methods (_create_pool_manager / _create_connector)
+        # and subclasses can read extension fields like trace_configs.
+        self.configuration = configuration
 
         # maxsize is number of requests to host that are allowed in parallel
         self.maxsize = configuration.connection_pool_maxsize
@@ -100,6 +104,40 @@ class RESTClientObject:
             await self.pool_manager.close()
         if self.retry_client is not None:
             await self.retry_client.close()
+
+    def _create_connector(self) -> aiohttp.TCPConnector:
+        """Build the TCPConnector used by the ClientSession.
+
+        Override in a subclass to customize DNS resolver, keepalive, etc.
+        """
+        kwargs: Dict[str, Any] = {
+            "limit": self.maxsize,
+            "ssl": self.ssl_context,
+        }
+        limit_per_host = getattr(self.configuration, "tcp_connector_limit_per_host", None)
+        if limit_per_host is not None:
+            kwargs["limit_per_host"] = limit_per_host
+        return aiohttp.TCPConnector(**kwargs)
+
+    def _create_pool_manager(self) -> aiohttp.ClientSession:
+        """Build the aiohttp.ClientSession used as the connection pool.
+
+        Override in a subclass to fully customize the session (e.g. attach
+        aiohttp.TraceConfig, swap json_serialize, etc.). Typed Configuration
+        fields (trace_configs / client_session_kwargs) are read via getattr
+        so older Configuration objects remain compatible.
+        """
+        kwargs: Dict[str, Any] = {
+            "connector": self._create_connector(),
+            "trust_env": True,
+        }
+        trace_configs = getattr(self.configuration, "trace_configs", None)
+        if trace_configs is not None:
+            kwargs["trace_configs"] = trace_configs
+        extra = getattr(self.configuration, "client_session_kwargs", None)
+        if extra:
+            kwargs.update(extra)
+        return aiohttp.ClientSession(**kwargs)
 
     async def request(
         self,
@@ -209,10 +247,7 @@ class RESTClientObject:
 
         # https pool manager
         if self.pool_manager is None:
-            self.pool_manager = aiohttp.ClientSession(
-                connector=aiohttp.TCPConnector(limit=self.maxsize, ssl=self.ssl_context),
-                trust_env=True,
-            )
+            self.pool_manager = self._create_pool_manager()
         pool_manager = self.pool_manager
 
         if self._effective_retry_options is not None and method in ALLOW_RETRY_METHODS:


### PR DESCRIPTION
Mirror the python/httpx template's `_create_pool_manager()` factory and add a parallel `_create_connector()` so subclasses can customize the `aiohttp.ClientSession` / `aiohttp.TCPConnector` without overriding `request()`.

Also surface three typed fields on `Configuration` (asyncio block):
  - `trace_configs: list[aiohttp.TraceConfig]` — forwarded to `ClientSession` for tracing / instrumentation (OpenTelemetry, etc.). This was the original issue request.
  - `tcp_connector_limit_per_host: int` — per-host concurrency cap forwarded to `aiohttp.TCPConnector(limit_per_host=...)`.
  - `client_session_kwargs: dict` — merged into `ClientSession(**kwargs)` for less common knobs (`json_serialize=orjson.dumps`, `cookie_jar=aiohttp.DummyCookieJar()`, `raise_for_status=...`).

All new Configuration fields are read via `getattr(self.configuration, ..., None)` so older Configuration objects (e.g. produced by an older generator version and passed manually) remain compatible. The httpx template is left untouched; only the asyncio side is changed in this PR. No Java code change is needed — the `{{#asyncio}}` mustache block already gates the new code path.

Closes #23830

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose extension points for asyncio clients and add typed config for tracing and connector limits so users can customize `aiohttp.ClientSession` without overriding `request()`. Closes #23830.

- **New Features**
  - Added `_create_pool_manager()` and `_create_connector()` so subclasses can customize `aiohttp.ClientSession` / `aiohttp.TCPConnector`.
  - New asyncio-only `Configuration` fields: `trace_configs: list[aiohttp.TraceConfig]`, `tcp_connector_limit_per_host: int`, `client_session_kwargs: dict` (forwarded to `ClientSession`/`TCPConnector`).
  - Backward compatible via `getattr`; `python/httpx` template unchanged.
  - Updated `python-aiohttp` samples to reflect the new fields.

<sup>Written for commit 2b0dbf41fd5a5831e990268cef6728431260ebac. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23847?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

