### PR TITLE
Fix #23903 by using method parameter names that are guaranteed not to…

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/api.mustache
@@ -69,7 +69,7 @@ public class {{classname}} {
      * {{summary}}
      * {{notes}}
 {{#responses}}     * <p><b>{{code}}</b>{{#message}} - {{.}}{{/message}}
-{{/responses}}{{#allParams}}     * @param {{paramName}} {{description}}{{^description}}The {{paramName}} parameter{{/description}}
+{{/responses}}{{#allParams}}     * @param __{{paramName}} {{description}}{{^description}}The {{paramName}} parameter{{/description}}
 {{/allParams}}{{#returnType}}     * @return {{.}}
 {{/returnType}}     * @throws RestClientResponseException if an error occurs while attempting to invoke the API
 {{#externalDocs}}
@@ -83,12 +83,12 @@ public class {{classname}} {
     {{#isDeprecated}}
     @Deprecated
     {{/isDeprecated}}
-    private ResponseSpec {{operationId}}RequestCreation({{#allParams}}{{#isFile}}{{#useAbstractionForFiles}}{{#collectionFormat}}java.util.Collection<org.springframework.core.io.Resource>{{/collectionFormat}}{{^collectionFormat}}org.springframework.core.io.Resource{{/collectionFormat}}{{/useAbstractionForFiles}}{{^useAbstractionForFiles}}{{>nullableArgument}}{{/useAbstractionForFiles}}{{/isFile}}{{^isFile}}{{>nullableArgument}}{{/isFile}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws RestClientResponseException {
-        Object postBody = {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
+    private ResponseSpec {{operationId}}RequestCreation({{#allParams}}{{#isFile}}{{#useAbstractionForFiles}}{{#collectionFormat}}java.util.Collection<org.springframework.core.io.Resource>{{/collectionFormat}}{{^collectionFormat}}org.springframework.core.io.Resource{{/collectionFormat}}{{/useAbstractionForFiles}}{{^useAbstractionForFiles}}{{>nullableArgument}}{{/useAbstractionForFiles}}{{/isFile}}{{^isFile}}{{>nullableArgument}}{{/isFile}} __{{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws RestClientResponseException {
+        Object postBody = {{#bodyParam}}__{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
         {{#allParams}}
         {{#required}}
         // verify the required parameter '{{paramName}}' is set
-        if ({{paramName}} == null) {
+        if (__{{paramName}} == null) {
             throw new RestClientResponseException("Missing the required parameter '{{paramName}}' when calling {{operationId}}", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         {{/required}}
@@ -98,7 +98,7 @@ public class {{classname}} {
         {{#hasPathParams}}
 
         {{#pathParams}}
-        pathParams.put("{{baseName}}", {{#collectionFormat}}apiClient.collectionPathParameterToString(ApiClient.CollectionFormat.valueOf("csv".toUpperCase()), {{/collectionFormat}}{{{paramName}}}{{#collectionFormat}}){{/collectionFormat}});
+        pathParams.put("{{baseName}}", {{#collectionFormat}}apiClient.collectionPathParameterToString(ApiClient.CollectionFormat.valueOf("csv".toUpperCase()), {{/collectionFormat}}__{{{paramName}}}{{#collectionFormat}}){{/collectionFormat}});
         {{/pathParams}}
         {{/hasPathParams}}
 
@@ -110,23 +110,23 @@ public class {{classname}} {
 
             {{#queryParams}}
             {{#queryIsJsonMimeType}}
-        queryParams.putAll(apiClient.parameterToMultiValueMapJson({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}));
+        queryParams.putAll(apiClient.parameterToMultiValueMapJson({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", __{{paramName}}));
             {{/queryIsJsonMimeType}}
             {{^queryIsJsonMimeType}}
             {{#isExplode}}
                 {{#hasVars}}
-        if ({{paramName}} != null) {
+        if (__{{paramName}} != null) {
                     {{#vars}}
-            queryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}.{{getter}}()));
+            queryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", __{{paramName}}.{{getter}}()));
                     {{/vars}}
         }
                 {{/hasVars}}
                 {{^hasVars}}
-        queryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}));
+        queryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", __{{paramName}}));
                 {{/hasVars}}
             {{/isExplode}}
             {{^isExplode}}
-        queryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}));
+        queryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", __{{paramName}}));
             {{/isExplode}}
             {{/queryIsJsonMimeType}}
             {{/queryParams}}
@@ -134,22 +134,22 @@ public class {{classname}} {
         {{#hasHeaderParams}}
 
         {{#headerParams}}
-        if ({{paramName}} != null)
-        headerParams.add("{{baseName}}", apiClient.parameterToString({{paramName}}));{{^-last}}
+        if (__{{paramName}} != null)
+        headerParams.add("{{baseName}}", apiClient.parameterToString(__{{paramName}}));{{^-last}}
         {{/-last}}
         {{/headerParams}}
         {{/hasHeaderParams}}
         {{#hasCookieParams}}
 
         {{#cookieParams}}
-        cookieParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}));
+        cookieParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", __{{paramName}}));
         {{/cookieParams}}
         {{/hasCookieParams}}
         {{#hasFormParams}}
 
         {{#formParams}}
-        if ({{paramName}} != null)
-            formParams.add{{#collectionFormat}}All{{/collectionFormat}}("{{baseName}}", {{#isFile}}{{^collectionFormat}}{{#useAbstractionForFiles}}{{paramName}}{{/useAbstractionForFiles}}{{^useAbstractionForFiles}}new FileSystemResource({{paramName}}){{/useAbstractionForFiles}}{{/collectionFormat}}{{/isFile}}{{#isFile}}{{#collectionFormat}}{{paramName}}.stream(){{^useAbstractionForFiles}}.map(FileSystemResource::new){{/useAbstractionForFiles}}.collect(Collectors.toList()){{/collectionFormat}}{{/isFile}}{{^isFile}}{{paramName}}{{/isFile}});
+        if (__{{paramName}} != null)
+            formParams.add{{#collectionFormat}}All{{/collectionFormat}}("{{baseName}}", {{#isFile}}{{^collectionFormat}}{{#useAbstractionForFiles}}__{{paramName}}{{/useAbstractionForFiles}}{{^useAbstractionForFiles}}new FileSystemResource(__{{paramName}}){{/useAbstractionForFiles}}{{/collectionFormat}}{{/isFile}}{{#isFile}}{{#collectionFormat}}__{{paramName}}.stream(){{^useAbstractionForFiles}}.map(FileSystemResource::new){{/useAbstractionForFiles}}.collect(Collectors.toList()){{/collectionFormat}}{{/isFile}}{{^isFile}}__{{paramName}}{{/isFile}});
         {{/formParams}}
         {{/hasFormParams}}
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -2734,7 +2734,7 @@ public class JavaClientCodegenTest {
         List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
 
         validateJavaSourceFiles(files);
-        assertFileContains(output.resolve("src/main/java/xyz/abcdef/api/DepartmentApi.java"), "if (filter != null) {");
+        assertFileContains(output.resolve("src/main/java/xyz/abcdef/api/DepartmentApi.java"), "if (__filter != null) {");
     }
 
     @Test
@@ -2816,15 +2816,15 @@ public class JavaClientCodegenTest {
                 // multiple files
                 "multipartArray(@jakarta.annotation.Nullable List<File> files)",
                 "formParams.addAll(\"files\","
-                        + " files.stream().map(FileSystemResource::new).collect(Collectors.toList()));",
+                        + " __files.stream().map(FileSystemResource::new).collect(Collectors.toList()));",
 
                 // mixed
                 "multipartMixed(@jakarta.annotation.Nonnull MultipartMixedStatus status, @jakarta.annotation.Nonnull File _file, @jakarta.annotation.Nullable MultipartMixedRequestMarker marker, @jakarta.annotation.Nullable List<MultipartMixedStatus> statusArray)",
-                "formParams.add(\"file\", new FileSystemResource(_file));",
+                "formParams.add(\"file\", new FileSystemResource(___file));",
 
                 // single file
                 "multipartSingle(@jakarta.annotation.Nullable File _file)",
-                "formParams.add(\"file\", new FileSystemResource(_file));"
+                "formParams.add(\"file\", new FileSystemResource(___file));"
         );
     }
 
@@ -2846,15 +2846,15 @@ public class JavaClientCodegenTest {
                 output.resolve("src/main/java/xyz/abcdef/api/MultipartApi.java"),
                 // multiple files
                 "multipartArray(java.util.Collection<org.springframework.core.io.Resource> files)",
-                "formParams.addAll(\"files\", files.stream().collect(Collectors.toList()));",
+                "formParams.addAll(\"files\", __files.stream().collect(Collectors.toList()));",
 
                 // mixed
                 "multipartMixed(@jakarta.annotation.Nonnull MultipartMixedStatus status, org.springframework.core.io.Resource _file, @jakarta.annotation.Nullable MultipartMixedRequestMarker marker, @jakarta.annotation.Nullable List<MultipartMixedStatus> statusArray)",
-                "formParams.add(\"file\", _file);",
+                "formParams.add(\"file\", ___file);",
 
                 // single file
                 "multipartSingle(org.springframework.core.io.Resource _file)",
-                "formParams.add(\"file\", _file);"
+                "formParams.add(\"file\", ___file);"
         );
     }
 
@@ -4244,16 +4244,19 @@ public class JavaClientCodegenTest {
                 .setLibrary(library)
                 .setInputSpec("src/test/resources/3_0/echo_api.yaml")
                 .setOutputDir(output.toString().replace("\\", "/"));
+        final String prefix = library == RESTCLIENT
+                 ? "__"
+                : "";
 
         new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
         assertFileContains(
                 output.resolve("src/main/java/org/openapitools/client/api/QueryApi.java"),
-                "queryParams.putAll(apiClient.parameterToMultiValueMapJson(null, \"json_serialized_object_ref_string_query\", jsonSerializedObjectRefStringQuery));"
+                "queryParams.putAll(apiClient.parameterToMultiValueMapJson(null, \"json_serialized_object_ref_string_query\", " + prefix + "jsonSerializedObjectRefStringQuery));"
         );
         assertFileContains(
                 output.resolve("src/main/java/org/openapitools/client/api/QueryApi.java"),
                 "queryParams.putAll(apiClient.parameterToMultiValueMapJson(ApiClient.CollectionFormat" +
-                        ".valueOf(\"csv\".toUpperCase(Locale.ROOT)), \"json_serialized_object_array_ref_string_query\", jsonSerializedObjectArrayRefStringQuery));"
+                        ".valueOf(\"csv\".toUpperCase(Locale.ROOT)), \"json_serialized_object_array_ref_string_query\", " + prefix + "jsonSerializedObjectArrayRefStringQuery));"
         );
     }
 

--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/BodyApi.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/BodyApi.java
@@ -116,12 +116,12 @@ public class BodyApi {
      * Test body parameter(s)
      * Test body parameter(s)
      * <p><b>200</b> - Successful operation
-     * @param body The body parameter
+     * @param __body The body parameter
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testBodyApplicationOctetstreamBinaryRequestCreation(@jakarta.annotation.Nullable File body) throws RestClientResponseException {
-        Object postBody = body;
+    private ResponseSpec testBodyApplicationOctetstreamBinaryRequestCreation(@jakarta.annotation.Nullable File __body) throws RestClientResponseException {
+        Object postBody = __body;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
@@ -187,14 +187,14 @@ public class BodyApi {
      * Test array of binary in multipart mime
      * Test array of binary in multipart mime
      * <p><b>200</b> - Successful operation
-     * @param files The files parameter
+     * @param __files The files parameter
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testBodyMultipartFormdataArrayOfBinaryRequestCreation(@jakarta.annotation.Nonnull List<File> files) throws RestClientResponseException {
+    private ResponseSpec testBodyMultipartFormdataArrayOfBinaryRequestCreation(@jakarta.annotation.Nonnull List<File> __files) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'files' is set
-        if (files == null) {
+        if (__files == null) {
             throw new RestClientResponseException("Missing the required parameter 'files' when calling testBodyMultipartFormdataArrayOfBinary", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -205,8 +205,8 @@ public class BodyApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (files != null)
-            formParams.addAll("files", files.stream().map(FileSystemResource::new).collect(Collectors.toList()));
+        if (__files != null)
+            formParams.addAll("files", __files.stream().map(FileSystemResource::new).collect(Collectors.toList()));
 
         final String[] localVarAccepts = { 
             "text/plain"
@@ -265,11 +265,11 @@ public class BodyApi {
      * Test single binary in multipart mime
      * Test single binary in multipart mime
      * <p><b>200</b> - Successful operation
-     * @param myFile The myFile parameter
+     * @param __myFile The myFile parameter
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testBodyMultipartFormdataSingleBinaryRequestCreation(@jakarta.annotation.Nullable File myFile) throws RestClientResponseException {
+    private ResponseSpec testBodyMultipartFormdataSingleBinaryRequestCreation(@jakarta.annotation.Nullable File __myFile) throws RestClientResponseException {
         Object postBody = null;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
@@ -279,8 +279,8 @@ public class BodyApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (myFile != null)
-            formParams.add("my-file", new FileSystemResource(myFile));
+        if (__myFile != null)
+            formParams.add("my-file", new FileSystemResource(__myFile));
 
         final String[] localVarAccepts = { 
             "text/plain"
@@ -339,12 +339,12 @@ public class BodyApi {
      * Test body parameter(s)
      * Test body parameter(s)
      * <p><b>200</b> - Successful operation
-     * @param pet Pet object that needs to be added to the store
+     * @param __pet Pet object that needs to be added to the store
      * @return Pet
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testEchoBodyAllOfPetRequestCreation(@jakarta.annotation.Nullable Pet pet) throws RestClientResponseException {
-        Object postBody = pet;
+    private ResponseSpec testEchoBodyAllOfPetRequestCreation(@jakarta.annotation.Nullable Pet __pet) throws RestClientResponseException {
+        Object postBody = __pet;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
@@ -410,12 +410,12 @@ public class BodyApi {
      * Test free form object
      * Test free form object
      * <p><b>200</b> - Successful operation
-     * @param body Free form object
+     * @param __body Free form object
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testEchoBodyFreeFormObjectResponseStringRequestCreation(@jakarta.annotation.Nullable Object body) throws RestClientResponseException {
-        Object postBody = body;
+    private ResponseSpec testEchoBodyFreeFormObjectResponseStringRequestCreation(@jakarta.annotation.Nullable Object __body) throws RestClientResponseException {
+        Object postBody = __body;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
@@ -481,12 +481,12 @@ public class BodyApi {
      * Test body parameter(s)
      * Test body parameter(s)
      * <p><b>200</b> - Successful operation
-     * @param pet Pet object that needs to be added to the store
+     * @param __pet Pet object that needs to be added to the store
      * @return Pet
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testEchoBodyPetRequestCreation(@jakarta.annotation.Nullable Pet pet) throws RestClientResponseException {
-        Object postBody = pet;
+    private ResponseSpec testEchoBodyPetRequestCreation(@jakarta.annotation.Nullable Pet __pet) throws RestClientResponseException {
+        Object postBody = __pet;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
@@ -552,12 +552,12 @@ public class BodyApi {
      * Test empty response body
      * Test empty response body
      * <p><b>200</b> - Successful operation
-     * @param pet Pet object that needs to be added to the store
+     * @param __pet Pet object that needs to be added to the store
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testEchoBodyPetResponseStringRequestCreation(@jakarta.annotation.Nullable Pet pet) throws RestClientResponseException {
-        Object postBody = pet;
+    private ResponseSpec testEchoBodyPetResponseStringRequestCreation(@jakarta.annotation.Nullable Pet __pet) throws RestClientResponseException {
+        Object postBody = __pet;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
@@ -623,12 +623,12 @@ public class BodyApi {
      * Test string enum response body
      * Test string enum response body
      * <p><b>200</b> - Successful operation
-     * @param body String enum
+     * @param __body String enum
      * @return StringEnumRef
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testEchoBodyStringEnumRequestCreation(@jakarta.annotation.Nullable String body) throws RestClientResponseException {
-        Object postBody = body;
+    private ResponseSpec testEchoBodyStringEnumRequestCreation(@jakarta.annotation.Nullable String __body) throws RestClientResponseException {
+        Object postBody = __body;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
@@ -694,12 +694,12 @@ public class BodyApi {
      * Test empty json (request body)
      * Test empty json (request body)
      * <p><b>200</b> - Successful operation
-     * @param tag Tag object
+     * @param __tag Tag object
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testEchoBodyTagResponseStringRequestCreation(@jakarta.annotation.Nullable Tag tag) throws RestClientResponseException {
-        Object postBody = tag;
+    private ResponseSpec testEchoBodyTagResponseStringRequestCreation(@jakarta.annotation.Nullable Tag __tag) throws RestClientResponseException {
+        Object postBody = __tag;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 

--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/FormApi.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/FormApi.java
@@ -48,13 +48,13 @@ public class FormApi {
      * Test form parameter(s)
      * Test form parameter(s)
      * <p><b>200</b> - Successful operation
-     * @param integerForm The integerForm parameter
-     * @param booleanForm The booleanForm parameter
-     * @param stringForm The stringForm parameter
+     * @param __integerForm The integerForm parameter
+     * @param __booleanForm The booleanForm parameter
+     * @param __stringForm The stringForm parameter
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testFormIntegerBooleanStringRequestCreation(@jakarta.annotation.Nullable Integer integerForm, @jakarta.annotation.Nullable Boolean booleanForm, @jakarta.annotation.Nullable String stringForm) throws RestClientResponseException {
+    private ResponseSpec testFormIntegerBooleanStringRequestCreation(@jakarta.annotation.Nullable Integer __integerForm, @jakarta.annotation.Nullable Boolean __booleanForm, @jakarta.annotation.Nullable String __stringForm) throws RestClientResponseException {
         Object postBody = null;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
@@ -64,12 +64,12 @@ public class FormApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (integerForm != null)
-            formParams.add("integer_form", integerForm);
-        if (booleanForm != null)
-            formParams.add("boolean_form", booleanForm);
-        if (stringForm != null)
-            formParams.add("string_form", stringForm);
+        if (__integerForm != null)
+            formParams.add("integer_form", __integerForm);
+        if (__booleanForm != null)
+            formParams.add("boolean_form", __booleanForm);
+        if (__stringForm != null)
+            formParams.add("string_form", __stringForm);
 
         final String[] localVarAccepts = { 
             "text/plain"
@@ -134,14 +134,14 @@ public class FormApi {
      * Test form parameter(s) for multipart schema
      * Test form parameter(s) for multipart schema
      * <p><b>200</b> - Successful operation
-     * @param marker The marker parameter
+     * @param __marker The marker parameter
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testFormObjectMultipartRequestCreation(@jakarta.annotation.Nonnull TestFormObjectMultipartRequestMarker marker) throws RestClientResponseException {
+    private ResponseSpec testFormObjectMultipartRequestCreation(@jakarta.annotation.Nonnull TestFormObjectMultipartRequestMarker __marker) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'marker' is set
-        if (marker == null) {
+        if (__marker == null) {
             throw new RestClientResponseException("Missing the required parameter 'marker' when calling testFormObjectMultipart", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -152,8 +152,8 @@ public class FormApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (marker != null)
-            formParams.add("marker", marker);
+        if (__marker != null)
+            formParams.add("marker", __marker);
 
         final String[] localVarAccepts = { 
             "text/plain"
@@ -212,16 +212,16 @@ public class FormApi {
      * Test form parameter(s) for oneOf schema
      * Test form parameter(s) for oneOf schema
      * <p><b>200</b> - Successful operation
-     * @param form1 The form1 parameter
-     * @param form2 The form2 parameter
-     * @param form3 The form3 parameter
-     * @param form4 The form4 parameter
-     * @param id The id parameter
-     * @param name The name parameter
+     * @param __form1 The form1 parameter
+     * @param __form2 The form2 parameter
+     * @param __form3 The form3 parameter
+     * @param __form4 The form4 parameter
+     * @param __id The id parameter
+     * @param __name The name parameter
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testFormOneofRequestCreation(@jakarta.annotation.Nullable String form1, @jakarta.annotation.Nullable Integer form2, @jakarta.annotation.Nullable String form3, @jakarta.annotation.Nullable Boolean form4, @jakarta.annotation.Nullable Long id, @jakarta.annotation.Nullable String name) throws RestClientResponseException {
+    private ResponseSpec testFormOneofRequestCreation(@jakarta.annotation.Nullable String __form1, @jakarta.annotation.Nullable Integer __form2, @jakarta.annotation.Nullable String __form3, @jakarta.annotation.Nullable Boolean __form4, @jakarta.annotation.Nullable Long __id, @jakarta.annotation.Nullable String __name) throws RestClientResponseException {
         Object postBody = null;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
@@ -231,18 +231,18 @@ public class FormApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (form1 != null)
-            formParams.add("form1", form1);
-        if (form2 != null)
-            formParams.add("form2", form2);
-        if (form3 != null)
-            formParams.add("form3", form3);
-        if (form4 != null)
-            formParams.add("form4", form4);
-        if (id != null)
-            formParams.add("id", id);
-        if (name != null)
-            formParams.add("name", name);
+        if (__form1 != null)
+            formParams.add("form1", __form1);
+        if (__form2 != null)
+            formParams.add("form2", __form2);
+        if (__form3 != null)
+            formParams.add("form3", __form3);
+        if (__form4 != null)
+            formParams.add("form4", __form4);
+        if (__id != null)
+            formParams.add("id", __id);
+        if (__name != null)
+            formParams.add("name", __name);
 
         final String[] localVarAccepts = { 
             "text/plain"

--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/HeaderApi.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/HeaderApi.java
@@ -48,15 +48,15 @@ public class HeaderApi {
      * Test header parameter(s)
      * Test header parameter(s)
      * <p><b>200</b> - Successful operation
-     * @param integerHeader The integerHeader parameter
-     * @param booleanHeader The booleanHeader parameter
-     * @param stringHeader The stringHeader parameter
-     * @param enumNonrefStringHeader The enumNonrefStringHeader parameter
-     * @param enumRefStringHeader The enumRefStringHeader parameter
+     * @param __integerHeader The integerHeader parameter
+     * @param __booleanHeader The booleanHeader parameter
+     * @param __stringHeader The stringHeader parameter
+     * @param __enumNonrefStringHeader The enumNonrefStringHeader parameter
+     * @param __enumRefStringHeader The enumRefStringHeader parameter
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testHeaderIntegerBooleanStringEnumsRequestCreation(@jakarta.annotation.Nullable Integer integerHeader, @jakarta.annotation.Nullable Boolean booleanHeader, @jakarta.annotation.Nullable String stringHeader, @jakarta.annotation.Nullable String enumNonrefStringHeader, @jakarta.annotation.Nullable StringEnumRef enumRefStringHeader) throws RestClientResponseException {
+    private ResponseSpec testHeaderIntegerBooleanStringEnumsRequestCreation(@jakarta.annotation.Nullable Integer __integerHeader, @jakarta.annotation.Nullable Boolean __booleanHeader, @jakarta.annotation.Nullable String __stringHeader, @jakarta.annotation.Nullable String __enumNonrefStringHeader, @jakarta.annotation.Nullable StringEnumRef __enumRefStringHeader) throws RestClientResponseException {
         Object postBody = null;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
@@ -66,16 +66,16 @@ public class HeaderApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (integerHeader != null)
-        headerParams.add("integer_header", apiClient.parameterToString(integerHeader));
-        if (booleanHeader != null)
-        headerParams.add("boolean_header", apiClient.parameterToString(booleanHeader));
-        if (stringHeader != null)
-        headerParams.add("string_header", apiClient.parameterToString(stringHeader));
-        if (enumNonrefStringHeader != null)
-        headerParams.add("enum_nonref_string_header", apiClient.parameterToString(enumNonrefStringHeader));
-        if (enumRefStringHeader != null)
-        headerParams.add("enum_ref_string_header", apiClient.parameterToString(enumRefStringHeader));
+        if (__integerHeader != null)
+        headerParams.add("integer_header", apiClient.parameterToString(__integerHeader));
+        if (__booleanHeader != null)
+        headerParams.add("boolean_header", apiClient.parameterToString(__booleanHeader));
+        if (__stringHeader != null)
+        headerParams.add("string_header", apiClient.parameterToString(__stringHeader));
+        if (__enumNonrefStringHeader != null)
+        headerParams.add("enum_nonref_string_header", apiClient.parameterToString(__enumNonrefStringHeader));
+        if (__enumRefStringHeader != null)
+        headerParams.add("enum_ref_string_header", apiClient.parameterToString(__enumRefStringHeader));
         final String[] localVarAccepts = { 
             "text/plain"
         };

--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/PathApi.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/PathApi.java
@@ -48,38 +48,38 @@ public class PathApi {
      * Test path parameter(s)
      * Test path parameter(s)
      * <p><b>200</b> - Successful operation
-     * @param pathString The pathString parameter
-     * @param pathInteger The pathInteger parameter
-     * @param enumNonrefStringPath The enumNonrefStringPath parameter
-     * @param enumRefStringPath The enumRefStringPath parameter
+     * @param __pathString The pathString parameter
+     * @param __pathInteger The pathInteger parameter
+     * @param __enumNonrefStringPath The enumNonrefStringPath parameter
+     * @param __enumRefStringPath The enumRefStringPath parameter
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathRequestCreation(@jakarta.annotation.Nonnull String pathString, @jakarta.annotation.Nonnull Integer pathInteger, @jakarta.annotation.Nonnull String enumNonrefStringPath, @jakarta.annotation.Nonnull StringEnumRef enumRefStringPath) throws RestClientResponseException {
+    private ResponseSpec testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathRequestCreation(@jakarta.annotation.Nonnull String __pathString, @jakarta.annotation.Nonnull Integer __pathInteger, @jakarta.annotation.Nonnull String __enumNonrefStringPath, @jakarta.annotation.Nonnull StringEnumRef __enumRefStringPath) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'pathString' is set
-        if (pathString == null) {
+        if (__pathString == null) {
             throw new RestClientResponseException("Missing the required parameter 'pathString' when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'pathInteger' is set
-        if (pathInteger == null) {
+        if (__pathInteger == null) {
             throw new RestClientResponseException("Missing the required parameter 'pathInteger' when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'enumNonrefStringPath' is set
-        if (enumNonrefStringPath == null) {
+        if (__enumNonrefStringPath == null) {
             throw new RestClientResponseException("Missing the required parameter 'enumNonrefStringPath' when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'enumRefStringPath' is set
-        if (enumRefStringPath == null) {
+        if (__enumRefStringPath == null) {
             throw new RestClientResponseException("Missing the required parameter 'enumRefStringPath' when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("path_string", pathString);
-        pathParams.put("path_integer", pathInteger);
-        pathParams.put("enum_nonref_string_path", enumNonrefStringPath);
-        pathParams.put("enum_ref_string_path", enumRefStringPath);
+        pathParams.put("path_string", __pathString);
+        pathParams.put("path_integer", __pathInteger);
+        pathParams.put("enum_nonref_string_path", __enumNonrefStringPath);
+        pathParams.put("enum_ref_string_path", __enumRefStringPath);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();

--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/QueryApi.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/QueryApi.java
@@ -54,12 +54,12 @@ public class QueryApi {
      * Test query parameter(s)
      * Test query parameter(s)
      * <p><b>200</b> - Successful operation
-     * @param enumNonrefStringQuery The enumNonrefStringQuery parameter
-     * @param enumRefStringQuery The enumRefStringQuery parameter
+     * @param __enumNonrefStringQuery The enumNonrefStringQuery parameter
+     * @param __enumRefStringQuery The enumRefStringQuery parameter
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testEnumRefStringRequestCreation(@jakarta.annotation.Nullable String enumNonrefStringQuery, @jakarta.annotation.Nullable StringEnumRef enumRefStringQuery) throws RestClientResponseException {
+    private ResponseSpec testEnumRefStringRequestCreation(@jakarta.annotation.Nullable String __enumNonrefStringQuery, @jakarta.annotation.Nullable StringEnumRef __enumRefStringQuery) throws RestClientResponseException {
         Object postBody = null;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
@@ -69,8 +69,8 @@ public class QueryApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_nonref_string_query", enumNonrefStringQuery));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_ref_string_query", enumRefStringQuery));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_nonref_string_query", __enumNonrefStringQuery));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_ref_string_query", __enumRefStringQuery));
 
         final String[] localVarAccepts = { 
             "text/plain"
@@ -130,13 +130,13 @@ public class QueryApi {
      * Test query parameter(s)
      * Test query parameter(s)
      * <p><b>200</b> - Successful operation
-     * @param datetimeQuery The datetimeQuery parameter
-     * @param dateQuery The dateQuery parameter
-     * @param stringQuery The stringQuery parameter
+     * @param __datetimeQuery The datetimeQuery parameter
+     * @param __dateQuery The dateQuery parameter
+     * @param __stringQuery The stringQuery parameter
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testQueryDatetimeDateStringRequestCreation(@jakarta.annotation.Nullable Instant datetimeQuery, @jakarta.annotation.Nullable LocalDate dateQuery, @jakarta.annotation.Nullable String stringQuery) throws RestClientResponseException {
+    private ResponseSpec testQueryDatetimeDateStringRequestCreation(@jakarta.annotation.Nullable Instant __datetimeQuery, @jakarta.annotation.Nullable LocalDate __dateQuery, @jakarta.annotation.Nullable String __stringQuery) throws RestClientResponseException {
         Object postBody = null;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
@@ -146,9 +146,9 @@ public class QueryApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "datetime_query", datetimeQuery));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "date_query", dateQuery));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "string_query", stringQuery));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "datetime_query", __datetimeQuery));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "date_query", __dateQuery));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "string_query", __stringQuery));
 
         final String[] localVarAccepts = { 
             "text/plain"
@@ -211,13 +211,13 @@ public class QueryApi {
      * Test query parameter(s)
      * Test query parameter(s)
      * <p><b>200</b> - Successful operation
-     * @param integerQuery The integerQuery parameter
-     * @param booleanQuery The booleanQuery parameter
-     * @param stringQuery The stringQuery parameter
+     * @param __integerQuery The integerQuery parameter
+     * @param __booleanQuery The booleanQuery parameter
+     * @param __stringQuery The stringQuery parameter
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testQueryIntegerBooleanStringRequestCreation(@jakarta.annotation.Nullable Integer integerQuery, @jakarta.annotation.Nullable Boolean booleanQuery, @jakarta.annotation.Nullable String stringQuery) throws RestClientResponseException {
+    private ResponseSpec testQueryIntegerBooleanStringRequestCreation(@jakarta.annotation.Nullable Integer __integerQuery, @jakarta.annotation.Nullable Boolean __booleanQuery, @jakarta.annotation.Nullable String __stringQuery) throws RestClientResponseException {
         Object postBody = null;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
@@ -227,9 +227,9 @@ public class QueryApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "integer_query", integerQuery));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "boolean_query", booleanQuery));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "string_query", stringQuery));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "integer_query", __integerQuery));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "boolean_query", __booleanQuery));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "string_query", __stringQuery));
 
         final String[] localVarAccepts = { 
             "text/plain"
@@ -292,11 +292,11 @@ public class QueryApi {
      * Test query parameter(s)
      * Test query parameter(s)
      * <p><b>200</b> - Successful operation
-     * @param queryObject The queryObject parameter
+     * @param __queryObject The queryObject parameter
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testQueryStyleDeepObjectExplodeTrueObjectRequestCreation(@jakarta.annotation.Nullable Pet queryObject) throws RestClientResponseException {
+    private ResponseSpec testQueryStyleDeepObjectExplodeTrueObjectRequestCreation(@jakarta.annotation.Nullable Pet __queryObject) throws RestClientResponseException {
         Object postBody = null;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
@@ -306,13 +306,13 @@ public class QueryApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (queryObject != null) {
-            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "id", queryObject.getId()));
-            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "name", queryObject.getName()));
-            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "category", queryObject.getCategory()));
-            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "photoUrls", queryObject.getPhotoUrls()));
-            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "tags", queryObject.getTags()));
-            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "status", queryObject.getStatus()));
+        if (__queryObject != null) {
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "id", __queryObject.getId()));
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "name", __queryObject.getName()));
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "category", __queryObject.getCategory()));
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "photoUrls", __queryObject.getPhotoUrls()));
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "tags", __queryObject.getTags()));
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "status", __queryObject.getStatus()));
         }
 
         final String[] localVarAccepts = { 
@@ -370,11 +370,11 @@ public class QueryApi {
      * Test query parameter(s)
      * Test query parameter(s)
      * <p><b>200</b> - Successful operation
-     * @param queryObject The queryObject parameter
+     * @param __queryObject The queryObject parameter
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testQueryStyleDeepObjectExplodeTrueObjectAllOfRequestCreation(@jakarta.annotation.Nullable TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter queryObject) throws RestClientResponseException {
+    private ResponseSpec testQueryStyleDeepObjectExplodeTrueObjectAllOfRequestCreation(@jakarta.annotation.Nullable TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter __queryObject) throws RestClientResponseException {
         Object postBody = null;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
@@ -384,7 +384,7 @@ public class QueryApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query_object", queryObject));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query_object", __queryObject));
 
         final String[] localVarAccepts = { 
             "text/plain"
@@ -441,11 +441,11 @@ public class QueryApi {
      * Test query parameter(s)
      * Test query parameter(s)
      * <p><b>200</b> - Successful operation
-     * @param queryObject The queryObject parameter
+     * @param __queryObject The queryObject parameter
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testQueryStyleFormExplodeFalseArrayIntegerRequestCreation(@jakarta.annotation.Nullable List<Integer> queryObject) throws RestClientResponseException {
+    private ResponseSpec testQueryStyleFormExplodeFalseArrayIntegerRequestCreation(@jakarta.annotation.Nullable List<Integer> __queryObject) throws RestClientResponseException {
         Object postBody = null;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
@@ -455,7 +455,7 @@ public class QueryApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "query_object", queryObject));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "query_object", __queryObject));
 
         final String[] localVarAccepts = { 
             "text/plain"
@@ -512,11 +512,11 @@ public class QueryApi {
      * Test query parameter(s)
      * Test query parameter(s)
      * <p><b>200</b> - Successful operation
-     * @param queryObject The queryObject parameter
+     * @param __queryObject The queryObject parameter
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testQueryStyleFormExplodeFalseArrayStringRequestCreation(@jakarta.annotation.Nullable List<String> queryObject) throws RestClientResponseException {
+    private ResponseSpec testQueryStyleFormExplodeFalseArrayStringRequestCreation(@jakarta.annotation.Nullable List<String> __queryObject) throws RestClientResponseException {
         Object postBody = null;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
@@ -526,7 +526,7 @@ public class QueryApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "query_object", queryObject));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "query_object", __queryObject));
 
         final String[] localVarAccepts = { 
             "text/plain"
@@ -583,11 +583,11 @@ public class QueryApi {
      * Test query parameter(s)
      * Test query parameter(s)
      * <p><b>200</b> - Successful operation
-     * @param queryObject The queryObject parameter
+     * @param __queryObject The queryObject parameter
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testQueryStyleFormExplodeTrueArrayStringRequestCreation(@jakarta.annotation.Nullable TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter queryObject) throws RestClientResponseException {
+    private ResponseSpec testQueryStyleFormExplodeTrueArrayStringRequestCreation(@jakarta.annotation.Nullable TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter __queryObject) throws RestClientResponseException {
         Object postBody = null;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
@@ -597,8 +597,8 @@ public class QueryApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (queryObject != null) {
-            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "values", queryObject.getValues()));
+        if (__queryObject != null) {
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "values", __queryObject.getValues()));
         }
 
         final String[] localVarAccepts = { 
@@ -656,11 +656,11 @@ public class QueryApi {
      * Test query parameter(s)
      * Test query parameter(s)
      * <p><b>200</b> - Successful operation
-     * @param queryObject The queryObject parameter
+     * @param __queryObject The queryObject parameter
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testQueryStyleFormExplodeTrueObjectRequestCreation(@jakarta.annotation.Nullable Pet queryObject) throws RestClientResponseException {
+    private ResponseSpec testQueryStyleFormExplodeTrueObjectRequestCreation(@jakarta.annotation.Nullable Pet __queryObject) throws RestClientResponseException {
         Object postBody = null;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
@@ -670,13 +670,13 @@ public class QueryApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (queryObject != null) {
-            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "id", queryObject.getId()));
-            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "name", queryObject.getName()));
-            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "category", queryObject.getCategory()));
-            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "photoUrls", queryObject.getPhotoUrls()));
-            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "tags", queryObject.getTags()));
-            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "status", queryObject.getStatus()));
+        if (__queryObject != null) {
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "id", __queryObject.getId()));
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "name", __queryObject.getName()));
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "category", __queryObject.getCategory()));
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "photoUrls", __queryObject.getPhotoUrls()));
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "tags", __queryObject.getTags()));
+            queryParams.putAll(apiClient.parameterToMultiValueMap(null, "status", __queryObject.getStatus()));
         }
 
         final String[] localVarAccepts = { 
@@ -734,11 +734,11 @@ public class QueryApi {
      * Test query parameter(s)
      * Test query parameter(s)
      * <p><b>200</b> - Successful operation
-     * @param queryObject The queryObject parameter
+     * @param __queryObject The queryObject parameter
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testQueryStyleFormExplodeTrueObjectAllOfRequestCreation(@jakarta.annotation.Nullable DataQuery queryObject) throws RestClientResponseException {
+    private ResponseSpec testQueryStyleFormExplodeTrueObjectAllOfRequestCreation(@jakarta.annotation.Nullable DataQuery __queryObject) throws RestClientResponseException {
         Object postBody = null;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
@@ -748,7 +748,7 @@ public class QueryApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query_object", queryObject));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query_object", __queryObject));
 
         final String[] localVarAccepts = { 
             "text/plain"
@@ -805,12 +805,12 @@ public class QueryApi {
      * Test query parameter(s)
      * Test query parameter(s)
      * <p><b>200</b> - Successful operation
-     * @param jsonSerializedObjectRefStringQuery The jsonSerializedObjectRefStringQuery parameter
-     * @param jsonSerializedObjectArrayRefStringQuery The jsonSerializedObjectArrayRefStringQuery parameter
+     * @param __jsonSerializedObjectRefStringQuery The jsonSerializedObjectRefStringQuery parameter
+     * @param __jsonSerializedObjectArrayRefStringQuery The jsonSerializedObjectArrayRefStringQuery parameter
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testQueryStyleJsonSerializationObjectRequestCreation(@jakarta.annotation.Nullable Pet jsonSerializedObjectRefStringQuery, @jakarta.annotation.Nullable List<Pet> jsonSerializedObjectArrayRefStringQuery) throws RestClientResponseException {
+    private ResponseSpec testQueryStyleJsonSerializationObjectRequestCreation(@jakarta.annotation.Nullable Pet __jsonSerializedObjectRefStringQuery, @jakarta.annotation.Nullable List<Pet> __jsonSerializedObjectArrayRefStringQuery) throws RestClientResponseException {
         Object postBody = null;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
@@ -820,8 +820,8 @@ public class QueryApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMapJson(null, "json_serialized_object_ref_string_query", jsonSerializedObjectRefStringQuery));
-        queryParams.putAll(apiClient.parameterToMultiValueMapJson(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "json_serialized_object_array_ref_string_query", jsonSerializedObjectArrayRefStringQuery));
+        queryParams.putAll(apiClient.parameterToMultiValueMapJson(null, "json_serialized_object_ref_string_query", __jsonSerializedObjectRefStringQuery));
+        queryParams.putAll(apiClient.parameterToMultiValueMapJson(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "json_serialized_object_array_ref_string_query", __jsonSerializedObjectArrayRefStringQuery));
 
         final String[] localVarAccepts = { 
             "text/plain"

--- a/samples/client/others/java/restclient-enum-in-multipart/src/main/java/org/openapitools/client/api/BasApi.java
+++ b/samples/client/others/java/restclient-enum-in-multipart/src/main/java/org/openapitools/client/api/BasApi.java
@@ -51,29 +51,29 @@ public class BasApi {
      * Creates a new message
      * Creates a new message
      * <p><b>201</b> - The message was created.
-     * @param fileContent The message payload
-     * @param idempotencyKey The idempotencyKey parameter
-     * @param dataDirection The dataDirection parameter
-     * @param dataChannel The dataChannel parameter
+     * @param __fileContent The message payload
+     * @param __idempotencyKey The idempotencyKey parameter
+     * @param __dataDirection The dataDirection parameter
+     * @param __dataChannel The dataChannel parameter
      * @return InlineObject
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec createMessageRequestCreation(@jakarta.annotation.Nonnull File fileContent, @jakarta.annotation.Nonnull String idempotencyKey, @jakarta.annotation.Nonnull DataDirection dataDirection, @jakarta.annotation.Nonnull DataChannel dataChannel) throws RestClientResponseException {
+    private ResponseSpec createMessageRequestCreation(@jakarta.annotation.Nonnull File __fileContent, @jakarta.annotation.Nonnull String __idempotencyKey, @jakarta.annotation.Nonnull DataDirection __dataDirection, @jakarta.annotation.Nonnull DataChannel __dataChannel) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'fileContent' is set
-        if (fileContent == null) {
+        if (__fileContent == null) {
             throw new RestClientResponseException("Missing the required parameter 'fileContent' when calling createMessage", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'idempotencyKey' is set
-        if (idempotencyKey == null) {
+        if (__idempotencyKey == null) {
             throw new RestClientResponseException("Missing the required parameter 'idempotencyKey' when calling createMessage", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'dataDirection' is set
-        if (dataDirection == null) {
+        if (__dataDirection == null) {
             throw new RestClientResponseException("Missing the required parameter 'dataDirection' when calling createMessage", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'dataChannel' is set
-        if (dataChannel == null) {
+        if (__dataChannel == null) {
             throw new RestClientResponseException("Missing the required parameter 'dataChannel' when calling createMessage", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -84,14 +84,14 @@ public class BasApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (fileContent != null)
-            formParams.add("fileContent", new FileSystemResource(fileContent));
-        if (idempotencyKey != null)
-            formParams.add("idempotencyKey", idempotencyKey);
-        if (dataDirection != null)
-            formParams.add("dataDirection", dataDirection);
-        if (dataChannel != null)
-            formParams.add("dataChannel", dataChannel);
+        if (__fileContent != null)
+            formParams.add("fileContent", new FileSystemResource(__fileContent));
+        if (__idempotencyKey != null)
+            formParams.add("idempotencyKey", __idempotencyKey);
+        if (__dataDirection != null)
+            formParams.add("dataDirection", __dataDirection);
+        if (__dataChannel != null)
+            formParams.add("dataChannel", __dataChannel);
 
         final String[] localVarAccepts = { 
             "application/json"

--- a/samples/client/others/java/restclient-sealedInterface/src/main/java/org/openapitools/client/api/BarApi.java
+++ b/samples/client/others/java/restclient-sealedInterface/src/main/java/org/openapitools/client/api/BarApi.java
@@ -49,14 +49,14 @@ public class BarApi {
      * Create a Bar
      * 
      * <p><b>200</b> - Bar created
-     * @param barCreate The barCreate parameter
+     * @param __barCreate The barCreate parameter
      * @return Bar
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec createBarRequestCreation(@jakarta.annotation.Nonnull BarCreate barCreate) throws RestClientResponseException {
-        Object postBody = barCreate;
+    private ResponseSpec createBarRequestCreation(@jakarta.annotation.Nonnull BarCreate __barCreate) throws RestClientResponseException {
+        Object postBody = __barCreate;
         // verify the required parameter 'barCreate' is set
-        if (barCreate == null) {
+        if (__barCreate == null) {
             throw new RestClientResponseException("Missing the required parameter 'barCreate' when calling createBar", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables

--- a/samples/client/others/java/restclient-sealedInterface/src/main/java/org/openapitools/client/api/FooApi.java
+++ b/samples/client/others/java/restclient-sealedInterface/src/main/java/org/openapitools/client/api/FooApi.java
@@ -49,12 +49,12 @@ public class FooApi {
      * Create a Foo
      * 
      * <p><b>201</b> - Error
-     * @param foo The Foo to be created
+     * @param __foo The Foo to be created
      * @return FooRefOrValue
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec createFooRequestCreation(@jakarta.annotation.Nullable Foo foo) throws RestClientResponseException {
-        Object postBody = foo;
+    private ResponseSpec createFooRequestCreation(@jakarta.annotation.Nullable Foo __foo) throws RestClientResponseException {
+        Object postBody = __foo;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 

--- a/samples/client/petstore/java/restclient-springBoot4-jackson2/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson2/src/main/java/org/openapitools/client/api/PetApi.java
@@ -49,14 +49,14 @@ public class PetApi {
      * 
      * <p><b>200</b> - successful operation
      * <p><b>405</b> - Invalid input
-     * @param pet Pet object that needs to be added to the store
+     * @param __pet Pet object that needs to be added to the store
      * @return Pet
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec addPetRequestCreation(@jakarta.annotation.Nonnull Pet pet) throws RestClientResponseException {
-        Object postBody = pet;
+    private ResponseSpec addPetRequestCreation(@jakarta.annotation.Nonnull Pet __pet) throws RestClientResponseException {
+        Object postBody = __pet;
         // verify the required parameter 'pet' is set
-        if (pet == null) {
+        if (__pet == null) {
             throw new RestClientResponseException("Missing the required parameter 'pet' when calling addPet", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -51,19 +51,19 @@ public class DefaultApi {
      * 
      * 
      * <p><b>200</b> - ok
-     * @param id The id parameter
+     * @param __id The id parameter
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fileIdGetRequestCreation(String id) throws RestClientResponseException {
+    private ResponseSpec fileIdGetRequestCreation(String __id) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'id' is set
-        if (id == null) {
+        if (__id == null) {
             throw new RestClientResponseException("Missing the required parameter 'id' when calling fileIdGet", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("id", id);
+        pathParams.put("id", __id);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -121,27 +121,27 @@ public class DefaultApi {
      * 
      * 
      * <p><b>0</b> - response
-     * @param dtParam The dtParam parameter
-     * @param dtQuery The dtQuery parameter
-     * @param dtCookie The dtCookie parameter
+     * @param __dtParam The dtParam parameter
+     * @param __dtQuery The dtQuery parameter
+     * @param __dtCookie The dtCookie parameter
      * @return Foo
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fooDtParamGetRequestCreation(java.time.@Nullable Instant dtParam, java.time.@Nullable Instant dtQuery, java.time.@Nullable Instant dtCookie) throws RestClientResponseException {
+    private ResponseSpec fooDtParamGetRequestCreation(java.time.@Nullable Instant __dtParam, java.time.@Nullable Instant __dtQuery, java.time.@Nullable Instant __dtCookie) throws RestClientResponseException {
         Object postBody = null;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("dtParam", dtParam);
+        pathParams.put("dtParam", __dtParam);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "dtQuery", dtQuery));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "dtQuery", __dtQuery));
 
-        cookieParams.putAll(apiClient.parameterToMultiValueMap(null, "dtCookie", dtCookie));
+        cookieParams.putAll(apiClient.parameterToMultiValueMap(null, "dtCookie", __dtCookie));
 
         final String[] localVarAccepts = { 
             "application/json"
@@ -204,10 +204,10 @@ public class DefaultApi {
      * 
      * 
      * <p><b>0</b> - ok
-     * @param _file The _file parameter
+     * @param ___file The _file parameter
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec uploadPostRequestCreation(@Nullable File _file) throws RestClientResponseException {
+    private ResponseSpec uploadPostRequestCreation(@Nullable File ___file) throws RestClientResponseException {
         Object postBody = null;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
@@ -217,8 +217,8 @@ public class DefaultApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (_file != null)
-            formParams.add("file", new FileSystemResource(_file));
+        if (___file != null)
+            formParams.add("file", new FileSystemResource(___file));
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3/src/main/java/org/openapitools/client/api/PetApi.java
@@ -49,14 +49,14 @@ public class PetApi {
      * 
      * <p><b>200</b> - successful operation
      * <p><b>405</b> - Invalid input
-     * @param pet Pet object that needs to be added to the store
+     * @param __pet Pet object that needs to be added to the store
      * @return Pet
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec addPetRequestCreation(@jakarta.annotation.Nonnull Pet pet) throws RestClientResponseException {
-        Object postBody = pet;
+    private ResponseSpec addPetRequestCreation(@jakarta.annotation.Nonnull Pet __pet) throws RestClientResponseException {
+        Object postBody = __pet;
         // verify the required parameter 'pet' is set
-        if (pet == null) {
+        if (__pet == null) {
             throw new RestClientResponseException("Missing the required parameter 'pet' when calling addPet", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -48,14 +48,14 @@ public class AnotherFakeApi {
      * To test special tags
      * To test special tags and operation ID starting with number
      * <p><b>200</b> - successful operation
-     * @param client client model
+     * @param __client client model
      * @return Client
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec call123testSpecialTagsRequestCreation(@jakarta.annotation.Nonnull Client client) throws RestClientResponseException {
-        Object postBody = client;
+    private ResponseSpec call123testSpecialTagsRequestCreation(@jakarta.annotation.Nonnull Client __client) throws RestClientResponseException {
+        Object postBody = __client;
         // verify the required parameter 'client' is set
-        if (client == null) {
+        if (__client == null) {
             throw new RestClientResponseException("Missing the required parameter 'client' when calling call123testSpecialTags", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -192,15 +192,15 @@ public class FakeApi {
      * test http signature authentication
      * 
      * <p><b>200</b> - The instance started successfully
-     * @param pet Pet object that needs to be added to the store
-     * @param query1 query parameter
-     * @param header1 header parameter
+     * @param __pet Pet object that needs to be added to the store
+     * @param __query1 query parameter
+     * @param __header1 header parameter
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fakeHttpSignatureTestRequestCreation(@jakarta.annotation.Nonnull Pet pet, @jakarta.annotation.Nullable String query1, @jakarta.annotation.Nullable String header1) throws RestClientResponseException {
-        Object postBody = pet;
+    private ResponseSpec fakeHttpSignatureTestRequestCreation(@jakarta.annotation.Nonnull Pet __pet, @jakarta.annotation.Nullable String __query1, @jakarta.annotation.Nullable String __header1) throws RestClientResponseException {
+        Object postBody = __pet;
         // verify the required parameter 'pet' is set
-        if (pet == null) {
+        if (__pet == null) {
             throw new RestClientResponseException("Missing the required parameter 'pet' when calling fakeHttpSignatureTest", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -211,10 +211,10 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query_1", query1));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query_1", __query1));
 
-        if (header1 != null)
-        headerParams.add("header_1", apiClient.parameterToString(header1));
+        if (__header1 != null)
+        headerParams.add("header_1", apiClient.parameterToString(__header1));
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { 
@@ -274,12 +274,12 @@ public class FakeApi {
      * 
      * Test serialization of outer boolean types
      * <p><b>200</b> - Output boolean
-     * @param body Input boolean as post body
+     * @param __body Input boolean as post body
      * @return Boolean
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fakeOuterBooleanSerializeRequestCreation(@jakarta.annotation.Nullable Boolean body) throws RestClientResponseException {
-        Object postBody = body;
+    private ResponseSpec fakeOuterBooleanSerializeRequestCreation(@jakarta.annotation.Nullable Boolean __body) throws RestClientResponseException {
+        Object postBody = __body;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
@@ -345,12 +345,12 @@ public class FakeApi {
      * 
      * Test serialization of object with outer number type
      * <p><b>200</b> - Output composite
-     * @param outerComposite Input composite as post body
+     * @param __outerComposite Input composite as post body
      * @return OuterComposite
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fakeOuterCompositeSerializeRequestCreation(@jakarta.annotation.Nullable OuterComposite outerComposite) throws RestClientResponseException {
-        Object postBody = outerComposite;
+    private ResponseSpec fakeOuterCompositeSerializeRequestCreation(@jakarta.annotation.Nullable OuterComposite __outerComposite) throws RestClientResponseException {
+        Object postBody = __outerComposite;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
@@ -416,12 +416,12 @@ public class FakeApi {
      * 
      * Test serialization of outer number types
      * <p><b>200</b> - Output number
-     * @param body Input number as post body
+     * @param __body Input number as post body
      * @return BigDecimal
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fakeOuterNumberSerializeRequestCreation(@jakarta.annotation.Nullable BigDecimal body) throws RestClientResponseException {
-        Object postBody = body;
+    private ResponseSpec fakeOuterNumberSerializeRequestCreation(@jakarta.annotation.Nullable BigDecimal __body) throws RestClientResponseException {
+        Object postBody = __body;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
@@ -487,12 +487,12 @@ public class FakeApi {
      * 
      * Test serialization of outer string types
      * <p><b>200</b> - Output string
-     * @param body Input string as post body
+     * @param __body Input string as post body
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fakeOuterStringSerializeRequestCreation(@jakarta.annotation.Nullable String body) throws RestClientResponseException {
-        Object postBody = body;
+    private ResponseSpec fakeOuterStringSerializeRequestCreation(@jakarta.annotation.Nullable String __body) throws RestClientResponseException {
+        Object postBody = __body;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
@@ -558,14 +558,14 @@ public class FakeApi {
      * 
      * Test serialization of enum (int) properties with examples
      * <p><b>200</b> - Output enum (int)
-     * @param outerObjectWithEnumProperty Input enum (int) as post body
+     * @param __outerObjectWithEnumProperty Input enum (int) as post body
      * @return OuterObjectWithEnumProperty
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fakePropertyEnumIntegerSerializeRequestCreation(@jakarta.annotation.Nonnull OuterObjectWithEnumProperty outerObjectWithEnumProperty) throws RestClientResponseException {
-        Object postBody = outerObjectWithEnumProperty;
+    private ResponseSpec fakePropertyEnumIntegerSerializeRequestCreation(@jakarta.annotation.Nonnull OuterObjectWithEnumProperty __outerObjectWithEnumProperty) throws RestClientResponseException {
+        Object postBody = __outerObjectWithEnumProperty;
         // verify the required parameter 'outerObjectWithEnumProperty' is set
-        if (outerObjectWithEnumProperty == null) {
+        if (__outerObjectWithEnumProperty == null) {
             throw new RestClientResponseException("Missing the required parameter 'outerObjectWithEnumProperty' when calling fakePropertyEnumIntegerSerialize", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -633,13 +633,13 @@ public class FakeApi {
      * test referenced additionalProperties
      * 
      * <p><b>200</b> - successful operation
-     * @param requestBody request body
+     * @param __requestBody request body
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testAdditionalPropertiesReferenceRequestCreation(@jakarta.annotation.Nonnull Map<String, Object> requestBody) throws RestClientResponseException {
-        Object postBody = requestBody;
+    private ResponseSpec testAdditionalPropertiesReferenceRequestCreation(@jakarta.annotation.Nonnull Map<String, Object> __requestBody) throws RestClientResponseException {
+        Object postBody = __requestBody;
         // verify the required parameter 'requestBody' is set
-        if (requestBody == null) {
+        if (__requestBody == null) {
             throw new RestClientResponseException("Missing the required parameter 'requestBody' when calling testAdditionalPropertiesReference", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -703,13 +703,13 @@ public class FakeApi {
      * 
      * For this test, the body has to be a binary file.
      * <p><b>200</b> - Success
-     * @param body image to upload
+     * @param __body image to upload
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testBodyWithBinaryRequestCreation(@jakarta.annotation.Nullable File body) throws RestClientResponseException {
-        Object postBody = body;
+    private ResponseSpec testBodyWithBinaryRequestCreation(@jakarta.annotation.Nullable File __body) throws RestClientResponseException {
+        Object postBody = __body;
         // verify the required parameter 'body' is set
-        if (body == null) {
+        if (__body == null) {
             throw new RestClientResponseException("Missing the required parameter 'body' when calling testBodyWithBinary", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -773,13 +773,13 @@ public class FakeApi {
      * 
      * For this test, the body for this request must reference a schema named &#x60;File&#x60;.
      * <p><b>200</b> - Success
-     * @param fileSchemaTestClass The fileSchemaTestClass parameter
+     * @param __fileSchemaTestClass The fileSchemaTestClass parameter
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testBodyWithFileSchemaRequestCreation(@jakarta.annotation.Nonnull FileSchemaTestClass fileSchemaTestClass) throws RestClientResponseException {
-        Object postBody = fileSchemaTestClass;
+    private ResponseSpec testBodyWithFileSchemaRequestCreation(@jakarta.annotation.Nonnull FileSchemaTestClass __fileSchemaTestClass) throws RestClientResponseException {
+        Object postBody = __fileSchemaTestClass;
         // verify the required parameter 'fileSchemaTestClass' is set
-        if (fileSchemaTestClass == null) {
+        if (__fileSchemaTestClass == null) {
             throw new RestClientResponseException("Missing the required parameter 'fileSchemaTestClass' when calling testBodyWithFileSchema", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -843,18 +843,18 @@ public class FakeApi {
      * 
      * 
      * <p><b>200</b> - Success
-     * @param query The query parameter
-     * @param user The user parameter
+     * @param __query The query parameter
+     * @param __user The user parameter
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testBodyWithQueryParamsRequestCreation(@jakarta.annotation.Nonnull String query, @jakarta.annotation.Nonnull User user) throws RestClientResponseException {
-        Object postBody = user;
+    private ResponseSpec testBodyWithQueryParamsRequestCreation(@jakarta.annotation.Nonnull String __query, @jakarta.annotation.Nonnull User __user) throws RestClientResponseException {
+        Object postBody = __user;
         // verify the required parameter 'query' is set
-        if (query == null) {
+        if (__query == null) {
             throw new RestClientResponseException("Missing the required parameter 'query' when calling testBodyWithQueryParams", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'user' is set
-        if (user == null) {
+        if (__user == null) {
             throw new RestClientResponseException("Missing the required parameter 'user' when calling testBodyWithQueryParams", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -865,7 +865,7 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query", query));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query", __query));
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -923,14 +923,14 @@ public class FakeApi {
      * To test \&quot;client\&quot; model
      * To test \&quot;client\&quot; model
      * <p><b>200</b> - successful operation
-     * @param client client model
+     * @param __client client model
      * @return Client
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testClientModelRequestCreation(@jakarta.annotation.Nonnull Client client) throws RestClientResponseException {
-        Object postBody = client;
+    private ResponseSpec testClientModelRequestCreation(@jakarta.annotation.Nonnull Client __client) throws RestClientResponseException {
+        Object postBody = __client;
         // verify the required parameter 'client' is set
-        if (client == null) {
+        if (__client == null) {
             throw new RestClientResponseException("Missing the required parameter 'client' when calling testClientModel", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -999,38 +999,38 @@ public class FakeApi {
      * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
      * <p><b>400</b> - Invalid username supplied
      * <p><b>404</b> - User not found
-     * @param number None
-     * @param _double None
-     * @param patternWithoutDelimiter None
-     * @param _byte None
-     * @param integer None
-     * @param int32 None
-     * @param int64 None
-     * @param _float None
-     * @param string None
-     * @param binary None
-     * @param date None
-     * @param dateTime None
-     * @param password None
-     * @param paramCallback None
+     * @param __number None
+     * @param ___double None
+     * @param __patternWithoutDelimiter None
+     * @param ___byte None
+     * @param __integer None
+     * @param __int32 None
+     * @param __int64 None
+     * @param ___float None
+     * @param __string None
+     * @param __binary None
+     * @param __date None
+     * @param __dateTime None
+     * @param __password None
+     * @param __paramCallback None
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testEndpointParametersRequestCreation(@jakarta.annotation.Nonnull BigDecimal number, @jakarta.annotation.Nonnull Double _double, @jakarta.annotation.Nonnull String patternWithoutDelimiter, @jakarta.annotation.Nonnull byte[] _byte, @jakarta.annotation.Nullable Integer integer, @jakarta.annotation.Nullable Integer int32, @jakarta.annotation.Nullable Long int64, @jakarta.annotation.Nullable Float _float, @jakarta.annotation.Nullable String string, @jakarta.annotation.Nullable File binary, @jakarta.annotation.Nullable LocalDate date, @jakarta.annotation.Nullable OffsetDateTime dateTime, @jakarta.annotation.Nullable String password, @jakarta.annotation.Nullable String paramCallback) throws RestClientResponseException {
+    private ResponseSpec testEndpointParametersRequestCreation(@jakarta.annotation.Nonnull BigDecimal __number, @jakarta.annotation.Nonnull Double ___double, @jakarta.annotation.Nonnull String __patternWithoutDelimiter, @jakarta.annotation.Nonnull byte[] ___byte, @jakarta.annotation.Nullable Integer __integer, @jakarta.annotation.Nullable Integer __int32, @jakarta.annotation.Nullable Long __int64, @jakarta.annotation.Nullable Float ___float, @jakarta.annotation.Nullable String __string, @jakarta.annotation.Nullable File __binary, @jakarta.annotation.Nullable LocalDate __date, @jakarta.annotation.Nullable OffsetDateTime __dateTime, @jakarta.annotation.Nullable String __password, @jakarta.annotation.Nullable String __paramCallback) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'number' is set
-        if (number == null) {
+        if (__number == null) {
             throw new RestClientResponseException("Missing the required parameter 'number' when calling testEndpointParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter '_double' is set
-        if (_double == null) {
+        if (___double == null) {
             throw new RestClientResponseException("Missing the required parameter '_double' when calling testEndpointParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'patternWithoutDelimiter' is set
-        if (patternWithoutDelimiter == null) {
+        if (__patternWithoutDelimiter == null) {
             throw new RestClientResponseException("Missing the required parameter 'patternWithoutDelimiter' when calling testEndpointParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter '_byte' is set
-        if (_byte == null) {
+        if (___byte == null) {
             throw new RestClientResponseException("Missing the required parameter '_byte' when calling testEndpointParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1041,34 +1041,34 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (integer != null)
-            formParams.add("integer", integer);
-        if (int32 != null)
-            formParams.add("int32", int32);
-        if (int64 != null)
-            formParams.add("int64", int64);
-        if (number != null)
-            formParams.add("number", number);
-        if (_float != null)
-            formParams.add("float", _float);
-        if (_double != null)
-            formParams.add("double", _double);
-        if (string != null)
-            formParams.add("string", string);
-        if (patternWithoutDelimiter != null)
-            formParams.add("pattern_without_delimiter", patternWithoutDelimiter);
-        if (_byte != null)
-            formParams.add("byte", _byte);
-        if (binary != null)
-            formParams.add("binary", new FileSystemResource(binary));
-        if (date != null)
-            formParams.add("date", date);
-        if (dateTime != null)
-            formParams.add("dateTime", dateTime);
-        if (password != null)
-            formParams.add("password", password);
-        if (paramCallback != null)
-            formParams.add("callback", paramCallback);
+        if (__integer != null)
+            formParams.add("integer", __integer);
+        if (__int32 != null)
+            formParams.add("int32", __int32);
+        if (__int64 != null)
+            formParams.add("int64", __int64);
+        if (__number != null)
+            formParams.add("number", __number);
+        if (___float != null)
+            formParams.add("float", ___float);
+        if (___double != null)
+            formParams.add("double", ___double);
+        if (__string != null)
+            formParams.add("string", __string);
+        if (__patternWithoutDelimiter != null)
+            formParams.add("pattern_without_delimiter", __patternWithoutDelimiter);
+        if (___byte != null)
+            formParams.add("byte", ___byte);
+        if (__binary != null)
+            formParams.add("binary", new FileSystemResource(__binary));
+        if (__date != null)
+            formParams.add("date", __date);
+        if (__dateTime != null)
+            formParams.add("dateTime", __dateTime);
+        if (__password != null)
+            formParams.add("password", __password);
+        if (__paramCallback != null)
+            formParams.add("callback", __paramCallback);
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -1166,18 +1166,18 @@ public class FakeApi {
      * To test enum parameters
      * <p><b>400</b> - Invalid request
      * <p><b>404</b> - Not found
-     * @param enumHeaderStringArray Header parameter enum test (string array)
-     * @param enumHeaderString Header parameter enum test (string)
-     * @param enumQueryStringArray Query parameter enum test (string array)
-     * @param enumQueryString Query parameter enum test (string)
-     * @param enumQueryInteger Query parameter enum test (double)
-     * @param enumQueryDouble Query parameter enum test (double)
-     * @param enumQueryModelArray The enumQueryModelArray parameter
-     * @param enumFormStringArray Form parameter enum test (string array)
-     * @param enumFormString Form parameter enum test (string)
+     * @param __enumHeaderStringArray Header parameter enum test (string array)
+     * @param __enumHeaderString Header parameter enum test (string)
+     * @param __enumQueryStringArray Query parameter enum test (string array)
+     * @param __enumQueryString Query parameter enum test (string)
+     * @param __enumQueryInteger Query parameter enum test (double)
+     * @param __enumQueryDouble Query parameter enum test (double)
+     * @param __enumQueryModelArray The enumQueryModelArray parameter
+     * @param __enumFormStringArray Form parameter enum test (string array)
+     * @param __enumFormString Form parameter enum test (string)
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testEnumParametersRequestCreation(@jakarta.annotation.Nullable List<String> enumHeaderStringArray, @jakarta.annotation.Nullable String enumHeaderString, @jakarta.annotation.Nullable List<String> enumQueryStringArray, @jakarta.annotation.Nullable String enumQueryString, @jakarta.annotation.Nullable Integer enumQueryInteger, @jakarta.annotation.Nullable Double enumQueryDouble, @jakarta.annotation.Nullable List<EnumClass> enumQueryModelArray, @jakarta.annotation.Nullable List<String> enumFormStringArray, @jakarta.annotation.Nullable String enumFormString) throws RestClientResponseException {
+    private ResponseSpec testEnumParametersRequestCreation(@jakarta.annotation.Nullable List<String> __enumHeaderStringArray, @jakarta.annotation.Nullable String __enumHeaderString, @jakarta.annotation.Nullable List<String> __enumQueryStringArray, @jakarta.annotation.Nullable String __enumQueryString, @jakarta.annotation.Nullable Integer __enumQueryInteger, @jakarta.annotation.Nullable Double __enumQueryDouble, @jakarta.annotation.Nullable List<EnumClass> __enumQueryModelArray, @jakarta.annotation.Nullable List<String> __enumFormStringArray, @jakarta.annotation.Nullable String __enumFormString) throws RestClientResponseException {
         Object postBody = null;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
@@ -1187,20 +1187,20 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "enum_query_string_array", enumQueryStringArray));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_string", enumQueryString));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_integer", enumQueryInteger));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_double", enumQueryDouble));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "enum_query_model_array", enumQueryModelArray));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "enum_query_string_array", __enumQueryStringArray));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_string", __enumQueryString));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_integer", __enumQueryInteger));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_double", __enumQueryDouble));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "enum_query_model_array", __enumQueryModelArray));
 
-        if (enumHeaderStringArray != null)
-        headerParams.add("enum_header_string_array", apiClient.parameterToString(enumHeaderStringArray));
-        if (enumHeaderString != null)
-        headerParams.add("enum_header_string", apiClient.parameterToString(enumHeaderString));
-        if (enumFormStringArray != null)
-            formParams.addAll("enum_form_string_array", enumFormStringArray);
-        if (enumFormString != null)
-            formParams.add("enum_form_string", enumFormString);
+        if (__enumHeaderStringArray != null)
+        headerParams.add("enum_header_string_array", apiClient.parameterToString(__enumHeaderStringArray));
+        if (__enumHeaderString != null)
+        headerParams.add("enum_header_string", apiClient.parameterToString(__enumHeaderString));
+        if (__enumFormStringArray != null)
+            formParams.addAll("enum_form_string_array", __enumFormStringArray);
+        if (__enumFormString != null)
+            formParams.add("enum_form_string", __enumFormString);
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -1282,26 +1282,26 @@ public class FakeApi {
      * Fake endpoint to test group parameters (optional)
      * Fake endpoint to test group parameters (optional)
      * <p><b>400</b> - Something wrong
-     * @param requiredStringGroup Required String in group parameters
-     * @param requiredBooleanGroup Required Boolean in group parameters
-     * @param requiredInt64Group Required Integer in group parameters
-     * @param stringGroup String in group parameters
-     * @param booleanGroup Boolean in group parameters
-     * @param int64Group Integer in group parameters
+     * @param __requiredStringGroup Required String in group parameters
+     * @param __requiredBooleanGroup Required Boolean in group parameters
+     * @param __requiredInt64Group Required Integer in group parameters
+     * @param __stringGroup String in group parameters
+     * @param __booleanGroup Boolean in group parameters
+     * @param __int64Group Integer in group parameters
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testGroupParametersRequestCreation(@jakarta.annotation.Nonnull Integer requiredStringGroup, @jakarta.annotation.Nonnull Boolean requiredBooleanGroup, @jakarta.annotation.Nonnull Long requiredInt64Group, @jakarta.annotation.Nullable Integer stringGroup, @jakarta.annotation.Nullable Boolean booleanGroup, @jakarta.annotation.Nullable Long int64Group) throws RestClientResponseException {
+    private ResponseSpec testGroupParametersRequestCreation(@jakarta.annotation.Nonnull Integer __requiredStringGroup, @jakarta.annotation.Nonnull Boolean __requiredBooleanGroup, @jakarta.annotation.Nonnull Long __requiredInt64Group, @jakarta.annotation.Nullable Integer __stringGroup, @jakarta.annotation.Nullable Boolean __booleanGroup, @jakarta.annotation.Nullable Long __int64Group) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'requiredStringGroup' is set
-        if (requiredStringGroup == null) {
+        if (__requiredStringGroup == null) {
             throw new RestClientResponseException("Missing the required parameter 'requiredStringGroup' when calling testGroupParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'requiredBooleanGroup' is set
-        if (requiredBooleanGroup == null) {
+        if (__requiredBooleanGroup == null) {
             throw new RestClientResponseException("Missing the required parameter 'requiredBooleanGroup' when calling testGroupParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'requiredInt64Group' is set
-        if (requiredInt64Group == null) {
+        if (__requiredInt64Group == null) {
             throw new RestClientResponseException("Missing the required parameter 'requiredInt64Group' when calling testGroupParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1312,15 +1312,15 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_string_group", requiredStringGroup));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_int64_group", requiredInt64Group));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "string_group", stringGroup));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "int64_group", int64Group));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_string_group", __requiredStringGroup));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_int64_group", __requiredInt64Group));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "string_group", __stringGroup));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "int64_group", __int64Group));
 
-        if (requiredBooleanGroup != null)
-        headerParams.add("required_boolean_group", apiClient.parameterToString(requiredBooleanGroup));
-        if (booleanGroup != null)
-        headerParams.add("boolean_group", apiClient.parameterToString(booleanGroup));
+        if (__requiredBooleanGroup != null)
+        headerParams.add("required_boolean_group", apiClient.parameterToString(__requiredBooleanGroup));
+        if (__booleanGroup != null)
+        headerParams.add("boolean_group", apiClient.parameterToString(__booleanGroup));
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { };
@@ -1387,13 +1387,13 @@ public class FakeApi {
      * test inline additionalProperties
      * 
      * <p><b>200</b> - successful operation
-     * @param requestBody request body
+     * @param __requestBody request body
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testInlineAdditionalPropertiesRequestCreation(@jakarta.annotation.Nonnull Map<String, String> requestBody) throws RestClientResponseException {
-        Object postBody = requestBody;
+    private ResponseSpec testInlineAdditionalPropertiesRequestCreation(@jakarta.annotation.Nonnull Map<String, String> __requestBody) throws RestClientResponseException {
+        Object postBody = __requestBody;
         // verify the required parameter 'requestBody' is set
-        if (requestBody == null) {
+        if (__requestBody == null) {
             throw new RestClientResponseException("Missing the required parameter 'requestBody' when calling testInlineAdditionalProperties", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1457,13 +1457,13 @@ public class FakeApi {
      * test inline free-form additionalProperties
      * 
      * <p><b>200</b> - successful operation
-     * @param testInlineFreeformAdditionalPropertiesRequest request body
+     * @param __testInlineFreeformAdditionalPropertiesRequest request body
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testInlineFreeformAdditionalPropertiesRequestCreation(@jakarta.annotation.Nonnull TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest) throws RestClientResponseException {
-        Object postBody = testInlineFreeformAdditionalPropertiesRequest;
+    private ResponseSpec testInlineFreeformAdditionalPropertiesRequestCreation(@jakarta.annotation.Nonnull TestInlineFreeformAdditionalPropertiesRequest __testInlineFreeformAdditionalPropertiesRequest) throws RestClientResponseException {
+        Object postBody = __testInlineFreeformAdditionalPropertiesRequest;
         // verify the required parameter 'testInlineFreeformAdditionalPropertiesRequest' is set
-        if (testInlineFreeformAdditionalPropertiesRequest == null) {
+        if (__testInlineFreeformAdditionalPropertiesRequest == null) {
             throw new RestClientResponseException("Missing the required parameter 'testInlineFreeformAdditionalPropertiesRequest' when calling testInlineFreeformAdditionalProperties", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1527,18 +1527,18 @@ public class FakeApi {
      * test json serialization of form data
      * 
      * <p><b>200</b> - successful operation
-     * @param param field1
-     * @param param2 field2
+     * @param __param field1
+     * @param __param2 field2
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testJsonFormDataRequestCreation(@jakarta.annotation.Nonnull String param, @jakarta.annotation.Nonnull String param2) throws RestClientResponseException {
+    private ResponseSpec testJsonFormDataRequestCreation(@jakarta.annotation.Nonnull String __param, @jakarta.annotation.Nonnull String __param2) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'param' is set
-        if (param == null) {
+        if (__param == null) {
             throw new RestClientResponseException("Missing the required parameter 'param' when calling testJsonFormData", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'param2' is set
-        if (param2 == null) {
+        if (__param2 == null) {
             throw new RestClientResponseException("Missing the required parameter 'param2' when calling testJsonFormData", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1549,10 +1549,10 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (param != null)
-            formParams.add("param", param);
-        if (param2 != null)
-            formParams.add("param2", param2);
+        if (__param != null)
+            formParams.add("param", __param);
+        if (__param2 != null)
+            formParams.add("param2", __param2);
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -1610,13 +1610,13 @@ public class FakeApi {
      * test nullable parent property
      * 
      * <p><b>200</b> - successful operation
-     * @param childWithNullable request body
+     * @param __childWithNullable request body
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testNullableRequestCreation(@jakarta.annotation.Nonnull ChildWithNullable childWithNullable) throws RestClientResponseException {
-        Object postBody = childWithNullable;
+    private ResponseSpec testNullableRequestCreation(@jakarta.annotation.Nonnull ChildWithNullable __childWithNullable) throws RestClientResponseException {
+        Object postBody = __childWithNullable;
         // verify the required parameter 'childWithNullable' is set
-        if (childWithNullable == null) {
+        if (__childWithNullable == null) {
             throw new RestClientResponseException("Missing the required parameter 'childWithNullable' when calling testNullable", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1680,39 +1680,39 @@ public class FakeApi {
      * 
      * To test the collection format in query parameters
      * <p><b>200</b> - Success
-     * @param pipe The pipe parameter
-     * @param ioutil The ioutil parameter
-     * @param http The http parameter
-     * @param url The url parameter
-     * @param context The context parameter
-     * @param allowEmpty The allowEmpty parameter
-     * @param language The language parameter
+     * @param __pipe The pipe parameter
+     * @param __ioutil The ioutil parameter
+     * @param __http The http parameter
+     * @param __url The url parameter
+     * @param __context The context parameter
+     * @param __allowEmpty The allowEmpty parameter
+     * @param __language The language parameter
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testQueryParameterCollectionFormatRequestCreation(@jakarta.annotation.Nonnull List<String> pipe, @jakarta.annotation.Nonnull List<String> ioutil, @jakarta.annotation.Nonnull List<String> http, @jakarta.annotation.Nonnull List<String> url, @jakarta.annotation.Nonnull List<String> context, @jakarta.annotation.Nonnull String allowEmpty, @jakarta.annotation.Nullable Map<String, String> language) throws RestClientResponseException {
+    private ResponseSpec testQueryParameterCollectionFormatRequestCreation(@jakarta.annotation.Nonnull List<String> __pipe, @jakarta.annotation.Nonnull List<String> __ioutil, @jakarta.annotation.Nonnull List<String> __http, @jakarta.annotation.Nonnull List<String> __url, @jakarta.annotation.Nonnull List<String> __context, @jakarta.annotation.Nonnull String __allowEmpty, @jakarta.annotation.Nullable Map<String, String> __language) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'pipe' is set
-        if (pipe == null) {
+        if (__pipe == null) {
             throw new RestClientResponseException("Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'ioutil' is set
-        if (ioutil == null) {
+        if (__ioutil == null) {
             throw new RestClientResponseException("Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'http' is set
-        if (http == null) {
+        if (__http == null) {
             throw new RestClientResponseException("Missing the required parameter 'http' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'url' is set
-        if (url == null) {
+        if (__url == null) {
             throw new RestClientResponseException("Missing the required parameter 'url' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'context' is set
-        if (context == null) {
+        if (__context == null) {
             throw new RestClientResponseException("Missing the required parameter 'context' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'allowEmpty' is set
-        if (allowEmpty == null) {
+        if (__allowEmpty == null) {
             throw new RestClientResponseException("Missing the required parameter 'allowEmpty' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1723,13 +1723,13 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("pipes".toUpperCase(Locale.ROOT)), "pipe", pipe));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "ioutil", ioutil));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("ssv".toUpperCase(Locale.ROOT)), "http", http));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "url", url));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "context", context));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "language", language));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "allowEmpty", allowEmpty));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("pipes".toUpperCase(Locale.ROOT)), "pipe", __pipe));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "ioutil", __ioutil));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("ssv".toUpperCase(Locale.ROOT)), "http", __http));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "url", __url));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "context", __context));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "language", __language));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "allowEmpty", __allowEmpty));
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -1800,13 +1800,13 @@ public class FakeApi {
      * test referenced string map
      * 
      * <p><b>200</b> - successful operation
-     * @param requestBody request body
+     * @param __requestBody request body
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testStringMapReferenceRequestCreation(@jakarta.annotation.Nonnull Map<String, String> requestBody) throws RestClientResponseException {
-        Object postBody = requestBody;
+    private ResponseSpec testStringMapReferenceRequestCreation(@jakarta.annotation.Nonnull Map<String, String> __requestBody) throws RestClientResponseException {
+        Object postBody = __requestBody;
         // verify the required parameter 'requestBody' is set
-        if (requestBody == null) {
+        if (__requestBody == null) {
             throw new RestClientResponseException("Missing the required parameter 'requestBody' when calling testStringMapReference", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -48,14 +48,14 @@ public class FakeClassnameTags123Api {
      * To test class name in snake case
      * To test class name in snake case
      * <p><b>200</b> - successful operation
-     * @param client client model
+     * @param __client client model
      * @return Client
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testClassnameRequestCreation(@jakarta.annotation.Nonnull Client client) throws RestClientResponseException {
-        Object postBody = client;
+    private ResponseSpec testClassnameRequestCreation(@jakarta.annotation.Nonnull Client __client) throws RestClientResponseException {
+        Object postBody = __client;
         // verify the required parameter 'client' is set
-        if (client == null) {
+        if (__client == null) {
             throw new RestClientResponseException("Missing the required parameter 'client' when calling testClassname", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/PetApi.java
@@ -52,13 +52,13 @@ public class PetApi {
      * 
      * <p><b>200</b> - Successful operation
      * <p><b>405</b> - Invalid input
-     * @param pet Pet object that needs to be added to the store
+     * @param __pet Pet object that needs to be added to the store
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec addPetRequestCreation(@jakarta.annotation.Nonnull Pet pet) throws RestClientResponseException {
-        Object postBody = pet;
+    private ResponseSpec addPetRequestCreation(@jakarta.annotation.Nonnull Pet __pet) throws RestClientResponseException {
+        Object postBody = __pet;
         // verify the required parameter 'pet' is set
-        if (pet == null) {
+        if (__pet == null) {
             throw new RestClientResponseException("Missing the required parameter 'pet' when calling addPet", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -126,28 +126,28 @@ public class PetApi {
      * 
      * <p><b>200</b> - Successful operation
      * <p><b>400</b> - Invalid pet value
-     * @param petId Pet id to delete
-     * @param apiKey The apiKey parameter
+     * @param __petId Pet id to delete
+     * @param __apiKey The apiKey parameter
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec deletePetRequestCreation(@jakarta.annotation.Nonnull Long petId, @jakarta.annotation.Nullable String apiKey) throws RestClientResponseException {
+    private ResponseSpec deletePetRequestCreation(@jakarta.annotation.Nonnull Long __petId, @jakarta.annotation.Nullable String __apiKey) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'petId' is set
-        if (petId == null) {
+        if (__petId == null) {
             throw new RestClientResponseException("Missing the required parameter 'petId' when calling deletePet", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("petId", petId);
+        pathParams.put("petId", __petId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (apiKey != null)
-        headerParams.add("api_key", apiClient.parameterToString(apiKey));
+        if (__apiKey != null)
+        headerParams.add("api_key", apiClient.parameterToString(__apiKey));
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { };
@@ -206,14 +206,14 @@ public class PetApi {
      * Multiple status values can be provided with comma separated strings
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid status value
-     * @param status Status values that need to be considered for filter
+     * @param __status Status values that need to be considered for filter
      * @return List&lt;Pet&gt;
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec findPetsByStatusRequestCreation(@jakarta.annotation.Nonnull List<String> status) throws RestClientResponseException {
+    private ResponseSpec findPetsByStatusRequestCreation(@jakarta.annotation.Nonnull List<String> __status) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'status' is set
-        if (status == null) {
+        if (__status == null) {
             throw new RestClientResponseException("Missing the required parameter 'status' when calling findPetsByStatus", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -224,7 +224,7 @@ public class PetApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "status", status));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "status", __status));
 
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
@@ -285,16 +285,16 @@ public class PetApi {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid tag value
-     * @param tags Tags to filter by
+     * @param __tags Tags to filter by
      * @return Set&lt;Pet&gt;
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      * @deprecated
      */
     @Deprecated
-    private ResponseSpec findPetsByTagsRequestCreation(@jakarta.annotation.Nonnull Set<String> tags) throws RestClientResponseException {
+    private ResponseSpec findPetsByTagsRequestCreation(@jakarta.annotation.Nonnull Set<String> __tags) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'tags' is set
-        if (tags == null) {
+        if (__tags == null) {
             throw new RestClientResponseException("Missing the required parameter 'tags' when calling findPetsByTags", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -305,7 +305,7 @@ public class PetApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "tags", tags));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "tags", __tags));
 
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
@@ -367,20 +367,20 @@ public class PetApi {
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid ID supplied
      * <p><b>404</b> - Pet not found
-     * @param petId ID of pet to return
+     * @param __petId ID of pet to return
      * @return Pet
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec getPetByIdRequestCreation(@jakarta.annotation.Nonnull Long petId) throws RestClientResponseException {
+    private ResponseSpec getPetByIdRequestCreation(@jakarta.annotation.Nonnull Long __petId) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'petId' is set
-        if (petId == null) {
+        if (__petId == null) {
             throw new RestClientResponseException("Missing the required parameter 'petId' when calling getPetById", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("petId", petId);
+        pathParams.put("petId", __petId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -451,13 +451,13 @@ public class PetApi {
      * <p><b>400</b> - Invalid ID supplied
      * <p><b>404</b> - Pet not found
      * <p><b>405</b> - Validation exception
-     * @param pet Pet object that needs to be added to the store
+     * @param __pet Pet object that needs to be added to the store
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec updatePetRequestCreation(@jakarta.annotation.Nonnull Pet pet) throws RestClientResponseException {
-        Object postBody = pet;
+    private ResponseSpec updatePetRequestCreation(@jakarta.annotation.Nonnull Pet __pet) throws RestClientResponseException {
+        Object postBody = __pet;
         // verify the required parameter 'pet' is set
-        if (pet == null) {
+        if (__pet == null) {
             throw new RestClientResponseException("Missing the required parameter 'pet' when calling updatePet", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -531,31 +531,31 @@ public class PetApi {
      * 
      * <p><b>200</b> - Successful operation
      * <p><b>405</b> - Invalid input
-     * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param __petId ID of pet that needs to be updated
+     * @param __name Updated name of the pet
+     * @param __status Updated status of the pet
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec updatePetWithFormRequestCreation(@jakarta.annotation.Nonnull Long petId, @jakarta.annotation.Nullable String name, @jakarta.annotation.Nullable String status) throws RestClientResponseException {
+    private ResponseSpec updatePetWithFormRequestCreation(@jakarta.annotation.Nonnull Long __petId, @jakarta.annotation.Nullable String __name, @jakarta.annotation.Nullable String __status) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'petId' is set
-        if (petId == null) {
+        if (__petId == null) {
             throw new RestClientResponseException("Missing the required parameter 'petId' when calling updatePetWithForm", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("petId", petId);
+        pathParams.put("petId", __petId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (name != null)
-            formParams.add("name", name);
-        if (status != null)
-            formParams.add("status", status);
+        if (__name != null)
+            formParams.add("name", __name);
+        if (__status != null)
+            formParams.add("status", __status);
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -619,32 +619,32 @@ public class PetApi {
      * uploads an image
      * 
      * <p><b>200</b> - successful operation
-     * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param _file file to upload
+     * @param __petId ID of pet to update
+     * @param __additionalMetadata Additional data to pass to server
+     * @param ___file file to upload
      * @return ModelApiResponse
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec uploadFileRequestCreation(@jakarta.annotation.Nonnull Long petId, @jakarta.annotation.Nullable String additionalMetadata, @jakarta.annotation.Nullable File _file) throws RestClientResponseException {
+    private ResponseSpec uploadFileRequestCreation(@jakarta.annotation.Nonnull Long __petId, @jakarta.annotation.Nullable String __additionalMetadata, @jakarta.annotation.Nullable File ___file) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'petId' is set
-        if (petId == null) {
+        if (__petId == null) {
             throw new RestClientResponseException("Missing the required parameter 'petId' when calling uploadFile", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("petId", petId);
+        pathParams.put("petId", __petId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (additionalMetadata != null)
-            formParams.add("additionalMetadata", additionalMetadata);
-        if (_file != null)
-            formParams.add("file", new FileSystemResource(_file));
+        if (__additionalMetadata != null)
+            formParams.add("additionalMetadata", __additionalMetadata);
+        if (___file != null)
+            formParams.add("file", new FileSystemResource(___file));
 
         final String[] localVarAccepts = { 
             "application/json"
@@ -709,36 +709,36 @@ public class PetApi {
      * uploads an image (required)
      * 
      * <p><b>200</b> - successful operation
-     * @param petId ID of pet to update
-     * @param requiredFile file to upload
-     * @param additionalMetadata Additional data to pass to server
+     * @param __petId ID of pet to update
+     * @param __requiredFile file to upload
+     * @param __additionalMetadata Additional data to pass to server
      * @return ModelApiResponse
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec uploadFileWithRequiredFileRequestCreation(@jakarta.annotation.Nonnull Long petId, @jakarta.annotation.Nonnull File requiredFile, @jakarta.annotation.Nullable String additionalMetadata) throws RestClientResponseException {
+    private ResponseSpec uploadFileWithRequiredFileRequestCreation(@jakarta.annotation.Nonnull Long __petId, @jakarta.annotation.Nonnull File __requiredFile, @jakarta.annotation.Nullable String __additionalMetadata) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'petId' is set
-        if (petId == null) {
+        if (__petId == null) {
             throw new RestClientResponseException("Missing the required parameter 'petId' when calling uploadFileWithRequiredFile", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'requiredFile' is set
-        if (requiredFile == null) {
+        if (__requiredFile == null) {
             throw new RestClientResponseException("Missing the required parameter 'requiredFile' when calling uploadFileWithRequiredFile", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("petId", petId);
+        pathParams.put("petId", __petId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (additionalMetadata != null)
-            formParams.add("additionalMetadata", additionalMetadata);
-        if (requiredFile != null)
-            formParams.add("requiredFile", new FileSystemResource(requiredFile));
+        if (__additionalMetadata != null)
+            formParams.add("additionalMetadata", __additionalMetadata);
+        if (__requiredFile != null)
+            formParams.add("requiredFile", new FileSystemResource(__requiredFile));
 
         final String[] localVarAccepts = { 
             "application/json"

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -49,19 +49,19 @@ public class StoreApi {
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * <p><b>400</b> - Invalid ID supplied
      * <p><b>404</b> - Order not found
-     * @param orderId ID of the order that needs to be deleted
+     * @param __orderId ID of the order that needs to be deleted
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec deleteOrderRequestCreation(@jakarta.annotation.Nonnull String orderId) throws RestClientResponseException {
+    private ResponseSpec deleteOrderRequestCreation(@jakarta.annotation.Nonnull String __orderId) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'orderId' is set
-        if (orderId == null) {
+        if (__orderId == null) {
             throw new RestClientResponseException("Missing the required parameter 'orderId' when calling deleteOrder", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("order_id", orderId);
+        pathParams.put("order_id", __orderId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -189,20 +189,20 @@ public class StoreApi {
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid ID supplied
      * <p><b>404</b> - Order not found
-     * @param orderId ID of pet that needs to be fetched
+     * @param __orderId ID of pet that needs to be fetched
      * @return Order
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec getOrderByIdRequestCreation(@jakarta.annotation.Nonnull Long orderId) throws RestClientResponseException {
+    private ResponseSpec getOrderByIdRequestCreation(@jakarta.annotation.Nonnull Long __orderId) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'orderId' is set
-        if (orderId == null) {
+        if (__orderId == null) {
             throw new RestClientResponseException("Missing the required parameter 'orderId' when calling getOrderById", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("order_id", orderId);
+        pathParams.put("order_id", __orderId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -271,14 +271,14 @@ public class StoreApi {
      * 
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid Order
-     * @param order order placed for purchasing the pet
+     * @param __order order placed for purchasing the pet
      * @return Order
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec placeOrderRequestCreation(@jakarta.annotation.Nonnull Order order) throws RestClientResponseException {
-        Object postBody = order;
+    private ResponseSpec placeOrderRequestCreation(@jakarta.annotation.Nonnull Order __order) throws RestClientResponseException {
+        Object postBody = __order;
         // verify the required parameter 'order' is set
-        if (order == null) {
+        if (__order == null) {
             throw new RestClientResponseException("Missing the required parameter 'order' when calling placeOrder", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/UserApi.java
@@ -49,13 +49,13 @@ public class UserApi {
      * Create user
      * This can only be done by the logged in user.
      * <p><b>0</b> - successful operation
-     * @param user Created user object
+     * @param __user Created user object
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec createUserRequestCreation(@jakarta.annotation.Nonnull User user) throws RestClientResponseException {
-        Object postBody = user;
+    private ResponseSpec createUserRequestCreation(@jakarta.annotation.Nonnull User __user) throws RestClientResponseException {
+        Object postBody = __user;
         // verify the required parameter 'user' is set
-        if (user == null) {
+        if (__user == null) {
             throw new RestClientResponseException("Missing the required parameter 'user' when calling createUser", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -119,13 +119,13 @@ public class UserApi {
      * Creates list of users with given input array
      * 
      * <p><b>0</b> - successful operation
-     * @param user List of user object
+     * @param __user List of user object
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec createUsersWithArrayInputRequestCreation(@jakarta.annotation.Nonnull List<User> user) throws RestClientResponseException {
-        Object postBody = user;
+    private ResponseSpec createUsersWithArrayInputRequestCreation(@jakarta.annotation.Nonnull List<User> __user) throws RestClientResponseException {
+        Object postBody = __user;
         // verify the required parameter 'user' is set
-        if (user == null) {
+        if (__user == null) {
             throw new RestClientResponseException("Missing the required parameter 'user' when calling createUsersWithArrayInput", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -189,13 +189,13 @@ public class UserApi {
      * Creates list of users with given input array
      * 
      * <p><b>0</b> - successful operation
-     * @param user List of user object
+     * @param __user List of user object
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec createUsersWithListInputRequestCreation(@jakarta.annotation.Nonnull List<User> user) throws RestClientResponseException {
-        Object postBody = user;
+    private ResponseSpec createUsersWithListInputRequestCreation(@jakarta.annotation.Nonnull List<User> __user) throws RestClientResponseException {
+        Object postBody = __user;
         // verify the required parameter 'user' is set
-        if (user == null) {
+        if (__user == null) {
             throw new RestClientResponseException("Missing the required parameter 'user' when calling createUsersWithListInput", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -260,19 +260,19 @@ public class UserApi {
      * This can only be done by the logged in user.
      * <p><b>400</b> - Invalid username supplied
      * <p><b>404</b> - User not found
-     * @param username The name that needs to be deleted
+     * @param __username The name that needs to be deleted
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec deleteUserRequestCreation(@jakarta.annotation.Nonnull String username) throws RestClientResponseException {
+    private ResponseSpec deleteUserRequestCreation(@jakarta.annotation.Nonnull String __username) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'username' is set
-        if (username == null) {
+        if (__username == null) {
             throw new RestClientResponseException("Missing the required parameter 'username' when calling deleteUser", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("username", username);
+        pathParams.put("username", __username);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -335,20 +335,20 @@ public class UserApi {
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid username supplied
      * <p><b>404</b> - User not found
-     * @param username The name that needs to be fetched. Use user1 for testing.
+     * @param __username The name that needs to be fetched. Use user1 for testing.
      * @return User
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec getUserByNameRequestCreation(@jakarta.annotation.Nonnull String username) throws RestClientResponseException {
+    private ResponseSpec getUserByNameRequestCreation(@jakarta.annotation.Nonnull String __username) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'username' is set
-        if (username == null) {
+        if (__username == null) {
             throw new RestClientResponseException("Missing the required parameter 'username' when calling getUserByName", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("username", username);
+        pathParams.put("username", __username);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -417,19 +417,19 @@ public class UserApi {
      * 
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid username/password supplied
-     * @param username The user name for login
-     * @param password The password for login in clear text
+     * @param __username The user name for login
+     * @param __password The password for login in clear text
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec loginUserRequestCreation(@jakarta.annotation.Nonnull String username, @jakarta.annotation.Nonnull String password) throws RestClientResponseException {
+    private ResponseSpec loginUserRequestCreation(@jakarta.annotation.Nonnull String __username, @jakarta.annotation.Nonnull String __password) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'username' is set
-        if (username == null) {
+        if (__username == null) {
             throw new RestClientResponseException("Missing the required parameter 'username' when calling loginUser", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'password' is set
-        if (password == null) {
+        if (__password == null) {
             throw new RestClientResponseException("Missing the required parameter 'password' when calling loginUser", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -440,8 +440,8 @@ public class UserApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "username", username));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "password", password));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "username", __username));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "password", __password));
 
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
@@ -565,24 +565,24 @@ public class UserApi {
      * This can only be done by the logged in user.
      * <p><b>400</b> - Invalid user supplied
      * <p><b>404</b> - User not found
-     * @param username name that need to be deleted
-     * @param user Updated user object
+     * @param __username name that need to be deleted
+     * @param __user Updated user object
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec updateUserRequestCreation(@jakarta.annotation.Nonnull String username, @jakarta.annotation.Nonnull User user) throws RestClientResponseException {
-        Object postBody = user;
+    private ResponseSpec updateUserRequestCreation(@jakarta.annotation.Nonnull String __username, @jakarta.annotation.Nonnull User __user) throws RestClientResponseException {
+        Object postBody = __user;
         // verify the required parameter 'username' is set
-        if (username == null) {
+        if (__username == null) {
             throw new RestClientResponseException("Missing the required parameter 'username' when calling updateUser", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'user' is set
-        if (user == null) {
+        if (__user == null) {
             throw new RestClientResponseException("Missing the required parameter 'user' when calling updateUser", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("username", username);
+        pathParams.put("username", __username);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -48,14 +48,14 @@ public class AnotherFakeApi {
      * To test special tags
      * To test special tags and operation ID starting with number
      * <p><b>200</b> - successful operation
-     * @param client client model
+     * @param __client client model
      * @return Client
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec call123testSpecialTagsRequestCreation(@jakarta.annotation.Nonnull Client client) throws RestClientResponseException {
-        Object postBody = client;
+    private ResponseSpec call123testSpecialTagsRequestCreation(@jakarta.annotation.Nonnull Client __client) throws RestClientResponseException {
+        Object postBody = __client;
         // verify the required parameter 'client' is set
-        if (client == null) {
+        if (__client == null) {
             throw new RestClientResponseException("Missing the required parameter 'client' when calling call123testSpecialTags", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -283,15 +283,15 @@ public class FakeApi {
      * test http signature authentication
      * 
      * <p><b>200</b> - The instance started successfully
-     * @param pet Pet object that needs to be added to the store
-     * @param query1 query parameter
-     * @param header1 header parameter
+     * @param __pet Pet object that needs to be added to the store
+     * @param __query1 query parameter
+     * @param __header1 header parameter
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fakeHttpSignatureTestRequestCreation(@jakarta.annotation.Nonnull Pet pet, @jakarta.annotation.Nullable String query1, @jakarta.annotation.Nullable String header1) throws RestClientResponseException {
-        Object postBody = pet;
+    private ResponseSpec fakeHttpSignatureTestRequestCreation(@jakarta.annotation.Nonnull Pet __pet, @jakarta.annotation.Nullable String __query1, @jakarta.annotation.Nullable String __header1) throws RestClientResponseException {
+        Object postBody = __pet;
         // verify the required parameter 'pet' is set
-        if (pet == null) {
+        if (__pet == null) {
             throw new RestClientResponseException("Missing the required parameter 'pet' when calling fakeHttpSignatureTest", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -302,10 +302,10 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query_1", query1));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query_1", __query1));
 
-        if (header1 != null)
-        headerParams.add("header_1", apiClient.parameterToString(header1));
+        if (__header1 != null)
+        headerParams.add("header_1", apiClient.parameterToString(__header1));
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { 
@@ -365,12 +365,12 @@ public class FakeApi {
      * 
      * Test serialization of outer boolean types
      * <p><b>200</b> - Output boolean
-     * @param body Input boolean as post body
+     * @param __body Input boolean as post body
      * @return Boolean
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fakeOuterBooleanSerializeRequestCreation(@jakarta.annotation.Nullable Boolean body) throws RestClientResponseException {
-        Object postBody = body;
+    private ResponseSpec fakeOuterBooleanSerializeRequestCreation(@jakarta.annotation.Nullable Boolean __body) throws RestClientResponseException {
+        Object postBody = __body;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
@@ -436,12 +436,12 @@ public class FakeApi {
      * 
      * Test serialization of object with outer number type
      * <p><b>200</b> - Output composite
-     * @param outerComposite Input composite as post body
+     * @param __outerComposite Input composite as post body
      * @return OuterComposite
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fakeOuterCompositeSerializeRequestCreation(@jakarta.annotation.Nullable OuterComposite outerComposite) throws RestClientResponseException {
-        Object postBody = outerComposite;
+    private ResponseSpec fakeOuterCompositeSerializeRequestCreation(@jakarta.annotation.Nullable OuterComposite __outerComposite) throws RestClientResponseException {
+        Object postBody = __outerComposite;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
@@ -507,12 +507,12 @@ public class FakeApi {
      * 
      * Test serialization of outer number types
      * <p><b>200</b> - Output number
-     * @param body Input number as post body
+     * @param __body Input number as post body
      * @return BigDecimal
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fakeOuterNumberSerializeRequestCreation(@jakarta.annotation.Nullable BigDecimal body) throws RestClientResponseException {
-        Object postBody = body;
+    private ResponseSpec fakeOuterNumberSerializeRequestCreation(@jakarta.annotation.Nullable BigDecimal __body) throws RestClientResponseException {
+        Object postBody = __body;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
@@ -578,12 +578,12 @@ public class FakeApi {
      * 
      * Test serialization of outer string types
      * <p><b>200</b> - Output string
-     * @param body Input string as post body
+     * @param __body Input string as post body
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fakeOuterStringSerializeRequestCreation(@jakarta.annotation.Nullable String body) throws RestClientResponseException {
-        Object postBody = body;
+    private ResponseSpec fakeOuterStringSerializeRequestCreation(@jakarta.annotation.Nullable String __body) throws RestClientResponseException {
+        Object postBody = __body;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
@@ -649,14 +649,14 @@ public class FakeApi {
      * 
      * Test serialization of enum (int) properties with examples
      * <p><b>200</b> - Output enum (int)
-     * @param outerObjectWithEnumProperty Input enum (int) as post body
+     * @param __outerObjectWithEnumProperty Input enum (int) as post body
      * @return OuterObjectWithEnumProperty
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fakePropertyEnumIntegerSerializeRequestCreation(@jakarta.annotation.Nonnull OuterObjectWithEnumProperty outerObjectWithEnumProperty) throws RestClientResponseException {
-        Object postBody = outerObjectWithEnumProperty;
+    private ResponseSpec fakePropertyEnumIntegerSerializeRequestCreation(@jakarta.annotation.Nonnull OuterObjectWithEnumProperty __outerObjectWithEnumProperty) throws RestClientResponseException {
+        Object postBody = __outerObjectWithEnumProperty;
         // verify the required parameter 'outerObjectWithEnumProperty' is set
-        if (outerObjectWithEnumProperty == null) {
+        if (__outerObjectWithEnumProperty == null) {
             throw new RestClientResponseException("Missing the required parameter 'outerObjectWithEnumProperty' when calling fakePropertyEnumIntegerSerialize", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -724,13 +724,13 @@ public class FakeApi {
      * test referenced additionalProperties
      * 
      * <p><b>200</b> - successful operation
-     * @param requestBody request body
+     * @param __requestBody request body
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testAdditionalPropertiesReferenceRequestCreation(@jakarta.annotation.Nonnull Map<String, Object> requestBody) throws RestClientResponseException {
-        Object postBody = requestBody;
+    private ResponseSpec testAdditionalPropertiesReferenceRequestCreation(@jakarta.annotation.Nonnull Map<String, Object> __requestBody) throws RestClientResponseException {
+        Object postBody = __requestBody;
         // verify the required parameter 'requestBody' is set
-        if (requestBody == null) {
+        if (__requestBody == null) {
             throw new RestClientResponseException("Missing the required parameter 'requestBody' when calling testAdditionalPropertiesReference", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -794,13 +794,13 @@ public class FakeApi {
      * 
      * For this test, the body has to be a binary file.
      * <p><b>200</b> - Success
-     * @param body image to upload
+     * @param __body image to upload
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testBodyWithBinaryRequestCreation(@jakarta.annotation.Nullable File body) throws RestClientResponseException {
-        Object postBody = body;
+    private ResponseSpec testBodyWithBinaryRequestCreation(@jakarta.annotation.Nullable File __body) throws RestClientResponseException {
+        Object postBody = __body;
         // verify the required parameter 'body' is set
-        if (body == null) {
+        if (__body == null) {
             throw new RestClientResponseException("Missing the required parameter 'body' when calling testBodyWithBinary", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -864,13 +864,13 @@ public class FakeApi {
      * 
      * For this test, the body for this request must reference a schema named &#x60;File&#x60;.
      * <p><b>200</b> - Success
-     * @param fileSchemaTestClass The fileSchemaTestClass parameter
+     * @param __fileSchemaTestClass The fileSchemaTestClass parameter
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testBodyWithFileSchemaRequestCreation(@jakarta.annotation.Nonnull FileSchemaTestClass fileSchemaTestClass) throws RestClientResponseException {
-        Object postBody = fileSchemaTestClass;
+    private ResponseSpec testBodyWithFileSchemaRequestCreation(@jakarta.annotation.Nonnull FileSchemaTestClass __fileSchemaTestClass) throws RestClientResponseException {
+        Object postBody = __fileSchemaTestClass;
         // verify the required parameter 'fileSchemaTestClass' is set
-        if (fileSchemaTestClass == null) {
+        if (__fileSchemaTestClass == null) {
             throw new RestClientResponseException("Missing the required parameter 'fileSchemaTestClass' when calling testBodyWithFileSchema", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1014,18 +1014,18 @@ public class FakeApi {
      * 
      * 
      * <p><b>200</b> - Success
-     * @param query The query parameter
-     * @param user The user parameter
+     * @param __query The query parameter
+     * @param __user The user parameter
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testBodyWithQueryParamsRequestCreation(@jakarta.annotation.Nonnull String query, @jakarta.annotation.Nonnull User user) throws RestClientResponseException {
-        Object postBody = user;
+    private ResponseSpec testBodyWithQueryParamsRequestCreation(@jakarta.annotation.Nonnull String __query, @jakarta.annotation.Nonnull User __user) throws RestClientResponseException {
+        Object postBody = __user;
         // verify the required parameter 'query' is set
-        if (query == null) {
+        if (__query == null) {
             throw new RestClientResponseException("Missing the required parameter 'query' when calling testBodyWithQueryParams", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'user' is set
-        if (user == null) {
+        if (__user == null) {
             throw new RestClientResponseException("Missing the required parameter 'user' when calling testBodyWithQueryParams", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1036,7 +1036,7 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query", query));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query", __query));
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -1094,14 +1094,14 @@ public class FakeApi {
      * To test \&quot;client\&quot; model
      * To test \&quot;client\&quot; model
      * <p><b>200</b> - successful operation
-     * @param client client model
+     * @param __client client model
      * @return Client
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testClientModelRequestCreation(@jakarta.annotation.Nonnull Client client) throws RestClientResponseException {
-        Object postBody = client;
+    private ResponseSpec testClientModelRequestCreation(@jakarta.annotation.Nonnull Client __client) throws RestClientResponseException {
+        Object postBody = __client;
         // verify the required parameter 'client' is set
-        if (client == null) {
+        if (__client == null) {
             throw new RestClientResponseException("Missing the required parameter 'client' when calling testClientModel", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1385,38 +1385,38 @@ public class FakeApi {
      * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
      * <p><b>400</b> - Invalid username supplied
      * <p><b>404</b> - User not found
-     * @param number None
-     * @param _double None
-     * @param patternWithoutDelimiter None
-     * @param _byte None
-     * @param integer None
-     * @param int32 None
-     * @param int64 None
-     * @param _float None
-     * @param string None
-     * @param binary None
-     * @param date None
-     * @param dateTime None
-     * @param password None
-     * @param paramCallback None
+     * @param __number None
+     * @param ___double None
+     * @param __patternWithoutDelimiter None
+     * @param ___byte None
+     * @param __integer None
+     * @param __int32 None
+     * @param __int64 None
+     * @param ___float None
+     * @param __string None
+     * @param __binary None
+     * @param __date None
+     * @param __dateTime None
+     * @param __password None
+     * @param __paramCallback None
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testEndpointParametersRequestCreation(@jakarta.annotation.Nonnull BigDecimal number, @jakarta.annotation.Nonnull Double _double, @jakarta.annotation.Nonnull String patternWithoutDelimiter, @jakarta.annotation.Nonnull byte[] _byte, @jakarta.annotation.Nullable Integer integer, @jakarta.annotation.Nullable Integer int32, @jakarta.annotation.Nullable Long int64, @jakarta.annotation.Nullable Float _float, @jakarta.annotation.Nullable String string, @jakarta.annotation.Nullable File binary, @jakarta.annotation.Nullable LocalDate date, @jakarta.annotation.Nullable OffsetDateTime dateTime, @jakarta.annotation.Nullable String password, @jakarta.annotation.Nullable String paramCallback) throws RestClientResponseException {
+    private ResponseSpec testEndpointParametersRequestCreation(@jakarta.annotation.Nonnull BigDecimal __number, @jakarta.annotation.Nonnull Double ___double, @jakarta.annotation.Nonnull String __patternWithoutDelimiter, @jakarta.annotation.Nonnull byte[] ___byte, @jakarta.annotation.Nullable Integer __integer, @jakarta.annotation.Nullable Integer __int32, @jakarta.annotation.Nullable Long __int64, @jakarta.annotation.Nullable Float ___float, @jakarta.annotation.Nullable String __string, @jakarta.annotation.Nullable File __binary, @jakarta.annotation.Nullable LocalDate __date, @jakarta.annotation.Nullable OffsetDateTime __dateTime, @jakarta.annotation.Nullable String __password, @jakarta.annotation.Nullable String __paramCallback) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'number' is set
-        if (number == null) {
+        if (__number == null) {
             throw new RestClientResponseException("Missing the required parameter 'number' when calling testEndpointParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter '_double' is set
-        if (_double == null) {
+        if (___double == null) {
             throw new RestClientResponseException("Missing the required parameter '_double' when calling testEndpointParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'patternWithoutDelimiter' is set
-        if (patternWithoutDelimiter == null) {
+        if (__patternWithoutDelimiter == null) {
             throw new RestClientResponseException("Missing the required parameter 'patternWithoutDelimiter' when calling testEndpointParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter '_byte' is set
-        if (_byte == null) {
+        if (___byte == null) {
             throw new RestClientResponseException("Missing the required parameter '_byte' when calling testEndpointParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1427,34 +1427,34 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (integer != null)
-            formParams.add("integer", integer);
-        if (int32 != null)
-            formParams.add("int32", int32);
-        if (int64 != null)
-            formParams.add("int64", int64);
-        if (number != null)
-            formParams.add("number", number);
-        if (_float != null)
-            formParams.add("float", _float);
-        if (_double != null)
-            formParams.add("double", _double);
-        if (string != null)
-            formParams.add("string", string);
-        if (patternWithoutDelimiter != null)
-            formParams.add("pattern_without_delimiter", patternWithoutDelimiter);
-        if (_byte != null)
-            formParams.add("byte", _byte);
-        if (binary != null)
-            formParams.add("binary", new FileSystemResource(binary));
-        if (date != null)
-            formParams.add("date", date);
-        if (dateTime != null)
-            formParams.add("dateTime", dateTime);
-        if (password != null)
-            formParams.add("password", password);
-        if (paramCallback != null)
-            formParams.add("callback", paramCallback);
+        if (__integer != null)
+            formParams.add("integer", __integer);
+        if (__int32 != null)
+            formParams.add("int32", __int32);
+        if (__int64 != null)
+            formParams.add("int64", __int64);
+        if (__number != null)
+            formParams.add("number", __number);
+        if (___float != null)
+            formParams.add("float", ___float);
+        if (___double != null)
+            formParams.add("double", ___double);
+        if (__string != null)
+            formParams.add("string", __string);
+        if (__patternWithoutDelimiter != null)
+            formParams.add("pattern_without_delimiter", __patternWithoutDelimiter);
+        if (___byte != null)
+            formParams.add("byte", ___byte);
+        if (__binary != null)
+            formParams.add("binary", new FileSystemResource(__binary));
+        if (__date != null)
+            formParams.add("date", __date);
+        if (__dateTime != null)
+            formParams.add("dateTime", __dateTime);
+        if (__password != null)
+            formParams.add("password", __password);
+        if (__paramCallback != null)
+            formParams.add("callback", __paramCallback);
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -1712,18 +1712,18 @@ public class FakeApi {
      * To test enum parameters
      * <p><b>400</b> - Invalid request
      * <p><b>404</b> - Not found
-     * @param enumHeaderStringArray Header parameter enum test (string array)
-     * @param enumHeaderString Header parameter enum test (string)
-     * @param enumQueryStringArray Query parameter enum test (string array)
-     * @param enumQueryString Query parameter enum test (string)
-     * @param enumQueryInteger Query parameter enum test (double)
-     * @param enumQueryDouble Query parameter enum test (double)
-     * @param enumQueryModelArray The enumQueryModelArray parameter
-     * @param enumFormStringArray Form parameter enum test (string array)
-     * @param enumFormString Form parameter enum test (string)
+     * @param __enumHeaderStringArray Header parameter enum test (string array)
+     * @param __enumHeaderString Header parameter enum test (string)
+     * @param __enumQueryStringArray Query parameter enum test (string array)
+     * @param __enumQueryString Query parameter enum test (string)
+     * @param __enumQueryInteger Query parameter enum test (double)
+     * @param __enumQueryDouble Query parameter enum test (double)
+     * @param __enumQueryModelArray The enumQueryModelArray parameter
+     * @param __enumFormStringArray Form parameter enum test (string array)
+     * @param __enumFormString Form parameter enum test (string)
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testEnumParametersRequestCreation(@jakarta.annotation.Nullable List<String> enumHeaderStringArray, @jakarta.annotation.Nullable String enumHeaderString, @jakarta.annotation.Nullable List<String> enumQueryStringArray, @jakarta.annotation.Nullable String enumQueryString, @jakarta.annotation.Nullable Integer enumQueryInteger, @jakarta.annotation.Nullable Double enumQueryDouble, @jakarta.annotation.Nullable List<EnumClass> enumQueryModelArray, @jakarta.annotation.Nullable List<String> enumFormStringArray, @jakarta.annotation.Nullable String enumFormString) throws RestClientResponseException {
+    private ResponseSpec testEnumParametersRequestCreation(@jakarta.annotation.Nullable List<String> __enumHeaderStringArray, @jakarta.annotation.Nullable String __enumHeaderString, @jakarta.annotation.Nullable List<String> __enumQueryStringArray, @jakarta.annotation.Nullable String __enumQueryString, @jakarta.annotation.Nullable Integer __enumQueryInteger, @jakarta.annotation.Nullable Double __enumQueryDouble, @jakarta.annotation.Nullable List<EnumClass> __enumQueryModelArray, @jakarta.annotation.Nullable List<String> __enumFormStringArray, @jakarta.annotation.Nullable String __enumFormString) throws RestClientResponseException {
         Object postBody = null;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
@@ -1733,20 +1733,20 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "enum_query_string_array", enumQueryStringArray));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_string", enumQueryString));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_integer", enumQueryInteger));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_double", enumQueryDouble));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "enum_query_model_array", enumQueryModelArray));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "enum_query_string_array", __enumQueryStringArray));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_string", __enumQueryString));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_integer", __enumQueryInteger));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_double", __enumQueryDouble));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "enum_query_model_array", __enumQueryModelArray));
 
-        if (enumHeaderStringArray != null)
-        headerParams.add("enum_header_string_array", apiClient.parameterToString(enumHeaderStringArray));
-        if (enumHeaderString != null)
-        headerParams.add("enum_header_string", apiClient.parameterToString(enumHeaderString));
-        if (enumFormStringArray != null)
-            formParams.addAll("enum_form_string_array", enumFormStringArray);
-        if (enumFormString != null)
-            formParams.add("enum_form_string", enumFormString);
+        if (__enumHeaderStringArray != null)
+        headerParams.add("enum_header_string_array", apiClient.parameterToString(__enumHeaderStringArray));
+        if (__enumHeaderString != null)
+        headerParams.add("enum_header_string", apiClient.parameterToString(__enumHeaderString));
+        if (__enumFormStringArray != null)
+            formParams.addAll("enum_form_string_array", __enumFormStringArray);
+        if (__enumFormString != null)
+            formParams.add("enum_form_string", __enumFormString);
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -1952,26 +1952,26 @@ public class FakeApi {
      * Fake endpoint to test group parameters (optional)
      * Fake endpoint to test group parameters (optional)
      * <p><b>400</b> - Something wrong
-     * @param requiredStringGroup Required String in group parameters
-     * @param requiredBooleanGroup Required Boolean in group parameters
-     * @param requiredInt64Group Required Integer in group parameters
-     * @param stringGroup String in group parameters
-     * @param booleanGroup Boolean in group parameters
-     * @param int64Group Integer in group parameters
+     * @param __requiredStringGroup Required String in group parameters
+     * @param __requiredBooleanGroup Required Boolean in group parameters
+     * @param __requiredInt64Group Required Integer in group parameters
+     * @param __stringGroup String in group parameters
+     * @param __booleanGroup Boolean in group parameters
+     * @param __int64Group Integer in group parameters
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testGroupParametersRequestCreation(@jakarta.annotation.Nonnull Integer requiredStringGroup, @jakarta.annotation.Nonnull Boolean requiredBooleanGroup, @jakarta.annotation.Nonnull Long requiredInt64Group, @jakarta.annotation.Nullable Integer stringGroup, @jakarta.annotation.Nullable Boolean booleanGroup, @jakarta.annotation.Nullable Long int64Group) throws RestClientResponseException {
+    private ResponseSpec testGroupParametersRequestCreation(@jakarta.annotation.Nonnull Integer __requiredStringGroup, @jakarta.annotation.Nonnull Boolean __requiredBooleanGroup, @jakarta.annotation.Nonnull Long __requiredInt64Group, @jakarta.annotation.Nullable Integer __stringGroup, @jakarta.annotation.Nullable Boolean __booleanGroup, @jakarta.annotation.Nullable Long __int64Group) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'requiredStringGroup' is set
-        if (requiredStringGroup == null) {
+        if (__requiredStringGroup == null) {
             throw new RestClientResponseException("Missing the required parameter 'requiredStringGroup' when calling testGroupParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'requiredBooleanGroup' is set
-        if (requiredBooleanGroup == null) {
+        if (__requiredBooleanGroup == null) {
             throw new RestClientResponseException("Missing the required parameter 'requiredBooleanGroup' when calling testGroupParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'requiredInt64Group' is set
-        if (requiredInt64Group == null) {
+        if (__requiredInt64Group == null) {
             throw new RestClientResponseException("Missing the required parameter 'requiredInt64Group' when calling testGroupParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1982,15 +1982,15 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_string_group", requiredStringGroup));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_int64_group", requiredInt64Group));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "string_group", stringGroup));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "int64_group", int64Group));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_string_group", __requiredStringGroup));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_int64_group", __requiredInt64Group));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "string_group", __stringGroup));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "int64_group", __int64Group));
 
-        if (requiredBooleanGroup != null)
-        headerParams.add("required_boolean_group", apiClient.parameterToString(requiredBooleanGroup));
-        if (booleanGroup != null)
-        headerParams.add("boolean_group", apiClient.parameterToString(booleanGroup));
+        if (__requiredBooleanGroup != null)
+        headerParams.add("required_boolean_group", apiClient.parameterToString(__requiredBooleanGroup));
+        if (__booleanGroup != null)
+        headerParams.add("boolean_group", apiClient.parameterToString(__booleanGroup));
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { };
@@ -2057,13 +2057,13 @@ public class FakeApi {
      * test inline additionalProperties
      * 
      * <p><b>200</b> - successful operation
-     * @param requestBody request body
+     * @param __requestBody request body
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testInlineAdditionalPropertiesRequestCreation(@jakarta.annotation.Nonnull Map<String, String> requestBody) throws RestClientResponseException {
-        Object postBody = requestBody;
+    private ResponseSpec testInlineAdditionalPropertiesRequestCreation(@jakarta.annotation.Nonnull Map<String, String> __requestBody) throws RestClientResponseException {
+        Object postBody = __requestBody;
         // verify the required parameter 'requestBody' is set
-        if (requestBody == null) {
+        if (__requestBody == null) {
             throw new RestClientResponseException("Missing the required parameter 'requestBody' when calling testInlineAdditionalProperties", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -2127,13 +2127,13 @@ public class FakeApi {
      * test inline free-form additionalProperties
      * 
      * <p><b>200</b> - successful operation
-     * @param testInlineFreeformAdditionalPropertiesRequest request body
+     * @param __testInlineFreeformAdditionalPropertiesRequest request body
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testInlineFreeformAdditionalPropertiesRequestCreation(@jakarta.annotation.Nonnull TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest) throws RestClientResponseException {
-        Object postBody = testInlineFreeformAdditionalPropertiesRequest;
+    private ResponseSpec testInlineFreeformAdditionalPropertiesRequestCreation(@jakarta.annotation.Nonnull TestInlineFreeformAdditionalPropertiesRequest __testInlineFreeformAdditionalPropertiesRequest) throws RestClientResponseException {
+        Object postBody = __testInlineFreeformAdditionalPropertiesRequest;
         // verify the required parameter 'testInlineFreeformAdditionalPropertiesRequest' is set
-        if (testInlineFreeformAdditionalPropertiesRequest == null) {
+        if (__testInlineFreeformAdditionalPropertiesRequest == null) {
             throw new RestClientResponseException("Missing the required parameter 'testInlineFreeformAdditionalPropertiesRequest' when calling testInlineFreeformAdditionalProperties", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -2277,18 +2277,18 @@ public class FakeApi {
      * test json serialization of form data
      * 
      * <p><b>200</b> - successful operation
-     * @param param field1
-     * @param param2 field2
+     * @param __param field1
+     * @param __param2 field2
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testJsonFormDataRequestCreation(@jakarta.annotation.Nonnull String param, @jakarta.annotation.Nonnull String param2) throws RestClientResponseException {
+    private ResponseSpec testJsonFormDataRequestCreation(@jakarta.annotation.Nonnull String __param, @jakarta.annotation.Nonnull String __param2) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'param' is set
-        if (param == null) {
+        if (__param == null) {
             throw new RestClientResponseException("Missing the required parameter 'param' when calling testJsonFormData", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'param2' is set
-        if (param2 == null) {
+        if (__param2 == null) {
             throw new RestClientResponseException("Missing the required parameter 'param2' when calling testJsonFormData", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -2299,10 +2299,10 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (param != null)
-            formParams.add("param", param);
-        if (param2 != null)
-            formParams.add("param2", param2);
+        if (__param != null)
+            formParams.add("param", __param);
+        if (__param2 != null)
+            formParams.add("param2", __param2);
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -2360,13 +2360,13 @@ public class FakeApi {
      * test nullable parent property
      * 
      * <p><b>200</b> - successful operation
-     * @param childWithNullable request body
+     * @param __childWithNullable request body
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testNullableRequestCreation(@jakarta.annotation.Nonnull ChildWithNullable childWithNullable) throws RestClientResponseException {
-        Object postBody = childWithNullable;
+    private ResponseSpec testNullableRequestCreation(@jakarta.annotation.Nonnull ChildWithNullable __childWithNullable) throws RestClientResponseException {
+        Object postBody = __childWithNullable;
         // verify the required parameter 'childWithNullable' is set
-        if (childWithNullable == null) {
+        if (__childWithNullable == null) {
             throw new RestClientResponseException("Missing the required parameter 'childWithNullable' when calling testNullable", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -2565,39 +2565,39 @@ public class FakeApi {
      * 
      * To test the collection format in query parameters
      * <p><b>200</b> - Success
-     * @param pipe The pipe parameter
-     * @param ioutil The ioutil parameter
-     * @param http The http parameter
-     * @param url The url parameter
-     * @param context The context parameter
-     * @param allowEmpty The allowEmpty parameter
-     * @param language The language parameter
+     * @param __pipe The pipe parameter
+     * @param __ioutil The ioutil parameter
+     * @param __http The http parameter
+     * @param __url The url parameter
+     * @param __context The context parameter
+     * @param __allowEmpty The allowEmpty parameter
+     * @param __language The language parameter
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testQueryParameterCollectionFormatRequestCreation(@jakarta.annotation.Nonnull List<String> pipe, @jakarta.annotation.Nonnull List<String> ioutil, @jakarta.annotation.Nonnull List<String> http, @jakarta.annotation.Nonnull List<String> url, @jakarta.annotation.Nonnull List<String> context, @jakarta.annotation.Nonnull String allowEmpty, @jakarta.annotation.Nullable Map<String, String> language) throws RestClientResponseException {
+    private ResponseSpec testQueryParameterCollectionFormatRequestCreation(@jakarta.annotation.Nonnull List<String> __pipe, @jakarta.annotation.Nonnull List<String> __ioutil, @jakarta.annotation.Nonnull List<String> __http, @jakarta.annotation.Nonnull List<String> __url, @jakarta.annotation.Nonnull List<String> __context, @jakarta.annotation.Nonnull String __allowEmpty, @jakarta.annotation.Nullable Map<String, String> __language) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'pipe' is set
-        if (pipe == null) {
+        if (__pipe == null) {
             throw new RestClientResponseException("Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'ioutil' is set
-        if (ioutil == null) {
+        if (__ioutil == null) {
             throw new RestClientResponseException("Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'http' is set
-        if (http == null) {
+        if (__http == null) {
             throw new RestClientResponseException("Missing the required parameter 'http' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'url' is set
-        if (url == null) {
+        if (__url == null) {
             throw new RestClientResponseException("Missing the required parameter 'url' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'context' is set
-        if (context == null) {
+        if (__context == null) {
             throw new RestClientResponseException("Missing the required parameter 'context' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'allowEmpty' is set
-        if (allowEmpty == null) {
+        if (__allowEmpty == null) {
             throw new RestClientResponseException("Missing the required parameter 'allowEmpty' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -2608,13 +2608,13 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("pipes".toUpperCase(Locale.ROOT)), "pipe", pipe));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "ioutil", ioutil));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("ssv".toUpperCase(Locale.ROOT)), "http", http));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "url", url));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "context", context));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "language", language));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "allowEmpty", allowEmpty));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("pipes".toUpperCase(Locale.ROOT)), "pipe", __pipe));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "ioutil", __ioutil));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("ssv".toUpperCase(Locale.ROOT)), "http", __http));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "url", __url));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "context", __context));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "language", __language));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "allowEmpty", __allowEmpty));
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -2685,13 +2685,13 @@ public class FakeApi {
      * test referenced string map
      * 
      * <p><b>200</b> - successful operation
-     * @param requestBody request body
+     * @param __requestBody request body
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testStringMapReferenceRequestCreation(@jakarta.annotation.Nonnull Map<String, String> requestBody) throws RestClientResponseException {
-        Object postBody = requestBody;
+    private ResponseSpec testStringMapReferenceRequestCreation(@jakarta.annotation.Nonnull Map<String, String> __requestBody) throws RestClientResponseException {
+        Object postBody = __requestBody;
         // verify the required parameter 'requestBody' is set
-        if (requestBody == null) {
+        if (__requestBody == null) {
             throw new RestClientResponseException("Missing the required parameter 'requestBody' when calling testStringMapReference", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -48,14 +48,14 @@ public class FakeClassnameTags123Api {
      * To test class name in snake case
      * To test class name in snake case
      * <p><b>200</b> - successful operation
-     * @param client client model
+     * @param __client client model
      * @return Client
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testClassnameRequestCreation(@jakarta.annotation.Nonnull Client client) throws RestClientResponseException {
-        Object postBody = client;
+    private ResponseSpec testClassnameRequestCreation(@jakarta.annotation.Nonnull Client __client) throws RestClientResponseException {
+        Object postBody = __client;
         // verify the required parameter 'client' is set
-        if (client == null) {
+        if (__client == null) {
             throw new RestClientResponseException("Missing the required parameter 'client' when calling testClassname", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/PetApi.java
@@ -52,13 +52,13 @@ public class PetApi {
      * 
      * <p><b>200</b> - Successful operation
      * <p><b>405</b> - Invalid input
-     * @param pet Pet object that needs to be added to the store
+     * @param __pet Pet object that needs to be added to the store
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec addPetRequestCreation(@jakarta.annotation.Nonnull Pet pet) throws RestClientResponseException {
-        Object postBody = pet;
+    private ResponseSpec addPetRequestCreation(@jakarta.annotation.Nonnull Pet __pet) throws RestClientResponseException {
+        Object postBody = __pet;
         // verify the required parameter 'pet' is set
-        if (pet == null) {
+        if (__pet == null) {
             throw new RestClientResponseException("Missing the required parameter 'pet' when calling addPet", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -209,28 +209,28 @@ public class PetApi {
      * 
      * <p><b>200</b> - Successful operation
      * <p><b>400</b> - Invalid pet value
-     * @param petId Pet id to delete
-     * @param apiKey The apiKey parameter
+     * @param __petId Pet id to delete
+     * @param __apiKey The apiKey parameter
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec deletePetRequestCreation(@jakarta.annotation.Nonnull Long petId, @jakarta.annotation.Nullable String apiKey) throws RestClientResponseException {
+    private ResponseSpec deletePetRequestCreation(@jakarta.annotation.Nonnull Long __petId, @jakarta.annotation.Nullable String __apiKey) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'petId' is set
-        if (petId == null) {
+        if (__petId == null) {
             throw new RestClientResponseException("Missing the required parameter 'petId' when calling deletePet", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("petId", petId);
+        pathParams.put("petId", __petId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (apiKey != null)
-        headerParams.add("api_key", apiClient.parameterToString(apiKey));
+        if (__apiKey != null)
+        headerParams.add("api_key", apiClient.parameterToString(__apiKey));
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { };
@@ -289,14 +289,14 @@ public class PetApi {
      * Multiple status values can be provided with comma separated strings
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid status value
-     * @param status Status values that need to be considered for filter
+     * @param __status Status values that need to be considered for filter
      * @return List&lt;Pet&gt;
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec findPetsByStatusRequestCreation(@jakarta.annotation.Nonnull List<String> status) throws RestClientResponseException {
+    private ResponseSpec findPetsByStatusRequestCreation(@jakarta.annotation.Nonnull List<String> __status) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'status' is set
-        if (status == null) {
+        if (__status == null) {
             throw new RestClientResponseException("Missing the required parameter 'status' when calling findPetsByStatus", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -307,7 +307,7 @@ public class PetApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "status", status));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "status", __status));
 
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
@@ -368,16 +368,16 @@ public class PetApi {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid tag value
-     * @param tags Tags to filter by
+     * @param __tags Tags to filter by
      * @return Set&lt;Pet&gt;
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      * @deprecated
      */
     @Deprecated
-    private ResponseSpec findPetsByTagsRequestCreation(@jakarta.annotation.Nonnull Set<String> tags) throws RestClientResponseException {
+    private ResponseSpec findPetsByTagsRequestCreation(@jakarta.annotation.Nonnull Set<String> __tags) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'tags' is set
-        if (tags == null) {
+        if (__tags == null) {
             throw new RestClientResponseException("Missing the required parameter 'tags' when calling findPetsByTags", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -388,7 +388,7 @@ public class PetApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "tags", tags));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "tags", __tags));
 
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
@@ -450,20 +450,20 @@ public class PetApi {
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid ID supplied
      * <p><b>404</b> - Pet not found
-     * @param petId ID of pet to return
+     * @param __petId ID of pet to return
      * @return Pet
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec getPetByIdRequestCreation(@jakarta.annotation.Nonnull Long petId) throws RestClientResponseException {
+    private ResponseSpec getPetByIdRequestCreation(@jakarta.annotation.Nonnull Long __petId) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'petId' is set
-        if (petId == null) {
+        if (__petId == null) {
             throw new RestClientResponseException("Missing the required parameter 'petId' when calling getPetById", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("petId", petId);
+        pathParams.put("petId", __petId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -534,13 +534,13 @@ public class PetApi {
      * <p><b>400</b> - Invalid ID supplied
      * <p><b>404</b> - Pet not found
      * <p><b>405</b> - Validation exception
-     * @param pet Pet object that needs to be added to the store
+     * @param __pet Pet object that needs to be added to the store
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec updatePetRequestCreation(@jakarta.annotation.Nonnull Pet pet) throws RestClientResponseException {
-        Object postBody = pet;
+    private ResponseSpec updatePetRequestCreation(@jakarta.annotation.Nonnull Pet __pet) throws RestClientResponseException {
+        Object postBody = __pet;
         // verify the required parameter 'pet' is set
-        if (pet == null) {
+        if (__pet == null) {
             throw new RestClientResponseException("Missing the required parameter 'pet' when calling updatePet", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -708,31 +708,31 @@ public class PetApi {
      * 
      * <p><b>200</b> - Successful operation
      * <p><b>405</b> - Invalid input
-     * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param __petId ID of pet that needs to be updated
+     * @param __name Updated name of the pet
+     * @param __status Updated status of the pet
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec updatePetWithFormRequestCreation(@jakarta.annotation.Nonnull Long petId, @jakarta.annotation.Nullable String name, @jakarta.annotation.Nullable String status) throws RestClientResponseException {
+    private ResponseSpec updatePetWithFormRequestCreation(@jakarta.annotation.Nonnull Long __petId, @jakarta.annotation.Nullable String __name, @jakarta.annotation.Nullable String __status) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'petId' is set
-        if (petId == null) {
+        if (__petId == null) {
             throw new RestClientResponseException("Missing the required parameter 'petId' when calling updatePetWithForm", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("petId", petId);
+        pathParams.put("petId", __petId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (name != null)
-            formParams.add("name", name);
-        if (status != null)
-            formParams.add("status", status);
+        if (__name != null)
+            formParams.add("name", __name);
+        if (__status != null)
+            formParams.add("status", __status);
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -889,32 +889,32 @@ public class PetApi {
      * uploads an image
      * 
      * <p><b>200</b> - successful operation
-     * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param _file file to upload
+     * @param __petId ID of pet to update
+     * @param __additionalMetadata Additional data to pass to server
+     * @param ___file file to upload
      * @return ModelApiResponse
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec uploadFileRequestCreation(@jakarta.annotation.Nonnull Long petId, @jakarta.annotation.Nullable String additionalMetadata, @jakarta.annotation.Nullable File _file) throws RestClientResponseException {
+    private ResponseSpec uploadFileRequestCreation(@jakarta.annotation.Nonnull Long __petId, @jakarta.annotation.Nullable String __additionalMetadata, @jakarta.annotation.Nullable File ___file) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'petId' is set
-        if (petId == null) {
+        if (__petId == null) {
             throw new RestClientResponseException("Missing the required parameter 'petId' when calling uploadFile", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("petId", petId);
+        pathParams.put("petId", __petId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (additionalMetadata != null)
-            formParams.add("additionalMetadata", additionalMetadata);
-        if (_file != null)
-            formParams.add("file", new FileSystemResource(_file));
+        if (__additionalMetadata != null)
+            formParams.add("additionalMetadata", __additionalMetadata);
+        if (___file != null)
+            formParams.add("file", new FileSystemResource(___file));
 
         final String[] localVarAccepts = { 
             "application/json"
@@ -1072,36 +1072,36 @@ public class PetApi {
      * uploads an image (required)
      * 
      * <p><b>200</b> - successful operation
-     * @param petId ID of pet to update
-     * @param requiredFile file to upload
-     * @param additionalMetadata Additional data to pass to server
+     * @param __petId ID of pet to update
+     * @param __requiredFile file to upload
+     * @param __additionalMetadata Additional data to pass to server
      * @return ModelApiResponse
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec uploadFileWithRequiredFileRequestCreation(@jakarta.annotation.Nonnull Long petId, @jakarta.annotation.Nonnull File requiredFile, @jakarta.annotation.Nullable String additionalMetadata) throws RestClientResponseException {
+    private ResponseSpec uploadFileWithRequiredFileRequestCreation(@jakarta.annotation.Nonnull Long __petId, @jakarta.annotation.Nonnull File __requiredFile, @jakarta.annotation.Nullable String __additionalMetadata) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'petId' is set
-        if (petId == null) {
+        if (__petId == null) {
             throw new RestClientResponseException("Missing the required parameter 'petId' when calling uploadFileWithRequiredFile", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'requiredFile' is set
-        if (requiredFile == null) {
+        if (__requiredFile == null) {
             throw new RestClientResponseException("Missing the required parameter 'requiredFile' when calling uploadFileWithRequiredFile", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("petId", petId);
+        pathParams.put("petId", __petId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (additionalMetadata != null)
-            formParams.add("additionalMetadata", additionalMetadata);
-        if (requiredFile != null)
-            formParams.add("requiredFile", new FileSystemResource(requiredFile));
+        if (__additionalMetadata != null)
+            formParams.add("additionalMetadata", __additionalMetadata);
+        if (__requiredFile != null)
+            formParams.add("requiredFile", new FileSystemResource(__requiredFile));
 
         final String[] localVarAccepts = { 
             "application/json"

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -49,19 +49,19 @@ public class StoreApi {
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * <p><b>400</b> - Invalid ID supplied
      * <p><b>404</b> - Order not found
-     * @param orderId ID of the order that needs to be deleted
+     * @param __orderId ID of the order that needs to be deleted
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec deleteOrderRequestCreation(@jakarta.annotation.Nonnull String orderId) throws RestClientResponseException {
+    private ResponseSpec deleteOrderRequestCreation(@jakarta.annotation.Nonnull String __orderId) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'orderId' is set
-        if (orderId == null) {
+        if (__orderId == null) {
             throw new RestClientResponseException("Missing the required parameter 'orderId' when calling deleteOrder", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("order_id", orderId);
+        pathParams.put("order_id", __orderId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -189,20 +189,20 @@ public class StoreApi {
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid ID supplied
      * <p><b>404</b> - Order not found
-     * @param orderId ID of pet that needs to be fetched
+     * @param __orderId ID of pet that needs to be fetched
      * @return Order
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec getOrderByIdRequestCreation(@jakarta.annotation.Nonnull Long orderId) throws RestClientResponseException {
+    private ResponseSpec getOrderByIdRequestCreation(@jakarta.annotation.Nonnull Long __orderId) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'orderId' is set
-        if (orderId == null) {
+        if (__orderId == null) {
             throw new RestClientResponseException("Missing the required parameter 'orderId' when calling getOrderById", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("order_id", orderId);
+        pathParams.put("order_id", __orderId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -271,14 +271,14 @@ public class StoreApi {
      * 
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid Order
-     * @param order order placed for purchasing the pet
+     * @param __order order placed for purchasing the pet
      * @return Order
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec placeOrderRequestCreation(@jakarta.annotation.Nonnull Order order) throws RestClientResponseException {
-        Object postBody = order;
+    private ResponseSpec placeOrderRequestCreation(@jakarta.annotation.Nonnull Order __order) throws RestClientResponseException {
+        Object postBody = __order;
         // verify the required parameter 'order' is set
-        if (order == null) {
+        if (__order == null) {
             throw new RestClientResponseException("Missing the required parameter 'order' when calling placeOrder", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/UserApi.java
@@ -49,13 +49,13 @@ public class UserApi {
      * Create user
      * This can only be done by the logged in user.
      * <p><b>0</b> - successful operation
-     * @param user Created user object
+     * @param __user Created user object
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec createUserRequestCreation(@jakarta.annotation.Nonnull User user) throws RestClientResponseException {
-        Object postBody = user;
+    private ResponseSpec createUserRequestCreation(@jakarta.annotation.Nonnull User __user) throws RestClientResponseException {
+        Object postBody = __user;
         // verify the required parameter 'user' is set
-        if (user == null) {
+        if (__user == null) {
             throw new RestClientResponseException("Missing the required parameter 'user' when calling createUser", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -119,13 +119,13 @@ public class UserApi {
      * Creates list of users with given input array
      * 
      * <p><b>0</b> - successful operation
-     * @param user List of user object
+     * @param __user List of user object
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec createUsersWithArrayInputRequestCreation(@jakarta.annotation.Nonnull List<User> user) throws RestClientResponseException {
-        Object postBody = user;
+    private ResponseSpec createUsersWithArrayInputRequestCreation(@jakarta.annotation.Nonnull List<User> __user) throws RestClientResponseException {
+        Object postBody = __user;
         // verify the required parameter 'user' is set
-        if (user == null) {
+        if (__user == null) {
             throw new RestClientResponseException("Missing the required parameter 'user' when calling createUsersWithArrayInput", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -189,13 +189,13 @@ public class UserApi {
      * Creates list of users with given input array
      * 
      * <p><b>0</b> - successful operation
-     * @param user List of user object
+     * @param __user List of user object
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec createUsersWithListInputRequestCreation(@jakarta.annotation.Nonnull List<User> user) throws RestClientResponseException {
-        Object postBody = user;
+    private ResponseSpec createUsersWithListInputRequestCreation(@jakarta.annotation.Nonnull List<User> __user) throws RestClientResponseException {
+        Object postBody = __user;
         // verify the required parameter 'user' is set
-        if (user == null) {
+        if (__user == null) {
             throw new RestClientResponseException("Missing the required parameter 'user' when calling createUsersWithListInput", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -260,19 +260,19 @@ public class UserApi {
      * This can only be done by the logged in user.
      * <p><b>400</b> - Invalid username supplied
      * <p><b>404</b> - User not found
-     * @param username The name that needs to be deleted
+     * @param __username The name that needs to be deleted
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec deleteUserRequestCreation(@jakarta.annotation.Nonnull String username) throws RestClientResponseException {
+    private ResponseSpec deleteUserRequestCreation(@jakarta.annotation.Nonnull String __username) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'username' is set
-        if (username == null) {
+        if (__username == null) {
             throw new RestClientResponseException("Missing the required parameter 'username' when calling deleteUser", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("username", username);
+        pathParams.put("username", __username);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -335,20 +335,20 @@ public class UserApi {
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid username supplied
      * <p><b>404</b> - User not found
-     * @param username The name that needs to be fetched. Use user1 for testing.
+     * @param __username The name that needs to be fetched. Use user1 for testing.
      * @return User
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec getUserByNameRequestCreation(@jakarta.annotation.Nonnull String username) throws RestClientResponseException {
+    private ResponseSpec getUserByNameRequestCreation(@jakarta.annotation.Nonnull String __username) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'username' is set
-        if (username == null) {
+        if (__username == null) {
             throw new RestClientResponseException("Missing the required parameter 'username' when calling getUserByName", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("username", username);
+        pathParams.put("username", __username);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -502,19 +502,19 @@ public class UserApi {
      * 
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid username/password supplied
-     * @param username The user name for login
-     * @param password The password for login in clear text
+     * @param __username The user name for login
+     * @param __password The password for login in clear text
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec loginUserRequestCreation(@jakarta.annotation.Nonnull String username, @jakarta.annotation.Nonnull String password) throws RestClientResponseException {
+    private ResponseSpec loginUserRequestCreation(@jakarta.annotation.Nonnull String __username, @jakarta.annotation.Nonnull String __password) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'username' is set
-        if (username == null) {
+        if (__username == null) {
             throw new RestClientResponseException("Missing the required parameter 'username' when calling loginUser", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'password' is set
-        if (password == null) {
+        if (__password == null) {
             throw new RestClientResponseException("Missing the required parameter 'password' when calling loginUser", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -525,8 +525,8 @@ public class UserApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "username", username));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "password", password));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "username", __username));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "password", __password));
 
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
@@ -733,24 +733,24 @@ public class UserApi {
      * This can only be done by the logged in user.
      * <p><b>400</b> - Invalid user supplied
      * <p><b>404</b> - User not found
-     * @param username name that need to be deleted
-     * @param user Updated user object
+     * @param __username name that need to be deleted
+     * @param __user Updated user object
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec updateUserRequestCreation(@jakarta.annotation.Nonnull String username, @jakarta.annotation.Nonnull User user) throws RestClientResponseException {
-        Object postBody = user;
+    private ResponseSpec updateUserRequestCreation(@jakarta.annotation.Nonnull String __username, @jakarta.annotation.Nonnull User __user) throws RestClientResponseException {
+        Object postBody = __user;
         // verify the required parameter 'username' is set
-        if (username == null) {
+        if (__username == null) {
             throw new RestClientResponseException("Missing the required parameter 'username' when calling updateUser", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'user' is set
-        if (user == null) {
+        if (__user == null) {
             throw new RestClientResponseException("Missing the required parameter 'user' when calling updateUser", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("username", username);
+        pathParams.put("username", __username);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -48,14 +48,14 @@ public class AnotherFakeApi {
      * To test special tags
      * To test special tags and operation ID starting with number
      * <p><b>200</b> - successful operation
-     * @param client client model
+     * @param __client client model
      * @return Client
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec call123testSpecialTagsRequestCreation(@jakarta.annotation.Nonnull Client client) throws RestClientResponseException {
-        Object postBody = client;
+    private ResponseSpec call123testSpecialTagsRequestCreation(@jakarta.annotation.Nonnull Client __client) throws RestClientResponseException {
+        Object postBody = __client;
         // verify the required parameter 'client' is set
-        if (client == null) {
+        if (__client == null) {
             throw new RestClientResponseException("Missing the required parameter 'client' when calling call123testSpecialTags", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -228,15 +228,15 @@ public class FakeApi {
      * test http signature authentication
      * 
      * <p><b>200</b> - The instance started successfully
-     * @param pet Pet object that needs to be added to the store
-     * @param query1 query parameter
-     * @param header1 header parameter
+     * @param __pet Pet object that needs to be added to the store
+     * @param __query1 query parameter
+     * @param __header1 header parameter
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fakeHttpSignatureTestRequestCreation(@jakarta.annotation.Nonnull Pet pet, @jakarta.annotation.Nullable String query1, @jakarta.annotation.Nullable String header1) throws RestClientResponseException {
-        Object postBody = pet;
+    private ResponseSpec fakeHttpSignatureTestRequestCreation(@jakarta.annotation.Nonnull Pet __pet, @jakarta.annotation.Nullable String __query1, @jakarta.annotation.Nullable String __header1) throws RestClientResponseException {
+        Object postBody = __pet;
         // verify the required parameter 'pet' is set
-        if (pet == null) {
+        if (__pet == null) {
             throw new RestClientResponseException("Missing the required parameter 'pet' when calling fakeHttpSignatureTest", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -247,10 +247,10 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query_1", query1));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query_1", __query1));
 
-        if (header1 != null)
-        headerParams.add("header_1", apiClient.parameterToString(header1));
+        if (__header1 != null)
+        headerParams.add("header_1", apiClient.parameterToString(__header1));
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { 
@@ -310,12 +310,12 @@ public class FakeApi {
      * 
      * Test serialization of outer boolean types
      * <p><b>200</b> - Output boolean
-     * @param body Input boolean as post body
+     * @param __body Input boolean as post body
      * @return Boolean
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fakeOuterBooleanSerializeRequestCreation(@jakarta.annotation.Nullable Boolean body) throws RestClientResponseException {
-        Object postBody = body;
+    private ResponseSpec fakeOuterBooleanSerializeRequestCreation(@jakarta.annotation.Nullable Boolean __body) throws RestClientResponseException {
+        Object postBody = __body;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
@@ -381,12 +381,12 @@ public class FakeApi {
      * 
      * Test serialization of object with outer number type
      * <p><b>200</b> - Output composite
-     * @param outerComposite Input composite as post body
+     * @param __outerComposite Input composite as post body
      * @return OuterComposite
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fakeOuterCompositeSerializeRequestCreation(@jakarta.annotation.Nullable OuterComposite outerComposite) throws RestClientResponseException {
-        Object postBody = outerComposite;
+    private ResponseSpec fakeOuterCompositeSerializeRequestCreation(@jakarta.annotation.Nullable OuterComposite __outerComposite) throws RestClientResponseException {
+        Object postBody = __outerComposite;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
@@ -452,12 +452,12 @@ public class FakeApi {
      * 
      * Test serialization of outer number types
      * <p><b>200</b> - Output number
-     * @param body Input number as post body
+     * @param __body Input number as post body
      * @return BigDecimal
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fakeOuterNumberSerializeRequestCreation(@jakarta.annotation.Nullable BigDecimal body) throws RestClientResponseException {
-        Object postBody = body;
+    private ResponseSpec fakeOuterNumberSerializeRequestCreation(@jakarta.annotation.Nullable BigDecimal __body) throws RestClientResponseException {
+        Object postBody = __body;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
@@ -523,12 +523,12 @@ public class FakeApi {
      * 
      * Test serialization of outer string types
      * <p><b>200</b> - Output string
-     * @param body Input string as post body
+     * @param __body Input string as post body
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fakeOuterStringSerializeRequestCreation(@jakarta.annotation.Nullable String body) throws RestClientResponseException {
-        Object postBody = body;
+    private ResponseSpec fakeOuterStringSerializeRequestCreation(@jakarta.annotation.Nullable String __body) throws RestClientResponseException {
+        Object postBody = __body;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
@@ -594,14 +594,14 @@ public class FakeApi {
      * 
      * Test serialization of enum (int) properties with examples
      * <p><b>200</b> - Output enum (int)
-     * @param outerObjectWithEnumProperty Input enum (int) as post body
+     * @param __outerObjectWithEnumProperty Input enum (int) as post body
      * @return OuterObjectWithEnumProperty
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fakePropertyEnumIntegerSerializeRequestCreation(@jakarta.annotation.Nonnull OuterObjectWithEnumProperty outerObjectWithEnumProperty) throws RestClientResponseException {
-        Object postBody = outerObjectWithEnumProperty;
+    private ResponseSpec fakePropertyEnumIntegerSerializeRequestCreation(@jakarta.annotation.Nonnull OuterObjectWithEnumProperty __outerObjectWithEnumProperty) throws RestClientResponseException {
+        Object postBody = __outerObjectWithEnumProperty;
         // verify the required parameter 'outerObjectWithEnumProperty' is set
-        if (outerObjectWithEnumProperty == null) {
+        if (__outerObjectWithEnumProperty == null) {
             throw new RestClientResponseException("Missing the required parameter 'outerObjectWithEnumProperty' when calling fakePropertyEnumIntegerSerialize", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -669,13 +669,13 @@ public class FakeApi {
      * test referenced additionalProperties
      * 
      * <p><b>200</b> - successful operation
-     * @param requestBody request body
+     * @param __requestBody request body
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testAdditionalPropertiesReferenceRequestCreation(@jakarta.annotation.Nonnull Map<String, Object> requestBody) throws RestClientResponseException {
-        Object postBody = requestBody;
+    private ResponseSpec testAdditionalPropertiesReferenceRequestCreation(@jakarta.annotation.Nonnull Map<String, Object> __requestBody) throws RestClientResponseException {
+        Object postBody = __requestBody;
         // verify the required parameter 'requestBody' is set
-        if (requestBody == null) {
+        if (__requestBody == null) {
             throw new RestClientResponseException("Missing the required parameter 'requestBody' when calling testAdditionalPropertiesReference", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -739,13 +739,13 @@ public class FakeApi {
      * 
      * For this test, the body has to be a binary file.
      * <p><b>200</b> - Success
-     * @param body image to upload
+     * @param __body image to upload
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testBodyWithBinaryRequestCreation(@jakarta.annotation.Nullable File body) throws RestClientResponseException {
-        Object postBody = body;
+    private ResponseSpec testBodyWithBinaryRequestCreation(@jakarta.annotation.Nullable File __body) throws RestClientResponseException {
+        Object postBody = __body;
         // verify the required parameter 'body' is set
-        if (body == null) {
+        if (__body == null) {
             throw new RestClientResponseException("Missing the required parameter 'body' when calling testBodyWithBinary", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -809,13 +809,13 @@ public class FakeApi {
      * 
      * For this test, the body for this request must reference a schema named &#x60;File&#x60;.
      * <p><b>200</b> - Success
-     * @param fileSchemaTestClass The fileSchemaTestClass parameter
+     * @param __fileSchemaTestClass The fileSchemaTestClass parameter
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testBodyWithFileSchemaRequestCreation(@jakarta.annotation.Nonnull FileSchemaTestClass fileSchemaTestClass) throws RestClientResponseException {
-        Object postBody = fileSchemaTestClass;
+    private ResponseSpec testBodyWithFileSchemaRequestCreation(@jakarta.annotation.Nonnull FileSchemaTestClass __fileSchemaTestClass) throws RestClientResponseException {
+        Object postBody = __fileSchemaTestClass;
         // verify the required parameter 'fileSchemaTestClass' is set
-        if (fileSchemaTestClass == null) {
+        if (__fileSchemaTestClass == null) {
             throw new RestClientResponseException("Missing the required parameter 'fileSchemaTestClass' when calling testBodyWithFileSchema", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -915,18 +915,18 @@ public class FakeApi {
      * 
      * 
      * <p><b>200</b> - Success
-     * @param query The query parameter
-     * @param user The user parameter
+     * @param __query The query parameter
+     * @param __user The user parameter
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testBodyWithQueryParamsRequestCreation(@jakarta.annotation.Nonnull String query, @jakarta.annotation.Nonnull User user) throws RestClientResponseException {
-        Object postBody = user;
+    private ResponseSpec testBodyWithQueryParamsRequestCreation(@jakarta.annotation.Nonnull String __query, @jakarta.annotation.Nonnull User __user) throws RestClientResponseException {
+        Object postBody = __user;
         // verify the required parameter 'query' is set
-        if (query == null) {
+        if (__query == null) {
             throw new RestClientResponseException("Missing the required parameter 'query' when calling testBodyWithQueryParams", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'user' is set
-        if (user == null) {
+        if (__user == null) {
             throw new RestClientResponseException("Missing the required parameter 'user' when calling testBodyWithQueryParams", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -937,7 +937,7 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query", query));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query", __query));
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -995,14 +995,14 @@ public class FakeApi {
      * To test \&quot;client\&quot; model
      * To test \&quot;client\&quot; model
      * <p><b>200</b> - successful operation
-     * @param client client model
+     * @param __client client model
      * @return Client
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testClientModelRequestCreation(@jakarta.annotation.Nonnull Client client) throws RestClientResponseException {
-        Object postBody = client;
+    private ResponseSpec testClientModelRequestCreation(@jakarta.annotation.Nonnull Client __client) throws RestClientResponseException {
+        Object postBody = __client;
         // verify the required parameter 'client' is set
-        if (client == null) {
+        if (__client == null) {
             throw new RestClientResponseException("Missing the required parameter 'client' when calling testClientModel", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1110,38 +1110,38 @@ public class FakeApi {
      * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
      * <p><b>400</b> - Invalid username supplied
      * <p><b>404</b> - User not found
-     * @param number None
-     * @param _double None
-     * @param patternWithoutDelimiter None
-     * @param _byte None
-     * @param integer None
-     * @param int32 None
-     * @param int64 None
-     * @param _float None
-     * @param string None
-     * @param binary None
-     * @param date None
-     * @param dateTime None
-     * @param password None
-     * @param paramCallback None
+     * @param __number None
+     * @param ___double None
+     * @param __patternWithoutDelimiter None
+     * @param ___byte None
+     * @param __integer None
+     * @param __int32 None
+     * @param __int64 None
+     * @param ___float None
+     * @param __string None
+     * @param __binary None
+     * @param __date None
+     * @param __dateTime None
+     * @param __password None
+     * @param __paramCallback None
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testEndpointParametersRequestCreation(@jakarta.annotation.Nonnull BigDecimal number, @jakarta.annotation.Nonnull Double _double, @jakarta.annotation.Nonnull String patternWithoutDelimiter, @jakarta.annotation.Nonnull byte[] _byte, @jakarta.annotation.Nullable Integer integer, @jakarta.annotation.Nullable Integer int32, @jakarta.annotation.Nullable Long int64, @jakarta.annotation.Nullable Float _float, @jakarta.annotation.Nullable String string, @jakarta.annotation.Nullable File binary, @jakarta.annotation.Nullable LocalDate date, @jakarta.annotation.Nullable OffsetDateTime dateTime, @jakarta.annotation.Nullable String password, @jakarta.annotation.Nullable String paramCallback) throws RestClientResponseException {
+    private ResponseSpec testEndpointParametersRequestCreation(@jakarta.annotation.Nonnull BigDecimal __number, @jakarta.annotation.Nonnull Double ___double, @jakarta.annotation.Nonnull String __patternWithoutDelimiter, @jakarta.annotation.Nonnull byte[] ___byte, @jakarta.annotation.Nullable Integer __integer, @jakarta.annotation.Nullable Integer __int32, @jakarta.annotation.Nullable Long __int64, @jakarta.annotation.Nullable Float ___float, @jakarta.annotation.Nullable String __string, @jakarta.annotation.Nullable File __binary, @jakarta.annotation.Nullable LocalDate __date, @jakarta.annotation.Nullable OffsetDateTime __dateTime, @jakarta.annotation.Nullable String __password, @jakarta.annotation.Nullable String __paramCallback) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'number' is set
-        if (number == null) {
+        if (__number == null) {
             throw new RestClientResponseException("Missing the required parameter 'number' when calling testEndpointParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter '_double' is set
-        if (_double == null) {
+        if (___double == null) {
             throw new RestClientResponseException("Missing the required parameter '_double' when calling testEndpointParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'patternWithoutDelimiter' is set
-        if (patternWithoutDelimiter == null) {
+        if (__patternWithoutDelimiter == null) {
             throw new RestClientResponseException("Missing the required parameter 'patternWithoutDelimiter' when calling testEndpointParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter '_byte' is set
-        if (_byte == null) {
+        if (___byte == null) {
             throw new RestClientResponseException("Missing the required parameter '_byte' when calling testEndpointParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1152,34 +1152,34 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (integer != null)
-            formParams.add("integer", integer);
-        if (int32 != null)
-            formParams.add("int32", int32);
-        if (int64 != null)
-            formParams.add("int64", int64);
-        if (number != null)
-            formParams.add("number", number);
-        if (_float != null)
-            formParams.add("float", _float);
-        if (_double != null)
-            formParams.add("double", _double);
-        if (string != null)
-            formParams.add("string", string);
-        if (patternWithoutDelimiter != null)
-            formParams.add("pattern_without_delimiter", patternWithoutDelimiter);
-        if (_byte != null)
-            formParams.add("byte", _byte);
-        if (binary != null)
-            formParams.add("binary", new FileSystemResource(binary));
-        if (date != null)
-            formParams.add("date", date);
-        if (dateTime != null)
-            formParams.add("dateTime", dateTime);
-        if (password != null)
-            formParams.add("password", password);
-        if (paramCallback != null)
-            formParams.add("callback", paramCallback);
+        if (__integer != null)
+            formParams.add("integer", __integer);
+        if (__int32 != null)
+            formParams.add("int32", __int32);
+        if (__int64 != null)
+            formParams.add("int64", __int64);
+        if (__number != null)
+            formParams.add("number", __number);
+        if (___float != null)
+            formParams.add("float", ___float);
+        if (___double != null)
+            formParams.add("double", ___double);
+        if (__string != null)
+            formParams.add("string", __string);
+        if (__patternWithoutDelimiter != null)
+            formParams.add("pattern_without_delimiter", __patternWithoutDelimiter);
+        if (___byte != null)
+            formParams.add("byte", ___byte);
+        if (__binary != null)
+            formParams.add("binary", new FileSystemResource(__binary));
+        if (__date != null)
+            formParams.add("date", __date);
+        if (__dateTime != null)
+            formParams.add("dateTime", __dateTime);
+        if (__password != null)
+            formParams.add("password", __password);
+        if (__paramCallback != null)
+            formParams.add("callback", __paramCallback);
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -1316,18 +1316,18 @@ public class FakeApi {
      * To test enum parameters
      * <p><b>400</b> - Invalid request
      * <p><b>404</b> - Not found
-     * @param enumHeaderStringArray Header parameter enum test (string array)
-     * @param enumHeaderString Header parameter enum test (string)
-     * @param enumQueryStringArray Query parameter enum test (string array)
-     * @param enumQueryString Query parameter enum test (string)
-     * @param enumQueryInteger Query parameter enum test (double)
-     * @param enumQueryDouble Query parameter enum test (double)
-     * @param enumQueryModelArray The enumQueryModelArray parameter
-     * @param enumFormStringArray Form parameter enum test (string array)
-     * @param enumFormString Form parameter enum test (string)
+     * @param __enumHeaderStringArray Header parameter enum test (string array)
+     * @param __enumHeaderString Header parameter enum test (string)
+     * @param __enumQueryStringArray Query parameter enum test (string array)
+     * @param __enumQueryString Query parameter enum test (string)
+     * @param __enumQueryInteger Query parameter enum test (double)
+     * @param __enumQueryDouble Query parameter enum test (double)
+     * @param __enumQueryModelArray The enumQueryModelArray parameter
+     * @param __enumFormStringArray Form parameter enum test (string array)
+     * @param __enumFormString Form parameter enum test (string)
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testEnumParametersRequestCreation(@jakarta.annotation.Nullable List<String> enumHeaderStringArray, @jakarta.annotation.Nullable String enumHeaderString, @jakarta.annotation.Nullable List<String> enumQueryStringArray, @jakarta.annotation.Nullable String enumQueryString, @jakarta.annotation.Nullable Integer enumQueryInteger, @jakarta.annotation.Nullable Double enumQueryDouble, @jakarta.annotation.Nullable List<EnumClass> enumQueryModelArray, @jakarta.annotation.Nullable List<String> enumFormStringArray, @jakarta.annotation.Nullable String enumFormString) throws RestClientResponseException {
+    private ResponseSpec testEnumParametersRequestCreation(@jakarta.annotation.Nullable List<String> __enumHeaderStringArray, @jakarta.annotation.Nullable String __enumHeaderString, @jakarta.annotation.Nullable List<String> __enumQueryStringArray, @jakarta.annotation.Nullable String __enumQueryString, @jakarta.annotation.Nullable Integer __enumQueryInteger, @jakarta.annotation.Nullable Double __enumQueryDouble, @jakarta.annotation.Nullable List<EnumClass> __enumQueryModelArray, @jakarta.annotation.Nullable List<String> __enumFormStringArray, @jakarta.annotation.Nullable String __enumFormString) throws RestClientResponseException {
         Object postBody = null;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
@@ -1337,20 +1337,20 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "enum_query_string_array", enumQueryStringArray));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_string", enumQueryString));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_integer", enumQueryInteger));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_double", enumQueryDouble));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "enum_query_model_array", enumQueryModelArray));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "enum_query_string_array", __enumQueryStringArray));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_string", __enumQueryString));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_integer", __enumQueryInteger));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_double", __enumQueryDouble));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "enum_query_model_array", __enumQueryModelArray));
 
-        if (enumHeaderStringArray != null)
-        headerParams.add("enum_header_string_array", apiClient.parameterToString(enumHeaderStringArray));
-        if (enumHeaderString != null)
-        headerParams.add("enum_header_string", apiClient.parameterToString(enumHeaderString));
-        if (enumFormStringArray != null)
-            formParams.addAll("enum_form_string_array", enumFormStringArray);
-        if (enumFormString != null)
-            formParams.add("enum_form_string", enumFormString);
+        if (__enumHeaderStringArray != null)
+        headerParams.add("enum_header_string_array", apiClient.parameterToString(__enumHeaderStringArray));
+        if (__enumHeaderString != null)
+        headerParams.add("enum_header_string", apiClient.parameterToString(__enumHeaderString));
+        if (__enumFormStringArray != null)
+            formParams.addAll("enum_form_string_array", __enumFormStringArray);
+        if (__enumFormString != null)
+            formParams.add("enum_form_string", __enumFormString);
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -1468,26 +1468,26 @@ public class FakeApi {
      * Fake endpoint to test group parameters (optional)
      * Fake endpoint to test group parameters (optional)
      * <p><b>400</b> - Something wrong
-     * @param requiredStringGroup Required String in group parameters
-     * @param requiredBooleanGroup Required Boolean in group parameters
-     * @param requiredInt64Group Required Integer in group parameters
-     * @param stringGroup String in group parameters
-     * @param booleanGroup Boolean in group parameters
-     * @param int64Group Integer in group parameters
+     * @param __requiredStringGroup Required String in group parameters
+     * @param __requiredBooleanGroup Required Boolean in group parameters
+     * @param __requiredInt64Group Required Integer in group parameters
+     * @param __stringGroup String in group parameters
+     * @param __booleanGroup Boolean in group parameters
+     * @param __int64Group Integer in group parameters
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testGroupParametersRequestCreation(@jakarta.annotation.Nonnull Integer requiredStringGroup, @jakarta.annotation.Nonnull Boolean requiredBooleanGroup, @jakarta.annotation.Nonnull Long requiredInt64Group, @jakarta.annotation.Nullable Integer stringGroup, @jakarta.annotation.Nullable Boolean booleanGroup, @jakarta.annotation.Nullable Long int64Group) throws RestClientResponseException {
+    private ResponseSpec testGroupParametersRequestCreation(@jakarta.annotation.Nonnull Integer __requiredStringGroup, @jakarta.annotation.Nonnull Boolean __requiredBooleanGroup, @jakarta.annotation.Nonnull Long __requiredInt64Group, @jakarta.annotation.Nullable Integer __stringGroup, @jakarta.annotation.Nullable Boolean __booleanGroup, @jakarta.annotation.Nullable Long __int64Group) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'requiredStringGroup' is set
-        if (requiredStringGroup == null) {
+        if (__requiredStringGroup == null) {
             throw new RestClientResponseException("Missing the required parameter 'requiredStringGroup' when calling testGroupParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'requiredBooleanGroup' is set
-        if (requiredBooleanGroup == null) {
+        if (__requiredBooleanGroup == null) {
             throw new RestClientResponseException("Missing the required parameter 'requiredBooleanGroup' when calling testGroupParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'requiredInt64Group' is set
-        if (requiredInt64Group == null) {
+        if (__requiredInt64Group == null) {
             throw new RestClientResponseException("Missing the required parameter 'requiredInt64Group' when calling testGroupParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1498,15 +1498,15 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_string_group", requiredStringGroup));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_int64_group", requiredInt64Group));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "string_group", stringGroup));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "int64_group", int64Group));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_string_group", __requiredStringGroup));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_int64_group", __requiredInt64Group));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "string_group", __stringGroup));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "int64_group", __int64Group));
 
-        if (requiredBooleanGroup != null)
-        headerParams.add("required_boolean_group", apiClient.parameterToString(requiredBooleanGroup));
-        if (booleanGroup != null)
-        headerParams.add("boolean_group", apiClient.parameterToString(booleanGroup));
+        if (__requiredBooleanGroup != null)
+        headerParams.add("required_boolean_group", apiClient.parameterToString(__requiredBooleanGroup));
+        if (__booleanGroup != null)
+        headerParams.add("boolean_group", apiClient.parameterToString(__booleanGroup));
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { };
@@ -1573,13 +1573,13 @@ public class FakeApi {
      * test inline additionalProperties
      * 
      * <p><b>200</b> - successful operation
-     * @param requestBody request body
+     * @param __requestBody request body
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testInlineAdditionalPropertiesRequestCreation(@jakarta.annotation.Nonnull Map<String, String> requestBody) throws RestClientResponseException {
-        Object postBody = requestBody;
+    private ResponseSpec testInlineAdditionalPropertiesRequestCreation(@jakarta.annotation.Nonnull Map<String, String> __requestBody) throws RestClientResponseException {
+        Object postBody = __requestBody;
         // verify the required parameter 'requestBody' is set
-        if (requestBody == null) {
+        if (__requestBody == null) {
             throw new RestClientResponseException("Missing the required parameter 'requestBody' when calling testInlineAdditionalProperties", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1643,13 +1643,13 @@ public class FakeApi {
      * test inline free-form additionalProperties
      * 
      * <p><b>200</b> - successful operation
-     * @param testInlineFreeformAdditionalPropertiesRequest request body
+     * @param __testInlineFreeformAdditionalPropertiesRequest request body
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testInlineFreeformAdditionalPropertiesRequestCreation(@jakarta.annotation.Nonnull TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest) throws RestClientResponseException {
-        Object postBody = testInlineFreeformAdditionalPropertiesRequest;
+    private ResponseSpec testInlineFreeformAdditionalPropertiesRequestCreation(@jakarta.annotation.Nonnull TestInlineFreeformAdditionalPropertiesRequest __testInlineFreeformAdditionalPropertiesRequest) throws RestClientResponseException {
+        Object postBody = __testInlineFreeformAdditionalPropertiesRequest;
         // verify the required parameter 'testInlineFreeformAdditionalPropertiesRequest' is set
-        if (testInlineFreeformAdditionalPropertiesRequest == null) {
+        if (__testInlineFreeformAdditionalPropertiesRequest == null) {
             throw new RestClientResponseException("Missing the required parameter 'testInlineFreeformAdditionalPropertiesRequest' when calling testInlineFreeformAdditionalProperties", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1749,18 +1749,18 @@ public class FakeApi {
      * test json serialization of form data
      * 
      * <p><b>200</b> - successful operation
-     * @param param field1
-     * @param param2 field2
+     * @param __param field1
+     * @param __param2 field2
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testJsonFormDataRequestCreation(@jakarta.annotation.Nonnull String param, @jakarta.annotation.Nonnull String param2) throws RestClientResponseException {
+    private ResponseSpec testJsonFormDataRequestCreation(@jakarta.annotation.Nonnull String __param, @jakarta.annotation.Nonnull String __param2) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'param' is set
-        if (param == null) {
+        if (__param == null) {
             throw new RestClientResponseException("Missing the required parameter 'param' when calling testJsonFormData", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'param2' is set
-        if (param2 == null) {
+        if (__param2 == null) {
             throw new RestClientResponseException("Missing the required parameter 'param2' when calling testJsonFormData", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1771,10 +1771,10 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (param != null)
-            formParams.add("param", param);
-        if (param2 != null)
-            formParams.add("param2", param2);
+        if (__param != null)
+            formParams.add("param", __param);
+        if (__param2 != null)
+            formParams.add("param2", __param2);
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -1832,13 +1832,13 @@ public class FakeApi {
      * test nullable parent property
      * 
      * <p><b>200</b> - successful operation
-     * @param childWithNullable request body
+     * @param __childWithNullable request body
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testNullableRequestCreation(@jakarta.annotation.Nonnull ChildWithNullable childWithNullable) throws RestClientResponseException {
-        Object postBody = childWithNullable;
+    private ResponseSpec testNullableRequestCreation(@jakarta.annotation.Nonnull ChildWithNullable __childWithNullable) throws RestClientResponseException {
+        Object postBody = __childWithNullable;
         // verify the required parameter 'childWithNullable' is set
-        if (childWithNullable == null) {
+        if (__childWithNullable == null) {
             throw new RestClientResponseException("Missing the required parameter 'childWithNullable' when calling testNullable", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1938,39 +1938,39 @@ public class FakeApi {
      * 
      * To test the collection format in query parameters
      * <p><b>200</b> - Success
-     * @param pipe The pipe parameter
-     * @param ioutil The ioutil parameter
-     * @param http The http parameter
-     * @param url The url parameter
-     * @param context The context parameter
-     * @param allowEmpty The allowEmpty parameter
-     * @param language The language parameter
+     * @param __pipe The pipe parameter
+     * @param __ioutil The ioutil parameter
+     * @param __http The http parameter
+     * @param __url The url parameter
+     * @param __context The context parameter
+     * @param __allowEmpty The allowEmpty parameter
+     * @param __language The language parameter
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testQueryParameterCollectionFormatRequestCreation(@jakarta.annotation.Nonnull List<String> pipe, @jakarta.annotation.Nonnull List<String> ioutil, @jakarta.annotation.Nonnull List<String> http, @jakarta.annotation.Nonnull List<String> url, @jakarta.annotation.Nonnull List<String> context, @jakarta.annotation.Nonnull String allowEmpty, @jakarta.annotation.Nullable Map<String, String> language) throws RestClientResponseException {
+    private ResponseSpec testQueryParameterCollectionFormatRequestCreation(@jakarta.annotation.Nonnull List<String> __pipe, @jakarta.annotation.Nonnull List<String> __ioutil, @jakarta.annotation.Nonnull List<String> __http, @jakarta.annotation.Nonnull List<String> __url, @jakarta.annotation.Nonnull List<String> __context, @jakarta.annotation.Nonnull String __allowEmpty, @jakarta.annotation.Nullable Map<String, String> __language) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'pipe' is set
-        if (pipe == null) {
+        if (__pipe == null) {
             throw new RestClientResponseException("Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'ioutil' is set
-        if (ioutil == null) {
+        if (__ioutil == null) {
             throw new RestClientResponseException("Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'http' is set
-        if (http == null) {
+        if (__http == null) {
             throw new RestClientResponseException("Missing the required parameter 'http' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'url' is set
-        if (url == null) {
+        if (__url == null) {
             throw new RestClientResponseException("Missing the required parameter 'url' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'context' is set
-        if (context == null) {
+        if (__context == null) {
             throw new RestClientResponseException("Missing the required parameter 'context' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'allowEmpty' is set
-        if (allowEmpty == null) {
+        if (__allowEmpty == null) {
             throw new RestClientResponseException("Missing the required parameter 'allowEmpty' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1981,13 +1981,13 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("pipes".toUpperCase(Locale.ROOT)), "pipe", pipe));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "ioutil", ioutil));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("ssv".toUpperCase(Locale.ROOT)), "http", http));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "url", url));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "context", context));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "language", language));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "allowEmpty", allowEmpty));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("pipes".toUpperCase(Locale.ROOT)), "pipe", __pipe));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "ioutil", __ioutil));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("ssv".toUpperCase(Locale.ROOT)), "http", __http));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "url", __url));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "context", __context));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "language", __language));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "allowEmpty", __allowEmpty));
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -2058,13 +2058,13 @@ public class FakeApi {
      * test referenced string map
      * 
      * <p><b>200</b> - successful operation
-     * @param requestBody request body
+     * @param __requestBody request body
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testStringMapReferenceRequestCreation(@jakarta.annotation.Nonnull Map<String, String> requestBody) throws RestClientResponseException {
-        Object postBody = requestBody;
+    private ResponseSpec testStringMapReferenceRequestCreation(@jakarta.annotation.Nonnull Map<String, String> __requestBody) throws RestClientResponseException {
+        Object postBody = __requestBody;
         // verify the required parameter 'requestBody' is set
-        if (requestBody == null) {
+        if (__requestBody == null) {
             throw new RestClientResponseException("Missing the required parameter 'requestBody' when calling testStringMapReference", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -48,14 +48,14 @@ public class FakeClassnameTags123Api {
      * To test class name in snake case
      * To test class name in snake case
      * <p><b>200</b> - successful operation
-     * @param client client model
+     * @param __client client model
      * @return Client
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testClassnameRequestCreation(@jakarta.annotation.Nonnull Client client) throws RestClientResponseException {
-        Object postBody = client;
+    private ResponseSpec testClassnameRequestCreation(@jakarta.annotation.Nonnull Client __client) throws RestClientResponseException {
+        Object postBody = __client;
         // verify the required parameter 'client' is set
-        if (client == null) {
+        if (__client == null) {
             throw new RestClientResponseException("Missing the required parameter 'client' when calling testClassname", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/PetApi.java
@@ -52,13 +52,13 @@ public class PetApi {
      * 
      * <p><b>200</b> - Successful operation
      * <p><b>405</b> - Invalid input
-     * @param pet Pet object that needs to be added to the store
+     * @param __pet Pet object that needs to be added to the store
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec addPetRequestCreation(@jakarta.annotation.Nonnull Pet pet) throws RestClientResponseException {
-        Object postBody = pet;
+    private ResponseSpec addPetRequestCreation(@jakarta.annotation.Nonnull Pet __pet) throws RestClientResponseException {
+        Object postBody = __pet;
         // verify the required parameter 'pet' is set
-        if (pet == null) {
+        if (__pet == null) {
             throw new RestClientResponseException("Missing the required parameter 'pet' when calling addPet", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -165,28 +165,28 @@ public class PetApi {
      * 
      * <p><b>200</b> - Successful operation
      * <p><b>400</b> - Invalid pet value
-     * @param petId Pet id to delete
-     * @param apiKey The apiKey parameter
+     * @param __petId Pet id to delete
+     * @param __apiKey The apiKey parameter
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec deletePetRequestCreation(@jakarta.annotation.Nonnull Long petId, @jakarta.annotation.Nullable String apiKey) throws RestClientResponseException {
+    private ResponseSpec deletePetRequestCreation(@jakarta.annotation.Nonnull Long __petId, @jakarta.annotation.Nullable String __apiKey) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'petId' is set
-        if (petId == null) {
+        if (__petId == null) {
             throw new RestClientResponseException("Missing the required parameter 'petId' when calling deletePet", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("petId", petId);
+        pathParams.put("petId", __petId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (apiKey != null)
-        headerParams.add("api_key", apiClient.parameterToString(apiKey));
+        if (__apiKey != null)
+        headerParams.add("api_key", apiClient.parameterToString(__apiKey));
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { };
@@ -245,14 +245,14 @@ public class PetApi {
      * Multiple status values can be provided with comma separated strings
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid status value
-     * @param status Status values that need to be considered for filter
+     * @param __status Status values that need to be considered for filter
      * @return List&lt;Pet&gt;
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec findPetsByStatusRequestCreation(@jakarta.annotation.Nonnull List<String> status) throws RestClientResponseException {
+    private ResponseSpec findPetsByStatusRequestCreation(@jakarta.annotation.Nonnull List<String> __status) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'status' is set
-        if (status == null) {
+        if (__status == null) {
             throw new RestClientResponseException("Missing the required parameter 'status' when calling findPetsByStatus", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -263,7 +263,7 @@ public class PetApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "status", status));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "status", __status));
 
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
@@ -324,16 +324,16 @@ public class PetApi {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid tag value
-     * @param tags Tags to filter by
+     * @param __tags Tags to filter by
      * @return Set&lt;Pet&gt;
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      * @deprecated
      */
     @Deprecated
-    private ResponseSpec findPetsByTagsRequestCreation(@jakarta.annotation.Nonnull Set<String> tags) throws RestClientResponseException {
+    private ResponseSpec findPetsByTagsRequestCreation(@jakarta.annotation.Nonnull Set<String> __tags) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'tags' is set
-        if (tags == null) {
+        if (__tags == null) {
             throw new RestClientResponseException("Missing the required parameter 'tags' when calling findPetsByTags", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -344,7 +344,7 @@ public class PetApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "tags", tags));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "tags", __tags));
 
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
@@ -406,20 +406,20 @@ public class PetApi {
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid ID supplied
      * <p><b>404</b> - Pet not found
-     * @param petId ID of pet to return
+     * @param __petId ID of pet to return
      * @return Pet
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec getPetByIdRequestCreation(@jakarta.annotation.Nonnull Long petId) throws RestClientResponseException {
+    private ResponseSpec getPetByIdRequestCreation(@jakarta.annotation.Nonnull Long __petId) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'petId' is set
-        if (petId == null) {
+        if (__petId == null) {
             throw new RestClientResponseException("Missing the required parameter 'petId' when calling getPetById", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("petId", petId);
+        pathParams.put("petId", __petId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -490,13 +490,13 @@ public class PetApi {
      * <p><b>400</b> - Invalid ID supplied
      * <p><b>404</b> - Pet not found
      * <p><b>405</b> - Validation exception
-     * @param pet Pet object that needs to be added to the store
+     * @param __pet Pet object that needs to be added to the store
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec updatePetRequestCreation(@jakarta.annotation.Nonnull Pet pet) throws RestClientResponseException {
-        Object postBody = pet;
+    private ResponseSpec updatePetRequestCreation(@jakarta.annotation.Nonnull Pet __pet) throws RestClientResponseException {
+        Object postBody = __pet;
         // verify the required parameter 'pet' is set
-        if (pet == null) {
+        if (__pet == null) {
             throw new RestClientResponseException("Missing the required parameter 'pet' when calling updatePet", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -609,31 +609,31 @@ public class PetApi {
      * 
      * <p><b>200</b> - Successful operation
      * <p><b>405</b> - Invalid input
-     * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param __petId ID of pet that needs to be updated
+     * @param __name Updated name of the pet
+     * @param __status Updated status of the pet
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec updatePetWithFormRequestCreation(@jakarta.annotation.Nonnull Long petId, @jakarta.annotation.Nullable String name, @jakarta.annotation.Nullable String status) throws RestClientResponseException {
+    private ResponseSpec updatePetWithFormRequestCreation(@jakarta.annotation.Nonnull Long __petId, @jakarta.annotation.Nullable String __name, @jakarta.annotation.Nullable String __status) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'petId' is set
-        if (petId == null) {
+        if (__petId == null) {
             throw new RestClientResponseException("Missing the required parameter 'petId' when calling updatePetWithForm", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("petId", petId);
+        pathParams.put("petId", __petId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (name != null)
-            formParams.add("name", name);
-        if (status != null)
-            formParams.add("status", status);
+        if (__name != null)
+            formParams.add("name", __name);
+        if (__status != null)
+            formParams.add("status", __status);
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -735,32 +735,32 @@ public class PetApi {
      * uploads an image
      * 
      * <p><b>200</b> - successful operation
-     * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param _file file to upload
+     * @param __petId ID of pet to update
+     * @param __additionalMetadata Additional data to pass to server
+     * @param ___file file to upload
      * @return ModelApiResponse
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec uploadFileRequestCreation(@jakarta.annotation.Nonnull Long petId, @jakarta.annotation.Nullable String additionalMetadata, @jakarta.annotation.Nullable File _file) throws RestClientResponseException {
+    private ResponseSpec uploadFileRequestCreation(@jakarta.annotation.Nonnull Long __petId, @jakarta.annotation.Nullable String __additionalMetadata, @jakarta.annotation.Nullable File ___file) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'petId' is set
-        if (petId == null) {
+        if (__petId == null) {
             throw new RestClientResponseException("Missing the required parameter 'petId' when calling uploadFile", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("petId", petId);
+        pathParams.put("petId", __petId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (additionalMetadata != null)
-            formParams.add("additionalMetadata", additionalMetadata);
-        if (_file != null)
-            formParams.add("file", new FileSystemResource(_file));
+        if (__additionalMetadata != null)
+            formParams.add("additionalMetadata", __additionalMetadata);
+        if (___file != null)
+            formParams.add("file", new FileSystemResource(___file));
 
         final String[] localVarAccepts = { 
             "application/json"
@@ -863,36 +863,36 @@ public class PetApi {
      * uploads an image (required)
      * 
      * <p><b>200</b> - successful operation
-     * @param petId ID of pet to update
-     * @param requiredFile file to upload
-     * @param additionalMetadata Additional data to pass to server
+     * @param __petId ID of pet to update
+     * @param __requiredFile file to upload
+     * @param __additionalMetadata Additional data to pass to server
      * @return ModelApiResponse
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec uploadFileWithRequiredFileRequestCreation(@jakarta.annotation.Nonnull Long petId, @jakarta.annotation.Nonnull File requiredFile, @jakarta.annotation.Nullable String additionalMetadata) throws RestClientResponseException {
+    private ResponseSpec uploadFileWithRequiredFileRequestCreation(@jakarta.annotation.Nonnull Long __petId, @jakarta.annotation.Nonnull File __requiredFile, @jakarta.annotation.Nullable String __additionalMetadata) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'petId' is set
-        if (petId == null) {
+        if (__petId == null) {
             throw new RestClientResponseException("Missing the required parameter 'petId' when calling uploadFileWithRequiredFile", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'requiredFile' is set
-        if (requiredFile == null) {
+        if (__requiredFile == null) {
             throw new RestClientResponseException("Missing the required parameter 'requiredFile' when calling uploadFileWithRequiredFile", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("petId", petId);
+        pathParams.put("petId", __petId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (additionalMetadata != null)
-            formParams.add("additionalMetadata", additionalMetadata);
-        if (requiredFile != null)
-            formParams.add("requiredFile", new FileSystemResource(requiredFile));
+        if (__additionalMetadata != null)
+            formParams.add("additionalMetadata", __additionalMetadata);
+        if (__requiredFile != null)
+            formParams.add("requiredFile", new FileSystemResource(__requiredFile));
 
         final String[] localVarAccepts = { 
             "application/json"

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -49,19 +49,19 @@ public class StoreApi {
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * <p><b>400</b> - Invalid ID supplied
      * <p><b>404</b> - Order not found
-     * @param orderId ID of the order that needs to be deleted
+     * @param __orderId ID of the order that needs to be deleted
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec deleteOrderRequestCreation(@jakarta.annotation.Nonnull String orderId) throws RestClientResponseException {
+    private ResponseSpec deleteOrderRequestCreation(@jakarta.annotation.Nonnull String __orderId) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'orderId' is set
-        if (orderId == null) {
+        if (__orderId == null) {
             throw new RestClientResponseException("Missing the required parameter 'orderId' when calling deleteOrder", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("order_id", orderId);
+        pathParams.put("order_id", __orderId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -189,20 +189,20 @@ public class StoreApi {
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid ID supplied
      * <p><b>404</b> - Order not found
-     * @param orderId ID of pet that needs to be fetched
+     * @param __orderId ID of pet that needs to be fetched
      * @return Order
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec getOrderByIdRequestCreation(@jakarta.annotation.Nonnull Long orderId) throws RestClientResponseException {
+    private ResponseSpec getOrderByIdRequestCreation(@jakarta.annotation.Nonnull Long __orderId) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'orderId' is set
-        if (orderId == null) {
+        if (__orderId == null) {
             throw new RestClientResponseException("Missing the required parameter 'orderId' when calling getOrderById", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("order_id", orderId);
+        pathParams.put("order_id", __orderId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -271,14 +271,14 @@ public class StoreApi {
      * 
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid Order
-     * @param order order placed for purchasing the pet
+     * @param __order order placed for purchasing the pet
      * @return Order
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec placeOrderRequestCreation(@jakarta.annotation.Nonnull Order order) throws RestClientResponseException {
-        Object postBody = order;
+    private ResponseSpec placeOrderRequestCreation(@jakarta.annotation.Nonnull Order __order) throws RestClientResponseException {
+        Object postBody = __order;
         // verify the required parameter 'order' is set
-        if (order == null) {
+        if (__order == null) {
             throw new RestClientResponseException("Missing the required parameter 'order' when calling placeOrder", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/UserApi.java
@@ -49,13 +49,13 @@ public class UserApi {
      * Create user
      * This can only be done by the logged in user.
      * <p><b>0</b> - successful operation
-     * @param user Created user object
+     * @param __user Created user object
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec createUserRequestCreation(@jakarta.annotation.Nonnull User user) throws RestClientResponseException {
-        Object postBody = user;
+    private ResponseSpec createUserRequestCreation(@jakarta.annotation.Nonnull User __user) throws RestClientResponseException {
+        Object postBody = __user;
         // verify the required parameter 'user' is set
-        if (user == null) {
+        if (__user == null) {
             throw new RestClientResponseException("Missing the required parameter 'user' when calling createUser", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -119,13 +119,13 @@ public class UserApi {
      * Creates list of users with given input array
      * 
      * <p><b>0</b> - successful operation
-     * @param user List of user object
+     * @param __user List of user object
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec createUsersWithArrayInputRequestCreation(@jakarta.annotation.Nonnull List<User> user) throws RestClientResponseException {
-        Object postBody = user;
+    private ResponseSpec createUsersWithArrayInputRequestCreation(@jakarta.annotation.Nonnull List<User> __user) throws RestClientResponseException {
+        Object postBody = __user;
         // verify the required parameter 'user' is set
-        if (user == null) {
+        if (__user == null) {
             throw new RestClientResponseException("Missing the required parameter 'user' when calling createUsersWithArrayInput", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -189,13 +189,13 @@ public class UserApi {
      * Creates list of users with given input array
      * 
      * <p><b>0</b> - successful operation
-     * @param user List of user object
+     * @param __user List of user object
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec createUsersWithListInputRequestCreation(@jakarta.annotation.Nonnull List<User> user) throws RestClientResponseException {
-        Object postBody = user;
+    private ResponseSpec createUsersWithListInputRequestCreation(@jakarta.annotation.Nonnull List<User> __user) throws RestClientResponseException {
+        Object postBody = __user;
         // verify the required parameter 'user' is set
-        if (user == null) {
+        if (__user == null) {
             throw new RestClientResponseException("Missing the required parameter 'user' when calling createUsersWithListInput", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -260,19 +260,19 @@ public class UserApi {
      * This can only be done by the logged in user.
      * <p><b>400</b> - Invalid username supplied
      * <p><b>404</b> - User not found
-     * @param username The name that needs to be deleted
+     * @param __username The name that needs to be deleted
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec deleteUserRequestCreation(@jakarta.annotation.Nonnull String username) throws RestClientResponseException {
+    private ResponseSpec deleteUserRequestCreation(@jakarta.annotation.Nonnull String __username) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'username' is set
-        if (username == null) {
+        if (__username == null) {
             throw new RestClientResponseException("Missing the required parameter 'username' when calling deleteUser", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("username", username);
+        pathParams.put("username", __username);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -335,20 +335,20 @@ public class UserApi {
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid username supplied
      * <p><b>404</b> - User not found
-     * @param username The name that needs to be fetched. Use user1 for testing.
+     * @param __username The name that needs to be fetched. Use user1 for testing.
      * @return User
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec getUserByNameRequestCreation(@jakarta.annotation.Nonnull String username) throws RestClientResponseException {
+    private ResponseSpec getUserByNameRequestCreation(@jakarta.annotation.Nonnull String __username) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'username' is set
-        if (username == null) {
+        if (__username == null) {
             throw new RestClientResponseException("Missing the required parameter 'username' when calling getUserByName", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("username", username);
+        pathParams.put("username", __username);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -458,19 +458,19 @@ public class UserApi {
      * 
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid username/password supplied
-     * @param username The user name for login
-     * @param password The password for login in clear text
+     * @param __username The user name for login
+     * @param __password The password for login in clear text
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec loginUserRequestCreation(@jakarta.annotation.Nonnull String username, @jakarta.annotation.Nonnull String password) throws RestClientResponseException {
+    private ResponseSpec loginUserRequestCreation(@jakarta.annotation.Nonnull String __username, @jakarta.annotation.Nonnull String __password) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'username' is set
-        if (username == null) {
+        if (__username == null) {
             throw new RestClientResponseException("Missing the required parameter 'username' when calling loginUser", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'password' is set
-        if (password == null) {
+        if (__password == null) {
             throw new RestClientResponseException("Missing the required parameter 'password' when calling loginUser", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -481,8 +481,8 @@ public class UserApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "username", username));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "password", password));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "username", __username));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "password", __password));
 
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
@@ -645,24 +645,24 @@ public class UserApi {
      * This can only be done by the logged in user.
      * <p><b>400</b> - Invalid user supplied
      * <p><b>404</b> - User not found
-     * @param username name that need to be deleted
-     * @param user Updated user object
+     * @param __username name that need to be deleted
+     * @param __user Updated user object
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec updateUserRequestCreation(@jakarta.annotation.Nonnull String username, @jakarta.annotation.Nonnull User user) throws RestClientResponseException {
-        Object postBody = user;
+    private ResponseSpec updateUserRequestCreation(@jakarta.annotation.Nonnull String __username, @jakarta.annotation.Nonnull User __user) throws RestClientResponseException {
+        Object postBody = __user;
         // verify the required parameter 'username' is set
-        if (username == null) {
+        if (__username == null) {
             throw new RestClientResponseException("Missing the required parameter 'username' when calling updateUser", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'user' is set
-        if (user == null) {
+        if (__user == null) {
             throw new RestClientResponseException("Missing the required parameter 'user' when calling updateUser", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("username", username);
+        pathParams.put("username", __username);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -48,14 +48,14 @@ public class AnotherFakeApi {
      * To test special tags
      * To test special tags and operation ID starting with number
      * <p><b>200</b> - successful operation
-     * @param client client model
+     * @param __client client model
      * @return Client
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec call123testSpecialTagsRequestCreation(@jakarta.annotation.Nonnull Client client) throws RestClientResponseException {
-        Object postBody = client;
+    private ResponseSpec call123testSpecialTagsRequestCreation(@jakarta.annotation.Nonnull Client __client) throws RestClientResponseException {
+        Object postBody = __client;
         // verify the required parameter 'client' is set
-        if (client == null) {
+        if (__client == null) {
             throw new RestClientResponseException("Missing the required parameter 'client' when calling call123testSpecialTags", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -192,15 +192,15 @@ public class FakeApi {
      * test http signature authentication
      * 
      * <p><b>200</b> - The instance started successfully
-     * @param pet Pet object that needs to be added to the store
-     * @param query1 query parameter
-     * @param header1 header parameter
+     * @param __pet Pet object that needs to be added to the store
+     * @param __query1 query parameter
+     * @param __header1 header parameter
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fakeHttpSignatureTestRequestCreation(@jakarta.annotation.Nonnull Pet pet, @jakarta.annotation.Nullable String query1, @jakarta.annotation.Nullable String header1) throws RestClientResponseException {
-        Object postBody = pet;
+    private ResponseSpec fakeHttpSignatureTestRequestCreation(@jakarta.annotation.Nonnull Pet __pet, @jakarta.annotation.Nullable String __query1, @jakarta.annotation.Nullable String __header1) throws RestClientResponseException {
+        Object postBody = __pet;
         // verify the required parameter 'pet' is set
-        if (pet == null) {
+        if (__pet == null) {
             throw new RestClientResponseException("Missing the required parameter 'pet' when calling fakeHttpSignatureTest", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -211,10 +211,10 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query_1", query1));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query_1", __query1));
 
-        if (header1 != null)
-        headerParams.add("header_1", apiClient.parameterToString(header1));
+        if (__header1 != null)
+        headerParams.add("header_1", apiClient.parameterToString(__header1));
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { 
@@ -274,12 +274,12 @@ public class FakeApi {
      * 
      * Test serialization of outer boolean types
      * <p><b>200</b> - Output boolean
-     * @param body Input boolean as post body
+     * @param __body Input boolean as post body
      * @return Boolean
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fakeOuterBooleanSerializeRequestCreation(@jakarta.annotation.Nullable Boolean body) throws RestClientResponseException {
-        Object postBody = body;
+    private ResponseSpec fakeOuterBooleanSerializeRequestCreation(@jakarta.annotation.Nullable Boolean __body) throws RestClientResponseException {
+        Object postBody = __body;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
@@ -345,12 +345,12 @@ public class FakeApi {
      * 
      * Test serialization of object with outer number type
      * <p><b>200</b> - Output composite
-     * @param outerComposite Input composite as post body
+     * @param __outerComposite Input composite as post body
      * @return OuterComposite
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fakeOuterCompositeSerializeRequestCreation(@jakarta.annotation.Nullable OuterComposite outerComposite) throws RestClientResponseException {
-        Object postBody = outerComposite;
+    private ResponseSpec fakeOuterCompositeSerializeRequestCreation(@jakarta.annotation.Nullable OuterComposite __outerComposite) throws RestClientResponseException {
+        Object postBody = __outerComposite;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
@@ -416,12 +416,12 @@ public class FakeApi {
      * 
      * Test serialization of outer number types
      * <p><b>200</b> - Output number
-     * @param body Input number as post body
+     * @param __body Input number as post body
      * @return BigDecimal
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fakeOuterNumberSerializeRequestCreation(@jakarta.annotation.Nullable BigDecimal body) throws RestClientResponseException {
-        Object postBody = body;
+    private ResponseSpec fakeOuterNumberSerializeRequestCreation(@jakarta.annotation.Nullable BigDecimal __body) throws RestClientResponseException {
+        Object postBody = __body;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
@@ -487,12 +487,12 @@ public class FakeApi {
      * 
      * Test serialization of outer string types
      * <p><b>200</b> - Output string
-     * @param body Input string as post body
+     * @param __body Input string as post body
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fakeOuterStringSerializeRequestCreation(@jakarta.annotation.Nullable String body) throws RestClientResponseException {
-        Object postBody = body;
+    private ResponseSpec fakeOuterStringSerializeRequestCreation(@jakarta.annotation.Nullable String __body) throws RestClientResponseException {
+        Object postBody = __body;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
@@ -558,14 +558,14 @@ public class FakeApi {
      * 
      * Test serialization of enum (int) properties with examples
      * <p><b>200</b> - Output enum (int)
-     * @param outerObjectWithEnumProperty Input enum (int) as post body
+     * @param __outerObjectWithEnumProperty Input enum (int) as post body
      * @return OuterObjectWithEnumProperty
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec fakePropertyEnumIntegerSerializeRequestCreation(@jakarta.annotation.Nonnull OuterObjectWithEnumProperty outerObjectWithEnumProperty) throws RestClientResponseException {
-        Object postBody = outerObjectWithEnumProperty;
+    private ResponseSpec fakePropertyEnumIntegerSerializeRequestCreation(@jakarta.annotation.Nonnull OuterObjectWithEnumProperty __outerObjectWithEnumProperty) throws RestClientResponseException {
+        Object postBody = __outerObjectWithEnumProperty;
         // verify the required parameter 'outerObjectWithEnumProperty' is set
-        if (outerObjectWithEnumProperty == null) {
+        if (__outerObjectWithEnumProperty == null) {
             throw new RestClientResponseException("Missing the required parameter 'outerObjectWithEnumProperty' when calling fakePropertyEnumIntegerSerialize", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -633,13 +633,13 @@ public class FakeApi {
      * test referenced additionalProperties
      * 
      * <p><b>200</b> - successful operation
-     * @param requestBody request body
+     * @param __requestBody request body
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testAdditionalPropertiesReferenceRequestCreation(@jakarta.annotation.Nonnull Map<String, Object> requestBody) throws RestClientResponseException {
-        Object postBody = requestBody;
+    private ResponseSpec testAdditionalPropertiesReferenceRequestCreation(@jakarta.annotation.Nonnull Map<String, Object> __requestBody) throws RestClientResponseException {
+        Object postBody = __requestBody;
         // verify the required parameter 'requestBody' is set
-        if (requestBody == null) {
+        if (__requestBody == null) {
             throw new RestClientResponseException("Missing the required parameter 'requestBody' when calling testAdditionalPropertiesReference", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -703,13 +703,13 @@ public class FakeApi {
      * 
      * For this test, the body has to be a binary file.
      * <p><b>200</b> - Success
-     * @param body image to upload
+     * @param __body image to upload
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testBodyWithBinaryRequestCreation(@jakarta.annotation.Nullable File body) throws RestClientResponseException {
-        Object postBody = body;
+    private ResponseSpec testBodyWithBinaryRequestCreation(@jakarta.annotation.Nullable File __body) throws RestClientResponseException {
+        Object postBody = __body;
         // verify the required parameter 'body' is set
-        if (body == null) {
+        if (__body == null) {
             throw new RestClientResponseException("Missing the required parameter 'body' when calling testBodyWithBinary", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -773,13 +773,13 @@ public class FakeApi {
      * 
      * For this test, the body for this request must reference a schema named &#x60;File&#x60;.
      * <p><b>200</b> - Success
-     * @param fileSchemaTestClass The fileSchemaTestClass parameter
+     * @param __fileSchemaTestClass The fileSchemaTestClass parameter
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testBodyWithFileSchemaRequestCreation(@jakarta.annotation.Nonnull FileSchemaTestClass fileSchemaTestClass) throws RestClientResponseException {
-        Object postBody = fileSchemaTestClass;
+    private ResponseSpec testBodyWithFileSchemaRequestCreation(@jakarta.annotation.Nonnull FileSchemaTestClass __fileSchemaTestClass) throws RestClientResponseException {
+        Object postBody = __fileSchemaTestClass;
         // verify the required parameter 'fileSchemaTestClass' is set
-        if (fileSchemaTestClass == null) {
+        if (__fileSchemaTestClass == null) {
             throw new RestClientResponseException("Missing the required parameter 'fileSchemaTestClass' when calling testBodyWithFileSchema", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -843,18 +843,18 @@ public class FakeApi {
      * 
      * 
      * <p><b>200</b> - Success
-     * @param query The query parameter
-     * @param user The user parameter
+     * @param __query The query parameter
+     * @param __user The user parameter
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testBodyWithQueryParamsRequestCreation(@jakarta.annotation.Nonnull String query, @jakarta.annotation.Nonnull User user) throws RestClientResponseException {
-        Object postBody = user;
+    private ResponseSpec testBodyWithQueryParamsRequestCreation(@jakarta.annotation.Nonnull String __query, @jakarta.annotation.Nonnull User __user) throws RestClientResponseException {
+        Object postBody = __user;
         // verify the required parameter 'query' is set
-        if (query == null) {
+        if (__query == null) {
             throw new RestClientResponseException("Missing the required parameter 'query' when calling testBodyWithQueryParams", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'user' is set
-        if (user == null) {
+        if (__user == null) {
             throw new RestClientResponseException("Missing the required parameter 'user' when calling testBodyWithQueryParams", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -865,7 +865,7 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query", query));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query", __query));
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -923,14 +923,14 @@ public class FakeApi {
      * To test \&quot;client\&quot; model
      * To test \&quot;client\&quot; model
      * <p><b>200</b> - successful operation
-     * @param client client model
+     * @param __client client model
      * @return Client
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testClientModelRequestCreation(@jakarta.annotation.Nonnull Client client) throws RestClientResponseException {
-        Object postBody = client;
+    private ResponseSpec testClientModelRequestCreation(@jakarta.annotation.Nonnull Client __client) throws RestClientResponseException {
+        Object postBody = __client;
         // verify the required parameter 'client' is set
-        if (client == null) {
+        if (__client == null) {
             throw new RestClientResponseException("Missing the required parameter 'client' when calling testClientModel", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -999,38 +999,38 @@ public class FakeApi {
      * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
      * <p><b>400</b> - Invalid username supplied
      * <p><b>404</b> - User not found
-     * @param number None
-     * @param _double None
-     * @param patternWithoutDelimiter None
-     * @param _byte None
-     * @param integer None
-     * @param int32 None
-     * @param int64 None
-     * @param _float None
-     * @param string None
-     * @param binary None
-     * @param date None
-     * @param dateTime None
-     * @param password None
-     * @param paramCallback None
+     * @param __number None
+     * @param ___double None
+     * @param __patternWithoutDelimiter None
+     * @param ___byte None
+     * @param __integer None
+     * @param __int32 None
+     * @param __int64 None
+     * @param ___float None
+     * @param __string None
+     * @param __binary None
+     * @param __date None
+     * @param __dateTime None
+     * @param __password None
+     * @param __paramCallback None
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testEndpointParametersRequestCreation(@jakarta.annotation.Nonnull BigDecimal number, @jakarta.annotation.Nonnull Double _double, @jakarta.annotation.Nonnull String patternWithoutDelimiter, @jakarta.annotation.Nonnull byte[] _byte, @jakarta.annotation.Nullable Integer integer, @jakarta.annotation.Nullable Integer int32, @jakarta.annotation.Nullable Long int64, @jakarta.annotation.Nullable Float _float, @jakarta.annotation.Nullable String string, @jakarta.annotation.Nullable File binary, @jakarta.annotation.Nullable LocalDate date, @jakarta.annotation.Nullable OffsetDateTime dateTime, @jakarta.annotation.Nullable String password, @jakarta.annotation.Nullable String paramCallback) throws RestClientResponseException {
+    private ResponseSpec testEndpointParametersRequestCreation(@jakarta.annotation.Nonnull BigDecimal __number, @jakarta.annotation.Nonnull Double ___double, @jakarta.annotation.Nonnull String __patternWithoutDelimiter, @jakarta.annotation.Nonnull byte[] ___byte, @jakarta.annotation.Nullable Integer __integer, @jakarta.annotation.Nullable Integer __int32, @jakarta.annotation.Nullable Long __int64, @jakarta.annotation.Nullable Float ___float, @jakarta.annotation.Nullable String __string, @jakarta.annotation.Nullable File __binary, @jakarta.annotation.Nullable LocalDate __date, @jakarta.annotation.Nullable OffsetDateTime __dateTime, @jakarta.annotation.Nullable String __password, @jakarta.annotation.Nullable String __paramCallback) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'number' is set
-        if (number == null) {
+        if (__number == null) {
             throw new RestClientResponseException("Missing the required parameter 'number' when calling testEndpointParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter '_double' is set
-        if (_double == null) {
+        if (___double == null) {
             throw new RestClientResponseException("Missing the required parameter '_double' when calling testEndpointParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'patternWithoutDelimiter' is set
-        if (patternWithoutDelimiter == null) {
+        if (__patternWithoutDelimiter == null) {
             throw new RestClientResponseException("Missing the required parameter 'patternWithoutDelimiter' when calling testEndpointParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter '_byte' is set
-        if (_byte == null) {
+        if (___byte == null) {
             throw new RestClientResponseException("Missing the required parameter '_byte' when calling testEndpointParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1041,34 +1041,34 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (integer != null)
-            formParams.add("integer", integer);
-        if (int32 != null)
-            formParams.add("int32", int32);
-        if (int64 != null)
-            formParams.add("int64", int64);
-        if (number != null)
-            formParams.add("number", number);
-        if (_float != null)
-            formParams.add("float", _float);
-        if (_double != null)
-            formParams.add("double", _double);
-        if (string != null)
-            formParams.add("string", string);
-        if (patternWithoutDelimiter != null)
-            formParams.add("pattern_without_delimiter", patternWithoutDelimiter);
-        if (_byte != null)
-            formParams.add("byte", _byte);
-        if (binary != null)
-            formParams.add("binary", new FileSystemResource(binary));
-        if (date != null)
-            formParams.add("date", date);
-        if (dateTime != null)
-            formParams.add("dateTime", dateTime);
-        if (password != null)
-            formParams.add("password", password);
-        if (paramCallback != null)
-            formParams.add("callback", paramCallback);
+        if (__integer != null)
+            formParams.add("integer", __integer);
+        if (__int32 != null)
+            formParams.add("int32", __int32);
+        if (__int64 != null)
+            formParams.add("int64", __int64);
+        if (__number != null)
+            formParams.add("number", __number);
+        if (___float != null)
+            formParams.add("float", ___float);
+        if (___double != null)
+            formParams.add("double", ___double);
+        if (__string != null)
+            formParams.add("string", __string);
+        if (__patternWithoutDelimiter != null)
+            formParams.add("pattern_without_delimiter", __patternWithoutDelimiter);
+        if (___byte != null)
+            formParams.add("byte", ___byte);
+        if (__binary != null)
+            formParams.add("binary", new FileSystemResource(__binary));
+        if (__date != null)
+            formParams.add("date", __date);
+        if (__dateTime != null)
+            formParams.add("dateTime", __dateTime);
+        if (__password != null)
+            formParams.add("password", __password);
+        if (__paramCallback != null)
+            formParams.add("callback", __paramCallback);
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -1166,18 +1166,18 @@ public class FakeApi {
      * To test enum parameters
      * <p><b>400</b> - Invalid request
      * <p><b>404</b> - Not found
-     * @param enumHeaderStringArray Header parameter enum test (string array)
-     * @param enumHeaderString Header parameter enum test (string)
-     * @param enumQueryStringArray Query parameter enum test (string array)
-     * @param enumQueryString Query parameter enum test (string)
-     * @param enumQueryInteger Query parameter enum test (double)
-     * @param enumQueryDouble Query parameter enum test (double)
-     * @param enumQueryModelArray The enumQueryModelArray parameter
-     * @param enumFormStringArray Form parameter enum test (string array)
-     * @param enumFormString Form parameter enum test (string)
+     * @param __enumHeaderStringArray Header parameter enum test (string array)
+     * @param __enumHeaderString Header parameter enum test (string)
+     * @param __enumQueryStringArray Query parameter enum test (string array)
+     * @param __enumQueryString Query parameter enum test (string)
+     * @param __enumQueryInteger Query parameter enum test (double)
+     * @param __enumQueryDouble Query parameter enum test (double)
+     * @param __enumQueryModelArray The enumQueryModelArray parameter
+     * @param __enumFormStringArray Form parameter enum test (string array)
+     * @param __enumFormString Form parameter enum test (string)
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testEnumParametersRequestCreation(@jakarta.annotation.Nullable List<String> enumHeaderStringArray, @jakarta.annotation.Nullable String enumHeaderString, @jakarta.annotation.Nullable List<String> enumQueryStringArray, @jakarta.annotation.Nullable String enumQueryString, @jakarta.annotation.Nullable Integer enumQueryInteger, @jakarta.annotation.Nullable Double enumQueryDouble, @jakarta.annotation.Nullable List<EnumClass> enumQueryModelArray, @jakarta.annotation.Nullable List<String> enumFormStringArray, @jakarta.annotation.Nullable String enumFormString) throws RestClientResponseException {
+    private ResponseSpec testEnumParametersRequestCreation(@jakarta.annotation.Nullable List<String> __enumHeaderStringArray, @jakarta.annotation.Nullable String __enumHeaderString, @jakarta.annotation.Nullable List<String> __enumQueryStringArray, @jakarta.annotation.Nullable String __enumQueryString, @jakarta.annotation.Nullable Integer __enumQueryInteger, @jakarta.annotation.Nullable Double __enumQueryDouble, @jakarta.annotation.Nullable List<EnumClass> __enumQueryModelArray, @jakarta.annotation.Nullable List<String> __enumFormStringArray, @jakarta.annotation.Nullable String __enumFormString) throws RestClientResponseException {
         Object postBody = null;
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
@@ -1187,20 +1187,20 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "enum_query_string_array", enumQueryStringArray));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_string", enumQueryString));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_integer", enumQueryInteger));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_double", enumQueryDouble));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "enum_query_model_array", enumQueryModelArray));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "enum_query_string_array", __enumQueryStringArray));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_string", __enumQueryString));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_integer", __enumQueryInteger));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_double", __enumQueryDouble));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "enum_query_model_array", __enumQueryModelArray));
 
-        if (enumHeaderStringArray != null)
-        headerParams.add("enum_header_string_array", apiClient.parameterToString(enumHeaderStringArray));
-        if (enumHeaderString != null)
-        headerParams.add("enum_header_string", apiClient.parameterToString(enumHeaderString));
-        if (enumFormStringArray != null)
-            formParams.addAll("enum_form_string_array", enumFormStringArray);
-        if (enumFormString != null)
-            formParams.add("enum_form_string", enumFormString);
+        if (__enumHeaderStringArray != null)
+        headerParams.add("enum_header_string_array", apiClient.parameterToString(__enumHeaderStringArray));
+        if (__enumHeaderString != null)
+        headerParams.add("enum_header_string", apiClient.parameterToString(__enumHeaderString));
+        if (__enumFormStringArray != null)
+            formParams.addAll("enum_form_string_array", __enumFormStringArray);
+        if (__enumFormString != null)
+            formParams.add("enum_form_string", __enumFormString);
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -1282,26 +1282,26 @@ public class FakeApi {
      * Fake endpoint to test group parameters (optional)
      * Fake endpoint to test group parameters (optional)
      * <p><b>400</b> - Something wrong
-     * @param requiredStringGroup Required String in group parameters
-     * @param requiredBooleanGroup Required Boolean in group parameters
-     * @param requiredInt64Group Required Integer in group parameters
-     * @param stringGroup String in group parameters
-     * @param booleanGroup Boolean in group parameters
-     * @param int64Group Integer in group parameters
+     * @param __requiredStringGroup Required String in group parameters
+     * @param __requiredBooleanGroup Required Boolean in group parameters
+     * @param __requiredInt64Group Required Integer in group parameters
+     * @param __stringGroup String in group parameters
+     * @param __booleanGroup Boolean in group parameters
+     * @param __int64Group Integer in group parameters
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testGroupParametersRequestCreation(@jakarta.annotation.Nonnull Integer requiredStringGroup, @jakarta.annotation.Nonnull Boolean requiredBooleanGroup, @jakarta.annotation.Nonnull Long requiredInt64Group, @jakarta.annotation.Nullable Integer stringGroup, @jakarta.annotation.Nullable Boolean booleanGroup, @jakarta.annotation.Nullable Long int64Group) throws RestClientResponseException {
+    private ResponseSpec testGroupParametersRequestCreation(@jakarta.annotation.Nonnull Integer __requiredStringGroup, @jakarta.annotation.Nonnull Boolean __requiredBooleanGroup, @jakarta.annotation.Nonnull Long __requiredInt64Group, @jakarta.annotation.Nullable Integer __stringGroup, @jakarta.annotation.Nullable Boolean __booleanGroup, @jakarta.annotation.Nullable Long __int64Group) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'requiredStringGroup' is set
-        if (requiredStringGroup == null) {
+        if (__requiredStringGroup == null) {
             throw new RestClientResponseException("Missing the required parameter 'requiredStringGroup' when calling testGroupParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'requiredBooleanGroup' is set
-        if (requiredBooleanGroup == null) {
+        if (__requiredBooleanGroup == null) {
             throw new RestClientResponseException("Missing the required parameter 'requiredBooleanGroup' when calling testGroupParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'requiredInt64Group' is set
-        if (requiredInt64Group == null) {
+        if (__requiredInt64Group == null) {
             throw new RestClientResponseException("Missing the required parameter 'requiredInt64Group' when calling testGroupParameters", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1312,15 +1312,15 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_string_group", requiredStringGroup));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_int64_group", requiredInt64Group));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "string_group", stringGroup));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "int64_group", int64Group));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_string_group", __requiredStringGroup));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_int64_group", __requiredInt64Group));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "string_group", __stringGroup));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "int64_group", __int64Group));
 
-        if (requiredBooleanGroup != null)
-        headerParams.add("required_boolean_group", apiClient.parameterToString(requiredBooleanGroup));
-        if (booleanGroup != null)
-        headerParams.add("boolean_group", apiClient.parameterToString(booleanGroup));
+        if (__requiredBooleanGroup != null)
+        headerParams.add("required_boolean_group", apiClient.parameterToString(__requiredBooleanGroup));
+        if (__booleanGroup != null)
+        headerParams.add("boolean_group", apiClient.parameterToString(__booleanGroup));
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { };
@@ -1387,13 +1387,13 @@ public class FakeApi {
      * test inline additionalProperties
      * 
      * <p><b>200</b> - successful operation
-     * @param requestBody request body
+     * @param __requestBody request body
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testInlineAdditionalPropertiesRequestCreation(@jakarta.annotation.Nonnull Map<String, String> requestBody) throws RestClientResponseException {
-        Object postBody = requestBody;
+    private ResponseSpec testInlineAdditionalPropertiesRequestCreation(@jakarta.annotation.Nonnull Map<String, String> __requestBody) throws RestClientResponseException {
+        Object postBody = __requestBody;
         // verify the required parameter 'requestBody' is set
-        if (requestBody == null) {
+        if (__requestBody == null) {
             throw new RestClientResponseException("Missing the required parameter 'requestBody' when calling testInlineAdditionalProperties", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1457,13 +1457,13 @@ public class FakeApi {
      * test inline free-form additionalProperties
      * 
      * <p><b>200</b> - successful operation
-     * @param testInlineFreeformAdditionalPropertiesRequest request body
+     * @param __testInlineFreeformAdditionalPropertiesRequest request body
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testInlineFreeformAdditionalPropertiesRequestCreation(@jakarta.annotation.Nonnull TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest) throws RestClientResponseException {
-        Object postBody = testInlineFreeformAdditionalPropertiesRequest;
+    private ResponseSpec testInlineFreeformAdditionalPropertiesRequestCreation(@jakarta.annotation.Nonnull TestInlineFreeformAdditionalPropertiesRequest __testInlineFreeformAdditionalPropertiesRequest) throws RestClientResponseException {
+        Object postBody = __testInlineFreeformAdditionalPropertiesRequest;
         // verify the required parameter 'testInlineFreeformAdditionalPropertiesRequest' is set
-        if (testInlineFreeformAdditionalPropertiesRequest == null) {
+        if (__testInlineFreeformAdditionalPropertiesRequest == null) {
             throw new RestClientResponseException("Missing the required parameter 'testInlineFreeformAdditionalPropertiesRequest' when calling testInlineFreeformAdditionalProperties", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1527,18 +1527,18 @@ public class FakeApi {
      * test json serialization of form data
      * 
      * <p><b>200</b> - successful operation
-     * @param param field1
-     * @param param2 field2
+     * @param __param field1
+     * @param __param2 field2
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testJsonFormDataRequestCreation(@jakarta.annotation.Nonnull String param, @jakarta.annotation.Nonnull String param2) throws RestClientResponseException {
+    private ResponseSpec testJsonFormDataRequestCreation(@jakarta.annotation.Nonnull String __param, @jakarta.annotation.Nonnull String __param2) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'param' is set
-        if (param == null) {
+        if (__param == null) {
             throw new RestClientResponseException("Missing the required parameter 'param' when calling testJsonFormData", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'param2' is set
-        if (param2 == null) {
+        if (__param2 == null) {
             throw new RestClientResponseException("Missing the required parameter 'param2' when calling testJsonFormData", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1549,10 +1549,10 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (param != null)
-            formParams.add("param", param);
-        if (param2 != null)
-            formParams.add("param2", param2);
+        if (__param != null)
+            formParams.add("param", __param);
+        if (__param2 != null)
+            formParams.add("param2", __param2);
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -1610,13 +1610,13 @@ public class FakeApi {
      * test nullable parent property
      * 
      * <p><b>200</b> - successful operation
-     * @param childWithNullable request body
+     * @param __childWithNullable request body
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testNullableRequestCreation(@jakarta.annotation.Nonnull ChildWithNullable childWithNullable) throws RestClientResponseException {
-        Object postBody = childWithNullable;
+    private ResponseSpec testNullableRequestCreation(@jakarta.annotation.Nonnull ChildWithNullable __childWithNullable) throws RestClientResponseException {
+        Object postBody = __childWithNullable;
         // verify the required parameter 'childWithNullable' is set
-        if (childWithNullable == null) {
+        if (__childWithNullable == null) {
             throw new RestClientResponseException("Missing the required parameter 'childWithNullable' when calling testNullable", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1680,39 +1680,39 @@ public class FakeApi {
      * 
      * To test the collection format in query parameters
      * <p><b>200</b> - Success
-     * @param pipe The pipe parameter
-     * @param ioutil The ioutil parameter
-     * @param http The http parameter
-     * @param url The url parameter
-     * @param context The context parameter
-     * @param allowEmpty The allowEmpty parameter
-     * @param language The language parameter
+     * @param __pipe The pipe parameter
+     * @param __ioutil The ioutil parameter
+     * @param __http The http parameter
+     * @param __url The url parameter
+     * @param __context The context parameter
+     * @param __allowEmpty The allowEmpty parameter
+     * @param __language The language parameter
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testQueryParameterCollectionFormatRequestCreation(@jakarta.annotation.Nonnull List<String> pipe, @jakarta.annotation.Nonnull List<String> ioutil, @jakarta.annotation.Nonnull List<String> http, @jakarta.annotation.Nonnull List<String> url, @jakarta.annotation.Nonnull List<String> context, @jakarta.annotation.Nonnull String allowEmpty, @jakarta.annotation.Nullable Map<String, String> language) throws RestClientResponseException {
+    private ResponseSpec testQueryParameterCollectionFormatRequestCreation(@jakarta.annotation.Nonnull List<String> __pipe, @jakarta.annotation.Nonnull List<String> __ioutil, @jakarta.annotation.Nonnull List<String> __http, @jakarta.annotation.Nonnull List<String> __url, @jakarta.annotation.Nonnull List<String> __context, @jakarta.annotation.Nonnull String __allowEmpty, @jakarta.annotation.Nullable Map<String, String> __language) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'pipe' is set
-        if (pipe == null) {
+        if (__pipe == null) {
             throw new RestClientResponseException("Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'ioutil' is set
-        if (ioutil == null) {
+        if (__ioutil == null) {
             throw new RestClientResponseException("Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'http' is set
-        if (http == null) {
+        if (__http == null) {
             throw new RestClientResponseException("Missing the required parameter 'http' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'url' is set
-        if (url == null) {
+        if (__url == null) {
             throw new RestClientResponseException("Missing the required parameter 'url' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'context' is set
-        if (context == null) {
+        if (__context == null) {
             throw new RestClientResponseException("Missing the required parameter 'context' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'allowEmpty' is set
-        if (allowEmpty == null) {
+        if (__allowEmpty == null) {
             throw new RestClientResponseException("Missing the required parameter 'allowEmpty' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -1723,13 +1723,13 @@ public class FakeApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("pipes".toUpperCase(Locale.ROOT)), "pipe", pipe));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "ioutil", ioutil));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("ssv".toUpperCase(Locale.ROOT)), "http", http));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "url", url));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "context", context));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "language", language));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "allowEmpty", allowEmpty));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("pipes".toUpperCase(Locale.ROOT)), "pipe", __pipe));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "ioutil", __ioutil));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("ssv".toUpperCase(Locale.ROOT)), "http", __http));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "url", __url));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "context", __context));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "language", __language));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "allowEmpty", __allowEmpty));
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -1800,13 +1800,13 @@ public class FakeApi {
      * test referenced string map
      * 
      * <p><b>200</b> - successful operation
-     * @param requestBody request body
+     * @param __requestBody request body
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testStringMapReferenceRequestCreation(@jakarta.annotation.Nonnull Map<String, String> requestBody) throws RestClientResponseException {
-        Object postBody = requestBody;
+    private ResponseSpec testStringMapReferenceRequestCreation(@jakarta.annotation.Nonnull Map<String, String> __requestBody) throws RestClientResponseException {
+        Object postBody = __requestBody;
         // verify the required parameter 'requestBody' is set
-        if (requestBody == null) {
+        if (__requestBody == null) {
             throw new RestClientResponseException("Missing the required parameter 'requestBody' when calling testStringMapReference", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -48,14 +48,14 @@ public class FakeClassnameTags123Api {
      * To test class name in snake case
      * To test class name in snake case
      * <p><b>200</b> - successful operation
-     * @param client client model
+     * @param __client client model
      * @return Client
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testClassnameRequestCreation(@jakarta.annotation.Nonnull Client client) throws RestClientResponseException {
-        Object postBody = client;
+    private ResponseSpec testClassnameRequestCreation(@jakarta.annotation.Nonnull Client __client) throws RestClientResponseException {
+        Object postBody = __client;
         // verify the required parameter 'client' is set
-        if (client == null) {
+        if (__client == null) {
             throw new RestClientResponseException("Missing the required parameter 'client' when calling testClassname", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/PetApi.java
@@ -52,13 +52,13 @@ public class PetApi {
      * 
      * <p><b>200</b> - Successful operation
      * <p><b>405</b> - Invalid input
-     * @param pet Pet object that needs to be added to the store
+     * @param __pet Pet object that needs to be added to the store
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec addPetRequestCreation(@jakarta.annotation.Nonnull Pet pet) throws RestClientResponseException {
-        Object postBody = pet;
+    private ResponseSpec addPetRequestCreation(@jakarta.annotation.Nonnull Pet __pet) throws RestClientResponseException {
+        Object postBody = __pet;
         // verify the required parameter 'pet' is set
-        if (pet == null) {
+        if (__pet == null) {
             throw new RestClientResponseException("Missing the required parameter 'pet' when calling addPet", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -126,28 +126,28 @@ public class PetApi {
      * 
      * <p><b>200</b> - Successful operation
      * <p><b>400</b> - Invalid pet value
-     * @param petId Pet id to delete
-     * @param apiKey The apiKey parameter
+     * @param __petId Pet id to delete
+     * @param __apiKey The apiKey parameter
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec deletePetRequestCreation(@jakarta.annotation.Nonnull Long petId, @jakarta.annotation.Nullable String apiKey) throws RestClientResponseException {
+    private ResponseSpec deletePetRequestCreation(@jakarta.annotation.Nonnull Long __petId, @jakarta.annotation.Nullable String __apiKey) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'petId' is set
-        if (petId == null) {
+        if (__petId == null) {
             throw new RestClientResponseException("Missing the required parameter 'petId' when calling deletePet", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("petId", petId);
+        pathParams.put("petId", __petId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (apiKey != null)
-        headerParams.add("api_key", apiClient.parameterToString(apiKey));
+        if (__apiKey != null)
+        headerParams.add("api_key", apiClient.parameterToString(__apiKey));
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { };
@@ -206,14 +206,14 @@ public class PetApi {
      * Multiple status values can be provided with comma separated strings
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid status value
-     * @param status Status values that need to be considered for filter
+     * @param __status Status values that need to be considered for filter
      * @return List&lt;Pet&gt;
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec findPetsByStatusRequestCreation(@jakarta.annotation.Nonnull List<String> status) throws RestClientResponseException {
+    private ResponseSpec findPetsByStatusRequestCreation(@jakarta.annotation.Nonnull List<String> __status) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'status' is set
-        if (status == null) {
+        if (__status == null) {
             throw new RestClientResponseException("Missing the required parameter 'status' when calling findPetsByStatus", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -224,7 +224,7 @@ public class PetApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "status", status));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "status", __status));
 
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
@@ -285,16 +285,16 @@ public class PetApi {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid tag value
-     * @param tags Tags to filter by
+     * @param __tags Tags to filter by
      * @return Set&lt;Pet&gt;
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      * @deprecated
      */
     @Deprecated
-    private ResponseSpec findPetsByTagsRequestCreation(@jakarta.annotation.Nonnull Set<String> tags) throws RestClientResponseException {
+    private ResponseSpec findPetsByTagsRequestCreation(@jakarta.annotation.Nonnull Set<String> __tags) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'tags' is set
-        if (tags == null) {
+        if (__tags == null) {
             throw new RestClientResponseException("Missing the required parameter 'tags' when calling findPetsByTags", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -305,7 +305,7 @@ public class PetApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "tags", tags));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "tags", __tags));
 
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
@@ -367,20 +367,20 @@ public class PetApi {
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid ID supplied
      * <p><b>404</b> - Pet not found
-     * @param petId ID of pet to return
+     * @param __petId ID of pet to return
      * @return Pet
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec getPetByIdRequestCreation(@jakarta.annotation.Nonnull Long petId) throws RestClientResponseException {
+    private ResponseSpec getPetByIdRequestCreation(@jakarta.annotation.Nonnull Long __petId) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'petId' is set
-        if (petId == null) {
+        if (__petId == null) {
             throw new RestClientResponseException("Missing the required parameter 'petId' when calling getPetById", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("petId", petId);
+        pathParams.put("petId", __petId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -451,13 +451,13 @@ public class PetApi {
      * <p><b>400</b> - Invalid ID supplied
      * <p><b>404</b> - Pet not found
      * <p><b>405</b> - Validation exception
-     * @param pet Pet object that needs to be added to the store
+     * @param __pet Pet object that needs to be added to the store
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec updatePetRequestCreation(@jakarta.annotation.Nonnull Pet pet) throws RestClientResponseException {
-        Object postBody = pet;
+    private ResponseSpec updatePetRequestCreation(@jakarta.annotation.Nonnull Pet __pet) throws RestClientResponseException {
+        Object postBody = __pet;
         // verify the required parameter 'pet' is set
-        if (pet == null) {
+        if (__pet == null) {
             throw new RestClientResponseException("Missing the required parameter 'pet' when calling updatePet", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -531,31 +531,31 @@ public class PetApi {
      * 
      * <p><b>200</b> - Successful operation
      * <p><b>405</b> - Invalid input
-     * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param __petId ID of pet that needs to be updated
+     * @param __name Updated name of the pet
+     * @param __status Updated status of the pet
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec updatePetWithFormRequestCreation(@jakarta.annotation.Nonnull Long petId, @jakarta.annotation.Nullable String name, @jakarta.annotation.Nullable String status) throws RestClientResponseException {
+    private ResponseSpec updatePetWithFormRequestCreation(@jakarta.annotation.Nonnull Long __petId, @jakarta.annotation.Nullable String __name, @jakarta.annotation.Nullable String __status) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'petId' is set
-        if (petId == null) {
+        if (__petId == null) {
             throw new RestClientResponseException("Missing the required parameter 'petId' when calling updatePetWithForm", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("petId", petId);
+        pathParams.put("petId", __petId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (name != null)
-            formParams.add("name", name);
-        if (status != null)
-            formParams.add("status", status);
+        if (__name != null)
+            formParams.add("name", __name);
+        if (__status != null)
+            formParams.add("status", __status);
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -619,32 +619,32 @@ public class PetApi {
      * uploads an image
      * 
      * <p><b>200</b> - successful operation
-     * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param _file file to upload
+     * @param __petId ID of pet to update
+     * @param __additionalMetadata Additional data to pass to server
+     * @param ___file file to upload
      * @return ModelApiResponse
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec uploadFileRequestCreation(@jakarta.annotation.Nonnull Long petId, @jakarta.annotation.Nullable String additionalMetadata, @jakarta.annotation.Nullable File _file) throws RestClientResponseException {
+    private ResponseSpec uploadFileRequestCreation(@jakarta.annotation.Nonnull Long __petId, @jakarta.annotation.Nullable String __additionalMetadata, @jakarta.annotation.Nullable File ___file) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'petId' is set
-        if (petId == null) {
+        if (__petId == null) {
             throw new RestClientResponseException("Missing the required parameter 'petId' when calling uploadFile", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("petId", petId);
+        pathParams.put("petId", __petId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (additionalMetadata != null)
-            formParams.add("additionalMetadata", additionalMetadata);
-        if (_file != null)
-            formParams.add("file", new FileSystemResource(_file));
+        if (__additionalMetadata != null)
+            formParams.add("additionalMetadata", __additionalMetadata);
+        if (___file != null)
+            formParams.add("file", new FileSystemResource(___file));
 
         final String[] localVarAccepts = { 
             "application/json"
@@ -709,36 +709,36 @@ public class PetApi {
      * uploads an image (required)
      * 
      * <p><b>200</b> - successful operation
-     * @param petId ID of pet to update
-     * @param requiredFile file to upload
-     * @param additionalMetadata Additional data to pass to server
+     * @param __petId ID of pet to update
+     * @param __requiredFile file to upload
+     * @param __additionalMetadata Additional data to pass to server
      * @return ModelApiResponse
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec uploadFileWithRequiredFileRequestCreation(@jakarta.annotation.Nonnull Long petId, @jakarta.annotation.Nonnull File requiredFile, @jakarta.annotation.Nullable String additionalMetadata) throws RestClientResponseException {
+    private ResponseSpec uploadFileWithRequiredFileRequestCreation(@jakarta.annotation.Nonnull Long __petId, @jakarta.annotation.Nonnull File __requiredFile, @jakarta.annotation.Nullable String __additionalMetadata) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'petId' is set
-        if (petId == null) {
+        if (__petId == null) {
             throw new RestClientResponseException("Missing the required parameter 'petId' when calling uploadFileWithRequiredFile", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'requiredFile' is set
-        if (requiredFile == null) {
+        if (__requiredFile == null) {
             throw new RestClientResponseException("Missing the required parameter 'requiredFile' when calling uploadFileWithRequiredFile", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("petId", petId);
+        pathParams.put("petId", __petId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        if (additionalMetadata != null)
-            formParams.add("additionalMetadata", additionalMetadata);
-        if (requiredFile != null)
-            formParams.add("requiredFile", new FileSystemResource(requiredFile));
+        if (__additionalMetadata != null)
+            formParams.add("additionalMetadata", __additionalMetadata);
+        if (__requiredFile != null)
+            formParams.add("requiredFile", new FileSystemResource(__requiredFile));
 
         final String[] localVarAccepts = { 
             "application/json"

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -49,19 +49,19 @@ public class StoreApi {
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * <p><b>400</b> - Invalid ID supplied
      * <p><b>404</b> - Order not found
-     * @param orderId ID of the order that needs to be deleted
+     * @param __orderId ID of the order that needs to be deleted
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec deleteOrderRequestCreation(@jakarta.annotation.Nonnull String orderId) throws RestClientResponseException {
+    private ResponseSpec deleteOrderRequestCreation(@jakarta.annotation.Nonnull String __orderId) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'orderId' is set
-        if (orderId == null) {
+        if (__orderId == null) {
             throw new RestClientResponseException("Missing the required parameter 'orderId' when calling deleteOrder", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("order_id", orderId);
+        pathParams.put("order_id", __orderId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -189,20 +189,20 @@ public class StoreApi {
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid ID supplied
      * <p><b>404</b> - Order not found
-     * @param orderId ID of pet that needs to be fetched
+     * @param __orderId ID of pet that needs to be fetched
      * @return Order
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec getOrderByIdRequestCreation(@jakarta.annotation.Nonnull Long orderId) throws RestClientResponseException {
+    private ResponseSpec getOrderByIdRequestCreation(@jakarta.annotation.Nonnull Long __orderId) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'orderId' is set
-        if (orderId == null) {
+        if (__orderId == null) {
             throw new RestClientResponseException("Missing the required parameter 'orderId' when calling getOrderById", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("order_id", orderId);
+        pathParams.put("order_id", __orderId);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -271,14 +271,14 @@ public class StoreApi {
      * 
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid Order
-     * @param order order placed for purchasing the pet
+     * @param __order order placed for purchasing the pet
      * @return Order
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec placeOrderRequestCreation(@jakarta.annotation.Nonnull Order order) throws RestClientResponseException {
-        Object postBody = order;
+    private ResponseSpec placeOrderRequestCreation(@jakarta.annotation.Nonnull Order __order) throws RestClientResponseException {
+        Object postBody = __order;
         // verify the required parameter 'order' is set
-        if (order == null) {
+        if (__order == null) {
             throw new RestClientResponseException("Missing the required parameter 'order' when calling placeOrder", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/UserApi.java
@@ -49,13 +49,13 @@ public class UserApi {
      * Create user
      * This can only be done by the logged in user.
      * <p><b>0</b> - successful operation
-     * @param user Created user object
+     * @param __user Created user object
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec createUserRequestCreation(@jakarta.annotation.Nonnull User user) throws RestClientResponseException {
-        Object postBody = user;
+    private ResponseSpec createUserRequestCreation(@jakarta.annotation.Nonnull User __user) throws RestClientResponseException {
+        Object postBody = __user;
         // verify the required parameter 'user' is set
-        if (user == null) {
+        if (__user == null) {
             throw new RestClientResponseException("Missing the required parameter 'user' when calling createUser", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -119,13 +119,13 @@ public class UserApi {
      * Creates list of users with given input array
      * 
      * <p><b>0</b> - successful operation
-     * @param user List of user object
+     * @param __user List of user object
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec createUsersWithArrayInputRequestCreation(@jakarta.annotation.Nonnull List<User> user) throws RestClientResponseException {
-        Object postBody = user;
+    private ResponseSpec createUsersWithArrayInputRequestCreation(@jakarta.annotation.Nonnull List<User> __user) throws RestClientResponseException {
+        Object postBody = __user;
         // verify the required parameter 'user' is set
-        if (user == null) {
+        if (__user == null) {
             throw new RestClientResponseException("Missing the required parameter 'user' when calling createUsersWithArrayInput", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -189,13 +189,13 @@ public class UserApi {
      * Creates list of users with given input array
      * 
      * <p><b>0</b> - successful operation
-     * @param user List of user object
+     * @param __user List of user object
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec createUsersWithListInputRequestCreation(@jakarta.annotation.Nonnull List<User> user) throws RestClientResponseException {
-        Object postBody = user;
+    private ResponseSpec createUsersWithListInputRequestCreation(@jakarta.annotation.Nonnull List<User> __user) throws RestClientResponseException {
+        Object postBody = __user;
         // verify the required parameter 'user' is set
-        if (user == null) {
+        if (__user == null) {
             throw new RestClientResponseException("Missing the required parameter 'user' when calling createUsersWithListInput", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -260,19 +260,19 @@ public class UserApi {
      * This can only be done by the logged in user.
      * <p><b>400</b> - Invalid username supplied
      * <p><b>404</b> - User not found
-     * @param username The name that needs to be deleted
+     * @param __username The name that needs to be deleted
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec deleteUserRequestCreation(@jakarta.annotation.Nonnull String username) throws RestClientResponseException {
+    private ResponseSpec deleteUserRequestCreation(@jakarta.annotation.Nonnull String __username) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'username' is set
-        if (username == null) {
+        if (__username == null) {
             throw new RestClientResponseException("Missing the required parameter 'username' when calling deleteUser", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("username", username);
+        pathParams.put("username", __username);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -335,20 +335,20 @@ public class UserApi {
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid username supplied
      * <p><b>404</b> - User not found
-     * @param username The name that needs to be fetched. Use user1 for testing.
+     * @param __username The name that needs to be fetched. Use user1 for testing.
      * @return User
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec getUserByNameRequestCreation(@jakarta.annotation.Nonnull String username) throws RestClientResponseException {
+    private ResponseSpec getUserByNameRequestCreation(@jakarta.annotation.Nonnull String __username) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'username' is set
-        if (username == null) {
+        if (__username == null) {
             throw new RestClientResponseException("Missing the required parameter 'username' when calling getUserByName", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("username", username);
+        pathParams.put("username", __username);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -417,19 +417,19 @@ public class UserApi {
      * 
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid username/password supplied
-     * @param username The user name for login
-     * @param password The password for login in clear text
+     * @param __username The user name for login
+     * @param __password The password for login in clear text
      * @return String
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec loginUserRequestCreation(@jakarta.annotation.Nonnull String username, @jakarta.annotation.Nonnull String password) throws RestClientResponseException {
+    private ResponseSpec loginUserRequestCreation(@jakarta.annotation.Nonnull String __username, @jakarta.annotation.Nonnull String __password) throws RestClientResponseException {
         Object postBody = null;
         // verify the required parameter 'username' is set
-        if (username == null) {
+        if (__username == null) {
             throw new RestClientResponseException("Missing the required parameter 'username' when calling loginUser", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'password' is set
-        if (password == null) {
+        if (__password == null) {
             throw new RestClientResponseException("Missing the required parameter 'password' when calling loginUser", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
@@ -440,8 +440,8 @@ public class UserApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "username", username));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "password", password));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "username", __username));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "password", __password));
 
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
@@ -565,24 +565,24 @@ public class UserApi {
      * This can only be done by the logged in user.
      * <p><b>400</b> - Invalid user supplied
      * <p><b>404</b> - User not found
-     * @param username name that need to be deleted
-     * @param user Updated user object
+     * @param __username name that need to be deleted
+     * @param __user Updated user object
      * @throws RestClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec updateUserRequestCreation(@jakarta.annotation.Nonnull String username, @jakarta.annotation.Nonnull User user) throws RestClientResponseException {
-        Object postBody = user;
+    private ResponseSpec updateUserRequestCreation(@jakarta.annotation.Nonnull String __username, @jakarta.annotation.Nonnull User __user) throws RestClientResponseException {
+        Object postBody = __user;
         // verify the required parameter 'username' is set
-        if (username == null) {
+        if (__username == null) {
             throw new RestClientResponseException("Missing the required parameter 'username' when calling updateUser", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // verify the required parameter 'user' is set
-        if (user == null) {
+        if (__user == null) {
             throw new RestClientResponseException("Missing the required parameter 'user' when calling updateUser", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<>();
 
-        pathParams.put("username", username);
+        pathParams.put("username", __username);
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         final HttpHeaders headerParams = new HttpHeaders();


### PR DESCRIPTION
… conflict with variables in the same method.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents name collisions in generated Java RestClient methods by prefixing all method parameters with "__", fixing cases where params shadow local variables. Fixes #23903.

- **Bug Fixes**
  - Updated `modules/openapi-generator/src/main/resources/Java/libraries/restclient/api.mustache` to emit `__paramName` for all method parameters (including Javadoc).
  - Applied the change across query, path, header, form, multipart, and body handling in request-creation methods.
  - Regenerated Java RestClient samples and updated tests (e.g., expect `if (__filter != null)`), ensuring no param/variable conflicts.

<sup>Written for commit 4acc766cf0420302ef414fe4c4808ce99610f065. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

