### PR TITLE
[Java][restclient] Build XmlMapper via builder when useJackson3=true

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/ApiClient.mustache
@@ -4,7 +4,12 @@ package {{invokerPackage}};
 
 {{#withXml}}
 import {{jacksonPackage}}.dataformat.xml.XmlMapper;
+{{^useJackson3}}
 import {{jacksonPackage}}.dataformat.xml.ser.ToXmlGenerator;
+{{/useJackson3}}
+{{#useJackson3}}
+import {{jacksonPackage}}.dataformat.xml.XmlWriteFeature;
+{{/useJackson3}}
 {{/withXml}}
 
 import {{jacksonPackage}}.databind.DeserializationFeature;
@@ -238,16 +243,21 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     */
     public static RestClient.Builder buildRestClientBuilder({{#useJackson3}}JsonMapper{{/useJackson3}}{{^useJackson3}}ObjectMapper{{/useJackson3}} mapper) {
         {{#withXml}}
+        {{#useJackson3}}
+        XmlMapper xmlMapper = XmlMapper.builder()
+                .enable(XmlWriteFeature.WRITE_XML_DECLARATION)
+                {{#openApiNullable}}
+                .addModule(new JsonNullableJackson3Module())
+                {{/openApiNullable}}
+                .build();
+        {{/useJackson3}}
+        {{^useJackson3}}
         XmlMapper xmlMapper = new XmlMapper();
         xmlMapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
         {{#openApiNullable}}
-        {{^useJackson3}}
         xmlMapper.registerModule(new JsonNullableModule());
-        {{/useJackson3}}
-        {{#useJackson3}}
-        xmlMapper.registerModule(new JsonNullableJackson3Module());
-        {{/useJackson3}}
         {{/openApiNullable}}
+        {{/useJackson3}}
         {{/withXml}}
 
         {{#useJackson3}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -3453,6 +3453,77 @@ public class JavaClientCodegenTest {
         );
     }
 
+    @Test(description = "Regression test for issue #23860: with useJackson3=true the generated"
+            + " restclient ApiClient must build XmlMapper via the immutable Builder API,"
+            + " because XmlMapper.configure(...) and registerModule(...) were removed in Jackson 3.")
+    public void testRestClientWithXMLAndJackson3_issue_23860() {
+        final Path output = newTempFolder();
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(JAVA_GENERATOR)
+                .setLibrary(JavaClientCodegen.RESTCLIENT)
+                .setAdditionalProperties(Map.of(
+                        CodegenConstants.API_PACKAGE, "xyz.abcdef.api",
+                        CodegenConstants.WITH_XML, true,
+                        JavaClientCodegen.USE_JACKSON_3, true,
+                        JavaClientCodegen.USE_SPRING_BOOT4, true,
+                        JavaClientCodegen.OPENAPI_NULLABLE, false
+                ))
+                .setInputSpec("src/test/resources/3_1/java/petstore.yaml")
+                .setOutputDir(output.toString().replace("\\", "/"));
+
+        List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+
+        validateJavaSourceFiles(files);
+        assertFileContains(
+                output.resolve("src/main/java/xyz/abcdef/ApiClient.java"),
+                "import tools.jackson.dataformat.xml.XmlMapper;",
+                "import tools.jackson.dataformat.xml.XmlWriteFeature;",
+                "XmlMapper xmlMapper = XmlMapper.builder()",
+                ".enable(XmlWriteFeature.WRITE_XML_DECLARATION)",
+                ".build();"
+        );
+        TestUtils.assertFileNotContains(
+                output.resolve("src/main/java/xyz/abcdef/ApiClient.java"),
+                "xmlMapper.configure(",
+                "xmlMapper.registerModule(",
+                "import tools.jackson.dataformat.xml.ser.ToXmlGenerator;"
+        );
+    }
+
+    @Test(description = "Regression test for issue #23860: with useJackson3=true and"
+            + " openApiNullable=true, the JsonNullableJackson3Module must be wired via the"
+            + " XmlMapper.Builder#addModule API.")
+    public void testRestClientWithXMLAndJackson3AndOpenApiNullable_issue_23860() {
+        final Path output = newTempFolder();
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(JAVA_GENERATOR)
+                .setLibrary(JavaClientCodegen.RESTCLIENT)
+                .setAdditionalProperties(Map.of(
+                        CodegenConstants.API_PACKAGE, "xyz.abcdef.api",
+                        CodegenConstants.WITH_XML, true,
+                        JavaClientCodegen.USE_JACKSON_3, true,
+                        JavaClientCodegen.USE_SPRING_BOOT4, true,
+                        JavaClientCodegen.OPENAPI_NULLABLE, true
+                ))
+                .setInputSpec("src/test/resources/3_1/java/petstore.yaml")
+                .setOutputDir(output.toString().replace("\\", "/"));
+
+        List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+
+        validateJavaSourceFiles(files);
+        assertFileContains(
+                output.resolve("src/main/java/xyz/abcdef/ApiClient.java"),
+                "import org.openapitools.jackson.nullable.JsonNullableJackson3Module;",
+                "XmlMapper xmlMapper = XmlMapper.builder()",
+                ".addModule(new JsonNullableJackson3Module())",
+                ".build();"
+        );
+        TestUtils.assertFileNotContains(
+                output.resolve("src/main/java/xyz/abcdef/ApiClient.java"),
+                "xmlMapper.registerModule("
+        );
+    }
+
 
     @Test
     public void testRestClientWithUseSingleRequestParameter_issue_19406() {


### PR DESCRIPTION
## Summary

Fixes #23860.

When generating the `restclient` library with `useJackson3=true` and
`withXml=true`, the generated `ApiClient.java` does not compile because
the template calls instance methods that Jackson 3 removed when it made
`ObjectMapper` immutable:

- `XmlMapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true)`
- `XmlMapper.registerModule(JsonNullableJackson3Module)`

Maven build reported by the issue reporter:
```
mvn compile  # fails on XmlMapper.configure(...)
```

## What changed

`modules/openapi-generator/src/main/resources/Java/libraries/restclient/ApiClient.mustache`:

- In Jackson 3 mode, build the `XmlMapper` via the immutable builder:
  ```java
  XmlMapper xmlMapper = XmlMapper.builder()
          .enable(XmlWriteFeature.WRITE_XML_DECLARATION)
          .addModule(new JsonNullableJackson3Module()) // when openApiNullable
          .build();
  ```
  This mirrors the `JsonMapper.builder()` pattern already used a few lines
  above in the same template.
- Add the matching `import tools.jackson.dataformat.xml.XmlWriteFeature;`
  for the Jackson 3 branch. `ToXmlGenerator.Feature` was removed in Jackson 3
  in favor of `XmlWriteFeature`.
- The Jackson 2 branch (`useJackson3=false`) is unchanged.

The `resttemplate` library has a similar pattern but is out of scope for
this PR (the issue is specifically about `restclient` and `wing328`
asked for a focused fix). Happy to follow up there as a separate change.

## Tests

Adds two regression tests in
`modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java`:

- `testRestClientWithXMLAndJackson3_issue_23860` — pins down that the
  Jackson 3 + withXml branch emits `XmlMapper.builder()` /
  `XmlWriteFeature.WRITE_XML_DECLARATION` and no longer emits the removed
  `xmlMapper.configure(...)` / `xmlMapper.registerModule(...)` calls or
  the removed `ToXmlGenerator` import.
- `testRestClientWithXMLAndJackson3AndOpenApiNullable_issue_23860` —
  same but with `openApiNullable=true`, asserts the
  `JsonNullableJackson3Module` is wired via `.addModule(...)` on the
  builder rather than `registerModule(...)` on the mapper.

Both tests fail without the template change (verified by reverting the
template, leaving the tests, and rerunning — they fail with
`File ... does not contain line [import tools.jackson.dataformat.xml.XmlWriteFeature;]`).

The pre-existing `testRestClientWithXML_issue_19137` (Jackson 2 + withXml)
still passes, confirming the Jackson 2 path is untouched.

```
$ ./mvnw -pl modules/openapi-generator -Dtest='JavaClientCodegenTest#testRestClientWithXMLAndJackson3_issue_23860+testRestClientWithXMLAndJackson3AndOpenApiNullable_issue_23860+testRestClientWithXML_issue_19137' test
...
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## Sample regeneration

Running `bin/generate-samples.sh bin/configs/java-restclient*.yaml`
produces no diff for the existing `restclient` samples — none of them
combine `withXml=true` with `useJackson3=true`, so they were not
affected by the bug and are not affected by the fix.

## PR checklist

- [x] Read the [contribution guidelines](https://github.com/OpenAPITools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull request title prefixed with `[Java][restclient]`.
- [x] Pull request filed against the `master` branch.
- [x] Run `./bin/generate-samples.sh` and commit the regenerated samples (no diff produced for affected configs).
- [x] Tested with `./mvnw -pl modules/openapi-generator -Dtest='JavaClientCodegenTest#...' test`.

@wing328 @jpfinne FYI per the issue thread.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the Java `restclient` generator to build Jackson 3 `XmlMapper` via the immutable builder when `withXml=true` and `useJackson3=true`, fixing compile errors in generated clients. Also adds the correct `tools.jackson.dataformat.xml.XmlWriteFeature` import and drops the Jackson 2-only `ToXmlGenerator` import from the Jackson 3 path. Fixes #23860.

- **Bug Fixes**
  - Build `XmlMapper` with `XmlMapper.builder().enable(XmlWriteFeature.WRITE_XML_DECLARATION)` and `.addModule(new JsonNullableJackson3Module())` when `openApiNullable=true`, replacing removed `configure`/`registerModule` calls.
  - Import `tools.jackson.dataformat.xml.XmlWriteFeature` for Jackson 3; keep `ToXmlGenerator` only for Jackson 2.
  - Add regression tests for the Jackson 3 XML path (with and without `openApiNullable`).

<sup>Written for commit 1e4794bd7ba3575e3f1fcb9d3a4a511ce683f012. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23872?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

