### PR TITLE
[python] Fix invalid pip syntax for httpx/tornado in requirements.txt

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python/requirements.mustache
@@ -7,10 +7,10 @@ aiohttp >= 3.8.4
 aiohttp-retry >= 2.8.3
 {{/asyncio}}
 {{#httpx}}
-httpx = ">= 0.28.1"
+httpx >= 0.28.1
 {{/httpx}}
 {{#tornado}}
-tornado = ">= 4.2, < 5"
+tornado >= 4.2, < 5
 {{/tornado}}
 {{#hasHttpSignatureMethods}}
 pem >= 19.3.0

--- a/samples/openapi3/client/petstore/python-httpx/requirements.txt
+++ b/samples/openapi3/client/petstore/python-httpx/requirements.txt
@@ -1,5 +1,5 @@
 python_dateutil >= 2.8.2
-httpx = ">= 0.28.1"
+httpx >= 0.28.1
 pem >= 19.3.0
 pycryptodome >= 3.9.0
 pydantic >= 2.11


### PR DESCRIPTION
### Description of the PR

The `httpx` and `tornado` entries in the python generator's
`requirements.mustache` template were written using TOML / Pipfile-style
`name = "spec"` assignment syntax, which is **not valid** in a pip
`requirements.txt` file. The other entries in the same template
(`urllib3`, `python_dateutil`, `pydantic`, `aiohttp`, etc.) all use the
correct pip syntax — only these two lines are wrong.

As a result, every Python client generated with `--library httpx`
fails immediately at `pip install -r requirements.txt`:

```
ERROR: Invalid requirement: 'httpx = ">= 0.28.1"': Expected semicolon (after name with no version specifier) or end
    httpx = ">= 0.28.1"
          ^ (from line 2 of requirements.txt)
```

The same bug would affect `--library tornado` (same broken pattern on the
line below it in the template), though that path is less commonly used.

#### What this PR changes

In `modules/openapi-generator/src/main/resources/python/requirements.mustache`:

```diff
 {{#httpx}}
-httpx = ">= 0.28.1"
+httpx >= 0.28.1
 {{/httpx}}
 {{#tornado}}
-tornado = ">= 4.2, < 5"
+tornado >= 4.2, < 5
 {{/tornado}}
```

And the committed sample at
`samples/openapi3/client/petstore/python-httpx/requirements.txt` is
regenerated to match.

#### Scope check — was this bug anywhere else?

I checked the other two python dependency templates:

- **`python/setup.mustache`** — *not affected*. The `install_requires`
  entries already use correct pip syntax: `"httpx >= 0.28.1"`,
  `"tornado>=4.2, < 5"`.
- **`python/pyproject.mustache`** — *not affected*. Both dependency
  sections are syntactically valid:
  - `[tool.poetry.dependencies]` uses `httpx = ">= 0.28.1"`, which is
    the correct TOML form for Poetry.
  - `[project].dependencies` uses `"httpx (>=0.28.1)"`, which is the
    correct PEP 621 form.

So the fix is isolated to `requirements.mustache` plus its
corresponding sample.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/OpenAPITools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under `.\bin\windows`) to update Petstore samples related to your fix. (Only the `python-httpx` sample changed; updated in this PR.)
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` branch for non-breaking changes.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @OpenAPITools/generator-core-team
cc python technical committee

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix pip requirement syntax for `httpx` and `tornado` in the Python generator so generated clients install cleanly. Replaces TOML-style `name = "spec"` with valid pip specifiers and updates the `python-httpx` sample.

- **Bug Fixes**
  - In `python/requirements.mustache`, use `httpx >= 0.28.1` and `tornado >= 4.2, < 5`.
  - Regenerated `samples/openapi3/client/petstore/python-httpx/requirements.txt`.
  - Verified `setup.mustache` and `pyproject.mustache` are already correct (no changes).

<sup>Written for commit f81d086ba759ba95b4514599bef73d8b20244212. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23889?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

