### PR TITLE
The jj ktor nullable responses

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-ktor/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-ktor/api.mustache
@@ -52,7 +52,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
         {{#returnType}}
             @Suppress("UNCHECKED_CAST")
         {{/returnType}}
-        {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}open suspend fun {{operationId}}({{#allParams}}{{{paramName}}}: {{{dataType}}}{{^required}}?{{/required}}{{^-last}}, {{/-last}}{{/allParams}}): HttpResponse<{{{returnType}}}{{^returnType}}Unit{{/returnType}}> {
+        {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}open suspend fun {{operationId}}({{#allParams}}{{{paramName}}}: {{{dataType}}}{{^required}}?{{/required}}{{^-last}}, {{/-last}}{{/allParams}}): HttpResponse<{{{returnType}}}{{^returnType}}Unit{{/returnType}}{{#returnProperty}}{{#isNullable}}?{{/isNullable}}{{/returnProperty}}> {
 
             val localVariableAuthNames = listOf<String>({{#authMethods}}"{{name}}"{{^-last}}, {{/-last}}{{/authMethods}})
 

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-ktor/infrastructure/HttpResponse.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-ktor/infrastructure/HttpResponse.kt.mustache
@@ -5,12 +5,12 @@ import io.ktor.http.isSuccess
 import io.ktor.util.reflect.TypeInfo
 import io.ktor.util.reflect.typeInfo
 
-{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}open class HttpResponse<T : Any>({{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val response: io.ktor.client.statement.HttpResponse, {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val provider: BodyProvider<T>) {
+{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}open class HttpResponse<T>({{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val response: io.ktor.client.statement.HttpResponse, {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val provider: BodyProvider<T>) {
     {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val status: Int = response.status.value
     {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val success: Boolean = response.status.isSuccess()
     {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val headers: Map<String, List<String>> = response.headers.mapEntries()
     {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}suspend fun body(): T = provider.body(response)
-    {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}suspend fun <V : Any> typedBody(type: TypeInfo): V = provider.typedBody(response, type)
+    {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}suspend fun <V> typedBody(type: TypeInfo): V = provider.typedBody(response, type)
 
     {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}companion object {
         private fun Headers.mapEntries(): Map<String, List<String>> {
@@ -21,31 +21,31 @@ import io.ktor.util.reflect.typeInfo
     }
 }
 
-{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}interface BodyProvider<T : Any> {
+{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}interface BodyProvider<T> {
     suspend fun body(response: io.ktor.client.statement.HttpResponse): T
-    suspend fun <V : Any> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V
+    suspend fun <V> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V
 }
 
-{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}class TypedBodyProvider<T : Any>(private val type: TypeInfo) : BodyProvider<T> {
+{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}class TypedBodyProvider<T>(private val type: TypeInfo) : BodyProvider<T> {
     @Suppress("UNCHECKED_CAST")
     override suspend fun body(response: io.ktor.client.statement.HttpResponse): T =
             response.call.body(type) as T
 
     @Suppress("UNCHECKED_CAST")
-    override suspend fun <V : Any> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V =
+    override suspend fun <V> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V =
             response.call.body(type) as V
 }
 
-{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}class MappedBodyProvider<S : Any, T : Any>(private val provider: BodyProvider<S>, private val block: S.() -> T) : BodyProvider<T> {
+{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}class MappedBodyProvider<S, T>(private val provider: BodyProvider<S>, private val block: S.() -> T) : BodyProvider<T> {
     override suspend fun body(response: io.ktor.client.statement.HttpResponse): T =
             block(provider.body(response))
 
-    override suspend fun <V : Any> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V =
+    override suspend fun <V> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V =
             provider.typedBody(response, type)
 }
 
-{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}inline fun <reified T : Any> io.ktor.client.statement.HttpResponse.wrap(): HttpResponse<T> =
+{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}inline fun <reified T> io.ktor.client.statement.HttpResponse.wrap(): HttpResponse<T> =
         HttpResponse(this, TypedBodyProvider(typeInfo<T>()))
 
-{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}fun <T : Any, V : Any> HttpResponse<T>.map(block: T.() -> V): HttpResponse<V> =
+{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}fun <T, V> HttpResponse<T>.map(block: T.() -> V): HttpResponse<V> =
         HttpResponse(response, MappedBodyProvider(provider, block))

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/infrastructure/HttpResponse.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/infrastructure/HttpResponse.kt
@@ -5,12 +5,12 @@ import io.ktor.http.isSuccess
 import io.ktor.util.reflect.TypeInfo
 import io.ktor.util.reflect.typeInfo
 
-open class HttpResponse<T : Any>(val response: io.ktor.client.statement.HttpResponse, val provider: BodyProvider<T>) {
+open class HttpResponse<T>(val response: io.ktor.client.statement.HttpResponse, val provider: BodyProvider<T>) {
     val status: Int = response.status.value
     val success: Boolean = response.status.isSuccess()
     val headers: Map<String, List<String>> = response.headers.mapEntries()
     suspend fun body(): T = provider.body(response)
-    suspend fun <V : Any> typedBody(type: TypeInfo): V = provider.typedBody(response, type)
+    suspend fun <V> typedBody(type: TypeInfo): V = provider.typedBody(response, type)
 
     companion object {
         private fun Headers.mapEntries(): Map<String, List<String>> {
@@ -21,31 +21,31 @@ open class HttpResponse<T : Any>(val response: io.ktor.client.statement.HttpResp
     }
 }
 
-interface BodyProvider<T : Any> {
+interface BodyProvider<T> {
     suspend fun body(response: io.ktor.client.statement.HttpResponse): T
-    suspend fun <V : Any> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V
+    suspend fun <V> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V
 }
 
-class TypedBodyProvider<T : Any>(private val type: TypeInfo) : BodyProvider<T> {
+class TypedBodyProvider<T>(private val type: TypeInfo) : BodyProvider<T> {
     @Suppress("UNCHECKED_CAST")
     override suspend fun body(response: io.ktor.client.statement.HttpResponse): T =
             response.call.body(type) as T
 
     @Suppress("UNCHECKED_CAST")
-    override suspend fun <V : Any> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V =
+    override suspend fun <V> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V =
             response.call.body(type) as V
 }
 
-class MappedBodyProvider<S : Any, T : Any>(private val provider: BodyProvider<S>, private val block: S.() -> T) : BodyProvider<T> {
+class MappedBodyProvider<S, T>(private val provider: BodyProvider<S>, private val block: S.() -> T) : BodyProvider<T> {
     override suspend fun body(response: io.ktor.client.statement.HttpResponse): T =
             block(provider.body(response))
 
-    override suspend fun <V : Any> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V =
+    override suspend fun <V> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V =
             provider.typedBody(response, type)
 }
 
-inline fun <reified T : Any> io.ktor.client.statement.HttpResponse.wrap(): HttpResponse<T> =
+inline fun <reified T> io.ktor.client.statement.HttpResponse.wrap(): HttpResponse<T> =
         HttpResponse(this, TypedBodyProvider(typeInfo<T>()))
 
-fun <T : Any, V : Any> HttpResponse<T>.map(block: T.() -> V): HttpResponse<V> =
+fun <T, V> HttpResponse<T>.map(block: T.() -> V): HttpResponse<V> =
         HttpResponse(response, MappedBodyProvider(provider, block))

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/infrastructure/HttpResponse.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/infrastructure/HttpResponse.kt
@@ -5,12 +5,12 @@ import io.ktor.http.isSuccess
 import io.ktor.util.reflect.TypeInfo
 import io.ktor.util.reflect.typeInfo
 
-open class HttpResponse<T : Any>(val response: io.ktor.client.statement.HttpResponse, val provider: BodyProvider<T>) {
+open class HttpResponse<T>(val response: io.ktor.client.statement.HttpResponse, val provider: BodyProvider<T>) {
     val status: Int = response.status.value
     val success: Boolean = response.status.isSuccess()
     val headers: Map<String, List<String>> = response.headers.mapEntries()
     suspend fun body(): T = provider.body(response)
-    suspend fun <V : Any> typedBody(type: TypeInfo): V = provider.typedBody(response, type)
+    suspend fun <V> typedBody(type: TypeInfo): V = provider.typedBody(response, type)
 
     companion object {
         private fun Headers.mapEntries(): Map<String, List<String>> {
@@ -21,31 +21,31 @@ open class HttpResponse<T : Any>(val response: io.ktor.client.statement.HttpResp
     }
 }
 
-interface BodyProvider<T : Any> {
+interface BodyProvider<T> {
     suspend fun body(response: io.ktor.client.statement.HttpResponse): T
-    suspend fun <V : Any> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V
+    suspend fun <V> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V
 }
 
-class TypedBodyProvider<T : Any>(private val type: TypeInfo) : BodyProvider<T> {
+class TypedBodyProvider<T>(private val type: TypeInfo) : BodyProvider<T> {
     @Suppress("UNCHECKED_CAST")
     override suspend fun body(response: io.ktor.client.statement.HttpResponse): T =
             response.call.body(type) as T
 
     @Suppress("UNCHECKED_CAST")
-    override suspend fun <V : Any> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V =
+    override suspend fun <V> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V =
             response.call.body(type) as V
 }
 
-class MappedBodyProvider<S : Any, T : Any>(private val provider: BodyProvider<S>, private val block: S.() -> T) : BodyProvider<T> {
+class MappedBodyProvider<S, T>(private val provider: BodyProvider<S>, private val block: S.() -> T) : BodyProvider<T> {
     override suspend fun body(response: io.ktor.client.statement.HttpResponse): T =
             block(provider.body(response))
 
-    override suspend fun <V : Any> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V =
+    override suspend fun <V> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V =
             provider.typedBody(response, type)
 }
 
-inline fun <reified T : Any> io.ktor.client.statement.HttpResponse.wrap(): HttpResponse<T> =
+inline fun <reified T> io.ktor.client.statement.HttpResponse.wrap(): HttpResponse<T> =
         HttpResponse(this, TypedBodyProvider(typeInfo<T>()))
 
-fun <T : Any, V : Any> HttpResponse<T>.map(block: T.() -> V): HttpResponse<V> =
+fun <T, V> HttpResponse<T>.map(block: T.() -> V): HttpResponse<V> =
         HttpResponse(response, MappedBodyProvider(provider, block))

--- a/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/HttpResponse.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/HttpResponse.kt
@@ -5,12 +5,12 @@ import io.ktor.http.isSuccess
 import io.ktor.util.reflect.TypeInfo
 import io.ktor.util.reflect.typeInfo
 
-open class HttpResponse<T : Any>(val response: io.ktor.client.statement.HttpResponse, val provider: BodyProvider<T>) {
+open class HttpResponse<T>(val response: io.ktor.client.statement.HttpResponse, val provider: BodyProvider<T>) {
     val status: Int = response.status.value
     val success: Boolean = response.status.isSuccess()
     val headers: Map<String, List<String>> = response.headers.mapEntries()
     suspend fun body(): T = provider.body(response)
-    suspend fun <V : Any> typedBody(type: TypeInfo): V = provider.typedBody(response, type)
+    suspend fun <V> typedBody(type: TypeInfo): V = provider.typedBody(response, type)
 
     companion object {
         private fun Headers.mapEntries(): Map<String, List<String>> {
@@ -21,31 +21,31 @@ open class HttpResponse<T : Any>(val response: io.ktor.client.statement.HttpResp
     }
 }
 
-interface BodyProvider<T : Any> {
+interface BodyProvider<T> {
     suspend fun body(response: io.ktor.client.statement.HttpResponse): T
-    suspend fun <V : Any> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V
+    suspend fun <V> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V
 }
 
-class TypedBodyProvider<T : Any>(private val type: TypeInfo) : BodyProvider<T> {
+class TypedBodyProvider<T>(private val type: TypeInfo) : BodyProvider<T> {
     @Suppress("UNCHECKED_CAST")
     override suspend fun body(response: io.ktor.client.statement.HttpResponse): T =
             response.call.body(type) as T
 
     @Suppress("UNCHECKED_CAST")
-    override suspend fun <V : Any> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V =
+    override suspend fun <V> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V =
             response.call.body(type) as V
 }
 
-class MappedBodyProvider<S : Any, T : Any>(private val provider: BodyProvider<S>, private val block: S.() -> T) : BodyProvider<T> {
+class MappedBodyProvider<S, T>(private val provider: BodyProvider<S>, private val block: S.() -> T) : BodyProvider<T> {
     override suspend fun body(response: io.ktor.client.statement.HttpResponse): T =
             block(provider.body(response))
 
-    override suspend fun <V : Any> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V =
+    override suspend fun <V> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V =
             provider.typedBody(response, type)
 }
 
-inline fun <reified T : Any> io.ktor.client.statement.HttpResponse.wrap(): HttpResponse<T> =
+inline fun <reified T> io.ktor.client.statement.HttpResponse.wrap(): HttpResponse<T> =
         HttpResponse(this, TypedBodyProvider(typeInfo<T>()))
 
-fun <T : Any, V : Any> HttpResponse<T>.map(block: T.() -> V): HttpResponse<V> =
+fun <T, V> HttpResponse<T>.map(block: T.() -> V): HttpResponse<V> =
         HttpResponse(response, MappedBodyProvider(provider, block))


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add nullable response support to the Kotlin `jvm-ktor` client so generated APIs can return `HttpResponse<T?>` when the OpenAPI response schema allows null.

- **Bug Fixes**
  - `api.mustache`: respects `returnProperty.isNullable` and appends `?` to the return type.
  - `HttpResponse.kt.mustache`: removed `: Any` bounds from generics (including `typedBody`) to allow nullable types.
  - Updated `kotlin-jvm-ktor` samples for `gson`, `jackson`, and `kotlinx_serialization`.

<sup>Written for commit a8d8cfc9d9b771664059814fff9765218eb4ba34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23888?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

