### PR TITLE
fix: x-pattern-message ignored for list items in Spring generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1253,8 +1253,8 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                             .replace("\\", "\\\\")
                             .replace("\"", "\\\""));
 
-            String patternMessage = (items.getVendorExtensions() != null)
-                    ? (String) items.getVendorExtensions().get("x-pattern-message")
+            String patternMessage = (items.getExtensions() != null)
+                    ? (String) items.getExtensions().get("x-pattern-message")
                     : null;
             validations = String.format(Locale.ROOT, "@Pattern(regexp = \"%s\"%s)",
                     pattern,

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1253,7 +1253,12 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                             .replace("\\", "\\\\")
                             .replace("\"", "\\\""));
 
-            validations = String.format(Locale.ROOT, "@Pattern(regexp = \"%s\")", pattern);
+            String patternMessage = (items.getVendorExtensions() != null)
+                    ? (String) items.getVendorExtensions().get("x-pattern-message")
+                    : null;
+            validations = String.format(Locale.ROOT, "@Pattern(regexp = \"%s\"%s)",
+                    pattern,
+                    (patternMessage != null ? ", message=\"" + patternMessage + "\"" : ""));
         }
 
         if (ModelUtils.isEmailSchema(items)) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -999,6 +999,21 @@ public class AbstractJavaCodegenTest {
     }
 
     @Test
+    public void annotationsContainerPatternMessageTest() {
+        codegen.setUseBeanValidation(true);
+
+        Schema<?> itemSchema = new Schema<>()
+                .type("string")
+                .pattern("^[a-z]$");
+        itemSchema.addExtension("x-pattern-message", "Custom message for list");
+
+        Schema<?> schema = new ArraySchema().items(itemSchema);
+        String defaultValue = codegen.getTypeDeclaration(schema);
+        Assert.assertEquals(defaultValue,
+                "List<@Pattern(regexp = \"^[a-z]$\", message=\"Custom message for list\")String>");
+    }
+
+    @Test
     public void disableDiscriminatorJsonIgnorePropertiesFlagTest() {
         codegen.additionalProperties().put(DISABLE_DISCRIMINATOR_JSON_IGNORE_PROPERTIES, true);
 


### PR DESCRIPTION
to close https://github.com/OpenAPITools/openapi-generator/issues/21167


<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `x-pattern-message` is respected for array item validations in the Java/Spring generator, fixing #21167. The message is now passed to the `@Pattern` annotation for list element types.

- **Bug Fixes**
  - Update `AbstractJavaCodegen#getStringBeanValidation` to include `message="..."` when `x-pattern-message` is set on item schemas.
  - Add `annotationsContainerPatternMessageTest`; fix build to ensure `List<@Pattern(..., message="...")String>` generation compiles.

<sup>Written for commit 79782d9c793909b671bef7706b7784041e3fcc18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

