### PR TITLE
fix(Kotlin): use the global apiNamePrefix and apiNameSuffix settings instead of apiSuffix (generator's option)

### DIFF
--- a/docs/generators/kotlin-misk.md
+++ b/docs/generators/kotlin-misk.md
@@ -26,7 +26,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |actionRequestContentTypePrefix|Request ContentType Prefix for Action| |MediaTypes|
 |addModelMoshiJsonAnnotation|Add a Moshi JSON adapter annotation to all model classes| |true|
 |additionalModelTypeAnnotations|Additional annotations for model type(class level annotations). List separated by semicolon(;) or new line (Linux or Windows)| |null|
-|apiSuffix|suffix for api classes| |Api|
 |artifactId|Generated artifact id (name of jar).| |null|
 |artifactVersion|Generated artifact's package version.| |1.0.0|
 |enumPropertyNaming|Naming convention for enum properties: 'camelCase', 'PascalCase', 'snake_case', 'UPPERCASE', 'original', and 'bestEffortBacktick' (like 'original' but tries to wrap values in backticks before falling back to sanitizing, e.g. `name,asc` stays `name,asc` rather than becoming nameCommaAsc; useful for sort/order enums)| |original|

--- a/docs/generators/kotlin-server.md
+++ b/docs/generators/kotlin-server.md
@@ -19,7 +19,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | Option | Description | Values | Default |
 | ------ | ----------- | ------ | ------- |
 |additionalModelTypeAnnotations|Additional annotations for model type(class level annotations). List separated by semicolon(;) or new line (Linux or Windows)| |null|
-|apiSuffix|suffix for api classes| |Api|
 |artifactId|Generated artifact id (name of jar).| |kotlin-server|
 |artifactVersion|Generated artifact's package version.| |1.0.0|
 |delegatePattern|Whether to generate the server files using the delegate pattern. This option is currently supported only when using ktor library.| |false|

--- a/docs/generators/kotlin-spring.md
+++ b/docs/generators/kotlin-spring.md
@@ -21,7 +21,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |additionalModelTypeAnnotations|Additional annotations for model type(class level annotations). List separated by semicolon(;) or new line (Linux or Windows)| |null|
 |annotationLibrary|Select the complementary documentation annotation library.|<dl><dt>**none**</dt><dd>Do not annotate Model and Api with complementary annotations.</dd><dt>**swagger1**</dt><dd>Annotate Model and Api using the Swagger Annotations 1.x library.</dd><dt>**swagger2**</dt><dd>Annotate Model and Api using the Swagger Annotations 2.x library.</dd></dl>|swagger2|
 |apiPackage|api package for generated code| |org.openapitools.api|
-|apiSuffix|suffix for api classes| |Api|
 |artifactId|Generated artifact id (name of jar).| |openapi-spring|
 |artifactVersion|Generated artifact's package version.| |1.0.0|
 |autoXSpringPaginated|Automatically add x-spring-paginated to operations that have 'page', 'size', and 'sort' query parameters. When enabled, operations with all three parameters will have Pageable support automatically applied. Operations with x-spring-paginated explicitly set to false will not be auto-detected.| |false|

--- a/docs/generators/kotlin-vertx.md
+++ b/docs/generators/kotlin-vertx.md
@@ -19,7 +19,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | Option | Description | Values | Default |
 | ------ | ----------- | ------ | ------- |
 |additionalModelTypeAnnotations|Additional annotations for model type(class level annotations). List separated by semicolon(;) or new line (Linux or Windows)| |null|
-|apiSuffix|suffix for api classes| |Api|
 |artifactId|Generated artifact id (name of jar).| |null|
 |artifactVersion|Generated artifact's package version.| |1.0.0|
 |enumPropertyNaming|Naming convention for enum properties: 'camelCase', 'PascalCase', 'snake_case', 'UPPERCASE', 'original', and 'bestEffortBacktick' (like 'original' but tries to wrap values in backticks before falling back to sanitizing, e.g. `name,asc` stays `name,asc` rather than becoming nameCommaAsc; useful for sort/order enums)| |original|

--- a/docs/generators/kotlin-wiremock.md
+++ b/docs/generators/kotlin-wiremock.md
@@ -19,7 +19,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | Option | Description | Values | Default |
 | ------ | ----------- | ------ | ------- |
 |additionalModelTypeAnnotations|Additional annotations for model type(class level annotations). List separated by semicolon(;) or new line (Linux or Windows)| |null|
-|apiSuffix|suffix for api classes| |Api|
 |artifactId|Generated artifact id (name of jar).| |null|
 |artifactVersion|Generated artifact's package version.| |1.0.0|
 |enumPropertyNaming|Naming convention for enum properties: 'camelCase', 'PascalCase', 'snake_case', 'UPPERCASE', 'original', and 'bestEffortBacktick' (like 'original' but tries to wrap values in backticks before falling back to sanitizing, e.g. `name,asc` stays `name,asc` rather than becoming nameCommaAsc; useful for sort/order enums)| |original|

--- a/docs/generators/kotlin.md
+++ b/docs/generators/kotlin.md
@@ -19,7 +19,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | Option | Description | Values | Default |
 | ------ | ----------- | ------ | ------- |
 |additionalModelTypeAnnotations|Additional annotations for model type(class level annotations). List separated by semicolon(;) or new line (Linux or Windows)| |null|
-|apiSuffix|suffix for api classes| |Api|
 |artifactId|Generated artifact id (name of jar).| |kotlin-client|
 |artifactVersion|Generated artifact's package version.| |1.0.0|
 |collectionType|Option. Collection type to use|<dl><dt>**array**</dt><dd>kotlin.Array</dd><dt>**list**</dt><dd>kotlin.collections.List</dd></dl>|list|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -41,9 +41,6 @@ public class CodegenConstants {
     public static final String API_PACKAGE = "apiPackage";
     public static final String API_PACKAGE_DESC = "package for generated api classes";
 
-    public static final String API_SUFFIX = "apiSuffix";
-    public static final String API_SUFFIX_DESC = "suffix for api classes";
-
     public static final String AUTOSET_CONSTANTS = "autosetConstants";
 
     public static final String MODEL_PACKAGE = "modelPackage";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -73,7 +73,6 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
     @Setter protected String artifactVersion = "1.0.0";
     @Setter protected String groupId = "org.openapitools";
     @Setter protected String packageName = "org.openapitools";
-    @Setter protected String apiSuffix = "Api";
 
     @Setter protected String sourceFolder = "src/main/kotlin";
     @Setter protected String testFolder = "src/test/kotlin";
@@ -309,7 +308,6 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
         cliOptions.clear();
         addOption(CodegenConstants.SOURCE_FOLDER, CodegenConstants.SOURCE_FOLDER_DESC, sourceFolder);
         addOption(CodegenConstants.PACKAGE_NAME, "Generated artifact package name.", packageName);
-        addOption(CodegenConstants.API_SUFFIX, CodegenConstants.API_SUFFIX_DESC, apiSuffix);
         addOption(CodegenConstants.GROUP_ID, "Generated artifact package's organization (i.e. maven groupId).", groupId);
         addOption(CodegenConstants.ARTIFACT_ID, "Generated artifact id (name of jar).", artifactId);
         addOption(CodegenConstants.ARTIFACT_VERSION, "Generated artifact's package version.", artifactVersion);
@@ -576,10 +574,6 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
             additionalProperties.put(CodegenConstants.PACKAGE_NAME, packageName);
         }
 
-        if (additionalProperties.containsKey(CodegenConstants.API_SUFFIX)) {
-            this.setApiSuffix((String) additionalProperties.get(CodegenConstants.API_SUFFIX));
-        }
-
         if (additionalProperties.containsKey(CodegenConstants.ARTIFACT_ID)) {
             this.setArtifactId((String) additionalProperties.get(CodegenConstants.ARTIFACT_ID));
         } else {
@@ -761,7 +755,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
         if (name.length() == 0) {
             return "DefaultApi";
         }
-        return (this.apiSuffix.isEmpty() ? camelize(name) : camelize(name) + this.apiSuffix);
+        return this.apiNamePrefix + camelize(name) + this.apiNameSuffix;
     }
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KtormSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KtormSchemaCodegen.java
@@ -227,7 +227,6 @@ public class KtormSchemaCodegen extends AbstractKotlinCodegen {
         // cliOptions default redefinition need to be updated
         updateOption(CodegenConstants.ARTIFACT_ID, artifactId);
         updateOption(CodegenConstants.PACKAGE_NAME, packageName);
-        removeOption(CodegenConstants.API_SUFFIX);
         removeOption(CodegenConstants.PARCELIZE_MODELS);
         removeOption(CodegenConstants.SERIALIZABLE_MODEL);
         removeOption(CodegenConstants.SERIALIZATION_LIBRARY);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
@@ -239,8 +239,23 @@ public class AbstractKotlinCodegenTest {
 
     @Test
     public void convertApiNameWithSuffix() {
-        codegen.setApiSuffix("Test");
+        codegen.setApiNameSuffix("Test");
         assertEquals(codegen.toApiName("Fake"), "FakeTest");
+        assertEquals(codegen.toApiName(""), "DefaultApi");
+    }
+
+    @Test
+    public void convertApiNameWithPrefix() {
+        codegen.setApiNamePrefix("Prefix");
+        assertEquals(codegen.toApiName("Fake"), "PrefixFakeApi");
+        assertEquals(codegen.toApiName(""), "DefaultApi");
+    }
+
+    @Test
+    public void convertApiNameWithPrefixAndSuffix() {
+        codegen.setApiNamePrefix("Prefix");
+        codegen.setApiNameSuffix("Suffix");
+        assertEquals(codegen.toApiName("Fake"), "PrefixFakeSuffix");
         assertEquals(codegen.toApiName(""), "DefaultApi");
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/misk/KotlinMiskServerCodegenOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/misk/KotlinMiskServerCodegenOptionsTest.java
@@ -34,7 +34,6 @@ public class KotlinMiskServerCodegenOptionsTest extends AbstractOptionsTest {
         verify(codegen).setEnumPropertyNaming(KotlinMiskServerCodegenOptionsProvider.ENUM_PROPERTY_NAMING_VALUE);
         verify(codegen).setSerializableModel(Boolean.valueOf(KotlinMiskServerCodegenOptionsProvider.SERIALIZABLE_MODEL_VALUE));
         verify(codegen).setParcelizeModels(Boolean.valueOf(KotlinMiskServerCodegenOptionsProvider.PARCELIZE_MODELS_VALUE));
-        verify(codegen).setApiSuffix(KotlinMiskServerCodegenOptionsProvider.API_SUFFIX_VALUE);
         verify(codegen).setAdditionalModelTypeAnnotations(List.of(KotlinMiskServerCodegenOptionsProvider.ADDITIONAL_MODEL_TYPE_ANNOTATIONS_VALUE));
         verify(codegen).setUseBeanValidation(Boolean.valueOf(KotlinMiskServerCodegenOptionsProvider.USE_BEAN_VALIDATION));
         verify(codegen).setModuleClassName(KotlinMiskServerCodegenOptionsProvider.MODULE_CLASS_NAME);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/KotlinMiskServerCodegenOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/KotlinMiskServerCodegenOptionsProvider.java
@@ -55,7 +55,6 @@ public class KotlinMiskServerCodegenOptionsProvider implements OptionsProvider {
             .put(CodegenConstants.ENUM_PROPERTY_NAMING, ENUM_PROPERTY_NAMING_VALUE)
             .put(CodegenConstants.SERIALIZABLE_MODEL, SERIALIZABLE_MODEL_VALUE)
             .put(CodegenConstants.PARCELIZE_MODELS, PARCELIZE_MODELS_VALUE)
-            .put(CodegenConstants.API_SUFFIX, API_SUFFIX_VALUE)
             .put(AbstractKotlinCodegen.MODEL_MUTABLE, MODEL_MUTABLE_VALUE)
             .put(AbstractKotlinCodegen.ADDITIONAL_MODEL_TYPE_ANNOTATIONS,
                 ADDITIONAL_MODEL_TYPE_ANNOTATIONS_VALUE)


### PR DESCRIPTION
fixes (#23822)

As discussed in #23834 opened PR for master aswell as the change has a fallback.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Removes Kotlin specific apiSuffix additionalSetting.
Adds support for global apiNamePrefix and apiNameSuffix settings to the kotlin generator.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Kotlin comittee members:
@karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06) @e5l (2024/10) @dennisameling (2026/02)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Kotlin generators now use the global `apiNamePrefix` and `apiNameSuffix` for API class names, replacing the Kotlin-only `apiSuffix`. Default behavior is unchanged: classes end with `Api`, and empty names produce `DefaultApi`.

- **Bug Fixes**
  - `AbstractKotlinCodegen.toApiName` now builds names as prefix + camelized name + suffix; empty names return `DefaultApi`.
  - Removed `apiSuffix` across the codebase (including `CodegenConstants`, generator options, docs, and tests). Added tests for prefix, suffix, and prefix+suffix.

- **Migration**
  - Replace `-DapiSuffix=Foo` with `-DapiNameSuffix=Foo` (and `-DapiNamePrefix=Bar` if needed). No change if you use the default `Api` suffix.

<sup>Written for commit 25a101af1e3d47671749845edb68acf5e0b1eb99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



