### PR TITLE
[typescript-nestjs] Use paramName for URL path substitution (fixes #16668)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptNestjsClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptNestjsClientCodegen.java
@@ -312,7 +312,11 @@ public class TypeScriptNestjsClientCodegen extends AbstractTypeScriptClientCodeg
 
                         // Add the more complicated component instead of just the brace.
                         CodegenParameter parameter = findPathParameterByName(op, parameterName.toString());
-                        pathBuffer.append(toVarName(parameterName.toString()));
+                        if (parameter != null) {
+                            pathBuffer.append(parameter.paramName);
+                        } else {
+                            pathBuffer.append(toVarName(parameterName.toString()));
+                        }
                         if (parameter != null && parameter.isDateTime) {
                             pathBuffer.append(".toISOString()");
                         }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnestjs/TypeScriptNestjsClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnestjs/TypeScriptNestjsClientCodegenTest.java
@@ -7,9 +7,15 @@ import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.openapitools.codegen.CodegenOperation;
+import org.openapitools.codegen.CodegenParameter;
 import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.languages.TypeScriptNestjsClientCodegen;
+import org.openapitools.codegen.model.OperationMap;
+import org.openapitools.codegen.model.OperationsMap;
 import org.openapitools.codegen.typescript.TypeScriptGroups;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -132,6 +138,43 @@ public class TypeScriptNestjsClientCodegenTest {
 
         String schemaType = codegen.getSchemaType(composedSchema);
         Assert.assertEquals(schemaType, "SchemaOne | SchemaTwo | SchemaThree");
+    }
+
+    @Test
+    public void testPathPropertyName() {
+        TypeScriptNestjsClientCodegen codegen = new TypeScriptNestjsClientCodegen();
+
+        CodegenOperation codegenOperation = new CodegenOperation();
+
+        CodegenParameter pathParam1 = createPathParam("pathParam1", "path_param1");
+        CodegenParameter pathParam2 = createPathParam("pathParam2", "pathParam2");
+
+        codegenOperation.httpMethod = "GET";
+        codegenOperation.path = "test/{path_param1}/{pathParam2}";
+        codegenOperation.allParams.addAll(Arrays.asList(pathParam1, pathParam2));
+        codegenOperation.pathParams.addAll(Arrays.asList(pathParam1, pathParam2));
+
+        OperationMap operations = new OperationMap();
+        operations.setOperation(codegenOperation);
+        operations.setClassname("TestService");
+
+        OperationsMap objs = new OperationsMap();
+        objs.setOperation(operations);
+        objs.setImports(List.of());
+
+        var res = codegen.postProcessOperationsWithModels(objs, Collections.emptyList());
+
+        Assert.assertEquals(res.getOperations().getOperation().get(0).path,
+            "test/${encodeURIComponent(String(pathParam1))}/${encodeURIComponent(String(pathParam2))}");
+    }
+
+    private CodegenParameter createPathParam(String paramName, String baseName) {
+        CodegenParameter codegenParameter = new CodegenParameter();
+        codegenParameter.paramName = paramName;
+        codegenParameter.baseName = baseName;
+        codegenParameter.dataType = "String";
+        codegenParameter.isPathParam = true;
+        return codegenParameter;
     }
 
 }


### PR DESCRIPTION
Fixes #16668. Same change as #16669, which never got merged because the original author's commits weren't linked to a GitHub account.

The bug: when a path parameter is declared with hyphens or underscores in the spec (e.g. `{payment_method_id}`), the typescript-nestjs generator emits a function signature with the camelCase identifier but a URL template that still references the raw spec name:

```typescript
public retailBrokerageApiGetPaymentMethod(paymentMethodId: string, ...) {
    return this.httpClient.get(
        `${this.basePath}/api/v3/brokerage/payment_methods/${encodeURIComponent(String(payment_method_id))}`,
        ...
    );
}
```

TypeScript then fails with `TS2304: Cannot find name 'payment_method_id'`. `paramNaming=original` doesn't help, it only changes the signature, not the URL template.

The fix: in `postProcessOperationsWithModels` the existing `findPathParameterByName` lookup result is now also used for the URL template substitution. When the parameter resolves, its already-normalised `paramName` is appended. Falls back to the previous `toVarName` behaviour otherwise.

New unit test `testPathPropertyName` covers a snake_case and a camelCase path parameter. I verified it fails on master without the fix and passes with it. `./bin/generate-samples.sh ./bin/configs/typescript-nestjs*.yaml` produces no sample drift because the petstore specs only use camelCase path parameters.

/cc @macjohnny from the TypeScript technical committee, and @wing328 who reviewed the original #16669.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect path param substitution in the `typescript-nestjs` generator by using the normalized `paramName` in URL templates. Fixes #16668 and prevents TS2304 errors when specs use snake_case or kebab-case path params.

- **Bug Fixes**
  - Use the resolved path parameter’s `paramName` for URL template substitution in `postProcessOperationsWithModels`, falling back to `toVarName` if not found.
  - Add `testPathPropertyName` to verify correct substitution for both snake_case and camelCase path parameters.

<sup>Written for commit 2c4204995072b9ae19c843b51d035e8081a1c812. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23868?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

