### PR TITLE
refactor: centralize definition of Python vendor extensions

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -487,6 +487,7 @@ public class CodegenConstants {
     public static final String X_NULLABLE_TYPE = "x-nullable-type";
     public static final String X_CSHARP_VALUE_TYPE = "x-csharp-value-type";
     public static final String X_REGEX = "x-regex";
+    public static final String X_PATTERN = "x-pattern";
     public static final String X_MODIFIERS = "x-modifiers";
     public static final String X_MODIFIER_PREFIX = "x-modifier-";
     public static final String X_MODEL_IS_MUTABLE = "x-model-is-mutable";
@@ -504,4 +505,17 @@ public class CodegenConstants {
     public static final String X_NULLABLE = "x-nullable";
     public static final String X_ENUM_VARNAMES = "x-enum-varnames";
     public static final String X_ENUM_DESCRIPTIONS = "x-enum-descriptions";
+    public static final String X_PY_TYPING = "x-py-typing";
+    public static final String X_PY_EXAMPLE = "x-py-example";
+    public static final String X_PY_EXAMPLE_IMPORT = "x-py-example-import";
+    public static final String X_PY_FASTAPI_EXAMPLE = "x-py-fastapi-example";
+    public static final String X_PY_NAME = "x-py-name";
+    public static final String X_PY_ENUM_TYPE = "x-py-enum-type";
+    public static final String X_PY_READONLY = "x-py-readonly";
+    public static final String X_PY_MODEL_IMPORTS = "x-py-model-imports";
+    public static final String X_PY_OTHER_IMPORTS = "x-py-other-imports";
+    public static final String X_PY_POSTPONED_MODEL_IMPORTS = "x-py-postponed-model-imports";
+    public static final String X_PY_TYPING_IMPORTS = "x-py-typing-imports";
+    public static final String X_PY_PYDANTIC_IMPORTS = "x-py-pydantic-imports";
+    public static final String X_PY_DATETIME_IMPORTS = "x-py-datetime-imports";
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -635,16 +635,16 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
 
         if (parameter.getExample() != null) {
             codegenParameter.example = parameter.getExample().toString();
-            codegenParameter.vendorExtensions.put("x-py-example", toPythonLiteral(parameter.getExample()));
+            codegenParameter.vendorExtensions.put(X_PY_EXAMPLE, toPythonLiteral(parameter.getExample()));
         } else if (parameter.getExamples() != null && !parameter.getExamples().isEmpty()) {
             Example example = parameter.getExamples().values().iterator().next();
             if (example.getValue() != null) {
                 codegenParameter.example = example.getValue().toString();
-                codegenParameter.vendorExtensions.put("x-py-example", toPythonLiteral(example.getValue()));
+                codegenParameter.vendorExtensions.put(X_PY_EXAMPLE, toPythonLiteral(example.getValue()));
             }
         } else if (schema != null && schema.getExample() != null) {
             codegenParameter.example = schema.getExample().toString();
-            codegenParameter.vendorExtensions.put("x-py-example", toPythonLiteral(schema.getExample()));
+            codegenParameter.vendorExtensions.put(X_PY_EXAMPLE, toPythonLiteral(schema.getExample()));
         }
 
         setParameterExampleValue(codegenParameter);
@@ -1040,13 +1040,13 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                 }
 
                 String typing = pydantic.generatePythonType(cp);
-                cp.vendorExtensions.put("x-py-typing", typing);
+                cp.vendorExtensions.put(X_PY_TYPING, typing);
 
                 // setup x-py-name for each oneOf/anyOf schema
                 if (!model.oneOf.isEmpty()) { // oneOf
-                    cp.vendorExtensions.put("x-py-name", String.format(Locale.ROOT, "oneof_schema_%d_validator", property_count++));
+                    cp.vendorExtensions.put(X_PY_NAME, String.format(Locale.ROOT, "oneof_schema_%d_validator", property_count++));
                 } else if (!model.anyOf.isEmpty()) { // anyOf
-                    cp.vendorExtensions.put("x-py-name", String.format(Locale.ROOT, "anyof_schema_%d_validator", property_count++));
+                    cp.vendorExtensions.put(X_PY_NAME, String.format(Locale.ROOT, "anyof_schema_%d_validator", property_count++));
                 }
             }
 
@@ -1061,13 +1061,13 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
             if (model.isEnum) {
                 for (Map<String, Object> enumVars : (List<Map<String, Object>>) model.getAllowableValues().get("enumVars")) {
                     if ((Boolean) enumVars.get("isString")) {
-                        model.vendorExtensions.putIfAbsent("x-py-enum-type", "str");
+                        model.vendorExtensions.putIfAbsent(X_PY_ENUM_TYPE, "str");
                         // Do not overwrite the variable name if already set through x-enum-varnames
                         if (model.vendorExtensions.get(X_ENUM_VARNAMES) == null) {
                             enumVars.put("name", toEnumVariableName((String) enumVars.get("value"), "str"));
                         }
                     } else {
-                        model.vendorExtensions.putIfAbsent("x-py-enum-type", "int");
+                        model.vendorExtensions.putIfAbsent(X_PY_ENUM_TYPE, "int");
                         // Do not overwrite the variable name if already set through x-enum-varnames
                         if (model.vendorExtensions.get(X_ENUM_VARNAMES) == null) {
                             enumVars.put("name", toEnumVariableName((String) enumVars.get("value"), "int"));
@@ -1077,7 +1077,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
             }
 
             // set the extensions if the key is absent
-            model.getVendorExtensions().putIfAbsent("x-py-readonly", readOnlyFields);
+            model.getVendorExtensions().putIfAbsent(X_PY_READONLY, readOnlyFields);
 
             // remove the items of postponedModelImports in modelImports to avoid circular imports error
             if (!modelImports.isEmpty() && !postponedModelImports.isEmpty()) {
@@ -1096,12 +1096,12 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                 }
 
                 if (!modelsToImport.isEmpty()) {
-                    model.getVendorExtensions().putIfAbsent("x-py-model-imports", modelsToImport);
+                    model.getVendorExtensions().putIfAbsent(X_PY_MODEL_IMPORTS, modelsToImport);
                 }
             }
 
             if (!moduleImports.isEmpty()) {
-                model.getVendorExtensions().putIfAbsent("x-py-other-imports", moduleImports.exports());
+                model.getVendorExtensions().putIfAbsent(X_PY_OTHER_IMPORTS, moduleImports.exports());
             }
 
 
@@ -1115,7 +1115,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                     modelsToImport.add("from " + packageName + ".models." + underscore(modelImport) + " import " + modelImport);
                 }
 
-                model.getVendorExtensions().putIfAbsent("x-py-postponed-model-imports", modelsToImport);
+                model.getVendorExtensions().putIfAbsent(X_PY_POSTPONED_MODEL_IMPORTS, modelsToImport);
             }
         }
 
@@ -1326,7 +1326,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                         null
                 );
                 String typing = pydantic.generatePythonType(cp);
-                cp.vendorExtensions.put("x-py-typing", typing);
+                cp.vendorExtensions.put(X_PY_TYPING, typing);
             }
 
             // update typing import for operation return type
@@ -1367,7 +1367,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                 for (String exampleImport : exampleImports) {
                     imports.add("from " + packageName + ".models." + underscore(exampleImport) + " import " + exampleImport);
                 }
-                operation.vendorExtensions.put("x-py-example-import", imports);
+                operation.vendorExtensions.put(X_PY_EXAMPLE_IMPORT, imports);
             }
 
             if (!postponedExampleImports.isEmpty()) {
@@ -1376,7 +1376,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                     imports.add("from " + packageName + ".models." + underscore(exampleImport) + " import "
                             + exampleImport);
                 }
-                operation.vendorExtensions.put("x-py-example-import", imports);
+                operation.vendorExtensions.put(X_PY_EXAMPLE_IMPORT, imports);
             }
 
             // Remove constant params from allParams list and add to constantParams
@@ -1462,7 +1462,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
             }
 
             vendorExtensions.put(X_REGEX, regex.replace("\"", "\\\""));
-            vendorExtensions.put("x-pattern", pattern.replace("\"", "\\\""));
+            vendorExtensions.put(X_PATTERN, pattern.replace("\"", "\\\""));
             vendorExtensions.put(X_MODIFIERS, modifiers);
         }
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonPydanticV1Codegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonPydanticV1Codegen.java
@@ -39,8 +39,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.openapitools.codegen.CodegenConstants.X_MODIFIERS;
-import static org.openapitools.codegen.CodegenConstants.X_REGEX;
+import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.StringUtils.*;
 
 public abstract class AbstractPythonPydanticV1Codegen extends DefaultCodegen implements CodegenConfig {
@@ -948,13 +947,13 @@ public abstract class AbstractPythonPydanticV1Codegen extends DefaultCodegen imp
                     fieldCustomization = "Field(...)";
                 }
 
-                cp.vendorExtensions.put("x-py-typing", typing + " = " + fieldCustomization);
+                cp.vendorExtensions.put(X_PY_TYPING, typing + " = " + fieldCustomization);
 
                 // setup x-py-name for each oneOf/anyOf schema
                 if (!model.oneOf.isEmpty()) { // oneOf
-                    cp.vendorExtensions.put("x-py-name", String.format(Locale.ROOT, "oneof_schema_%d_validator", property_count++));
+                    cp.vendorExtensions.put(X_PY_NAME, String.format(Locale.ROOT, "oneof_schema_%d_validator", property_count++));
                 } else if (!model.anyOf.isEmpty()) { // anyOf
-                    cp.vendorExtensions.put("x-py-name", String.format(Locale.ROOT, "anyof_schema_%d_validator", property_count++));
+                    cp.vendorExtensions.put(X_PY_NAME, String.format(Locale.ROOT, "anyof_schema_%d_validator", property_count++));
                 }
             }
 
@@ -969,21 +968,21 @@ public abstract class AbstractPythonPydanticV1Codegen extends DefaultCodegen imp
             if (model.isEnum) {
                 for (Map<String, Object> enumVars : (List<Map<String, Object>>) model.getAllowableValues().get("enumVars")) {
                     if ((Boolean) enumVars.get("isString")) {
-                        model.vendorExtensions.putIfAbsent("x-py-enum-type", "str");
+                        model.vendorExtensions.putIfAbsent(X_PY_ENUM_TYPE, "str");
                         // update `name`, e.g.
                         enumVars.put("name", toEnumVariableName((String) enumVars.get("value"), "str"));
                     } else {
-                        model.vendorExtensions.putIfAbsent("x-py-enum-type", "int");
+                        model.vendorExtensions.putIfAbsent(X_PY_ENUM_TYPE, "int");
                         enumVars.put("name", toEnumVariableName((String) enumVars.get("value"), "int"));
                     }
                 }
             }
 
             // set the extensions if the key is absent
-            model.getVendorExtensions().putIfAbsent("x-py-typing-imports", typingImports);
-            model.getVendorExtensions().putIfAbsent("x-py-pydantic-imports", pydanticImports);
-            model.getVendorExtensions().putIfAbsent("x-py-datetime-imports", datetimeImports);
-            model.getVendorExtensions().putIfAbsent("x-py-readonly", readOnlyFields);
+            model.getVendorExtensions().putIfAbsent(X_PY_TYPING_IMPORTS, typingImports);
+            model.getVendorExtensions().putIfAbsent(X_PY_PYDANTIC_IMPORTS, pydanticImports);
+            model.getVendorExtensions().putIfAbsent(X_PY_DATETIME_IMPORTS, datetimeImports);
+            model.getVendorExtensions().putIfAbsent(X_PY_READONLY, readOnlyFields);
 
             // remove the items of postponedModelImports in modelImports to avoid circular imports error
             if (!modelImports.isEmpty() && !postponedModelImports.isEmpty()) {
@@ -1001,7 +1000,7 @@ public abstract class AbstractPythonPydanticV1Codegen extends DefaultCodegen imp
                     modelsToImport.add("from " + packageName + ".models." + underscore(modelImport) + " import " + modelImport);
                 }
 
-                model.getVendorExtensions().putIfAbsent("x-py-model-imports", modelsToImport);
+                model.getVendorExtensions().putIfAbsent(X_PY_MODEL_IMPORTS, modelsToImport);
             }
 
             if (!postponedModelImports.isEmpty()) {
@@ -1014,7 +1013,7 @@ public abstract class AbstractPythonPydanticV1Codegen extends DefaultCodegen imp
                     modelsToImport.add("from " + packageName + ".models." + underscore(modelImport) + " import " + modelImport);
                 }
 
-                model.getVendorExtensions().putIfAbsent("x-py-postponed-model-imports", modelsToImport);
+                model.getVendorExtensions().putIfAbsent(X_PY_POSTPONED_MODEL_IMPORTS, modelsToImport);
             }
 
         }
@@ -1789,9 +1788,9 @@ public abstract class AbstractPythonPydanticV1Codegen extends DefaultCodegen imp
                 }
 
                 if ("Field()".equals(fieldCustomization)) {
-                    param.vendorExtensions.put("x-py-typing", typing);
+                    param.vendorExtensions.put(X_PY_TYPING, typing);
                 } else {
-                    param.vendorExtensions.put("x-py-typing", String.format(Locale.ROOT, "Annotated[%s, %s]", typing, fieldCustomization));
+                    param.vendorExtensions.put(X_PY_TYPING, String.format(Locale.ROOT, "Annotated[%s, %s]", typing, fieldCustomization));
                     importAnnotated = true;
                 }
             }
@@ -1809,7 +1808,7 @@ public abstract class AbstractPythonPydanticV1Codegen extends DefaultCodegen imp
                 for (String exampleImport : exampleImports) {
                     imports.add("from " + packageName + ".models." + underscore(exampleImport) + " import " + exampleImport);
                 }
-                operation.vendorExtensions.put("x-py-example-import", imports);
+                operation.vendorExtensions.put(X_PY_EXAMPLE_IMPORT, imports);
             }
 
             if (!postponedExampleImports.isEmpty()) {
@@ -1818,7 +1817,7 @@ public abstract class AbstractPythonPydanticV1Codegen extends DefaultCodegen imp
                     imports.add("from " + packageName + ".models." + underscore(exampleImport) + " import "
                             + exampleImport);
                 }
-                operation.vendorExtensions.put("x-py-example-import", imports);
+                operation.vendorExtensions.put(X_PY_EXAMPLE_IMPORT, imports);
             }
         }
 
@@ -1918,7 +1917,7 @@ public abstract class AbstractPythonPydanticV1Codegen extends DefaultCodegen imp
             }
 
             vendorExtensions.put(X_REGEX, regex.replace("\"", "\\\""));
-            vendorExtensions.put("x-pattern", pattern.replace("\"", "\\\""));
+            vendorExtensions.put(X_PATTERN, pattern.replace("\"", "\\\""));
             vendorExtensions.put(X_MODIFIERS, modifiers);
         }
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonFastAPIServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonFastAPIServerCodegen.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.*;
 
+import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
 /**
@@ -284,13 +285,13 @@ public class PythonFastAPIServerCodegen extends AbstractPythonCodegen {
         boolean changed = false;
         for (CodegenParameter param : operation.allParams) {
             if (param.isFormParam && param.isFile) {
-                param.vendorExtensions.put("x-py-typing", param.required ? "UploadFile" : "Optional[UploadFile]");
+                param.vendorExtensions.put(X_PY_TYPING, param.required ? "UploadFile" : "Optional[UploadFile]");
                 changed = true;
             }
         }
         for (CodegenParameter param : operation.formParams) {
             if (param.isFile) {
-                param.vendorExtensions.put("x-py-typing", param.required ? "UploadFile" : "Optional[UploadFile]");
+                param.vendorExtensions.put(X_PY_TYPING, param.required ? "UploadFile" : "Optional[UploadFile]");
             }
         }
         return changed;
@@ -397,35 +398,35 @@ public class PythonFastAPIServerCodegen extends AbstractPythonCodegen {
     }
 
     private void clearBodyParamExample(CodegenOperation operation) {
-        operation.bodyParam.vendorExtensions.remove("x-py-example");
-        operation.bodyParam.vendorExtensions.remove("x-py-fastapi-example");
+        operation.bodyParam.vendorExtensions.remove(X_PY_EXAMPLE);
+        operation.bodyParam.vendorExtensions.remove(X_PY_FASTAPI_EXAMPLE);
         for (CodegenParameter param : operation.allParams) {
             if (param.isBodyParam || Objects.equals(param.paramName, operation.bodyParam.paramName)) {
-                param.vendorExtensions.remove("x-py-example");
-                param.vendorExtensions.remove("x-py-fastapi-example");
+                param.vendorExtensions.remove(X_PY_EXAMPLE);
+                param.vendorExtensions.remove(X_PY_FASTAPI_EXAMPLE);
             }
         }
         for (CodegenParameter param : operation.bodyParams) {
             if (param.isBodyParam || Objects.equals(param.paramName, operation.bodyParam.paramName)) {
-                param.vendorExtensions.remove("x-py-example");
-                param.vendorExtensions.remove("x-py-fastapi-example");
+                param.vendorExtensions.remove(X_PY_EXAMPLE);
+                param.vendorExtensions.remove(X_PY_FASTAPI_EXAMPLE);
             }
         }
     }
 
     private void setBodyParamExample(CodegenOperation operation, String example) {
-        operation.bodyParam.vendorExtensions.remove("x-py-example");
-        operation.bodyParam.vendorExtensions.put("x-py-fastapi-example", example);
+        operation.bodyParam.vendorExtensions.remove(X_PY_EXAMPLE);
+        operation.bodyParam.vendorExtensions.put(X_PY_FASTAPI_EXAMPLE, example);
         for (CodegenParameter param : operation.allParams) {
             if (param.isBodyParam || Objects.equals(param.paramName, operation.bodyParam.paramName)) {
-                param.vendorExtensions.remove("x-py-example");
-                param.vendorExtensions.put("x-py-fastapi-example", example);
+                param.vendorExtensions.remove(X_PY_EXAMPLE);
+                param.vendorExtensions.put(X_PY_FASTAPI_EXAMPLE, example);
             }
         }
         for (CodegenParameter param : operation.bodyParams) {
             if (param.isBodyParam || Objects.equals(param.paramName, operation.bodyParam.paramName)) {
-                param.vendorExtensions.remove("x-py-example");
-                param.vendorExtensions.put("x-py-fastapi-example", example);
+                param.vendorExtensions.remove(X_PY_EXAMPLE);
+                param.vendorExtensions.put(X_PY_FASTAPI_EXAMPLE, example);
             }
         }
     }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Centralize the Python vendor extension definitions in `CodegenConstants` like how it is done for most other extensions. This make it easier to get an overview of how and where they are used.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized Python vendor extension keys in `CodegenConstants` and updated all Python generators to use these constants. This removes string literals, reduces typos, and improves discoverability with no behavior changes.

- **Refactors**
  - Added constants for Python vendor extensions in `CodegenConstants` (e.g., `X_PY_TYPING`, `X_PY_EXAMPLE`, `X_PY_ENUM_TYPE`, `X_PY_MODEL_IMPORTS`, `X_PY_PYDANTIC_IMPORTS`) and `X_PATTERN`.
  - Replaced string keys with constants in `AbstractPythonCodegen`, `AbstractPythonPydanticV1Codegen`, and `PythonFastAPIServerCodegen`.
  - No template or runtime changes; extension names are unchanged and backwards-compatible.

<sup>Written for commit b6284e95a31496b0b0d5791bc8383463d6168827. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23898?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

