### PR TITLE
[kotlin-client][jvm-ktor] Support nullable response types

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-ktor/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-ktor/api.mustache
@@ -52,7 +52,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
         {{#returnType}}
             @Suppress("UNCHECKED_CAST")
         {{/returnType}}
-        {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}open suspend fun {{operationId}}({{#allParams}}{{{paramName}}}: {{{dataType}}}{{^required}}?{{/required}}{{^-last}}, {{/-last}}{{/allParams}}): HttpResponse<{{{returnType}}}{{^returnType}}Unit{{/returnType}}> {
+        {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}open suspend fun {{operationId}}({{#allParams}}{{{paramName}}}: {{{dataType}}}{{^required}}?{{/required}}{{^-last}}, {{/-last}}{{/allParams}}): HttpResponse<{{{returnType}}}{{^returnType}}Unit{{/returnType}}{{#returnProperty}}{{#isNullable}}?{{/isNullable}}{{/returnProperty}}> {
 
             val localVariableAuthNames = listOf<String>({{#authMethods}}"{{name}}"{{^-last}}, {{/-last}}{{/authMethods}})
 

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-ktor/infrastructure/HttpResponse.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-ktor/infrastructure/HttpResponse.kt.mustache
@@ -5,12 +5,12 @@ import io.ktor.http.isSuccess
 import io.ktor.util.reflect.TypeInfo
 import io.ktor.util.reflect.typeInfo
 
-{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}open class HttpResponse<T : Any>({{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val response: io.ktor.client.statement.HttpResponse, {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val provider: BodyProvider<T>) {
+{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}open class HttpResponse<T>({{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val response: io.ktor.client.statement.HttpResponse, {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val provider: BodyProvider<T>) {
     {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val status: Int = response.status.value
     {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val success: Boolean = response.status.isSuccess()
     {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val headers: Map<String, List<String>> = response.headers.mapEntries()
     {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}suspend fun body(): T = provider.body(response)
-    {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}suspend fun <V : Any> typedBody(type: TypeInfo): V = provider.typedBody(response, type)
+    {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}suspend fun <V> typedBody(type: TypeInfo): V = provider.typedBody(response, type)
 
     {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}companion object {
         private fun Headers.mapEntries(): Map<String, List<String>> {
@@ -21,31 +21,31 @@ import io.ktor.util.reflect.typeInfo
     }
 }
 
-{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}interface BodyProvider<T : Any> {
+{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}interface BodyProvider<T> {
     suspend fun body(response: io.ktor.client.statement.HttpResponse): T
-    suspend fun <V : Any> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V
+    suspend fun <V> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V
 }
 
-{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}class TypedBodyProvider<T : Any>(private val type: TypeInfo) : BodyProvider<T> {
+{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}class TypedBodyProvider<T>(private val type: TypeInfo) : BodyProvider<T> {
     @Suppress("UNCHECKED_CAST")
     override suspend fun body(response: io.ktor.client.statement.HttpResponse): T =
             response.call.body(type) as T
 
     @Suppress("UNCHECKED_CAST")
-    override suspend fun <V : Any> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V =
+    override suspend fun <V> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V =
             response.call.body(type) as V
 }
 
-{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}class MappedBodyProvider<S : Any, T : Any>(private val provider: BodyProvider<S>, private val block: S.() -> T) : BodyProvider<T> {
+{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}class MappedBodyProvider<S, T>(private val provider: BodyProvider<S>, private val block: S.() -> T) : BodyProvider<T> {
     override suspend fun body(response: io.ktor.client.statement.HttpResponse): T =
             block(provider.body(response))
 
-    override suspend fun <V : Any> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V =
+    override suspend fun <V> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V =
             provider.typedBody(response, type)
 }
 
-{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}inline fun <reified T : Any> io.ktor.client.statement.HttpResponse.wrap(): HttpResponse<T> =
+{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}inline fun <reified T> io.ktor.client.statement.HttpResponse.wrap(): HttpResponse<T> =
         HttpResponse(this, TypedBodyProvider(typeInfo<T>()))
 
-{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}fun <T : Any, V : Any> HttpResponse<T>.map(block: T.() -> V): HttpResponse<V> =
+{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}fun <T, V> HttpResponse<T>.map(block: T.() -> V): HttpResponse<V> =
         HttpResponse(response, MappedBodyProvider(provider, block))


### PR DESCRIPTION
The `jvm-ktor` library did not handle OpenAPI schemas that allow null as a valid response body (e.g. anyOf: `[T, {type: null}]` or `allOf: [T]` with `nullable: true`).

Two template bugs prevented this from working:

1. `api.mustache` used `{{{returnType}}}` directly, ignoring the `isNullable` flag on the response property. Now it appends `?` when `returnProperty.isNullable` is `true`.

2. `HttpResponse.kt.mustache` hardcoded `<T : Any>` on every generic type parameter. This made `HttpResponse<SomeType?>` invalid at the Kotlin type-system level. Removing the `: Any` constraint lets the generated code use nullable types naturally.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
  - @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06) @e5l (2024/10) @dennisameling (2026/02)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables nullable response bodies in the Kotlin `jvm-ktor` generator so clients can return HttpResponse<T?> when an OpenAPI schema allows null (e.g., anyOf [T, null] or nullable: true). Generated code now compiles and handles nulls correctly.

- **Bug Fixes**
  - `api.mustache` now appends `?` to the return type when `returnProperty.isNullable` is true.
  - Removed `: Any` bounds from generics in `HttpResponse.kt.mustache` (including `HttpResponse`, `BodyProvider`, `TypedBodyProvider`, `MappedBodyProvider`, `wrap`, and `typedBody/map`) to allow nullable types.

<sup>Written for commit df3caf7379a2f903285efb64a6006ba3339c854e. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23870?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

