### PR TITLE
[typescript-angular] Fix recursive Query-Param Object name

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.base.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.base.service.mustache
@@ -41,7 +41,7 @@ export class BaseService {
             }
 
             return Object.keys(value as Record<string, any>).reduce(
-                (hp, k) => hp.append(`${key}[${k}]`, value[k]),
+                (hp, k) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, value[k]),
                 httpParams,
             );
         } else if (paramStyle === QueryParamStyle.Json) {
@@ -83,6 +83,27 @@ export class BaseService {
                     return concatHttpParamsObject(httpParams, key, value, '|');
                 }
             }
+        }
+    }
+
+    private addToHttpParamsDeepObject(httpParams: OpenApiHttpParams, key: string, value: any | null | undefined): OpenApiHttpParams {
+        if (value == null) {
+            return httpParams;
+        } else if (value instanceof Date) {
+            return httpParams.append(key, value.toISOString());
+        } else if (Object(value) !== value) {
+            return httpParams.append(key, value.toString());
+        } else if (Array.isArray(value) || value instanceof Set) {
+            const array = Array.isArray(value) ? value : Array.from(value);
+            array.forEach((item, index) => {
+                httpParams = this.addToHttpParamsDeepObject(httpParams, `${key}[${index}]`, item);
+            });
+            return httpParams;
+        } else {
+            return Object.entries(value).reduce(
+                (hp, [k, v]) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, v),
+                httpParams,
+            );
         }
     }
 }

--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.base.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.base.service.mustache
@@ -70,7 +70,7 @@ export class BaseService {
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
                         Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, k, value[k], paramStyle, explode);
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.base.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.base.service.mustache
@@ -69,8 +69,8 @@ export class BaseService {
                 // Otherwise, if it's an object, add each field.
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
-                        Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
+                        Object.entries(value).forEach(([k, v]) => {
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, v, paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularClientCodegenTest.java
@@ -488,6 +488,10 @@ public class TypeScriptAngularClientCodegenTest {
         final String fileContents = Files.readString(Paths.get(output + "/api/default.service.ts"));
         assertThat(fileContents).containsSubsequence("'options',\n", "<any>options,\n", "QueryParamStyle.DeepObject,\n", "true,\n");
         assertThat(fileContents).containsSubsequence("'inputOptions',\n", "<any>inputOptions,\n", "QueryParamStyle.DeepObject,\n", "true,\n");
+
+        final String baseServiceContents = Files.readString(Paths.get(output + "/api.base.service.ts"));
+        assertThat(baseServiceContents).contains("this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, value[k])");
+        assertThat(baseServiceContents).contains("this.addToHttpParamsDeepObject(httpParams, `${key}[${index}]`, item)");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/additional-properties-expected/api.base.service.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/additional-properties-expected/api.base.service.ts
@@ -76,8 +76,8 @@ export class BaseService {
                 // Otherwise, if it's an object, add each field.
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
-                        Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
+                        Object.entries(value).forEach(([k, v]) => {
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, v, paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/additional-properties-expected/api.base.service.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/additional-properties-expected/api.base.service.ts
@@ -49,7 +49,7 @@ export class BaseService {
             }
 
             return Object.keys(value as Record<string, any>).reduce(
-                (hp, k) => hp.append(`${key}[${k}]`, value[k]),
+                (hp, k) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, value[k]),
                 httpParams,
             );
         } else if (paramStyle === QueryParamStyle.Json) {
@@ -90,6 +90,27 @@ export class BaseService {
                     return concatHttpParamsObject(httpParams, key, value, '|');
                 }
             }
+        }
+    }
+    
+    private addToHttpParamsDeepObject(httpParams: OpenApiHttpParams, key: string, value: any | null | undefined): OpenApiHttpParams {
+        if (value == null) {
+            return httpParams;
+        } else if (value instanceof Date) {
+            return httpParams.append(key, value.toISOString());
+        } else if (Object(value) !== value) {
+            return httpParams.append(key, value.toString());
+        } else if (Array.isArray(value) || value instanceof Set) {
+            const array = Array.isArray(value) ? value : Array.from(value);
+            array.forEach((item, index) => {
+                httpParams = this.addToHttpParamsDeepObject(httpParams, `${key}[${index}]`, item);
+            });
+            return httpParams;
+        } else {
+            return Object.entries(value).reduce(
+                (hp, [k, v]) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, v),
+                httpParams,
+            );
         }
     }
 }

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/additional-properties-expected/api.base.service.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/additional-properties-expected/api.base.service.ts
@@ -77,7 +77,7 @@ export class BaseService {
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
                         Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, k, value[k], paramStyle, explode);
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/array-and-object-expected/api.base.service.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/array-and-object-expected/api.base.service.ts
@@ -76,8 +76,8 @@ export class BaseService {
                 // Otherwise, if it's an object, add each field.
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
-                        Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
+                        Object.entries(value).forEach(([k, v]) => {
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, v, paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/array-and-object-expected/api.base.service.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/array-and-object-expected/api.base.service.ts
@@ -77,7 +77,7 @@ export class BaseService {
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
                         Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, k, value[k], paramStyle, explode);
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/array-and-object-expected/api.base.service.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/array-and-object-expected/api.base.service.ts
@@ -49,7 +49,7 @@ export class BaseService {
             }
 
             return Object.keys(value as Record<string, any>).reduce(
-                (hp, k) => hp.append(`${key}[${k}]`, value[k]),
+                (hp, k) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, value[k]),
                 httpParams,
             );
         } else if (paramStyle === QueryParamStyle.Json) {
@@ -90,6 +90,27 @@ export class BaseService {
                     return concatHttpParamsObject(httpParams, key, value, '|');
                 }
             }
+        }
+    }
+
+    private addToHttpParamsDeepObject(httpParams: OpenApiHttpParams, key: string, value: any | null | undefined): OpenApiHttpParams {
+        if (value == null) {
+            return httpParams;
+        } else if (value instanceof Date) {
+            return httpParams.append(key, value.toISOString());
+        } else if (Object(value) !== value) {
+            return httpParams.append(key, value.toString());
+        } else if (Array.isArray(value) || value instanceof Set) {
+            const array = Array.isArray(value) ? value : Array.from(value);
+            array.forEach((item, index) => {
+                httpParams = this.addToHttpParamsDeepObject(httpParams, `${key}[${index}]`, item);
+            });
+            return httpParams;
+        } else {
+            return Object.entries(value).reduce(
+                (hp, [k, v]) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, v),
+                httpParams,
+            );
         }
     }
 }

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/custom-path-params-expected/api.base.service.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/custom-path-params-expected/api.base.service.ts
@@ -76,8 +76,8 @@ export class BaseService {
                 // Otherwise, if it's an object, add each field.
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
-                        Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
+                        Object.entries(value).forEach(([k, v]) => {
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, v, paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/custom-path-params-expected/api.base.service.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/custom-path-params-expected/api.base.service.ts
@@ -77,7 +77,7 @@ export class BaseService {
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
                         Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, k, value[k], paramStyle, explode);
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/custom-path-params-expected/api.base.service.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/custom-path-params-expected/api.base.service.ts
@@ -49,7 +49,7 @@ export class BaseService {
             }
 
             return Object.keys(value as Record<string, any>).reduce(
-                (hp, k) => hp.append(`${key}[${k}]`, value[k]),
+                (hp, k) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, value[k]),
                 httpParams,
             );
         } else if (paramStyle === QueryParamStyle.Json) {
@@ -90,6 +90,27 @@ export class BaseService {
                     return concatHttpParamsObject(httpParams, key, value, '|');
                 }
             }
+        }
+    }
+
+    private addToHttpParamsDeepObject(httpParams: OpenApiHttpParams, key: string, value: any | null | undefined): OpenApiHttpParams {
+        if (value == null) {
+            return httpParams;
+        } else if (value instanceof Date) {
+            return httpParams.append(key, value.toISOString());
+        } else if (Object(value) !== value) {
+            return httpParams.append(key, value.toString());
+        } else if (Array.isArray(value) || value instanceof Set) {
+            const array = Array.isArray(value) ? value : Array.from(value);
+            array.forEach((item, index) => {
+                httpParams = this.addToHttpParamsDeepObject(httpParams, `${key}[${index}]`, item);
+            });
+            return httpParams;
+        } else {
+            return Object.entries(value).reduce(
+                (hp, [k, v]) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, v),
+                httpParams,
+            );
         }
     }
 }

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/petstore-expected/api.base.service.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/petstore-expected/api.base.service.ts
@@ -76,8 +76,8 @@ export class BaseService {
                 // Otherwise, if it's an object, add each field.
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
-                        Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
+                        Object.entries(value).forEach(([k, v]) => {
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, v, paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/petstore-expected/api.base.service.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/petstore-expected/api.base.service.ts
@@ -77,7 +77,7 @@ export class BaseService {
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
                         Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, k, value[k], paramStyle, explode);
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/petstore-expected/api.base.service.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/petstore-expected/api.base.service.ts
@@ -49,7 +49,7 @@ export class BaseService {
             }
 
             return Object.keys(value as Record<string, any>).reduce(
-                (hp, k) => hp.append(`${key}[${k}]`, value[k]),
+                (hp, k) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, value[k]),
                 httpParams,
             );
         } else if (paramStyle === QueryParamStyle.Json) {
@@ -90,6 +90,27 @@ export class BaseService {
                     return concatHttpParamsObject(httpParams, key, value, '|');
                 }
             }
+        }
+    }
+
+    private addToHttpParamsDeepObject(httpParams: OpenApiHttpParams, key: string, value: any | null | undefined): OpenApiHttpParams {
+        if (value == null) {
+            return httpParams;
+        } else if (value instanceof Date) {
+            return httpParams.append(key, value.toISOString());
+        } else if (Object(value) !== value) {
+            return httpParams.append(key, value.toString());
+        } else if (Array.isArray(value) || value instanceof Set) {
+            const array = Array.isArray(value) ? value : Array.from(value);
+            array.forEach((item, index) => {
+                httpParams = this.addToHttpParamsDeepObject(httpParams, `${key}[${index}]`, item);
+            });
+            return httpParams;
+        } else {
+            return Object.entries(value).reduce(
+                (hp, [k, v]) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, v),
+                httpParams,
+            );
         }
     }
 }

--- a/samples/client/others/typescript-angular-v20/builds/query-param-deep-object/api.base.service.ts
+++ b/samples/client/others/typescript-angular-v20/builds/query-param-deep-object/api.base.service.ts
@@ -49,7 +49,7 @@ export class BaseService {
             }
 
             return Object.keys(value as Record<string, any>).reduce(
-                (hp, k) => hp.append(`${key}[${k}]`, value[k]),
+                (hp, k) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, value[k]),
                 httpParams,
             );
         } else if (paramStyle === QueryParamStyle.Json) {
@@ -91,6 +91,27 @@ export class BaseService {
                     return concatHttpParamsObject(httpParams, key, value, '|');
                 }
             }
+        }
+    }
+
+    private addToHttpParamsDeepObject(httpParams: OpenApiHttpParams, key: string, value: any | null | undefined): OpenApiHttpParams {
+        if (value == null) {
+            return httpParams;
+        } else if (value instanceof Date) {
+            return httpParams.append(key, value.toISOString());
+        } else if (Object(value) !== value) {
+            return httpParams.append(key, value.toString());
+        } else if (Array.isArray(value) || value instanceof Set) {
+            const array = Array.isArray(value) ? value : Array.from(value);
+            array.forEach((item, index) => {
+                httpParams = this.addToHttpParamsDeepObject(httpParams, `${key}[${index}]`, item);
+            });
+            return httpParams;
+        } else {
+            return Object.entries(value).reduce(
+                (hp, [k, v]) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, v),
+                httpParams,
+            );
         }
     }
 }

--- a/samples/client/others/typescript-angular-v20/builds/query-param-deep-object/api.base.service.ts
+++ b/samples/client/others/typescript-angular-v20/builds/query-param-deep-object/api.base.service.ts
@@ -77,8 +77,8 @@ export class BaseService {
                 // Otherwise, if it's an object, add each field.
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
-                        Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
+                        Object.entries(value).forEach(([k, v]) => {
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, v, paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/others/typescript-angular-v20/builds/query-param-deep-object/api.base.service.ts
+++ b/samples/client/others/typescript-angular-v20/builds/query-param-deep-object/api.base.service.ts
@@ -78,7 +78,7 @@ export class BaseService {
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
                         Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, k, value[k], paramStyle, explode);
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/others/typescript-angular-v20/builds/query-param-form/api.base.service.ts
+++ b/samples/client/others/typescript-angular-v20/builds/query-param-form/api.base.service.ts
@@ -49,7 +49,7 @@ export class BaseService {
             }
 
             return Object.keys(value as Record<string, any>).reduce(
-                (hp, k) => hp.append(`${key}[${k}]`, value[k]),
+                (hp, k) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, value[k]),
                 httpParams,
             );
         } else if (paramStyle === QueryParamStyle.Json) {
@@ -91,6 +91,27 @@ export class BaseService {
                     return concatHttpParamsObject(httpParams, key, value, '|');
                 }
             }
+        }
+    }
+
+    private addToHttpParamsDeepObject(httpParams: OpenApiHttpParams, key: string, value: any | null | undefined): OpenApiHttpParams {
+        if (value == null) {
+            return httpParams;
+        } else if (value instanceof Date) {
+            return httpParams.append(key, value.toISOString());
+        } else if (Object(value) !== value) {
+            return httpParams.append(key, value.toString());
+        } else if (Array.isArray(value) || value instanceof Set) {
+            const array = Array.isArray(value) ? value : Array.from(value);
+            array.forEach((item, index) => {
+                httpParams = this.addToHttpParamsDeepObject(httpParams, `${key}[${index}]`, item);
+            });
+            return httpParams;
+        } else {
+            return Object.entries(value).reduce(
+                (hp, [k, v]) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, v),
+                httpParams,
+            );
         }
     }
 }

--- a/samples/client/others/typescript-angular-v20/builds/query-param-form/api.base.service.ts
+++ b/samples/client/others/typescript-angular-v20/builds/query-param-form/api.base.service.ts
@@ -77,8 +77,8 @@ export class BaseService {
                 // Otherwise, if it's an object, add each field.
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
-                        Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
+                        Object.entries(value).forEach(([k, v]) => {
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, v, paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/others/typescript-angular-v20/builds/query-param-form/api.base.service.ts
+++ b/samples/client/others/typescript-angular-v20/builds/query-param-form/api.base.service.ts
@@ -78,7 +78,7 @@ export class BaseService {
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
                         Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, k, value[k], paramStyle, explode);
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/others/typescript-angular-v20/builds/query-param-json/api.base.service.ts
+++ b/samples/client/others/typescript-angular-v20/builds/query-param-json/api.base.service.ts
@@ -49,7 +49,7 @@ export class BaseService {
             }
 
             return Object.keys(value as Record<string, any>).reduce(
-                (hp, k) => hp.append(`${key}[${k}]`, value[k]),
+                (hp, k) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, value[k]),
                 httpParams,
             );
         } else if (paramStyle === QueryParamStyle.Json) {
@@ -91,6 +91,27 @@ export class BaseService {
                     return concatHttpParamsObject(httpParams, key, value, '|');
                 }
             }
+        }
+    }
+
+    private addToHttpParamsDeepObject(httpParams: OpenApiHttpParams, key: string, value: any | null | undefined): OpenApiHttpParams {
+        if (value == null) {
+            return httpParams;
+        } else if (value instanceof Date) {
+            return httpParams.append(key, value.toISOString());
+        } else if (Object(value) !== value) {
+            return httpParams.append(key, value.toString());
+        } else if (Array.isArray(value) || value instanceof Set) {
+            const array = Array.isArray(value) ? value : Array.from(value);
+            array.forEach((item, index) => {
+                httpParams = this.addToHttpParamsDeepObject(httpParams, `${key}[${index}]`, item);
+            });
+            return httpParams;
+        } else {
+            return Object.entries(value).reduce(
+                (hp, [k, v]) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, v),
+                httpParams,
+            );
         }
     }
 }

--- a/samples/client/others/typescript-angular-v20/builds/query-param-json/api.base.service.ts
+++ b/samples/client/others/typescript-angular-v20/builds/query-param-json/api.base.service.ts
@@ -77,8 +77,8 @@ export class BaseService {
                 // Otherwise, if it's an object, add each field.
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
-                        Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
+                        Object.entries(value).forEach(([k, v]) => {
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, v, paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/others/typescript-angular-v20/builds/query-param-json/api.base.service.ts
+++ b/samples/client/others/typescript-angular-v20/builds/query-param-json/api.base.service.ts
@@ -78,7 +78,7 @@ export class BaseService {
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
                         Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, k, value[k], paramStyle, explode);
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/others/typescript-angular/builds/composed-schemas-tagged-unions/api.base.service.ts
+++ b/samples/client/others/typescript-angular/builds/composed-schemas-tagged-unions/api.base.service.ts
@@ -49,7 +49,7 @@ export class BaseService {
             }
 
             return Object.keys(value as Record<string, any>).reduce(
-                (hp, k) => hp.append(`${key}[${k}]`, value[k]),
+                (hp, k) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, value[k]),
                 httpParams,
             );
         } else if (paramStyle === QueryParamStyle.Json) {
@@ -91,6 +91,27 @@ export class BaseService {
                     return concatHttpParamsObject(httpParams, key, value, '|');
                 }
             }
+        }
+    }
+
+    private addToHttpParamsDeepObject(httpParams: OpenApiHttpParams, key: string, value: any | null | undefined): OpenApiHttpParams {
+        if (value == null) {
+            return httpParams;
+        } else if (value instanceof Date) {
+            return httpParams.append(key, value.toISOString());
+        } else if (Object(value) !== value) {
+            return httpParams.append(key, value.toString());
+        } else if (Array.isArray(value) || value instanceof Set) {
+            const array = Array.isArray(value) ? value : Array.from(value);
+            array.forEach((item, index) => {
+                httpParams = this.addToHttpParamsDeepObject(httpParams, `${key}[${index}]`, item);
+            });
+            return httpParams;
+        } else {
+            return Object.entries(value).reduce(
+                (hp, [k, v]) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, v),
+                httpParams,
+            );
         }
     }
 }

--- a/samples/client/others/typescript-angular/builds/composed-schemas-tagged-unions/api.base.service.ts
+++ b/samples/client/others/typescript-angular/builds/composed-schemas-tagged-unions/api.base.service.ts
@@ -77,8 +77,8 @@ export class BaseService {
                 // Otherwise, if it's an object, add each field.
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
-                        Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
+                        Object.entries(value).forEach(([k, v]) => {
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, v, paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/others/typescript-angular/builds/composed-schemas-tagged-unions/api.base.service.ts
+++ b/samples/client/others/typescript-angular/builds/composed-schemas-tagged-unions/api.base.service.ts
@@ -78,7 +78,7 @@ export class BaseService {
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
                         Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, k, value[k], paramStyle, explode);
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/others/typescript-angular/builds/composed-schemas/api.base.service.ts
+++ b/samples/client/others/typescript-angular/builds/composed-schemas/api.base.service.ts
@@ -49,7 +49,7 @@ export class BaseService {
             }
 
             return Object.keys(value as Record<string, any>).reduce(
-                (hp, k) => hp.append(`${key}[${k}]`, value[k]),
+                (hp, k) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, value[k]),
                 httpParams,
             );
         } else if (paramStyle === QueryParamStyle.Json) {
@@ -91,6 +91,27 @@ export class BaseService {
                     return concatHttpParamsObject(httpParams, key, value, '|');
                 }
             }
+        }
+    }
+
+    private addToHttpParamsDeepObject(httpParams: OpenApiHttpParams, key: string, value: any | null | undefined): OpenApiHttpParams {
+        if (value == null) {
+            return httpParams;
+        } else if (value instanceof Date) {
+            return httpParams.append(key, value.toISOString());
+        } else if (Object(value) !== value) {
+            return httpParams.append(key, value.toString());
+        } else if (Array.isArray(value) || value instanceof Set) {
+            const array = Array.isArray(value) ? value : Array.from(value);
+            array.forEach((item, index) => {
+                httpParams = this.addToHttpParamsDeepObject(httpParams, `${key}[${index}]`, item);
+            });
+            return httpParams;
+        } else {
+            return Object.entries(value).reduce(
+                (hp, [k, v]) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, v),
+                httpParams,
+            );
         }
     }
 }

--- a/samples/client/others/typescript-angular/builds/composed-schemas/api.base.service.ts
+++ b/samples/client/others/typescript-angular/builds/composed-schemas/api.base.service.ts
@@ -77,8 +77,8 @@ export class BaseService {
                 // Otherwise, if it's an object, add each field.
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
-                        Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
+                        Object.entries(value).forEach(([k, v]) => {
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, v, paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/others/typescript-angular/builds/composed-schemas/api.base.service.ts
+++ b/samples/client/others/typescript-angular/builds/composed-schemas/api.base.service.ts
@@ -78,7 +78,7 @@ export class BaseService {
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
                         Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, k, value[k], paramStyle, explode);
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/petstore/typescript-angular-v16-provided-in-root/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v16-provided-in-root/builds/default/api.base.service.ts
@@ -49,7 +49,7 @@ export class BaseService {
             }
 
             return Object.keys(value as Record<string, any>).reduce(
-                (hp, k) => hp.append(`${key}[${k}]`, value[k]),
+                (hp, k) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, value[k]),
                 httpParams,
             );
         } else if (paramStyle === QueryParamStyle.Json) {
@@ -91,6 +91,27 @@ export class BaseService {
                     return concatHttpParamsObject(httpParams, key, value, '|');
                 }
             }
+        }
+    }
+
+    private addToHttpParamsDeepObject(httpParams: OpenApiHttpParams, key: string, value: any | null | undefined): OpenApiHttpParams {
+        if (value == null) {
+            return httpParams;
+        } else if (value instanceof Date) {
+            return httpParams.append(key, value.toISOString());
+        } else if (Object(value) !== value) {
+            return httpParams.append(key, value.toString());
+        } else if (Array.isArray(value) || value instanceof Set) {
+            const array = Array.isArray(value) ? value : Array.from(value);
+            array.forEach((item, index) => {
+                httpParams = this.addToHttpParamsDeepObject(httpParams, `${key}[${index}]`, item);
+            });
+            return httpParams;
+        } else {
+            return Object.entries(value).reduce(
+                (hp, [k, v]) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, v),
+                httpParams,
+            );
         }
     }
 }

--- a/samples/client/petstore/typescript-angular-v16-provided-in-root/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v16-provided-in-root/builds/default/api.base.service.ts
@@ -78,7 +78,7 @@ export class BaseService {
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
                         Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, k, value[k], paramStyle, explode);
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/petstore/typescript-angular-v17-provided-in-root/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v17-provided-in-root/builds/default/api.base.service.ts
@@ -49,7 +49,7 @@ export class BaseService {
             }
 
             return Object.keys(value as Record<string, any>).reduce(
-                (hp, k) => hp.append(`${key}[${k}]`, value[k]),
+                (hp, k) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, value[k]),
                 httpParams,
             );
         } else if (paramStyle === QueryParamStyle.Json) {
@@ -91,6 +91,27 @@ export class BaseService {
                     return concatHttpParamsObject(httpParams, key, value, '|');
                 }
             }
+        }
+    }
+
+    private addToHttpParamsDeepObject(httpParams: OpenApiHttpParams, key: string, value: any | null | undefined): OpenApiHttpParams {
+        if (value == null) {
+            return httpParams;
+        } else if (value instanceof Date) {
+            return httpParams.append(key, value.toISOString());
+        } else if (Object(value) !== value) {
+            return httpParams.append(key, value.toString());
+        } else if (Array.isArray(value) || value instanceof Set) {
+            const array = Array.isArray(value) ? value : Array.from(value);
+            array.forEach((item, index) => {
+                httpParams = this.addToHttpParamsDeepObject(httpParams, `${key}[${index}]`, item);
+            });
+            return httpParams;
+        } else {
+            return Object.entries(value).reduce(
+                (hp, [k, v]) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, v),
+                httpParams,
+            );
         }
     }
 }

--- a/samples/client/petstore/typescript-angular-v17-provided-in-root/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v17-provided-in-root/builds/default/api.base.service.ts
@@ -77,8 +77,8 @@ export class BaseService {
                 // Otherwise, if it's an object, add each field.
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
-                        Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
+                        Object.entries(value).forEach(([k, v]) => {
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, v, paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/petstore/typescript-angular-v17-provided-in-root/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v17-provided-in-root/builds/default/api.base.service.ts
@@ -78,7 +78,7 @@ export class BaseService {
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
                         Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, k, value[k], paramStyle, explode);
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/api.base.service.ts
@@ -49,7 +49,7 @@ export class BaseService {
             }
 
             return Object.keys(value as Record<string, any>).reduce(
-                (hp, k) => hp.append(`${key}[${k}]`, value[k]),
+                (hp, k) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, value[k]),
                 httpParams,
             );
         } else if (paramStyle === QueryParamStyle.Json) {
@@ -91,6 +91,27 @@ export class BaseService {
                     return concatHttpParamsObject(httpParams, key, value, '|');
                 }
             }
+        }
+    }
+
+    private addToHttpParamsDeepObject(httpParams: OpenApiHttpParams, key: string, value: any | null | undefined): OpenApiHttpParams {
+        if (value == null) {
+            return httpParams;
+        } else if (value instanceof Date) {
+            return httpParams.append(key, value.toISOString());
+        } else if (Object(value) !== value) {
+            return httpParams.append(key, value.toString());
+        } else if (Array.isArray(value) || value instanceof Set) {
+            const array = Array.isArray(value) ? value : Array.from(value);
+            array.forEach((item, index) => {
+                httpParams = this.addToHttpParamsDeepObject(httpParams, `${key}[${index}]`, item);
+            });
+            return httpParams;
+        } else {
+            return Object.entries(value).reduce(
+                (hp, [k, v]) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, v),
+                httpParams,
+            );
         }
     }
 }

--- a/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/api.base.service.ts
@@ -77,8 +77,8 @@ export class BaseService {
                 // Otherwise, if it's an object, add each field.
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
-                        Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
+                        Object.entries(value).forEach(([k, v]) => {
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, v, paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/api.base.service.ts
@@ -78,7 +78,7 @@ export class BaseService {
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
                         Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, k, value[k], paramStyle, explode);
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/petstore/typescript-angular-v19-provided-in-root/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v19-provided-in-root/builds/default/api.base.service.ts
@@ -49,7 +49,7 @@ export class BaseService {
             }
 
             return Object.keys(value as Record<string, any>).reduce(
-                (hp, k) => hp.append(`${key}[${k}]`, value[k]),
+                (hp, k) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, value[k]),
                 httpParams,
             );
         } else if (paramStyle === QueryParamStyle.Json) {
@@ -91,6 +91,27 @@ export class BaseService {
                     return concatHttpParamsObject(httpParams, key, value, '|');
                 }
             }
+        }
+    }
+
+    private addToHttpParamsDeepObject(httpParams: OpenApiHttpParams, key: string, value: any | null | undefined): OpenApiHttpParams {
+        if (value == null) {
+            return httpParams;
+        } else if (value instanceof Date) {
+            return httpParams.append(key, value.toISOString());
+        } else if (Object(value) !== value) {
+            return httpParams.append(key, value.toString());
+        } else if (Array.isArray(value) || value instanceof Set) {
+            const array = Array.isArray(value) ? value : Array.from(value);
+            array.forEach((item, index) => {
+                httpParams = this.addToHttpParamsDeepObject(httpParams, `${key}[${index}]`, item);
+            });
+            return httpParams;
+        } else {
+            return Object.entries(value).reduce(
+                (hp, [k, v]) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, v),
+                httpParams,
+            );
         }
     }
 }

--- a/samples/client/petstore/typescript-angular-v19-provided-in-root/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v19-provided-in-root/builds/default/api.base.service.ts
@@ -77,8 +77,8 @@ export class BaseService {
                 // Otherwise, if it's an object, add each field.
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
-                        Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
+                        Object.entries(value).forEach(([k, v]) => {
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, v, paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/petstore/typescript-angular-v19-provided-in-root/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v19-provided-in-root/builds/default/api.base.service.ts
@@ -78,7 +78,7 @@ export class BaseService {
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
                         Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, k, value[k], paramStyle, explode);
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/api.base.service.ts
@@ -49,7 +49,7 @@ export class BaseService {
             }
 
             return Object.keys(value as Record<string, any>).reduce(
-                (hp, k) => hp.append(`${key}[${k}]`, value[k]),
+                (hp, k) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, value[k]),
                 httpParams,
             );
         } else if (paramStyle === QueryParamStyle.Json) {
@@ -91,6 +91,27 @@ export class BaseService {
                     return concatHttpParamsObject(httpParams, key, value, '|');
                 }
             }
+        }
+    }
+
+    private addToHttpParamsDeepObject(httpParams: OpenApiHttpParams, key: string, value: any | null | undefined): OpenApiHttpParams {
+        if (value == null) {
+            return httpParams;
+        } else if (value instanceof Date) {
+            return httpParams.append(key, value.toISOString());
+        } else if (Object(value) !== value) {
+            return httpParams.append(key, value.toString());
+        } else if (Array.isArray(value) || value instanceof Set) {
+            const array = Array.isArray(value) ? value : Array.from(value);
+            array.forEach((item, index) => {
+                httpParams = this.addToHttpParamsDeepObject(httpParams, `${key}[${index}]`, item);
+            });
+            return httpParams;
+        } else {
+            return Object.entries(value).reduce(
+                (hp, [k, v]) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, v),
+                httpParams,
+            );
         }
     }
 }

--- a/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/api.base.service.ts
@@ -77,8 +77,8 @@ export class BaseService {
                 // Otherwise, if it's an object, add each field.
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
-                        Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
+                        Object.entries(value).forEach(([k, v]) => {
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, v, paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/api.base.service.ts
@@ -78,7 +78,7 @@ export class BaseService {
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
                         Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, k, value[k], paramStyle, explode);
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/petstore/typescript-angular-v19/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v19/builds/default/api.base.service.ts
@@ -49,7 +49,7 @@ export class BaseService {
             }
 
             return Object.keys(value as Record<string, any>).reduce(
-                (hp, k) => hp.append(`${key}[${k}]`, value[k]),
+                (hp, k) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, value[k]),
                 httpParams,
             );
         } else if (paramStyle === QueryParamStyle.Json) {
@@ -91,6 +91,27 @@ export class BaseService {
                     return concatHttpParamsObject(httpParams, key, value, '|');
                 }
             }
+        }
+    }
+
+    private addToHttpParamsDeepObject(httpParams: OpenApiHttpParams, key: string, value: any | null | undefined): OpenApiHttpParams {
+        if (value == null) {
+            return httpParams;
+        } else if (value instanceof Date) {
+            return httpParams.append(key, value.toISOString());
+        } else if (Object(value) !== value) {
+            return httpParams.append(key, value.toString());
+        } else if (Array.isArray(value) || value instanceof Set) {
+            const array = Array.isArray(value) ? value : Array.from(value);
+            array.forEach((item, index) => {
+                httpParams = this.addToHttpParamsDeepObject(httpParams, `${key}[${index}]`, item);
+            });
+            return httpParams;
+        } else {
+            return Object.entries(value).reduce(
+                (hp, [k, v]) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, v),
+                httpParams,
+            );
         }
     }
 }

--- a/samples/client/petstore/typescript-angular-v19/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v19/builds/default/api.base.service.ts
@@ -77,8 +77,8 @@ export class BaseService {
                 // Otherwise, if it's an object, add each field.
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
-                        Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
+                        Object.entries(value).forEach(([k, v]) => {
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, v, paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/petstore/typescript-angular-v19/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v19/builds/default/api.base.service.ts
@@ -78,7 +78,7 @@ export class BaseService {
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
                         Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, k, value[k], paramStyle, explode);
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/petstore/typescript-angular-v20-provided-in-root/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v20-provided-in-root/builds/default/api.base.service.ts
@@ -49,7 +49,7 @@ export class BaseService {
             }
 
             return Object.keys(value as Record<string, any>).reduce(
-                (hp, k) => hp.append(`${key}[${k}]`, value[k]),
+                (hp, k) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, value[k]),
                 httpParams,
             );
         } else if (paramStyle === QueryParamStyle.Json) {
@@ -91,6 +91,27 @@ export class BaseService {
                     return concatHttpParamsObject(httpParams, key, value, '|');
                 }
             }
+        }
+    }
+
+    private addToHttpParamsDeepObject(httpParams: OpenApiHttpParams, key: string, value: any | null | undefined): OpenApiHttpParams {
+        if (value == null) {
+            return httpParams;
+        } else if (value instanceof Date) {
+            return httpParams.append(key, value.toISOString());
+        } else if (Object(value) !== value) {
+            return httpParams.append(key, value.toString());
+        } else if (Array.isArray(value) || value instanceof Set) {
+            const array = Array.isArray(value) ? value : Array.from(value);
+            array.forEach((item, index) => {
+                httpParams = this.addToHttpParamsDeepObject(httpParams, `${key}[${index}]`, item);
+            });
+            return httpParams;
+        } else {
+            return Object.entries(value).reduce(
+                (hp, [k, v]) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, v),
+                httpParams,
+            );
         }
     }
 }

--- a/samples/client/petstore/typescript-angular-v20-provided-in-root/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v20-provided-in-root/builds/default/api.base.service.ts
@@ -77,8 +77,8 @@ export class BaseService {
                 // Otherwise, if it's an object, add each field.
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
-                        Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
+                        Object.entries(value).forEach(([k, v]) => {
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, v, paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/petstore/typescript-angular-v20-provided-in-root/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v20-provided-in-root/builds/default/api.base.service.ts
@@ -78,7 +78,7 @@ export class BaseService {
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
                         Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, k, value[k], paramStyle, explode);
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/petstore/typescript-angular-v20/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v20/builds/default/api.base.service.ts
@@ -49,7 +49,7 @@ export class BaseService {
             }
 
             return Object.keys(value as Record<string, any>).reduce(
-                (hp, k) => hp.append(`${key}[${k}]`, value[k]),
+                (hp, k) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, value[k]),
                 httpParams,
             );
         } else if (paramStyle === QueryParamStyle.Json) {
@@ -91,6 +91,27 @@ export class BaseService {
                     return concatHttpParamsObject(httpParams, key, value, '|');
                 }
             }
+        }
+    }
+
+    private addToHttpParamsDeepObject(httpParams: OpenApiHttpParams, key: string, value: any | null | undefined): OpenApiHttpParams {
+        if (value == null) {
+            return httpParams;
+        } else if (value instanceof Date) {
+            return httpParams.append(key, value.toISOString());
+        } else if (Object(value) !== value) {
+            return httpParams.append(key, value.toString());
+        } else if (Array.isArray(value) || value instanceof Set) {
+            const array = Array.isArray(value) ? value : Array.from(value);
+            array.forEach((item, index) => {
+                httpParams = this.addToHttpParamsDeepObject(httpParams, `${key}[${index}]`, item);
+            });
+            return httpParams;
+        } else {
+            return Object.entries(value).reduce(
+                (hp, [k, v]) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, v),
+                httpParams,
+            );
         }
     }
 }

--- a/samples/client/petstore/typescript-angular-v20/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v20/builds/default/api.base.service.ts
@@ -77,8 +77,8 @@ export class BaseService {
                 // Otherwise, if it's an object, add each field.
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
-                        Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
+                        Object.entries(value).forEach(([k, v]) => {
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, v, paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/petstore/typescript-angular-v20/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v20/builds/default/api.base.service.ts
@@ -78,7 +78,7 @@ export class BaseService {
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
                         Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, k, value[k], paramStyle, explode);
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/petstore/typescript-angular-v21-provided-in-root/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v21-provided-in-root/builds/default/api.base.service.ts
@@ -49,7 +49,7 @@ export class BaseService {
             }
 
             return Object.keys(value as Record<string, any>).reduce(
-                (hp, k) => hp.append(`${key}[${k}]`, value[k]),
+                (hp, k) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, value[k]),
                 httpParams,
             );
         } else if (paramStyle === QueryParamStyle.Json) {
@@ -91,6 +91,27 @@ export class BaseService {
                     return concatHttpParamsObject(httpParams, key, value, '|');
                 }
             }
+        }
+    }
+
+    private addToHttpParamsDeepObject(httpParams: OpenApiHttpParams, key: string, value: any | null | undefined): OpenApiHttpParams {
+        if (value == null) {
+            return httpParams;
+        } else if (value instanceof Date) {
+            return httpParams.append(key, value.toISOString());
+        } else if (Object(value) !== value) {
+            return httpParams.append(key, value.toString());
+        } else if (Array.isArray(value) || value instanceof Set) {
+            const array = Array.isArray(value) ? value : Array.from(value);
+            array.forEach((item, index) => {
+                httpParams = this.addToHttpParamsDeepObject(httpParams, `${key}[${index}]`, item);
+            });
+            return httpParams;
+        } else {
+            return Object.entries(value).reduce(
+                (hp, [k, v]) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, v),
+                httpParams,
+            );
         }
     }
 }

--- a/samples/client/petstore/typescript-angular-v21-provided-in-root/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v21-provided-in-root/builds/default/api.base.service.ts
@@ -77,8 +77,8 @@ export class BaseService {
                 // Otherwise, if it's an object, add each field.
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
-                        Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
+                        Object.entries(value).forEach(([k, v]) => {
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, v, paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/petstore/typescript-angular-v21-provided-in-root/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v21-provided-in-root/builds/default/api.base.service.ts
@@ -78,7 +78,7 @@ export class BaseService {
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
                         Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, k, value[k], paramStyle, explode);
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/petstore/typescript-angular-v21/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v21/builds/default/api.base.service.ts
@@ -49,7 +49,7 @@ export class BaseService {
             }
 
             return Object.keys(value as Record<string, any>).reduce(
-                (hp, k) => hp.append(`${key}[${k}]`, value[k]),
+                (hp, k) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, value[k]),
                 httpParams,
             );
         } else if (paramStyle === QueryParamStyle.Json) {
@@ -91,6 +91,27 @@ export class BaseService {
                     return concatHttpParamsObject(httpParams, key, value, '|');
                 }
             }
+        }
+    }
+
+    private addToHttpParamsDeepObject(httpParams: OpenApiHttpParams, key: string, value: any | null | undefined): OpenApiHttpParams {
+        if (value == null) {
+            return httpParams;
+        } else if (value instanceof Date) {
+            return httpParams.append(key, value.toISOString());
+        } else if (Object(value) !== value) {
+            return httpParams.append(key, value.toString());
+        } else if (Array.isArray(value) || value instanceof Set) {
+            const array = Array.isArray(value) ? value : Array.from(value);
+            array.forEach((item, index) => {
+                httpParams = this.addToHttpParamsDeepObject(httpParams, `${key}[${index}]`, item);
+            });
+            return httpParams;
+        } else {
+            return Object.entries(value).reduce(
+                (hp, [k, v]) => this.addToHttpParamsDeepObject(hp, `${key}[${k}]`, v),
+                httpParams,
+            );
         }
     }
 }

--- a/samples/client/petstore/typescript-angular-v21/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v21/builds/default/api.base.service.ts
@@ -77,8 +77,8 @@ export class BaseService {
                 // Otherwise, if it's an object, add each field.
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
-                        Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
+                        Object.entries(value).forEach(([k, v]) => {
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, v, paramStyle, explode);
                         });
                         return httpParams;
                     } else {

--- a/samples/client/petstore/typescript-angular-v21/builds/default/api.base.service.ts
+++ b/samples/client/petstore/typescript-angular-v21/builds/default/api.base.service.ts
@@ -78,7 +78,7 @@ export class BaseService {
                 if (paramStyle === QueryParamStyle.Form) {
                     if (explode) {
                         Object.keys(value).forEach(k => {
-                            httpParams = this.addToHttpParams(httpParams, k, value[k], paramStyle, explode);
+                            httpParams = this.addToHttpParams(httpParams, `${key}.${k}`, value[k], paramStyle, explode);
                         });
                         return httpParams;
                     } else {


### PR DESCRIPTION
Fixes https://github.com/OpenAPITools/openapi-generator/issues/23895

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nested query param naming and serialization in the `typescript-angular` generator. Form+explode now prefixes child keys with dot notation (e.g., user.name), and DeepObject recurses with bracket notation (e.g., options[foo][0]) to preserve structure and avoid collisions (fixes #23895).

- **Bug Fixes**
  - For Form + explode objects, recurse with `${key}.${k}` in `api.base.service.mustache`.
  - Route DeepObject through a private `addToHttpParamsDeepObject` to serialize nested objects/arrays/sets with `${key}[...]`; updated tests and sample outputs.

<sup>Written for commit 66bad2b44a328375e8ee727f6d1660664b6152fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

