### PR TITLE
fix: core: recognize OAS 3.1 contentMediaType for binary classification

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -743,9 +743,10 @@ public class ModelUtils {
 
     public static boolean isBinarySchema(Schema schema) {
         return (schema instanceof BinarySchema) ||
-                // format: binary
+                // format: binary, or contentMediaType: application/octet-stream (OAS 3.1)
                 (SchemaTypeUtil.STRING_TYPE.equals(getType(schema))
-                        && SchemaTypeUtil.BINARY_FORMAT.equals(schema.getFormat()));
+                        && (SchemaTypeUtil.BINARY_FORMAT.equals(schema.getFormat())
+                                || "application/octet-stream".equals(schema.getContentMediaType())));
     }
 
     public static boolean isFileSchema(Schema schema) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -751,6 +751,21 @@ public class ModelUtilsTest {
     }
 
     @Test
+    public void testIsBinarySchemaOAS30FormatBinary() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/binary-schema.yaml");
+        Schema fileProp = (Schema) ModelUtils.getSchema(openAPI, "UploadBody").getProperties().get("file");
+        assertTrue(ModelUtils.isBinarySchema(fileProp));
+    }
+
+    @Test
+    public void testIsBinarySchemaOAS31ContentMediaType() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_1/binary-schema.yaml");
+        Map<String, Schema> props = ModelUtils.getSchema(openAPI, "UploadBody").getProperties();
+        assertTrue(ModelUtils.isBinarySchema(props.get("file")));
+        assertFalse(ModelUtils.isBinarySchema(props.get("image")));
+    }
+
+    @Test
     public void getParentNameMultipleInterfacesTest() {
         OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/oneOf_innerModel.yaml");
         Map<String, Schema> allSchemas = openAPI.getComponents().getSchemas();

--- a/modules/openapi-generator/src/test/resources/3_0/binary-schema.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/binary-schema.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.3
+info:
+  title: t
+  version: 1.0.0
+paths:
+  /upload:
+    post:
+      operationId: upload
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/UploadBody'
+      responses:
+        '200':
+          description: ok
+components:
+  schemas:
+    UploadBody:
+      type: object
+      properties:
+        file:
+          type: string
+          format: binary
+      required:
+        - file

--- a/modules/openapi-generator/src/test/resources/3_1/binary-schema.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/binary-schema.yaml
@@ -1,0 +1,29 @@
+openapi: 3.1.0
+info:
+  title: t
+  version: 1.0.0
+paths:
+  /upload:
+    post:
+      operationId: upload
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/UploadBody'
+      responses:
+        '200':
+          description: ok
+components:
+  schemas:
+    UploadBody:
+      type: object
+      properties:
+        file:
+          type: string
+          contentMediaType: application/octet-stream
+        image:
+          type: string
+          contentMediaType: image/png
+      required:
+        - file


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ```
  All three ran clean; no incidental sample or doc diff.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (additive, non-breaking).
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (fixes #23095 below).
- [ ] If your PR is targeting a particular programming language, @mention the technical committee members. _N/A — core change; every language target benefits via the shared classifier._

## Description

**Problem.** OpenAPI 3.1 declares binary string fields with JSON Schema 2020-12's `contentMediaType` keyword:

```yaml
type: string
contentMediaType: application/octet-stream
```

`ModelUtils.isBinarySchema()` only recognized the 3.0 idiom (`format: binary`), so 3.1 specs (e.g. anything emitted by FastAPI ≥0.99) failed to classify file fields. Downstream, parameters were routed through `_form_params` (plain text) rather than `_files` (binary multipart).

**Change.** Extend `isBinarySchema()` to also match `contentMediaType: application/octet-stream`. `format: binary` remains valid in 3.1 (deprecated but not removed) and continues to match. The fix is additive at the single chokepoint used by twelve `isFile = true` sites in `DefaultCodegen` and eleven other language targets, so every consumer picks up correct 3.1 handling without target-specific changes.

**Tests.** `testIsBinarySchemaOAS30FormatBinary` guards the existing 3.0 path; `testIsBinarySchemaOAS31ContentMediaType` covers the new 3.1 path and asserts a non-`octet-stream` `contentMediaType` (e.g. `image/png`) does not false-positive. Paired `3_0/binary-schema.yaml` and `3_1/binary-schema.yaml` fixtures show the same upload body in both dialects.

**Validation.** Full `ModelUtilsTest` passes (38 cases). `bin/generate-samples.sh ./bin/configs/*.yaml` and `bin/utils/export_docs_generators.sh` both produce zero diff — no existing spec uses `contentMediaType`.

fixes #23095
refs #13083, #9083