### PR TITLE
[dart-dio] Fix nullable inline object models

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4318,8 +4318,8 @@ public class DefaultCodegen implements CodegenConfig {
 
     private static boolean hasNullableMarker(Schema schema) {
         return schema != null && (schema.getNullable() != null ||
-                schema.getTypes() != null && schema.getTypes().contains("null") ||
-                schema.getExtensions() != null && schema.getExtensions().containsKey(X_NULLABLE) ||
+                ModelUtils.hasType(schema, "null") ||
+                ModelUtils.hasExtension(schema, X_NULLABLE) ||
                 ModelUtils.isNullableComposedSchema(schema));
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2891,7 +2891,7 @@ public class DefaultCodegen implements CodegenConfig {
             addAdditionPropertiesToCodeGenModel(m, schema);
         }
 
-        if (Boolean.TRUE.equals(schema.getNullable())) {
+        if (ModelUtils.isNullable(schema)) {
             m.isNullable = Boolean.TRUE;
         }
 
@@ -3132,7 +3132,7 @@ public class DefaultCodegen implements CodegenConfig {
         if (!ModelUtils.isArraySchema(schema)) {
             m.dataType = getSchemaType(schema);
         }
-        if (!ModelUtils.isAnyType(schema) && Boolean.TRUE.equals(schema.getNullable())) {
+        if (!ModelUtils.isAnyType(schema) && ModelUtils.isNullable(schema)) {
             m.isNullable = Boolean.TRUE;
         }
 
@@ -4108,9 +4108,7 @@ public class DefaultCodegen implements CodegenConfig {
         if (p.getWriteOnly() != null) {
             property.isWriteOnly = p.getWriteOnly();
         }
-        if (p.getNullable() != null) {
-            property.isNullable = p.getNullable();
-        }
+        property.isNullable = ModelUtils.isNullable(p);
 
         if (p.getExtensions() != null && !p.getExtensions().isEmpty()) {
             property.getVendorExtensions().putAll(p.getExtensions());
@@ -4160,11 +4158,8 @@ public class DefaultCodegen implements CodegenConfig {
         }
 
         // set isNullable using nullable or x-nullable in the schema
-        if (referencedSchema.getNullable() != null) {
-            property.isNullable = referencedSchema.getNullable();
-        } else if (referencedSchema.getExtensions() != null &&
-                referencedSchema.getExtensions().containsKey(X_NULLABLE)) {
-            property.isNullable = (Boolean) referencedSchema.getExtensions().get(X_NULLABLE);
+        if (referencedSchema != p) {
+            property.isNullable = property.isNullable || ModelUtils.isNullable(referencedSchema);
         }
 
         final XML referencedSchemaXml = referencedSchema.getXml();
@@ -4263,10 +4258,8 @@ public class DefaultCodegen implements CodegenConfig {
         if (original != null) {
             p = original;
             // evaluate common attributes if defined in the top level
-            if (p.getNullable() != null) {
-                property.isNullable = p.getNullable();
-            } else if (p.getExtensions() != null && p.getExtensions().containsKey(X_NULLABLE)) {
-                property.isNullable = (Boolean) p.getExtensions().get(X_NULLABLE);
+            if (hasNullableMarker(p)) {
+                property.isNullable = ModelUtils.isNullable(p);
             }
 
             if (p.getReadOnly() != null) {
@@ -4321,6 +4314,13 @@ public class DefaultCodegen implements CodegenConfig {
         LOGGER.debug("debugging from property return: {}", property);
         schemaCodegenPropertyCache.put(ns, property);
         return property;
+    }
+
+    private static boolean hasNullableMarker(Schema schema) {
+        return schema != null && (schema.getNullable() != null ||
+                schema.getTypes() != null && schema.getTypes().contains("null") ||
+                schema.getExtensions() != null && schema.getExtensions().containsKey(X_NULLABLE) ||
+                ModelUtils.isNullableComposedSchema(schema));
     }
 
     /**
@@ -5463,9 +5463,7 @@ public class DefaultCodegen implements CodegenConfig {
         codegenParameter.setTypeProperties(parameterSchema, openAPI);
         codegenParameter.setComposedSchemas(getComposedSchemas(parameterSchema));
 
-        if (Boolean.TRUE.equals(parameterSchema.getNullable())) { // use nullable defined in the spec
-            codegenParameter.isNullable = true;
-        }
+        codegenParameter.isNullable = ModelUtils.isNullable(parameterSchema);
 
         if (parameter.getStyle() != null) {
             codegenParameter.style = parameter.getStyle().toString();
@@ -8221,10 +8219,8 @@ public class DefaultCodegen implements CodegenConfig {
         // restore original schema with description, extensions etc
         if (original != null) {
             // evaluate common attributes such as description if defined in the top level
-            if (original.getNullable() != null) {
-                codegenParameter.isNullable = original.getNullable();
-            } else if (original.getExtensions() != null && original.getExtensions().containsKey(X_NULLABLE)) {
-                codegenParameter.isNullable = (Boolean) original.getExtensions().get(X_NULLABLE);
+            if (hasNullableMarker(original)) {
+                codegenParameter.isNullable = ModelUtils.isNullable(original);
             }
 
             if (original.getExtensions() != null) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/InlineModelResolver.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/InlineModelResolver.java
@@ -826,13 +826,10 @@ public class InlineModelResolver {
                 Schema model = modelFromProperty(openAPI, op, modelName);
                 String existing = matchGenerated(model);
                 if (existing != null) {
-                    Schema schema = new Schema().$ref(existing);
-                    schema.setRequired(op.getRequired());
-                    propsToUpdate.put(key, schema);
+                    propsToUpdate.put(key, makeSchema(existing, op));
                 } else {
                     modelName = addSchemas(modelName, model);
-                    Schema schema = new Schema().$ref(modelName);
-                    schema.setRequired(op.getRequired());
+                    Schema schema = makeSchema(modelName, op);
                     propsToUpdate.put(key, schema);
                     modelsToAdd.put(modelName, model);
                 }
@@ -846,23 +843,17 @@ public class InlineModelResolver {
                         Schema innerModel = modelFromProperty(openAPI, op, modelName);
                         String existing = matchGenerated(innerModel);
                         if (existing != null) {
-                            Schema schema = new Schema().$ref(existing);
-                            schema.setRequired(op.getRequired());
-                            property.setItems(schema);
+                            property.setItems(makeSchema(existing, op));
                         } else {
                             modelName = addSchemas(modelName, innerModel);
-                            Schema schema = new Schema().$ref(modelName);
-                            schema.setRequired(op.getRequired());
-                            property.setItems(schema);
+                            property.setItems(makeSchema(modelName, op));
                         }
                     }
                 } else if (ModelUtils.isComposedSchema(inner)) {
                     String innerModelName = resolveModelName(inner.getTitle(), path + "_" + key);
                     gatherInlineModels(inner, innerModelName);
                     innerModelName = addSchemas(innerModelName, inner);
-                    Schema schema = new Schema().$ref(innerModelName);
-                    schema.setRequired(inner.getRequired());
-                    property.setItems(schema);
+                    property.setItems(makeSchema(innerModelName, inner));
                 } else {
                     LOGGER.debug("Schema not yet handled in model resolver: {}", inner);
                 }
@@ -876,23 +867,17 @@ public class InlineModelResolver {
                         Schema innerModel = modelFromProperty(openAPI, op, modelName);
                         String existing = matchGenerated(innerModel);
                         if (existing != null) {
-                            Schema schema = new Schema().$ref(existing);
-                            schema.setRequired(op.getRequired());
-                            property.setAdditionalProperties(schema);
+                            property.setAdditionalProperties(makeSchema(existing, op));
                         } else {
                             modelName = addSchemas(modelName, innerModel);
-                            Schema schema = new Schema().$ref(modelName);
-                            schema.setRequired(op.getRequired());
-                            property.setAdditionalProperties(schema);
+                            property.setAdditionalProperties(makeSchema(modelName, op));
                         }
                     }
                 } else if (ModelUtils.isComposedSchema(inner)) {
                     String innerModelName = resolveModelName(inner.getTitle(), path + "_" + key);
                     gatherInlineModels(inner, innerModelName);
                     innerModelName = addSchemas(innerModelName, inner);
-                    Schema schema = new Schema().$ref(innerModelName);
-                    schema.setRequired(inner.getRequired());
-                    property.setAdditionalProperties(schema);
+                    property.setAdditionalProperties(makeSchema(innerModelName, inner));
                 } else {
                     LOGGER.debug("Schema not yet handled in model resolver: {}", inner);
                 }
@@ -907,9 +892,7 @@ public class InlineModelResolver {
                     String propertyModelName = resolveModelName(property.getTitle(), path + "_" + key);
                     gatherInlineModels(property, propertyModelName);
                     propertyModelName = addSchemas(propertyModelName, property);
-                    Schema schema = new Schema().$ref(propertyModelName);
-                    schema.setRequired(property.getRequired());
-                    propsToUpdate.put(key, schema);
+                    propsToUpdate.put(key, makeSchema(propertyModelName, property));
                 }
             } else {
                 LOGGER.debug("Schema not yet handled in model resolver: {}", property);
@@ -1007,6 +990,9 @@ public class InlineModelResolver {
             refSchema = new Schema().$ref(name);
         }
         this.copyVendorExtensions(schema, refSchema);
+        if (ModelUtils.isNullable(schema)) {
+            refSchema.setNullable(true);
+        }
 
         return refSchema;
     }
@@ -1020,6 +1006,10 @@ public class InlineModelResolver {
      */
     private Schema makeSchema(String ref, Schema property) {
         Schema newProperty = new Schema().$ref(ref);
+        newProperty.setRequired(property.getRequired());
+        if (ModelUtils.isNullable(property)) {
+            newProperty.setNullable(true);
+        }
         this.copyVendorExtensions(property, newProperty);
         return newProperty;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -418,10 +418,24 @@ public class ModelUtils {
         return schema.getEnum() != null && !schema.getEnum().isEmpty();
     }
 
+    /**
+     * Return true if the schema's OAS 3.1 type array contains the specified type.
+     *
+     * @param schema the OAS schema
+     * @param type   the type to look for
+     * @return true if the schema's type array contains the specified type
+     */
     public static boolean hasType(Schema<?> schema, String type) {
         return schema != null && schema.getTypes() != null && schema.getTypes().contains(type);
     }
 
+    /**
+     * Return true if the schema contains the specified vendor extension.
+     *
+     * @param schema        the OAS schema
+     * @param extensionName the vendor extension name
+     * @return true if the schema contains the specified vendor extension
+     */
     public static boolean hasExtension(Schema<?> schema, String extensionName) {
         return schema != null && schema.getExtensions() != null && schema.getExtensions().containsKey(extensionName);
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -418,6 +418,14 @@ public class ModelUtils {
         return schema.getEnum() != null && !schema.getEnum().isEmpty();
     }
 
+    public static boolean hasType(Schema<?> schema, String type) {
+        return schema != null && schema.getTypes() != null && schema.getTypes().contains(type);
+    }
+
+    public static boolean hasExtension(Schema<?> schema, String extensionName) {
+        return schema != null && schema.getExtensions() != null && schema.getExtensions().containsKey(extensionName);
+    }
+
     /**
      * Return true if the specified schema is type object
      * Only considers OAS 3.0 {@code type} and not OAS 3.1 {@code types}
@@ -1792,10 +1800,13 @@ public class ModelUtils {
             return true;
         }
 
-        if (schema.getExtensions() != null && schema.getExtensions().get(X_NULLABLE) != null) {
-            return Boolean.parseBoolean(schema.getExtensions().get(X_NULLABLE).toString());
+        if (hasExtension(schema, X_NULLABLE)) {
+            Object nullable = schema.getExtensions().get(X_NULLABLE);
+            if (nullable != null) {
+                return Boolean.parseBoolean(nullable.toString());
+            }
         }
-        if (schema.getTypes() != null && schema.getTypes().contains("null")) {
+        if (hasType(schema, "null")) {
             return true;
         }
         // In OAS 3.1, the recommended way to define a nullable property or object is to use oneOf.

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1767,9 +1767,10 @@ public class ModelUtils {
      * Return true if the 'nullable' attribute is set to true in the schema, i.e. if the value
      * of the property can be the null value.
      * <p>
-     * In addition, if the OAS document is 3.1 or above, isNullable returns true if the input
-     * schema is a 'oneOf' composed document with at most two children, and one of the children
-     * is the 'null' type.
+     * In addition, isNullable returns true if the input schema uses JSON Schema nullability
+     * forms adopted by OAS 3.1: a 'oneOf' composed document with at most two children where
+     * one child is the 'null' type, or a type-array form where one of the types is 'null'.
+     * This method checks schema shape only and does not validate the OpenAPI document version.
      * <p>
      * The caller is responsible for resolving schema references before invoking isNullable.
      * If the input schema is a $ref and the referenced schema has 'nullable: true', this method
@@ -1793,6 +1794,9 @@ public class ModelUtils {
 
         if (schema.getExtensions() != null && schema.getExtensions().get(X_NULLABLE) != null) {
             return Boolean.parseBoolean(schema.getExtensions().get(X_NULLABLE).toString());
+        }
+        if (schema.getTypes() != null && schema.getTypes().contains("null")) {
+            return true;
         }
         // In OAS 3.1, the recommended way to define a nullable property or object is to use oneOf.
         if (isComposedSchema(schema)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
@@ -140,9 +140,11 @@ class OpenApiSchemaValidations extends GenericValidator<SchemaWrapper> {
         if (Boolean.TRUE.equals(schema.getNullable())) {
             return true;
         }
-        return schema.getExtensions() != null
-                && schema.getExtensions().get(CodegenConstants.X_NULLABLE) != null
-                && Boolean.parseBoolean(schema.getExtensions().get(CodegenConstants.X_NULLABLE).toString());
+        if (ModelUtils.hasExtension(schema, CodegenConstants.X_NULLABLE)) {
+            Object nullable = schema.getExtensions().get(CodegenConstants.X_NULLABLE);
+            return nullable != null && Boolean.parseBoolean(nullable.toString());
+        }
+        return false;
     }
 
     private static String nameOf(Schema schema) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
@@ -1,6 +1,7 @@
 package org.openapitools.codegen.validations.oas;
 
 import io.swagger.v3.oas.models.media.Schema;
+import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.openapitools.codegen.utils.SemVer;
 import org.openapitools.codegen.validation.GenericValidator;
@@ -120,7 +121,7 @@ class OpenApiSchemaValidations extends GenericValidator<SchemaWrapper> {
         if (schemaWrapper.getOpenAPI() != null) {
             SemVer version = new SemVer(schemaWrapper.getOpenAPI().getOpenapi());
             if (version.atLeast("3.1")) {
-                if (ModelUtils.isNullable(schema)) {
+                if (usesNullableAttribute(schema)) {
                     result = new ValidationRule.Fail();
                     result.setDetails(String.format(Locale.ROOT,
                             "OAS document is version '%s'. Schema '%s' uses 'nullable' attribute, which has been deprecated in OAS 3.1.",
@@ -130,6 +131,18 @@ class OpenApiSchemaValidations extends GenericValidator<SchemaWrapper> {
             }
         }
         return result;
+    }
+
+    private static boolean usesNullableAttribute(Schema schema) {
+        if (schema == null) {
+            return false;
+        }
+        if (Boolean.TRUE.equals(schema.getNullable())) {
+            return true;
+        }
+        return schema.getExtensions() != null
+                && schema.getExtensions().get(CodegenConstants.X_NULLABLE) != null
+                && Boolean.parseBoolean(schema.getExtensions().get(CodegenConstants.X_NULLABLE).toString());
     }
 
     private static String nameOf(Schema schema) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
@@ -133,6 +133,15 @@ class OpenApiSchemaValidations extends GenericValidator<SchemaWrapper> {
         return result;
     }
 
+    /**
+     * Return true if the schema explicitly uses the deprecated nullable markers.
+     * <p>
+     * This intentionally excludes JSON Schema nullability forms such as type arrays containing
+     * {@code null} or oneOf schemas with a null type, which are valid OAS 3.1 nullability forms.
+     *
+     * @param schema the OAS schema.
+     * @return true if the schema uses the {@code nullable} attribute or {@code x-nullable} extension.
+     */
     private static boolean usesNullableAttribute(Schema schema) {
         if (schema == null) {
             return false;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -2463,6 +2463,25 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void nullableTypeArrayProperty() {
+        DefaultCodegen codegen = new DefaultCodegen();
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_1/dart-dio/issue_23866.yaml");
+        codegen.setOpenAPI(openAPI);
+
+        CodegenModel model = codegen.fromModel(
+                "EnvelopeNullableLoginResponse",
+                openAPI.getComponents().getSchemas().get("EnvelopeNullableLoginResponse"));
+
+        CodegenProperty data = model.vars.stream()
+                .filter(v -> "data".equals(v.name))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("data property not found"));
+
+        assertTrue(data.isNullable,
+                "data must be nullable because its OAS 3.1 type array includes null");
+    }
+
+    @Test
     public void operationIdNameMapping() {
         DefaultCodegen codegen = new DefaultCodegen();
         codegen.operationIdNameMapping.put("edge case !@# 123", "fix_edge_case");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/dio/DartDioModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/dio/DartDioModelTest.java
@@ -520,4 +520,26 @@ public class DartDioModelTest {
 
         Assert.assertEquals(codegen.getTypeDeclaration(schema), "BuiltList<BuiltList<String?>>");
     }
+
+    @Test(description = "OAS 3.1 nullable inline object properties keep nullable field type")
+    public void nullableInlineObjectPropertyWithTypeArray() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_1/dart-dio/issue_23866.yaml");
+        final DartDioClientCodegen codegen = new DartDioClientCodegen();
+        codegen.additionalProperties().put(CodegenConstants.SERIALIZATION_LIBRARY, DartDioClientCodegen.SERIALIZATION_LIBRARY_BUILT_VALUE);
+        codegen.processOpts();
+        codegen.setOpenAPI(openAPI);
+
+        final Schema model = openAPI.getComponents().getSchemas().get("EnvelopeNullableLoginResponse");
+        final CodegenModel cm = codegen.fromModel("EnvelopeNullableLoginResponse", model);
+
+        final CodegenProperty data = cm.vars.stream()
+                .filter(property -> "data".equals(property.baseName))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("data property not found"));
+
+        Assert.assertEquals(data.dataType, "EnvelopeNullableLoginResponseData");
+        Assert.assertEquals(data.datatypeWithEnum, "EnvelopeNullableLoginResponseData");
+        Assert.assertTrue(data.required);
+        Assert.assertTrue(data.isNullable);
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -625,6 +625,28 @@ public class ModelUtilsTest {
     }
 
     @Test
+    public void hasTypeChecksSchemaTypes() {
+        Schema<?> schema = new Schema<>();
+        schema.setTypes(new LinkedHashSet<>(Arrays.asList("object", "null")));
+
+        assertTrue(ModelUtils.hasType(schema, "null"));
+        assertFalse(ModelUtils.hasType(schema, "string"));
+        assertFalse(ModelUtils.hasType(new Schema<>(), "null"));
+        assertFalse(ModelUtils.hasType(null, "null"));
+    }
+
+    @Test
+    public void hasExtensionChecksSchemaExtensions() {
+        Schema<?> schema = new Schema<>();
+        schema.addExtension("x-nullable", Boolean.TRUE);
+
+        assertTrue(ModelUtils.hasExtension(schema, "x-nullable"));
+        assertFalse(ModelUtils.hasExtension(schema, "x-other"));
+        assertFalse(ModelUtils.hasExtension(new Schema<>(), "x-nullable"));
+        assertFalse(ModelUtils.hasExtension(null, "x-nullable"));
+    }
+
+    @Test
     public void isNullTypeSchemaTest() {
         OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/null_schema_test.yaml");
         Map<String, String> options = new HashMap<>();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -30,6 +30,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -613,6 +614,14 @@ public class ModelUtilsTest {
                 anyOfParentWithChildDescription,
                 anyOfParentWithChildDescription.getAnyOf());
         assertEquals(anyOfSchemaWithChildDescription.getDescription(), "Child description");
+    }
+
+    @Test
+    public void isNullableWithTypeArrayNull() {
+        Schema<?> schema = new Schema<>();
+        schema.setTypes(new LinkedHashSet<>(Arrays.asList("object", "null")));
+
+        assertTrue(ModelUtils.isNullable(schema));
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidationsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidationsTest.java
@@ -1,5 +1,6 @@
 package org.openapitools.codegen.validations.oas;
 
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.*;
 import org.openapitools.codegen.validation.Invalid;
 import org.openapitools.codegen.validation.ValidationResult;
@@ -8,6 +9,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -65,6 +67,26 @@ public class OpenApiSchemaValidationsTest {
 
         Assert.assertNotNull(warnings);
         Assert.assertEquals(warnings.size(), 0, "Expected rule to be disabled.");
+    }
+
+    @Test(description = "OAS 3.1 type-array null is not the deprecated nullable attribute")
+    public void testNullableAttributeRecommendationIgnoresTypeArrayNull() {
+        RuleConfiguration config = new RuleConfiguration();
+        config.setEnableRecommendations(true);
+        OpenApiSchemaValidations validator = new OpenApiSchemaValidations(config);
+
+        OpenAPI openAPI = new OpenAPI().openapi("3.1.0");
+        Schema schema = new Schema();
+        schema.setTypes(new LinkedHashSet<>(Arrays.asList("object", "null")));
+
+        ValidationResult result = validator.validate(new SchemaWrapper(openAPI, schema));
+        Assert.assertNotNull(result.getWarnings());
+
+        List<Invalid> warnings = result.getWarnings().stream()
+                .filter(invalid -> "Schema uses the 'nullable' attribute.".equals(invalid.getRule().getDescription()))
+                .collect(Collectors.toList());
+
+        Assert.assertEquals(warnings.size(), 0, "Expected type-array null not to trigger nullable attribute recommendation.");
     }
 
     @DataProvider(name = "apacheNginxRecommendationExpectations")

--- a/modules/openapi-generator/src/test/resources/3_1/dart-dio/issue_23866.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/dart-dio/issue_23866.yaml
@@ -1,0 +1,38 @@
+openapi: 3.1.0
+info:
+  title: Repro
+  version: "1.0"
+paths:
+  /login:
+    post:
+      operationId: login
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EnvelopeNullableLoginResponse"
+components:
+  schemas:
+    EnvelopeNullableLoginResponse:
+      type: object
+      required:
+        - code
+        - data
+        - message
+      properties:
+        code:
+          type: integer
+        data:
+          type:
+            - object
+            - "null"
+          description: Business data; null on failure
+          required:
+            - token
+          properties:
+            token:
+              type: string
+        message:
+          type: string


### PR DESCRIPTION
## What does this PR do?

Fixes nullable handling for OAS 3.1 inline object schemas using the type-array form, e.g. `type: [object, null]`, after they are promoted to inline component models.

This keeps `dart-dio` fields nullable for schemas like issue #23866.

## How was this tested?

```sh
mvn -s /tmp/openapi-generator-maven-settings.xml \
  -pl modules/openapi-generator \
  -Dtest=org.openapitools.codegen.dart.dio.DartDioModelTest,org.openapitools.codegen.utils.ModelUtilsTest,org.openapitools.codegen.validations.oas.OpenApiSchemaValidationsTest,org.openapitools.codegen.DefaultCodegenTest \
  test
```

Result: `Tests run: 254, Failures: 0, Errors: 0, Skipped: 0`.

Fixes #23866


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nullable handling for OAS 3.1 inline object schemas using type arrays like `type: [object, null]`, so promoted inline models keep nullability. Generated `dart-dio` models now correctly mark these fields (and request params) as nullable.

- **Bug Fixes**
  - Extend `ModelUtils.isNullable` to detect type-array `null`; apply across model, property, parameter, and request body generation (including `$ref`s).
  - Preserve `nullable` when promoting inline schemas and when creating `$ref`s/components in `InlineModelResolver` and `DefaultCodegen` (also carry `required`).
  - Update OAS 3.1 validation to ignore type-array `null` and warn only on deprecated `nullable`/`x-nullable`; document the nullable-attribute helper; add tests and a 3.1 fixture.

- **Refactors**
  - Add `ModelUtils.hasType`, `ModelUtils.hasExtension`, and `DefaultCodegen.hasNullableMarker` to centralize nullability markers and reduce duplicate checks.

<sup>Written for commit 5668185d22523b4eba71d1f38301530d6d9906ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


