### PR TITLE
fix(go): avoid duplicate unknown enum defaults

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -577,22 +577,34 @@ public class GoClientCodegen extends AbstractGoCodegen {
         return objs;
     }
 
+    /**
+     * Prefixes the generated {@code unknown_default_open_api} enum case with the model name when enum class prefixing
+     * is disabled.
+     * <p>
+     * Go enum constants are emitted at package scope, so multiple models otherwise generate duplicate
+     * {@code UNKNOWN_DEFAULT_OPEN_API} constants.
+     */
     @SuppressWarnings("unchecked")
     private void prefixEnumUnknownDefaultCase(CodegenModel model) {
+        // Only the synthetic unknown-default fallback needs a model-specific prefix. Regular enum class prefixing
+        // already prefixes every enum case, and models without allowable values do not need any post-processing.
         if (!enumUnknownDefaultCase || enumClassPrefix || model.allowableValues == null) {
             return;
         }
 
+        // The enum variables are stored by the shared enum post-processing as allowableValues["enumVars"].
         Object enumVarsObject = model.allowableValues.get("enumVars");
         if (!(enumVarsObject instanceof List)) {
             return;
         }
 
+        // The unknown-default fallback is appended as the last enum variable. If that shape changes, skip safely.
         List<?> enumVars = (List<?>) enumVarsObject;
         if (enumVars.isEmpty() || !(enumVars.get(enumVars.size() - 1) instanceof Map)) {
             return;
         }
 
+        // Prefix only the fallback name so user-defined enum values keep their existing generated names.
         Map<String, Object> fallbackEnumVar = (Map<String, Object>) enumVars.get(enumVars.size() - 1);
         Object fallbackName = fallbackEnumVar.get("name");
         if (fallbackName instanceof String) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -514,6 +514,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
         for (ModelMap m : objs.getModels()) {
             CodegenModel model = m.getModel();
             if (model.isEnum) {
+                prefixEnumUnknownDefaultCase(model);
                 continue;
             }
 
@@ -574,6 +575,29 @@ public class GoClientCodegen extends AbstractGoCodegen {
             }
         }
         return objs;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void prefixEnumUnknownDefaultCase(CodegenModel model) {
+        if (!enumUnknownDefaultCase || enumClassPrefix || model.allowableValues == null) {
+            return;
+        }
+
+        Object enumVarsObject = model.allowableValues.get("enumVars");
+        if (!(enumVarsObject instanceof List)) {
+            return;
+        }
+
+        List<?> enumVars = (List<?>) enumVarsObject;
+        if (enumVars.isEmpty() || !(enumVars.get(enumVars.size() - 1) instanceof Map)) {
+            return;
+        }
+
+        Map<String, Object> fallbackEnumVar = (Map<String, Object>) enumVars.get(enumVars.size() - 1);
+        Object fallbackName = fallbackEnumVar.get("name");
+        if (fallbackName instanceof String) {
+            fallbackEnumVar.put("name", model.classname.toUpperCase(Locale.ROOT) + "_" + fallbackName);
+        }
     }
 
     @Override

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
@@ -199,6 +199,37 @@ public class GoClientCodegenTest {
     }
 
     @Test
+    public void testEnumUnknownDefaultCaseUsesModelSpecificNamesWhenEnumClassPrefixDisabled() throws IOException {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(CodegenConstants.ENUM_UNKNOWN_DEFAULT_CASE, true);
+        properties.put(CodegenConstants.ENUM_CLASS_PREFIX, false);
+
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("go")
+                .setAdditionalProperties(properties)
+                .setInputSpec("src/test/resources/3_0/go/enum_unknown_default_case_multiple_models.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        Path statusA = Paths.get(output + "/model_status_a.go");
+        Path statusB = Paths.get(output + "/model_status_b.go");
+        TestUtils.assertFileContains(statusA,
+                "STATUSA_UNKNOWN_DEFAULT_OPEN_API StatusA = \"unknown_default_open_api\"",
+                "*v = STATUSA_UNKNOWN_DEFAULT_OPEN_API");
+        TestUtils.assertFileContains(statusB,
+                "STATUSB_UNKNOWN_DEFAULT_OPEN_API StatusB = \"unknown_default_open_api\"",
+                "*v = STATUSB_UNKNOWN_DEFAULT_OPEN_API");
+        TestUtils.assertFileNotContains(statusA, "\n\tUNKNOWN_DEFAULT_OPEN_API StatusA =");
+        TestUtils.assertFileNotContains(statusB, "\n\tUNKNOWN_DEFAULT_OPEN_API StatusB =");
+    }
+
+    @Test
     public void testAdditionalPropertiesModelFileFolder() throws Exception {
         final GoClientCodegen codegen = new GoClientCodegen();
         codegen.additionalProperties().put(GoClientCodegen.MODEL_FILE_FOLDER, "model_dir");

--- a/modules/openapi-generator/src/test/resources/3_0/go/enum_unknown_default_case_multiple_models.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/go/enum_unknown_default_case_multiple_models.yaml
@@ -1,0 +1,15 @@
+openapi: 3.0.3
+info:
+  title: Go enum unknown default case
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    StatusA:
+      type: string
+      enum:
+        - active
+    StatusB:
+      type: string
+      enum:
+        - active


### PR DESCRIPTION
Fixes #23844.

### What
- Adds a model-specific prefix to the synthetic Go `unknown_default_open_api` enum fallback when `enumClassPrefix=false`.
- Leaves user-defined enum constants unprefixed.
- Adds regression coverage with two enum models generated into the same Go package.

### Testing
- `./mvnw -pl modules/openapi-generator -am -Dtest=org.openapitools.codegen.go.GoClientCodegenTest#testEnumUnknownDefaultCaseUsesModelSpecificNamesWhenEnumClassPrefixDisabled -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl modules/openapi-generator -am -Dtest=org.openapitools.codegen.go.GoClientCodegenTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoids duplicate Go enum fallback constants by prefixing the synthetic unknown default with the model name when `enumClassPrefix=false`. Fixes #23844.

- **Bug Fixes**
  - Prefixes the `unknown_default_open_api` fallback with the model name when `enumUnknownDefaultCase=true` and `enumClassPrefix=false`, preventing collisions across models in the same package.
  - Leaves user-defined enum constants unchanged.
  - Adds regression test with two enum models to verify unique names (e.g., STATUSA_UNKNOWN_DEFAULT_OPEN_API, STATUSB_UNKNOWN_DEFAULT_OPEN_API).
  - Documents the prefixing behavior in the Go generator docs.

<sup>Written for commit e2306993fab4dda0ef0f181d2ae59de2514f210e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

