### PR TITLE
fix(core): normalize OAS 3.1 content media schemas

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -52,6 +52,7 @@ public class OpenAPINormalizer {
     private TreeSet<String> anyTypeTreeSet = new TreeSet<>();
 
     protected static final Logger LOGGER = LoggerFactory.getLogger(OpenAPINormalizer.class);
+    protected static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
 
     Set<String> ruleNames = new TreeSet<>();
     Set<String> rulesDefaultToTrue = new TreeSet<>();
@@ -918,6 +919,10 @@ public class OpenAPINormalizer {
         if (skipNormalization(schema, visitedSchemas)) {
             return schema;
         }
+
+        // Normalize contentMediaType-only schemas before type-less JsonSchema instances
+        // are treated as empty/null schemas.
+        normalizeBinaryContentSchema31(schema);
 
         if (ModelUtils.isNullTypeSchema(openAPI, schema)) {
             return schema;
@@ -2308,6 +2313,68 @@ public class OpenAPINormalizer {
         }
 
         return schema;
+    }
+
+    /**
+     * Normalizes OAS 3.1 binary content media schemas to the OAS 3.0 binary schema shape.
+     *
+     * @param schema Schema to normalize
+     */
+    protected void normalizeBinaryContentSchema31(Schema<?> schema) {
+        if (!getRule(NORMALIZE_31SPEC)) {
+            return;
+        }
+        if (schema == null || schema.get$ref() != null) {
+            return;
+        }
+        if (StringUtils.isNotBlank(schema.getFormat()) || StringUtils.isNotBlank(schema.getContentEncoding())) {
+            return;
+        }
+        if (!isContentMediaType(schema.getContentMediaType(), APPLICATION_OCTET_STREAM)) {
+            return;
+        }
+        if (!isStringTypeOrTypeAbsent(schema)) {
+            return;
+        }
+
+        if (schema.getTypes() != null && !schema.getTypes().isEmpty()) {
+            schema.setType("string");
+        } else {
+            ModelUtils.setType(schema, "string");
+        }
+        schema.setFormat("binary");
+    }
+
+    /**
+     * Checks whether the schema has no type or only string/null types.
+     *
+     * @param schema Schema to check
+     * @return true if the schema can be treated as a string schema
+     */
+    protected boolean isStringTypeOrTypeAbsent(Schema<?> schema) {
+        boolean hasType = StringUtils.isNotBlank(schema.getType());
+        boolean hasTypes = schema.getTypes() != null && !schema.getTypes().isEmpty();
+        if (!hasType && !hasTypes) {
+            return true;
+        }
+        if (hasType) {
+            return "string".equals(schema.getType());
+        }
+        return schema.getTypes().stream()
+                .map(String::valueOf)
+                .allMatch(type -> "string".equals(type) || "null".equals(type));
+    }
+
+    /**
+     * Compares media types without parameters and case sensitivity.
+     *
+     * @param actualContentMediaType   Actual media type
+     * @param expectedContentMediaType Expected media type
+     * @return true if the media types match
+     */
+    protected boolean isContentMediaType(String actualContentMediaType, String expectedContentMediaType) {
+        String normalizedContentMediaType = StringUtils.substringBefore(actualContentMediaType, ";");
+        return StringUtils.equalsIgnoreCase(StringUtils.trim(normalizedContentMediaType), expectedContentMediaType);
     }
 
     private void normalizeExclusiveMinMax31(Schema<?> schema) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -288,6 +288,46 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void testOAS31ContentMediaTypeBinaryFormParameter() {
+        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/binary-schema.yaml");
+        new OpenAPINormalizer(openAPI, Map.of("NORMALIZE_31SPEC", "true")).normalize();
+        new InlineModelResolver().flatten(openAPI);
+
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        RequestBody requestBody = openAPI.getPaths().get("/upload").getPost().getRequestBody();
+        List<CodegenParameter> formParams = codegen.fromRequestBodyToFormParameters(requestBody, new HashSet<>());
+        Map<String, CodegenParameter> paramsByBaseName = formParams.stream()
+                .collect(Collectors.toMap(param -> param.baseName, param -> param));
+
+        CodegenParameter file = paramsByBaseName.get("file");
+        assertTrue(file.isFormParam);
+        assertTrue(file.isBinary);
+        assertTrue(file.isFile);
+
+        CodegenParameter nullableFile = paramsByBaseName.get("nullableFile");
+        assertTrue(nullableFile.isFormParam);
+        assertTrue(nullableFile.isBinary);
+        assertTrue(nullableFile.isFile);
+
+        CodegenParameter encodedFile = paramsByBaseName.get("encodedFile");
+        assertTrue(encodedFile.isFormParam);
+        assertFalse(encodedFile.isBinary);
+        assertFalse(encodedFile.isFile);
+
+        CodegenParameter inferredFile = paramsByBaseName.get("inferredFile");
+        assertTrue(inferredFile.isFormParam);
+        assertTrue(inferredFile.isBinary);
+        assertTrue(inferredFile.isFile);
+
+        CodegenParameter image = paramsByBaseName.get("image");
+        assertTrue(image.isFormParam);
+        assertFalse(image.isBinary);
+        assertFalse(image.isFile);
+    }
+
+    @Test
     public void testOriginalOpenApiDocumentVersion() {
         // Test with OAS 2.0 document.
         String location = "src/test/resources/2_0/python-prior/petstore-with-fake-endpoints-models-for-testing.yaml";

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -597,6 +597,38 @@ public class OpenAPINormalizerTest {
     }
 
     @Test
+    public void testNormalize31BinaryContentMediaType() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/binary-schema.yaml");
+
+        OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, Map.of("NORMALIZE_31SPEC", "true"));
+        openAPINormalizer.normalize();
+
+        Map<String, Schema> properties = ModelUtils.getSchema(openAPI, "UploadBody").getProperties();
+
+        Schema file = properties.get("file");
+        assertEquals(file.getType(), "string");
+        assertEquals(file.getFormat(), "binary");
+
+        Schema nullableFile = properties.get("nullableFile");
+        assertEquals(nullableFile.getType(), "string");
+        assertEquals(nullableFile.getFormat(), "binary");
+        assertTrue(nullableFile.getNullable());
+
+        Schema inferredFile = properties.get("inferredFile");
+        assertEquals(ModelUtils.getType(inferredFile), "string");
+        assertEquals(inferredFile.getType(), "string");
+        assertEquals(inferredFile.getFormat(), "binary");
+
+        Schema encodedFile = properties.get("encodedFile");
+        assertEquals(encodedFile.getType(), "string");
+        assertNull(encodedFile.getFormat());
+
+        Schema image = properties.get("image");
+        assertEquals(image.getType(), "string");
+        assertNull(image.getFormat());
+    }
+
+    @Test
     public void testNormalize31Parameters() {
         OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/common-parameters.yaml");
 

--- a/modules/openapi-generator/src/test/resources/3_1/binary-schema.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/binary-schema.yaml
@@ -1,0 +1,40 @@
+openapi: 3.1.0
+info:
+  title: t
+  version: 1.0.0
+paths:
+  /upload:
+    post:
+      operationId: upload
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/UploadBody'
+      responses:
+        '200':
+          description: ok
+components:
+  schemas:
+    UploadBody:
+      type: object
+      properties:
+        file:
+          type: string
+          contentMediaType: application/octet-stream
+        nullableFile:
+          type:
+            - string
+            - 'null'
+          contentMediaType: application/octet-stream
+        encodedFile:
+          type: string
+          contentEncoding: base64
+          contentMediaType: application/octet-stream
+        inferredFile:
+          contentMediaType: application/octet-stream
+        image:
+          type: string
+          contentMediaType: image/png
+      required:
+        - file


### PR DESCRIPTION
Refs #23095
Refs #13083, #9083

OpenAPI 3.1 allows a binary string payload to be represented with JSON Schema content keywords, for example:

```yaml
type: string
contentMediaType: application/octet-stream
```

OpenAPI Generator already has binary/file handling around the normalized `type: string` + `format: binary` shape. This PR normalizes that OAS 3.1 form before schema processing treats type-less content schemas as empty schemas.

With this change, OAS 3.1 `contentMediaType: application/octet-stream` schemas normalize to `type: string` and `format: binary`. It also covers nullable `type: [string, "null"]` and type-less content schemas. Schemas with `contentEncoding`, non-binary media types, existing explicit formats, refs, or non-string types are left unchanged.

I added focused coverage for the normalizer and multipart form parameter handling using an OAS 3.1 fixture, and ran the checklist build/sample/docs commands locally.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
