### PR TITLE
[csharp] Render date examples in UTC (time-zone independent)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -1523,9 +1523,19 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen {
      */
     @Override
     public String toExampleValue(Schema p) {
-        return p.getExample() == null
-                ? null
-                : p.getExample().toString();
+        Object example = p.getExample();
+        if (example == null) {
+            return null;
+        }
+        if (example instanceof java.util.Date) {
+            // Render date / date-time examples in UTC so the generated output does not
+            // depend on the JVM's default time zone (keeps samples reproducible across
+            // developer machines and CI). Mirrors the format of Date#toString().
+            java.text.SimpleDateFormat formatter = new java.text.SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy", java.util.Locale.US);
+            formatter.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
+            return formatter.format((java.util.Date) example);
+        }
+        return example.toString();
     }
 
     /**

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpClientCodegenTest.java
@@ -41,6 +41,22 @@ import static org.openapitools.codegen.TestUtils.assertFileNotContains;
 public class CSharpClientCodegenTest {
 
     @Test
+    public void testDateExampleRenderedInUtc() {
+        // A date example must render in UTC regardless of the JVM's default time zone,
+        // so generated samples are reproducible across developer machines and CI.
+        final CSharpClientCodegen codegen = new CSharpClientCodegen();
+        Schema<?> schema = new Schema<>().example(java.util.Date.from(java.time.Instant.parse("2020-02-02T00:00:00Z")));
+
+        java.util.TimeZone original = java.util.TimeZone.getDefault();
+        try {
+            java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("America/Los_Angeles"));
+            Assert.assertEquals(codegen.toExampleValue(schema), "Sun Feb 02 00:00:00 UTC 2020");
+        } finally {
+            java.util.TimeZone.setDefault(original);
+        }
+    }
+
+    @Test
     public void testToEnumVarName() {
         final CSharpClientCodegen codegen = new CSharpClientCodegen();
         codegen.setLibrary("restsharp");


### PR DESCRIPTION
`AbstractCSharpCodegen.toExampleValue` stringified a date/date-time example with `Object.toString()`. For a `java.util.Date` — how the OpenAPI parser represents an unquoted date example in the spec — `Date.toString()` uses the **JVM's default time zone**. So the generated `<example>` comment differs by machine: UTC on CI, local time for a developer who regenerates samples, e.g.

```
- /* <example>Sun Feb 02 00:00:00 UTC 2020</example> */
+ /* <example>Sun Feb 02 01:00:00 CET 2020</example> */
```

This shows up as spurious, confusing diffs whenever a contributor regenerates the C# samples outside UTC.

### Fix
Format `java.util.Date` examples explicitly in **UTC** (same layout as `Date#toString()`), so the output is reproducible regardless of the default time zone. Non-date examples are unchanged.

### No sample churn
CI already runs in UTC, so the regenerated samples are byte-for-byte unchanged. I verified by rebuilding and regenerating **all 74 C# generators in a non-UTC (CET) environment** — `git diff` shows **no sample changes**, only the code + test. Before the fix the same regen drifted every date example to local time.

### Test
`CSharpClientCodegenTest#testDateExampleRenderedInUtc` sets the default time zone to `America/Los_Angeles` and asserts a date example renders as `Sun Feb 02 00:00:00 UTC 2020`. It fails before the fix (returns the PST-local string) and passes after.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Title/description describe the change and how to validate it.
- [x] Built the project and ran `./bin/generate-samples.sh ./bin/configs/csharp*.yaml`; no sample changes resulted (the fix is a no-op under UTC).
- [x] Filed against `master`.
- [ ] No existing issue (searched).
- [x] Technical committee: @devhl-labs, @Blackclaws, @jimschubert (C#)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render C# date/date-time example values in UTC so generated <example> comments are time‑zone independent and no longer churn when developers regenerate locally. CI output stays the same.

- **Bug Fixes**
  - Format `java.util.Date` examples in `AbstractCSharpCodegen.toExampleValue` using UTC, matching `Date#toString()` layout.
  - Add a unit test that forces a non-UTC default timezone and asserts UTC output to prevent regressions.

<sup>Written for commit d572868ac19f92dc9125adc42edcff0760243883. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

