### PR TITLE
feat(dart): make requests abortable

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api.mustache
@@ -50,7 +50,7 @@ class {{{classname}}} {
   ///
     {{/-last}}
   {{/allParams}}
-  Future<Response> {{{nickname}}}WithHttpInfo({{#allParams}}{{#required}}{{{dataType}}} {{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}}{{#hasOptionalParams}}{ {{#allParams}}{{^required}}{{{dataType}}}? {{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}} }{{/hasOptionalParams}}) async {
+  Future<Response> {{{nickname}}}WithHttpInfo({{#allParams}}{{#required}}{{{dataType}}} {{{paramName}}}, {{/required}}{{/allParams}}{ {{#allParams}}{{^required}}{{{dataType}}}? {{{paramName}}}, {{/required}}{{/allParams}}Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'{{{path}}}'{{#pathParams}}
       .replaceAll({{=<% %>=}}'{<% baseName %>}'<%={{ }}=%>, {{{paramName}}}{{^isString}}.toString(){{/isString}}){{/pathParams}};
@@ -129,6 +129,7 @@ class {{{classname}}} {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -162,8 +163,8 @@ class {{{classname}}} {
   ///
     {{/-last}}
   {{/allParams}}
-  Future<{{#returnType}}{{{.}}}?{{/returnType}}{{^returnType}}void{{/returnType}}> {{{nickname}}}({{#allParams}}{{#required}}{{{dataType}}} {{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}}{{#hasOptionalParams}}{ {{#allParams}}{{^required}}{{{dataType}}}? {{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}} }{{/hasOptionalParams}}) async {
-    final response = await {{{nickname}}}WithHttpInfo({{#allParams}}{{#required}}{{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}}{{#hasOptionalParams}} {{#allParams}}{{^required}}{{{paramName}}}: {{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}} {{/hasOptionalParams}});
+  Future<{{#returnType}}{{{.}}}?{{/returnType}}{{^returnType}}void{{/returnType}}> {{{nickname}}}({{#allParams}}{{#required}}{{{dataType}}} {{{paramName}}}, {{/required}}{{/allParams}}{ {{#allParams}}{{^required}}{{{dataType}}}? {{{paramName}}}, {{/required}}{{/allParams}}Future<void>? abortTrigger, }) async {
+    final response = await {{{nickname}}}WithHttpInfo({{#allParams}}{{#required}}{{{paramName}}}, {{/required}}{{/allParams}}{{#allParams}}{{^required}}{{{paramName}}}: {{{paramName}}}, {{/required}}{{/allParams}}abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/modules/openapi-generator/src/main/resources/dart2/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api_client.mustache
@@ -35,8 +35,9 @@ class ApiClient {
     Object? body,
     Map<String, String> headerParams,
     Map<String, String> formParams,
-    String? contentType,
-  ) async {
+    String? contentType, {
+    Future<void>? abortTrigger,
+  }) async {
     await authentication?.applyToParams(queryParams, headerParams);
 
     headerParams.addAll(_defaultHeaderMap);
@@ -54,7 +55,7 @@ class ApiClient {
         body is MultipartFile && (contentType == null ||
         !contentType.toLowerCase().startsWith('multipart/form-data'))
       ) {
-        final request = StreamedRequest(method, uri);
+        final request = AbortableStreamedRequest(method, uri, abortTrigger: abortTrigger);
         request.headers.addAll(headerParams);
         request.contentLength = body.length;
         body.finalize().listen(
@@ -69,7 +70,7 @@ class ApiClient {
       }
 
       if (body is MultipartRequest) {
-        final request = MultipartRequest(method, uri);
+        final request = AbortableMultipartRequest(method, uri, abortTrigger: abortTrigger);
         request.fields.addAll(body.fields);
         request.files.addAll(body.files);
         request.headers.addAll(body.headers);
@@ -83,14 +84,19 @@ class ApiClient {
         : await serializeAsync(body);
       final nullableHeaderParams = headerParams.isEmpty ? null : headerParams;
 
-      switch(method) {
-        case 'POST': return await _client.post(uri, headers: nullableHeaderParams, body: msgBody,);
-        case 'PUT': return await _client.put(uri, headers: nullableHeaderParams, body: msgBody,);
-        case 'DELETE': return await _client.delete(uri, headers: nullableHeaderParams, body: msgBody,);
-        case 'PATCH': return await _client.patch(uri, headers: nullableHeaderParams, body: msgBody,);
-        case 'HEAD': return await _client.head(uri, headers: nullableHeaderParams,);
-        case 'GET': return await _client.get(uri, headers: nullableHeaderParams,);
+      final request = AbortableRequest(method, uri, abortTrigger: abortTrigger);
+      if (nullableHeaderParams != null) {
+        request.headers.addAll(nullableHeaderParams);
       }
+      if (msgBody is String) {
+        request.body = msgBody;
+      } else if (msgBody is List<int>) {
+        request.bodyBytes = msgBody;
+      } else if (msgBody is Map<String, String>) {
+        request.bodyFields = msgBody;
+      }
+      final response = await _client.send(request);
+      return Response.fromStream(response);
     } on SocketException catch (error, trace) {
       throw ApiException.withInner(
         HttpStatus.badRequest,
@@ -127,11 +133,6 @@ class ApiClient {
         trace,
       );
     }
-
-    throw ApiException(
-      HttpStatus.badRequest,
-      'Invalid HTTP operation: $method $path',
-    );
   }
 {{#native_serialization}}
 

--- a/modules/openapi-generator/src/main/resources/dart2/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api_client.mustache
@@ -88,9 +88,9 @@ class ApiClient {
       if (nullableHeaderParams != null) {
         request.headers.addAll(nullableHeaderParams);
       }
-      if (msgBody is String) {
+      if (msgBody is String && msgBody.isNotEmpty) {
         request.body = msgBody;
-      } else if (msgBody is List<int>) {
+      } else if (msgBody is List<int> && msgBody.isNotEmpty) {
         request.bodyBytes = msgBody;
       } else if (msgBody is Map<String, String>) {
         request.bodyFields = msgBody;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/pet_api.dart
@@ -26,7 +26,7 @@ class PetApi {
   ///
   /// * [Pet] pet (required):
   ///   Pet object that needs to be added to the store
-  Future<Response> addPetWithHttpInfo(Pet pet,) async {
+  Future<Response> addPetWithHttpInfo(Pet pet, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/pet';
 
@@ -48,6 +48,7 @@ class PetApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -59,8 +60,8 @@ class PetApi {
   ///
   /// * [Pet] pet (required):
   ///   Pet object that needs to be added to the store
-  Future<Pet?> addPet(Pet pet,) async {
-    final response = await addPetWithHttpInfo(pet,);
+  Future<Pet?> addPet(Pet pet, { Future<void>? abortTrigger, }) async {
+    final response = await addPetWithHttpInfo(pet, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -86,7 +87,7 @@ class PetApi {
   ///   Pet id to delete
   ///
   /// * [String] apiKey:
-  Future<Response> deletePetWithHttpInfo(int petId, { String? apiKey, }) async {
+  Future<Response> deletePetWithHttpInfo(int petId, { String? apiKey, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/pet/{petId}'
       .replaceAll('{petId}', petId.toString());
@@ -113,6 +114,7 @@ class PetApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -126,8 +128,8 @@ class PetApi {
   ///   Pet id to delete
   ///
   /// * [String] apiKey:
-  Future<void> deletePet(int petId, { String? apiKey, }) async {
-    final response = await deletePetWithHttpInfo(petId,  apiKey: apiKey, );
+  Future<void> deletePet(int petId, { String? apiKey, Future<void>? abortTrigger, }) async {
+    final response = await deletePetWithHttpInfo(petId, apiKey: apiKey, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -143,7 +145,7 @@ class PetApi {
   ///
   /// * [List<String>] status (required):
   ///   Status values that need to be considered for filter
-  Future<Response> findPetsByStatusWithHttpInfo(List<String> status,) async {
+  Future<Response> findPetsByStatusWithHttpInfo(List<String> status, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/pet/findByStatus';
 
@@ -167,6 +169,7 @@ class PetApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -178,8 +181,8 @@ class PetApi {
   ///
   /// * [List<String>] status (required):
   ///   Status values that need to be considered for filter
-  Future<List<Pet>?> findPetsByStatus(List<String> status,) async {
-    final response = await findPetsByStatusWithHttpInfo(status,);
+  Future<List<Pet>?> findPetsByStatus(List<String> status, { Future<void>? abortTrigger, }) async {
+    final response = await findPetsByStatusWithHttpInfo(status, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -206,7 +209,7 @@ class PetApi {
   ///
   /// * [List<String>] tags (required):
   ///   Tags to filter by
-  Future<Response> findPetsByTagsWithHttpInfo(List<String> tags,) async {
+  Future<Response> findPetsByTagsWithHttpInfo(List<String> tags, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/pet/findByTags';
 
@@ -230,6 +233,7 @@ class PetApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -241,8 +245,8 @@ class PetApi {
   ///
   /// * [List<String>] tags (required):
   ///   Tags to filter by
-  Future<List<Pet>?> findPetsByTags(List<String> tags,) async {
-    final response = await findPetsByTagsWithHttpInfo(tags,);
+  Future<List<Pet>?> findPetsByTags(List<String> tags, { Future<void>? abortTrigger, }) async {
+    final response = await findPetsByTagsWithHttpInfo(tags, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -269,7 +273,7 @@ class PetApi {
   ///
   /// * [int] petId (required):
   ///   ID of pet to return
-  Future<Response> getPetByIdWithHttpInfo(int petId,) async {
+  Future<Response> getPetByIdWithHttpInfo(int petId, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/pet/{petId}'
       .replaceAll('{petId}', petId.toString());
@@ -292,6 +296,7 @@ class PetApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -303,8 +308,8 @@ class PetApi {
   ///
   /// * [int] petId (required):
   ///   ID of pet to return
-  Future<Pet?> getPetById(int petId,) async {
-    final response = await getPetByIdWithHttpInfo(petId,);
+  Future<Pet?> getPetById(int petId, { Future<void>? abortTrigger, }) async {
+    final response = await getPetByIdWithHttpInfo(petId, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -328,7 +333,7 @@ class PetApi {
   ///
   /// * [Pet] pet (required):
   ///   Pet object that needs to be added to the store
-  Future<Response> updatePetWithHttpInfo(Pet pet,) async {
+  Future<Response> updatePetWithHttpInfo(Pet pet, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/pet';
 
@@ -350,6 +355,7 @@ class PetApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -361,8 +367,8 @@ class PetApi {
   ///
   /// * [Pet] pet (required):
   ///   Pet object that needs to be added to the store
-  Future<Pet?> updatePet(Pet pet,) async {
-    final response = await updatePetWithHttpInfo(pet,);
+  Future<Pet?> updatePet(Pet pet, { Future<void>? abortTrigger, }) async {
+    final response = await updatePetWithHttpInfo(pet, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -392,7 +398,7 @@ class PetApi {
   ///
   /// * [String] status:
   ///   Updated status of the pet
-  Future<Response> updatePetWithFormWithHttpInfo(int petId, { String? name, String? status, }) async {
+  Future<Response> updatePetWithFormWithHttpInfo(int petId, { String? name, String? status, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/pet/{petId}'
       .replaceAll('{petId}', petId.toString());
@@ -421,6 +427,7 @@ class PetApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -438,8 +445,8 @@ class PetApi {
   ///
   /// * [String] status:
   ///   Updated status of the pet
-  Future<void> updatePetWithForm(int petId, { String? name, String? status, }) async {
-    final response = await updatePetWithFormWithHttpInfo(petId,  name: name, status: status, );
+  Future<void> updatePetWithForm(int petId, { String? name, String? status, Future<void>? abortTrigger, }) async {
+    final response = await updatePetWithFormWithHttpInfo(petId, name: name, status: status, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -461,7 +468,7 @@ class PetApi {
   ///
   /// * [MultipartFile] file:
   ///   file to upload
-  Future<Response> uploadFileWithHttpInfo(int petId, { String? additionalMetadata, MultipartFile? file, }) async {
+  Future<Response> uploadFileWithHttpInfo(int petId, { String? additionalMetadata, MultipartFile? file, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/pet/{petId}/uploadImage'
       .replaceAll('{petId}', petId.toString());
@@ -498,6 +505,7 @@ class PetApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -515,8 +523,8 @@ class PetApi {
   ///
   /// * [MultipartFile] file:
   ///   file to upload
-  Future<ApiResponse?> uploadFile(int petId, { String? additionalMetadata, MultipartFile? file, }) async {
-    final response = await uploadFileWithHttpInfo(petId,  additionalMetadata: additionalMetadata, file: file, );
+  Future<ApiResponse?> uploadFile(int petId, { String? additionalMetadata, MultipartFile? file, Future<void>? abortTrigger, }) async {
+    final response = await uploadFileWithHttpInfo(petId, additionalMetadata: additionalMetadata, file: file, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/store_api.dart
@@ -26,7 +26,7 @@ class StoreApi {
   ///
   /// * [String] orderId (required):
   ///   ID of the order that needs to be deleted
-  Future<Response> deleteOrderWithHttpInfo(String orderId,) async {
+  Future<Response> deleteOrderWithHttpInfo(String orderId, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/store/order/{orderId}'
       .replaceAll('{orderId}', orderId);
@@ -49,6 +49,7 @@ class StoreApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -60,8 +61,8 @@ class StoreApi {
   ///
   /// * [String] orderId (required):
   ///   ID of the order that needs to be deleted
-  Future<void> deleteOrder(String orderId,) async {
-    final response = await deleteOrderWithHttpInfo(orderId,);
+  Future<void> deleteOrder(String orderId, { Future<void>? abortTrigger, }) async {
+    final response = await deleteOrderWithHttpInfo(orderId, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -72,7 +73,7 @@ class StoreApi {
   /// Returns a map of status codes to quantities
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getInventoryWithHttpInfo() async {
+  Future<Response> getInventoryWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/store/inventory';
 
@@ -94,14 +95,15 @@ class StoreApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Returns pet inventories by status
   ///
   /// Returns a map of status codes to quantities
-  Future<Map<String, int>?> getInventory() async {
-    final response = await getInventoryWithHttpInfo();
+  Future<Map<String, int>?> getInventory({ Future<void>? abortTrigger, }) async {
+    final response = await getInventoryWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -125,7 +127,7 @@ class StoreApi {
   ///
   /// * [int] orderId (required):
   ///   ID of pet that needs to be fetched
-  Future<Response> getOrderByIdWithHttpInfo(int orderId,) async {
+  Future<Response> getOrderByIdWithHttpInfo(int orderId, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/store/order/{orderId}'
       .replaceAll('{orderId}', orderId.toString());
@@ -148,6 +150,7 @@ class StoreApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -159,8 +162,8 @@ class StoreApi {
   ///
   /// * [int] orderId (required):
   ///   ID of pet that needs to be fetched
-  Future<Order?> getOrderById(int orderId,) async {
-    final response = await getOrderByIdWithHttpInfo(orderId,);
+  Future<Order?> getOrderById(int orderId, { Future<void>? abortTrigger, }) async {
+    final response = await getOrderByIdWithHttpInfo(orderId, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -184,7 +187,7 @@ class StoreApi {
   ///
   /// * [Order] order (required):
   ///   order placed for purchasing the pet
-  Future<Response> placeOrderWithHttpInfo(Order order,) async {
+  Future<Response> placeOrderWithHttpInfo(Order order, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/store/order';
 
@@ -206,6 +209,7 @@ class StoreApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -217,8 +221,8 @@ class StoreApi {
   ///
   /// * [Order] order (required):
   ///   order placed for purchasing the pet
-  Future<Order?> placeOrder(Order order,) async {
-    final response = await placeOrderWithHttpInfo(order,);
+  Future<Order?> placeOrder(Order order, { Future<void>? abortTrigger, }) async {
+    final response = await placeOrderWithHttpInfo(order, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/user_api.dart
@@ -26,7 +26,7 @@ class UserApi {
   ///
   /// * [User] user (required):
   ///   Created user object
-  Future<Response> createUserWithHttpInfo(User user,) async {
+  Future<Response> createUserWithHttpInfo(User user, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/user';
 
@@ -48,6 +48,7 @@ class UserApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -59,8 +60,8 @@ class UserApi {
   ///
   /// * [User] user (required):
   ///   Created user object
-  Future<void> createUser(User user,) async {
-    final response = await createUserWithHttpInfo(user,);
+  Future<void> createUser(User user, { Future<void>? abortTrigger, }) async {
+    final response = await createUserWithHttpInfo(user, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -76,7 +77,7 @@ class UserApi {
   ///
   /// * [List<User>] user (required):
   ///   List of user object
-  Future<Response> createUsersWithArrayInputWithHttpInfo(List<User> user,) async {
+  Future<Response> createUsersWithArrayInputWithHttpInfo(List<User> user, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/user/createWithArray';
 
@@ -98,6 +99,7 @@ class UserApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -109,8 +111,8 @@ class UserApi {
   ///
   /// * [List<User>] user (required):
   ///   List of user object
-  Future<void> createUsersWithArrayInput(List<User> user,) async {
-    final response = await createUsersWithArrayInputWithHttpInfo(user,);
+  Future<void> createUsersWithArrayInput(List<User> user, { Future<void>? abortTrigger, }) async {
+    final response = await createUsersWithArrayInputWithHttpInfo(user, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -126,7 +128,7 @@ class UserApi {
   ///
   /// * [List<User>] user (required):
   ///   List of user object
-  Future<Response> createUsersWithListInputWithHttpInfo(List<User> user,) async {
+  Future<Response> createUsersWithListInputWithHttpInfo(List<User> user, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/user/createWithList';
 
@@ -148,6 +150,7 @@ class UserApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -159,8 +162,8 @@ class UserApi {
   ///
   /// * [List<User>] user (required):
   ///   List of user object
-  Future<void> createUsersWithListInput(List<User> user,) async {
-    final response = await createUsersWithListInputWithHttpInfo(user,);
+  Future<void> createUsersWithListInput(List<User> user, { Future<void>? abortTrigger, }) async {
+    final response = await createUsersWithListInputWithHttpInfo(user, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -176,7 +179,7 @@ class UserApi {
   ///
   /// * [String] username (required):
   ///   The name that needs to be deleted
-  Future<Response> deleteUserWithHttpInfo(String username,) async {
+  Future<Response> deleteUserWithHttpInfo(String username, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/user/{username}'
       .replaceAll('{username}', username);
@@ -199,6 +202,7 @@ class UserApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -210,8 +214,8 @@ class UserApi {
   ///
   /// * [String] username (required):
   ///   The name that needs to be deleted
-  Future<void> deleteUser(String username,) async {
-    final response = await deleteUserWithHttpInfo(username,);
+  Future<void> deleteUser(String username, { Future<void>? abortTrigger, }) async {
+    final response = await deleteUserWithHttpInfo(username, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -227,7 +231,7 @@ class UserApi {
   ///
   /// * [String] username (required):
   ///   The name that needs to be fetched. Use user1 for testing.
-  Future<Response> getUserByNameWithHttpInfo(String username,) async {
+  Future<Response> getUserByNameWithHttpInfo(String username, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/user/{username}'
       .replaceAll('{username}', username);
@@ -250,6 +254,7 @@ class UserApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -261,8 +266,8 @@ class UserApi {
   ///
   /// * [String] username (required):
   ///   The name that needs to be fetched. Use user1 for testing.
-  Future<User?> getUserByName(String username,) async {
-    final response = await getUserByNameWithHttpInfo(username,);
+  Future<User?> getUserByName(String username, { Future<void>? abortTrigger, }) async {
+    final response = await getUserByNameWithHttpInfo(username, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -289,7 +294,7 @@ class UserApi {
   ///
   /// * [String] password (required):
   ///   The password for login in clear text
-  Future<Response> loginUserWithHttpInfo(String username, String password,) async {
+  Future<Response> loginUserWithHttpInfo(String username, String password, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/user/login';
 
@@ -314,6 +319,7 @@ class UserApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -328,8 +334,8 @@ class UserApi {
   ///
   /// * [String] password (required):
   ///   The password for login in clear text
-  Future<String?> loginUser(String username, String password,) async {
-    final response = await loginUserWithHttpInfo(username, password,);
+  Future<String?> loginUser(String username, String password, { Future<void>? abortTrigger, }) async {
+    final response = await loginUserWithHttpInfo(username, password, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -348,7 +354,7 @@ class UserApi {
   /// 
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> logoutUserWithHttpInfo() async {
+  Future<Response> logoutUserWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/user/logout';
 
@@ -370,14 +376,15 @@ class UserApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Logs out current logged in user session
   ///
   /// 
-  Future<void> logoutUser() async {
-    final response = await logoutUserWithHttpInfo();
+  Future<void> logoutUser({ Future<void>? abortTrigger, }) async {
+    final response = await logoutUserWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -396,7 +403,7 @@ class UserApi {
   ///
   /// * [User] user (required):
   ///   Updated user object
-  Future<Response> updateUserWithHttpInfo(String username, User user,) async {
+  Future<Response> updateUserWithHttpInfo(String username, User user, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/user/{username}'
       .replaceAll('{username}', username);
@@ -419,6 +426,7 @@ class UserApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -433,8 +441,8 @@ class UserApi {
   ///
   /// * [User] user (required):
   ///   Updated user object
-  Future<void> updateUser(String username, User user,) async {
-    final response = await updateUserWithHttpInfo(username, user,);
+  Future<void> updateUser(String username, User user, { Future<void>? abortTrigger, }) async {
+    final response = await updateUserWithHttpInfo(username, user, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_client.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_client.dart
@@ -97,9 +97,9 @@ class ApiClient {
       if (nullableHeaderParams != null) {
         request.headers.addAll(nullableHeaderParams);
       }
-      if (msgBody is String) {
+      if (msgBody is String && msgBody.isNotEmpty) {
         request.body = msgBody;
-      } else if (msgBody is List<int>) {
+      } else if (msgBody is List<int> && msgBody.isNotEmpty) {
         request.bodyBytes = msgBody;
       } else if (msgBody is Map<String, String>) {
         request.bodyFields = msgBody;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_client.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_client.dart
@@ -44,8 +44,9 @@ class ApiClient {
     Object? body,
     Map<String, String> headerParams,
     Map<String, String> formParams,
-    String? contentType,
-  ) async {
+    String? contentType, {
+    Future<void>? abortTrigger,
+  }) async {
     await authentication?.applyToParams(queryParams, headerParams);
 
     headerParams.addAll(_defaultHeaderMap);
@@ -63,7 +64,7 @@ class ApiClient {
         body is MultipartFile && (contentType == null ||
         !contentType.toLowerCase().startsWith('multipart/form-data'))
       ) {
-        final request = StreamedRequest(method, uri);
+        final request = AbortableStreamedRequest(method, uri, abortTrigger: abortTrigger);
         request.headers.addAll(headerParams);
         request.contentLength = body.length;
         body.finalize().listen(
@@ -78,7 +79,7 @@ class ApiClient {
       }
 
       if (body is MultipartRequest) {
-        final request = MultipartRequest(method, uri);
+        final request = AbortableMultipartRequest(method, uri, abortTrigger: abortTrigger);
         request.fields.addAll(body.fields);
         request.files.addAll(body.files);
         request.headers.addAll(body.headers);
@@ -92,14 +93,19 @@ class ApiClient {
         : await serializeAsync(body);
       final nullableHeaderParams = headerParams.isEmpty ? null : headerParams;
 
-      switch(method) {
-        case 'POST': return await _client.post(uri, headers: nullableHeaderParams, body: msgBody,);
-        case 'PUT': return await _client.put(uri, headers: nullableHeaderParams, body: msgBody,);
-        case 'DELETE': return await _client.delete(uri, headers: nullableHeaderParams, body: msgBody,);
-        case 'PATCH': return await _client.patch(uri, headers: nullableHeaderParams, body: msgBody,);
-        case 'HEAD': return await _client.head(uri, headers: nullableHeaderParams,);
-        case 'GET': return await _client.get(uri, headers: nullableHeaderParams,);
+      final request = AbortableRequest(method, uri, abortTrigger: abortTrigger);
+      if (nullableHeaderParams != null) {
+        request.headers.addAll(nullableHeaderParams);
       }
+      if (msgBody is String) {
+        request.body = msgBody;
+      } else if (msgBody is List<int>) {
+        request.bodyBytes = msgBody;
+      } else if (msgBody is Map<String, String>) {
+        request.bodyFields = msgBody;
+      }
+      final response = await _client.send(request);
+      return Response.fromStream(response);
     } on SocketException catch (error, trace) {
       throw ApiException.withInner(
         HttpStatus.badRequest,
@@ -136,11 +142,6 @@ class ApiClient {
         trace,
       );
     }
-
-    throw ApiException(
-      HttpStatus.badRequest,
-      'Invalid HTTP operation: $method $path',
-    );
   }
 
   Future<dynamic> deserializeAsync(String value, String targetType, {bool growable = false,}) async =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/another_fake_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/another_fake_api.dart
@@ -26,7 +26,7 @@ class AnotherFakeApi {
   ///
   /// * [ModelClient] modelClient (required):
   ///   client model
-  Future<Response> call123testSpecialTagsWithHttpInfo(ModelClient modelClient,) async {
+  Future<Response> call123testSpecialTagsWithHttpInfo(ModelClient modelClient, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/another-fake/dummy';
 
@@ -48,6 +48,7 @@ class AnotherFakeApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -59,8 +60,8 @@ class AnotherFakeApi {
   ///
   /// * [ModelClient] modelClient (required):
   ///   client model
-  Future<ModelClient?> call123testSpecialTags(ModelClient modelClient,) async {
-    final response = await call123testSpecialTagsWithHttpInfo(modelClient,);
+  Future<ModelClient?> call123testSpecialTags(ModelClient modelClient, { Future<void>? abortTrigger, }) async {
+    final response = await call123testSpecialTagsWithHttpInfo(modelClient, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/default_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/default_api.dart
@@ -17,7 +17,7 @@ class DefaultApi {
   final ApiClient apiClient;
 
   /// Performs an HTTP 'GET /foo' operation and returns the [Response].
-  Future<Response> fooGetWithHttpInfo() async {
+  Future<Response> fooGetWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/foo';
 
@@ -39,11 +39,12 @@ class DefaultApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
-  Future<FooGetDefaultResponse?> fooGet() async {
-    final response = await fooGetWithHttpInfo();
+  Future<FooGetDefaultResponse?> fooGet({ Future<void>? abortTrigger, }) async {
+    final response = await fooGetWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/fake_api.dart
@@ -19,7 +19,7 @@ class FakeApi {
   /// for Java apache and Java native, test toUrlQueryString for maps with BegDecimal keys
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> fakeBigDecimalMapWithHttpInfo() async {
+  Future<Response> fakeBigDecimalMapWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake/BigDecimalMap';
 
@@ -41,12 +41,13 @@ class FakeApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// for Java apache and Java native, test toUrlQueryString for maps with BegDecimal keys
-  Future<FakeBigDecimalMap200Response?> fakeBigDecimalMap() async {
-    final response = await fakeBigDecimalMapWithHttpInfo();
+  Future<FakeBigDecimalMap200Response?> fakeBigDecimalMap({ Future<void>? abortTrigger, }) async {
+    final response = await fakeBigDecimalMapWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -63,7 +64,7 @@ class FakeApi {
   /// test objects with duplicate inline enums see issue# 21582
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> fakeDuplicateInlineEnumWithHttpInfo() async {
+  Future<Response> fakeDuplicateInlineEnumWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake/duplicate-inline-enums';
 
@@ -85,12 +86,13 @@ class FakeApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// test objects with duplicate inline enums see issue# 21582
-  Future<ObjectThatReferencesObjectsWithDuplicateInlineEnums?> fakeDuplicateInlineEnum() async {
-    final response = await fakeDuplicateInlineEnumWithHttpInfo();
+  Future<ObjectThatReferencesObjectsWithDuplicateInlineEnums?> fakeDuplicateInlineEnum({ Future<void>? abortTrigger, }) async {
+    final response = await fakeDuplicateInlineEnumWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -107,7 +109,7 @@ class FakeApi {
   /// Health check endpoint
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> fakeHealthGetWithHttpInfo() async {
+  Future<Response> fakeHealthGetWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake/health';
 
@@ -129,12 +131,13 @@ class FakeApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Health check endpoint
-  Future<HealthCheckResult?> fakeHealthGet() async {
-    final response = await fakeHealthGetWithHttpInfo();
+  Future<HealthCheckResult?> fakeHealthGet({ Future<void>? abortTrigger, }) async {
+    final response = await fakeHealthGetWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -162,7 +165,7 @@ class FakeApi {
   ///
   /// * [String] header1:
   ///   header parameter
-  Future<Response> fakeHttpSignatureTestWithHttpInfo(Pet pet, { String? query1, String? header1, }) async {
+  Future<Response> fakeHttpSignatureTestWithHttpInfo(Pet pet, { String? query1, String? header1, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake/http-signature-test';
 
@@ -192,6 +195,7 @@ class FakeApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -207,8 +211,8 @@ class FakeApi {
   ///
   /// * [String] header1:
   ///   header parameter
-  Future<void> fakeHttpSignatureTest(Pet pet, { String? query1, String? header1, }) async {
-    final response = await fakeHttpSignatureTestWithHttpInfo(pet,  query1: query1, header1: header1, );
+  Future<void> fakeHttpSignatureTest(Pet pet, { String? query1, String? header1, Future<void>? abortTrigger, }) async {
+    final response = await fakeHttpSignatureTestWithHttpInfo(pet, query1: query1, header1: header1, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -222,7 +226,7 @@ class FakeApi {
   ///
   /// * [bool] body:
   ///   Input boolean as post body
-  Future<Response> fakeOuterBooleanSerializeWithHttpInfo({ bool? body, }) async {
+  Future<Response> fakeOuterBooleanSerializeWithHttpInfo({ bool? body, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake/outer/boolean';
 
@@ -244,6 +248,7 @@ class FakeApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -253,8 +258,8 @@ class FakeApi {
   ///
   /// * [bool] body:
   ///   Input boolean as post body
-  Future<bool?> fakeOuterBooleanSerialize({ bool? body, }) async {
-    final response = await fakeOuterBooleanSerializeWithHttpInfo( body: body, );
+  Future<bool?> fakeOuterBooleanSerialize({ bool? body, Future<void>? abortTrigger, }) async {
+    final response = await fakeOuterBooleanSerializeWithHttpInfo(body: body, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -276,7 +281,7 @@ class FakeApi {
   ///
   /// * [OuterComposite] outerComposite:
   ///   Input composite as post body
-  Future<Response> fakeOuterCompositeSerializeWithHttpInfo({ OuterComposite? outerComposite, }) async {
+  Future<Response> fakeOuterCompositeSerializeWithHttpInfo({ OuterComposite? outerComposite, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake/outer/composite';
 
@@ -298,6 +303,7 @@ class FakeApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -307,8 +313,8 @@ class FakeApi {
   ///
   /// * [OuterComposite] outerComposite:
   ///   Input composite as post body
-  Future<OuterComposite?> fakeOuterCompositeSerialize({ OuterComposite? outerComposite, }) async {
-    final response = await fakeOuterCompositeSerializeWithHttpInfo( outerComposite: outerComposite, );
+  Future<OuterComposite?> fakeOuterCompositeSerialize({ OuterComposite? outerComposite, Future<void>? abortTrigger, }) async {
+    final response = await fakeOuterCompositeSerializeWithHttpInfo(outerComposite: outerComposite, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -330,7 +336,7 @@ class FakeApi {
   ///
   /// * [num] body:
   ///   Input number as post body
-  Future<Response> fakeOuterNumberSerializeWithHttpInfo({ num? body, }) async {
+  Future<Response> fakeOuterNumberSerializeWithHttpInfo({ num? body, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake/outer/number';
 
@@ -352,6 +358,7 @@ class FakeApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -361,8 +368,8 @@ class FakeApi {
   ///
   /// * [num] body:
   ///   Input number as post body
-  Future<num?> fakeOuterNumberSerialize({ num? body, }) async {
-    final response = await fakeOuterNumberSerializeWithHttpInfo( body: body, );
+  Future<num?> fakeOuterNumberSerialize({ num? body, Future<void>? abortTrigger, }) async {
+    final response = await fakeOuterNumberSerializeWithHttpInfo(body: body, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -384,7 +391,7 @@ class FakeApi {
   ///
   /// * [String] body:
   ///   Input string as post body
-  Future<Response> fakeOuterStringSerializeWithHttpInfo({ String? body, }) async {
+  Future<Response> fakeOuterStringSerializeWithHttpInfo({ String? body, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake/outer/string';
 
@@ -406,6 +413,7 @@ class FakeApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -415,8 +423,8 @@ class FakeApi {
   ///
   /// * [String] body:
   ///   Input string as post body
-  Future<String?> fakeOuterStringSerialize({ String? body, }) async {
-    final response = await fakeOuterStringSerializeWithHttpInfo( body: body, );
+  Future<String?> fakeOuterStringSerialize({ String? body, Future<void>? abortTrigger, }) async {
+    final response = await fakeOuterStringSerializeWithHttpInfo(body: body, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -438,7 +446,7 @@ class FakeApi {
   ///
   /// * [OuterObjectWithEnumProperty] outerObjectWithEnumProperty (required):
   ///   Input enum (int) as post body
-  Future<Response> fakePropertyEnumIntegerSerializeWithHttpInfo(OuterObjectWithEnumProperty outerObjectWithEnumProperty,) async {
+  Future<Response> fakePropertyEnumIntegerSerializeWithHttpInfo(OuterObjectWithEnumProperty outerObjectWithEnumProperty, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake/property/enum-int';
 
@@ -460,6 +468,7 @@ class FakeApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -469,8 +478,8 @@ class FakeApi {
   ///
   /// * [OuterObjectWithEnumProperty] outerObjectWithEnumProperty (required):
   ///   Input enum (int) as post body
-  Future<OuterObjectWithEnumProperty?> fakePropertyEnumIntegerSerialize(OuterObjectWithEnumProperty outerObjectWithEnumProperty,) async {
-    final response = await fakePropertyEnumIntegerSerializeWithHttpInfo(outerObjectWithEnumProperty,);
+  Future<OuterObjectWithEnumProperty?> fakePropertyEnumIntegerSerialize(OuterObjectWithEnumProperty outerObjectWithEnumProperty, { Future<void>? abortTrigger, }) async {
+    final response = await fakePropertyEnumIntegerSerializeWithHttpInfo(outerObjectWithEnumProperty, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -494,7 +503,7 @@ class FakeApi {
   ///
   /// * [Map<String, Object>] requestBody (required):
   ///   request body
-  Future<Response> testAdditionalPropertiesReferenceWithHttpInfo(Map<String, Object> requestBody,) async {
+  Future<Response> testAdditionalPropertiesReferenceWithHttpInfo(Map<String, Object> requestBody, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake/additionalProperties-reference';
 
@@ -516,6 +525,7 @@ class FakeApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -527,8 +537,8 @@ class FakeApi {
   ///
   /// * [Map<String, Object>] requestBody (required):
   ///   request body
-  Future<void> testAdditionalPropertiesReference(Map<String, Object> requestBody,) async {
-    final response = await testAdditionalPropertiesReferenceWithHttpInfo(requestBody,);
+  Future<void> testAdditionalPropertiesReference(Map<String, Object> requestBody, { Future<void>? abortTrigger, }) async {
+    final response = await testAdditionalPropertiesReferenceWithHttpInfo(requestBody, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -542,7 +552,7 @@ class FakeApi {
   ///
   /// * [MultipartFile] body (required):
   ///   image to upload
-  Future<Response> testBodyWithBinaryWithHttpInfo(MultipartFile body,) async {
+  Future<Response> testBodyWithBinaryWithHttpInfo(MultipartFile body, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake/body-with-binary';
 
@@ -564,6 +574,7 @@ class FakeApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -573,8 +584,8 @@ class FakeApi {
   ///
   /// * [MultipartFile] body (required):
   ///   image to upload
-  Future<void> testBodyWithBinary(MultipartFile body,) async {
-    final response = await testBodyWithBinaryWithHttpInfo(body,);
+  Future<void> testBodyWithBinary(MultipartFile body, { Future<void>? abortTrigger, }) async {
+    final response = await testBodyWithBinaryWithHttpInfo(body, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -587,7 +598,7 @@ class FakeApi {
   /// Parameters:
   ///
   /// * [FileSchemaTestClass] fileSchemaTestClass (required):
-  Future<Response> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass fileSchemaTestClass,) async {
+  Future<Response> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass fileSchemaTestClass, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake/body-with-file-schema';
 
@@ -609,6 +620,7 @@ class FakeApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -617,8 +629,8 @@ class FakeApi {
   /// Parameters:
   ///
   /// * [FileSchemaTestClass] fileSchemaTestClass (required):
-  Future<void> testBodyWithFileSchema(FileSchemaTestClass fileSchemaTestClass,) async {
-    final response = await testBodyWithFileSchemaWithHttpInfo(fileSchemaTestClass,);
+  Future<void> testBodyWithFileSchema(FileSchemaTestClass fileSchemaTestClass, { Future<void>? abortTrigger, }) async {
+    final response = await testBodyWithFileSchemaWithHttpInfo(fileSchemaTestClass, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -630,7 +642,7 @@ class FakeApi {
   /// * [String] query (required):
   ///
   /// * [User] user (required):
-  Future<Response> testBodyWithQueryParamsWithHttpInfo(String query, User user,) async {
+  Future<Response> testBodyWithQueryParamsWithHttpInfo(String query, User user, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake/body-with-query-params';
 
@@ -654,6 +666,7 @@ class FakeApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -662,8 +675,8 @@ class FakeApi {
   /// * [String] query (required):
   ///
   /// * [User] user (required):
-  Future<void> testBodyWithQueryParams(String query, User user,) async {
-    final response = await testBodyWithQueryParamsWithHttpInfo(query, user,);
+  Future<void> testBodyWithQueryParams(String query, User user, { Future<void>? abortTrigger, }) async {
+    final response = await testBodyWithQueryParamsWithHttpInfo(query, user, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -679,7 +692,7 @@ class FakeApi {
   ///
   /// * [ModelClient] modelClient (required):
   ///   client model
-  Future<Response> testClientModelWithHttpInfo(ModelClient modelClient,) async {
+  Future<Response> testClientModelWithHttpInfo(ModelClient modelClient, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake';
 
@@ -701,6 +714,7 @@ class FakeApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -712,8 +726,8 @@ class FakeApi {
   ///
   /// * [ModelClient] modelClient (required):
   ///   client model
-  Future<ModelClient?> testClientModel(ModelClient modelClient,) async {
-    final response = await testClientModelWithHttpInfo(modelClient,);
+  Future<ModelClient?> testClientModel(ModelClient modelClient, { Future<void>? abortTrigger, }) async {
+    final response = await testClientModelWithHttpInfo(modelClient, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -776,7 +790,7 @@ class FakeApi {
   ///
   /// * [String] callback:
   ///   None
-  Future<Response> testEndpointParametersWithHttpInfo(num number, double double_, String patternWithoutDelimiter, String byte, { int? integer, int? int32, int? int64, double? float, String? string, MultipartFile? binary, DateTime? date, DateTime? dateTime, String? password, String? callback, }) async {
+  Future<Response> testEndpointParametersWithHttpInfo(num number, double double_, String patternWithoutDelimiter, String byte, { int? integer, int? int32, int? int64, double? float, String? string, MultipartFile? binary, DateTime? date, DateTime? dateTime, String? password, String? callback, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake';
 
@@ -837,6 +851,7 @@ class FakeApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -887,8 +902,8 @@ class FakeApi {
   ///
   /// * [String] callback:
   ///   None
-  Future<void> testEndpointParameters(num number, double double_, String patternWithoutDelimiter, String byte, { int? integer, int? int32, int? int64, double? float, String? string, MultipartFile? binary, DateTime? date, DateTime? dateTime, String? password, String? callback, }) async {
-    final response = await testEndpointParametersWithHttpInfo(number, double_, patternWithoutDelimiter, byte,  integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback, );
+  Future<void> testEndpointParameters(num number, double double_, String patternWithoutDelimiter, String byte, { int? integer, int? int32, int? int64, double? float, String? string, MultipartFile? binary, DateTime? date, DateTime? dateTime, String? password, String? callback, Future<void>? abortTrigger, }) async {
+    final response = await testEndpointParametersWithHttpInfo(number, double_, patternWithoutDelimiter, byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -927,7 +942,7 @@ class FakeApi {
   ///
   /// * [String] enumFormString:
   ///   Form parameter enum test (string)
-  Future<Response> testEnumParametersWithHttpInfo({ List<String>? enumHeaderStringArray, String? enumHeaderString, List<String>? enumQueryStringArray, String? enumQueryString, int? enumQueryInteger, double? enumQueryDouble, List<EnumClass>? enumQueryModelArray, List<String>? enumFormStringArray, String? enumFormString, }) async {
+  Future<Response> testEnumParametersWithHttpInfo({ List<String>? enumHeaderStringArray, String? enumHeaderString, List<String>? enumQueryStringArray, String? enumQueryString, int? enumQueryInteger, double? enumQueryDouble, List<EnumClass>? enumQueryModelArray, List<String>? enumFormStringArray, String? enumFormString, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake';
 
@@ -978,6 +993,7 @@ class FakeApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -1012,8 +1028,8 @@ class FakeApi {
   ///
   /// * [String] enumFormString:
   ///   Form parameter enum test (string)
-  Future<void> testEnumParameters({ List<String>? enumHeaderStringArray, String? enumHeaderString, List<String>? enumQueryStringArray, String? enumQueryString, int? enumQueryInteger, double? enumQueryDouble, List<EnumClass>? enumQueryModelArray, List<String>? enumFormStringArray, String? enumFormString, }) async {
-    final response = await testEnumParametersWithHttpInfo( enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumQueryModelArray: enumQueryModelArray, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString, );
+  Future<void> testEnumParameters({ List<String>? enumHeaderStringArray, String? enumHeaderString, List<String>? enumQueryStringArray, String? enumQueryString, int? enumQueryInteger, double? enumQueryDouble, List<EnumClass>? enumQueryModelArray, List<String>? enumFormStringArray, String? enumFormString, Future<void>? abortTrigger, }) async {
+    final response = await testEnumParametersWithHttpInfo(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumQueryModelArray: enumQueryModelArray, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -1044,7 +1060,7 @@ class FakeApi {
   ///
   /// * [int] int64Group:
   ///   Integer in group parameters
-  Future<Response> testGroupParametersWithHttpInfo(int requiredStringGroup, bool requiredBooleanGroup, int requiredInt64Group, { int? stringGroup, bool? booleanGroup, int? int64Group, }) async {
+  Future<Response> testGroupParametersWithHttpInfo(int requiredStringGroup, bool requiredBooleanGroup, int requiredInt64Group, { int? stringGroup, bool? booleanGroup, int? int64Group, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake';
 
@@ -1080,6 +1096,7 @@ class FakeApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -1106,8 +1123,8 @@ class FakeApi {
   ///
   /// * [int] int64Group:
   ///   Integer in group parameters
-  Future<void> testGroupParameters(int requiredStringGroup, bool requiredBooleanGroup, int requiredInt64Group, { int? stringGroup, bool? booleanGroup, int? int64Group, }) async {
-    final response = await testGroupParametersWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group,  stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group, );
+  Future<void> testGroupParameters(int requiredStringGroup, bool requiredBooleanGroup, int requiredInt64Group, { int? stringGroup, bool? booleanGroup, int? int64Group, Future<void>? abortTrigger, }) async {
+    final response = await testGroupParametersWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -1123,7 +1140,7 @@ class FakeApi {
   ///
   /// * [Map<String, String>] requestBody (required):
   ///   request body
-  Future<Response> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> requestBody,) async {
+  Future<Response> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> requestBody, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake/inline-additionalProperties';
 
@@ -1145,6 +1162,7 @@ class FakeApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -1156,8 +1174,8 @@ class FakeApi {
   ///
   /// * [Map<String, String>] requestBody (required):
   ///   request body
-  Future<void> testInlineAdditionalProperties(Map<String, String> requestBody,) async {
-    final response = await testInlineAdditionalPropertiesWithHttpInfo(requestBody,);
+  Future<void> testInlineAdditionalProperties(Map<String, String> requestBody, { Future<void>? abortTrigger, }) async {
+    final response = await testInlineAdditionalPropertiesWithHttpInfo(requestBody, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -1173,7 +1191,7 @@ class FakeApi {
   ///
   /// * [TestInlineFreeformAdditionalPropertiesRequest] testInlineFreeformAdditionalPropertiesRequest (required):
   ///   request body
-  Future<Response> testInlineFreeformAdditionalPropertiesWithHttpInfo(TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest,) async {
+  Future<Response> testInlineFreeformAdditionalPropertiesWithHttpInfo(TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake/inline-freeform-additionalProperties';
 
@@ -1195,6 +1213,7 @@ class FakeApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -1206,8 +1225,8 @@ class FakeApi {
   ///
   /// * [TestInlineFreeformAdditionalPropertiesRequest] testInlineFreeformAdditionalPropertiesRequest (required):
   ///   request body
-  Future<void> testInlineFreeformAdditionalProperties(TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest,) async {
-    final response = await testInlineFreeformAdditionalPropertiesWithHttpInfo(testInlineFreeformAdditionalPropertiesRequest,);
+  Future<void> testInlineFreeformAdditionalProperties(TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest, { Future<void>? abortTrigger, }) async {
+    final response = await testInlineFreeformAdditionalPropertiesWithHttpInfo(testInlineFreeformAdditionalPropertiesRequest, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -1226,7 +1245,7 @@ class FakeApi {
   ///
   /// * [String] param2 (required):
   ///   field2
-  Future<Response> testJsonFormDataWithHttpInfo(String param, String param2,) async {
+  Future<Response> testJsonFormDataWithHttpInfo(String param, String param2, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake/jsonFormData';
 
@@ -1254,6 +1273,7 @@ class FakeApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -1268,8 +1288,8 @@ class FakeApi {
   ///
   /// * [String] param2 (required):
   ///   field2
-  Future<void> testJsonFormData(String param, String param2,) async {
-    final response = await testJsonFormDataWithHttpInfo(param, param2,);
+  Future<void> testJsonFormData(String param, String param2, { Future<void>? abortTrigger, }) async {
+    final response = await testJsonFormDataWithHttpInfo(param, param2, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -1285,7 +1305,7 @@ class FakeApi {
   ///
   /// * [ChildWithNullable] childWithNullable (required):
   ///   request body
-  Future<Response> testNullableWithHttpInfo(ChildWithNullable childWithNullable,) async {
+  Future<Response> testNullableWithHttpInfo(ChildWithNullable childWithNullable, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake/nullable';
 
@@ -1307,6 +1327,7 @@ class FakeApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -1318,8 +1339,8 @@ class FakeApi {
   ///
   /// * [ChildWithNullable] childWithNullable (required):
   ///   request body
-  Future<void> testNullable(ChildWithNullable childWithNullable,) async {
-    final response = await testNullableWithHttpInfo(childWithNullable,);
+  Future<void> testNullable(ChildWithNullable childWithNullable, { Future<void>? abortTrigger, }) async {
+    final response = await testNullableWithHttpInfo(childWithNullable, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -1344,7 +1365,7 @@ class FakeApi {
   /// * [String] allowEmpty (required):
   ///
   /// * [Map<String, String>] language:
-  Future<Response> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, String allowEmpty, { Map<String, String>? language, }) async {
+  Future<Response> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, String allowEmpty, { Map<String, String>? language, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake/test-query-parameters';
 
@@ -1376,6 +1397,7 @@ class FakeApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -1396,8 +1418,8 @@ class FakeApi {
   /// * [String] allowEmpty (required):
   ///
   /// * [Map<String, String>] language:
-  Future<void> testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, String allowEmpty, { Map<String, String>? language, }) async {
-    final response = await testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, allowEmpty,  language: language, );
+  Future<void> testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, String allowEmpty, { Map<String, String>? language, Future<void>? abortTrigger, }) async {
+    final response = await testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, allowEmpty, language: language, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -1413,7 +1435,7 @@ class FakeApi {
   ///
   /// * [Map<String, String>] requestBody (required):
   ///   request body
-  Future<Response> testStringMapReferenceWithHttpInfo(Map<String, String> requestBody,) async {
+  Future<Response> testStringMapReferenceWithHttpInfo(Map<String, String> requestBody, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake/stringMap-reference';
 
@@ -1435,6 +1457,7 @@ class FakeApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -1446,8 +1469,8 @@ class FakeApi {
   ///
   /// * [Map<String, String>] requestBody (required):
   ///   request body
-  Future<void> testStringMapReference(Map<String, String> requestBody,) async {
-    final response = await testStringMapReferenceWithHttpInfo(requestBody,);
+  Future<void> testStringMapReference(Map<String, String> requestBody, { Future<void>? abortTrigger, }) async {
+    final response = await testStringMapReferenceWithHttpInfo(requestBody, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/fake_classname_tags123_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/fake_classname_tags123_api.dart
@@ -26,7 +26,7 @@ class FakeClassnameTags123Api {
   ///
   /// * [ModelClient] modelClient (required):
   ///   client model
-  Future<Response> testClassnameWithHttpInfo(ModelClient modelClient,) async {
+  Future<Response> testClassnameWithHttpInfo(ModelClient modelClient, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake_classname_test';
 
@@ -48,6 +48,7 @@ class FakeClassnameTags123Api {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -59,8 +60,8 @@ class FakeClassnameTags123Api {
   ///
   /// * [ModelClient] modelClient (required):
   ///   client model
-  Future<ModelClient?> testClassname(ModelClient modelClient,) async {
-    final response = await testClassnameWithHttpInfo(modelClient,);
+  Future<ModelClient?> testClassname(ModelClient modelClient, { Future<void>? abortTrigger, }) async {
+    final response = await testClassnameWithHttpInfo(modelClient, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/pet_api.dart
@@ -26,7 +26,7 @@ class PetApi {
   ///
   /// * [Pet] pet (required):
   ///   Pet object that needs to be added to the store
-  Future<Response> addPetWithHttpInfo(Pet pet,) async {
+  Future<Response> addPetWithHttpInfo(Pet pet, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/pet';
 
@@ -48,6 +48,7 @@ class PetApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -59,8 +60,8 @@ class PetApi {
   ///
   /// * [Pet] pet (required):
   ///   Pet object that needs to be added to the store
-  Future<void> addPet(Pet pet,) async {
-    final response = await addPetWithHttpInfo(pet,);
+  Future<void> addPet(Pet pet, { Future<void>? abortTrigger, }) async {
+    final response = await addPetWithHttpInfo(pet, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -78,7 +79,7 @@ class PetApi {
   ///   Pet id to delete
   ///
   /// * [String] apiKey:
-  Future<Response> deletePetWithHttpInfo(int petId, { String? apiKey, }) async {
+  Future<Response> deletePetWithHttpInfo(int petId, { String? apiKey, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/pet/{petId}'
       .replaceAll('{petId}', petId.toString());
@@ -105,6 +106,7 @@ class PetApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -118,8 +120,8 @@ class PetApi {
   ///   Pet id to delete
   ///
   /// * [String] apiKey:
-  Future<void> deletePet(int petId, { String? apiKey, }) async {
-    final response = await deletePetWithHttpInfo(petId,  apiKey: apiKey, );
+  Future<void> deletePet(int petId, { String? apiKey, Future<void>? abortTrigger, }) async {
+    final response = await deletePetWithHttpInfo(petId, apiKey: apiKey, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -135,7 +137,7 @@ class PetApi {
   ///
   /// * [List<String>] status (required):
   ///   Status values that need to be considered for filter
-  Future<Response> findPetsByStatusWithHttpInfo(List<String> status,) async {
+  Future<Response> findPetsByStatusWithHttpInfo(List<String> status, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/pet/findByStatus';
 
@@ -159,6 +161,7 @@ class PetApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -170,8 +173,8 @@ class PetApi {
   ///
   /// * [List<String>] status (required):
   ///   Status values that need to be considered for filter
-  Future<List<Pet>?> findPetsByStatus(List<String> status,) async {
-    final response = await findPetsByStatusWithHttpInfo(status,);
+  Future<List<Pet>?> findPetsByStatus(List<String> status, { Future<void>? abortTrigger, }) async {
+    final response = await findPetsByStatusWithHttpInfo(status, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -198,7 +201,7 @@ class PetApi {
   ///
   /// * [Set<String>] tags (required):
   ///   Tags to filter by
-  Future<Response> findPetsByTagsWithHttpInfo(Set<String> tags,) async {
+  Future<Response> findPetsByTagsWithHttpInfo(Set<String> tags, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/pet/findByTags';
 
@@ -222,6 +225,7 @@ class PetApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -233,8 +237,8 @@ class PetApi {
   ///
   /// * [Set<String>] tags (required):
   ///   Tags to filter by
-  Future<Set<Pet>?> findPetsByTags(Set<String> tags,) async {
-    final response = await findPetsByTagsWithHttpInfo(tags,);
+  Future<Set<Pet>?> findPetsByTags(Set<String> tags, { Future<void>? abortTrigger, }) async {
+    final response = await findPetsByTagsWithHttpInfo(tags, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -261,7 +265,7 @@ class PetApi {
   ///
   /// * [int] petId (required):
   ///   ID of pet to return
-  Future<Response> getPetByIdWithHttpInfo(int petId,) async {
+  Future<Response> getPetByIdWithHttpInfo(int petId, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/pet/{petId}'
       .replaceAll('{petId}', petId.toString());
@@ -284,6 +288,7 @@ class PetApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -295,8 +300,8 @@ class PetApi {
   ///
   /// * [int] petId (required):
   ///   ID of pet to return
-  Future<Pet?> getPetById(int petId,) async {
-    final response = await getPetByIdWithHttpInfo(petId,);
+  Future<Pet?> getPetById(int petId, { Future<void>? abortTrigger, }) async {
+    final response = await getPetByIdWithHttpInfo(petId, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -320,7 +325,7 @@ class PetApi {
   ///
   /// * [Pet] pet (required):
   ///   Pet object that needs to be added to the store
-  Future<Response> updatePetWithHttpInfo(Pet pet,) async {
+  Future<Response> updatePetWithHttpInfo(Pet pet, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/pet';
 
@@ -342,6 +347,7 @@ class PetApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -353,8 +359,8 @@ class PetApi {
   ///
   /// * [Pet] pet (required):
   ///   Pet object that needs to be added to the store
-  Future<void> updatePet(Pet pet,) async {
-    final response = await updatePetWithHttpInfo(pet,);
+  Future<void> updatePet(Pet pet, { Future<void>? abortTrigger, }) async {
+    final response = await updatePetWithHttpInfo(pet, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -376,7 +382,7 @@ class PetApi {
   ///
   /// * [String] status:
   ///   Updated status of the pet
-  Future<Response> updatePetWithFormWithHttpInfo(int petId, { String? name, String? status, }) async {
+  Future<Response> updatePetWithFormWithHttpInfo(int petId, { String? name, String? status, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/pet/{petId}'
       .replaceAll('{petId}', petId.toString());
@@ -405,6 +411,7 @@ class PetApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -422,8 +429,8 @@ class PetApi {
   ///
   /// * [String] status:
   ///   Updated status of the pet
-  Future<void> updatePetWithForm(int petId, { String? name, String? status, }) async {
-    final response = await updatePetWithFormWithHttpInfo(petId,  name: name, status: status, );
+  Future<void> updatePetWithForm(int petId, { String? name, String? status, Future<void>? abortTrigger, }) async {
+    final response = await updatePetWithFormWithHttpInfo(petId, name: name, status: status, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -445,7 +452,7 @@ class PetApi {
   ///
   /// * [MultipartFile] file:
   ///   file to upload
-  Future<Response> uploadFileWithHttpInfo(int petId, { String? additionalMetadata, MultipartFile? file, }) async {
+  Future<Response> uploadFileWithHttpInfo(int petId, { String? additionalMetadata, MultipartFile? file, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/pet/{petId}/uploadImage'
       .replaceAll('{petId}', petId.toString());
@@ -482,6 +489,7 @@ class PetApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -499,8 +507,8 @@ class PetApi {
   ///
   /// * [MultipartFile] file:
   ///   file to upload
-  Future<ApiResponse?> uploadFile(int petId, { String? additionalMetadata, MultipartFile? file, }) async {
-    final response = await uploadFileWithHttpInfo(petId,  additionalMetadata: additionalMetadata, file: file, );
+  Future<ApiResponse?> uploadFile(int petId, { String? additionalMetadata, MultipartFile? file, Future<void>? abortTrigger, }) async {
+    final response = await uploadFileWithHttpInfo(petId, additionalMetadata: additionalMetadata, file: file, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -530,7 +538,7 @@ class PetApi {
   ///
   /// * [String] additionalMetadata:
   ///   Additional data to pass to server
-  Future<Response> uploadFileWithRequiredFileWithHttpInfo(int petId, MultipartFile requiredFile, { String? additionalMetadata, }) async {
+  Future<Response> uploadFileWithRequiredFileWithHttpInfo(int petId, MultipartFile requiredFile, { String? additionalMetadata, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/fake/{petId}/uploadImageWithRequiredFile'
       .replaceAll('{petId}', petId.toString());
@@ -567,6 +575,7 @@ class PetApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -584,8 +593,8 @@ class PetApi {
   ///
   /// * [String] additionalMetadata:
   ///   Additional data to pass to server
-  Future<ApiResponse?> uploadFileWithRequiredFile(int petId, MultipartFile requiredFile, { String? additionalMetadata, }) async {
-    final response = await uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile,  additionalMetadata: additionalMetadata, );
+  Future<ApiResponse?> uploadFileWithRequiredFile(int petId, MultipartFile requiredFile, { String? additionalMetadata, Future<void>? abortTrigger, }) async {
+    final response = await uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata: additionalMetadata, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/store_api.dart
@@ -26,7 +26,7 @@ class StoreApi {
   ///
   /// * [String] orderId (required):
   ///   ID of the order that needs to be deleted
-  Future<Response> deleteOrderWithHttpInfo(String orderId,) async {
+  Future<Response> deleteOrderWithHttpInfo(String orderId, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/store/order/{order_id}'
       .replaceAll('{order_id}', orderId);
@@ -49,6 +49,7 @@ class StoreApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -60,8 +61,8 @@ class StoreApi {
   ///
   /// * [String] orderId (required):
   ///   ID of the order that needs to be deleted
-  Future<void> deleteOrder(String orderId,) async {
-    final response = await deleteOrderWithHttpInfo(orderId,);
+  Future<void> deleteOrder(String orderId, { Future<void>? abortTrigger, }) async {
+    final response = await deleteOrderWithHttpInfo(orderId, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -72,7 +73,7 @@ class StoreApi {
   /// Returns a map of status codes to quantities
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getInventoryWithHttpInfo() async {
+  Future<Response> getInventoryWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/store/inventory';
 
@@ -94,14 +95,15 @@ class StoreApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Returns pet inventories by status
   ///
   /// Returns a map of status codes to quantities
-  Future<Map<String, int>?> getInventory() async {
-    final response = await getInventoryWithHttpInfo();
+  Future<Map<String, int>?> getInventory({ Future<void>? abortTrigger, }) async {
+    final response = await getInventoryWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -125,7 +127,7 @@ class StoreApi {
   ///
   /// * [int] orderId (required):
   ///   ID of pet that needs to be fetched
-  Future<Response> getOrderByIdWithHttpInfo(int orderId,) async {
+  Future<Response> getOrderByIdWithHttpInfo(int orderId, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/store/order/{order_id}'
       .replaceAll('{order_id}', orderId.toString());
@@ -148,6 +150,7 @@ class StoreApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -159,8 +162,8 @@ class StoreApi {
   ///
   /// * [int] orderId (required):
   ///   ID of pet that needs to be fetched
-  Future<Order?> getOrderById(int orderId,) async {
-    final response = await getOrderByIdWithHttpInfo(orderId,);
+  Future<Order?> getOrderById(int orderId, { Future<void>? abortTrigger, }) async {
+    final response = await getOrderByIdWithHttpInfo(orderId, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -184,7 +187,7 @@ class StoreApi {
   ///
   /// * [Order] order (required):
   ///   order placed for purchasing the pet
-  Future<Response> placeOrderWithHttpInfo(Order order,) async {
+  Future<Response> placeOrderWithHttpInfo(Order order, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/store/order';
 
@@ -206,6 +209,7 @@ class StoreApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -217,8 +221,8 @@ class StoreApi {
   ///
   /// * [Order] order (required):
   ///   order placed for purchasing the pet
-  Future<Order?> placeOrder(Order order,) async {
-    final response = await placeOrderWithHttpInfo(order,);
+  Future<Order?> placeOrder(Order order, { Future<void>? abortTrigger, }) async {
+    final response = await placeOrderWithHttpInfo(order, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/user_api.dart
@@ -26,7 +26,7 @@ class UserApi {
   ///
   /// * [User] user (required):
   ///   Created user object
-  Future<Response> createUserWithHttpInfo(User user,) async {
+  Future<Response> createUserWithHttpInfo(User user, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/user';
 
@@ -48,6 +48,7 @@ class UserApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -59,8 +60,8 @@ class UserApi {
   ///
   /// * [User] user (required):
   ///   Created user object
-  Future<void> createUser(User user,) async {
-    final response = await createUserWithHttpInfo(user,);
+  Future<void> createUser(User user, { Future<void>? abortTrigger, }) async {
+    final response = await createUserWithHttpInfo(user, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -76,7 +77,7 @@ class UserApi {
   ///
   /// * [List<User>] user (required):
   ///   List of user object
-  Future<Response> createUsersWithArrayInputWithHttpInfo(List<User> user,) async {
+  Future<Response> createUsersWithArrayInputWithHttpInfo(List<User> user, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/user/createWithArray';
 
@@ -98,6 +99,7 @@ class UserApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -109,8 +111,8 @@ class UserApi {
   ///
   /// * [List<User>] user (required):
   ///   List of user object
-  Future<void> createUsersWithArrayInput(List<User> user,) async {
-    final response = await createUsersWithArrayInputWithHttpInfo(user,);
+  Future<void> createUsersWithArrayInput(List<User> user, { Future<void>? abortTrigger, }) async {
+    final response = await createUsersWithArrayInputWithHttpInfo(user, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -126,7 +128,7 @@ class UserApi {
   ///
   /// * [List<User>] user (required):
   ///   List of user object
-  Future<Response> createUsersWithListInputWithHttpInfo(List<User> user,) async {
+  Future<Response> createUsersWithListInputWithHttpInfo(List<User> user, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/user/createWithList';
 
@@ -148,6 +150,7 @@ class UserApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -159,8 +162,8 @@ class UserApi {
   ///
   /// * [List<User>] user (required):
   ///   List of user object
-  Future<void> createUsersWithListInput(List<User> user,) async {
-    final response = await createUsersWithListInputWithHttpInfo(user,);
+  Future<void> createUsersWithListInput(List<User> user, { Future<void>? abortTrigger, }) async {
+    final response = await createUsersWithListInputWithHttpInfo(user, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -176,7 +179,7 @@ class UserApi {
   ///
   /// * [String] username (required):
   ///   The name that needs to be deleted
-  Future<Response> deleteUserWithHttpInfo(String username,) async {
+  Future<Response> deleteUserWithHttpInfo(String username, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/user/{username}'
       .replaceAll('{username}', username);
@@ -199,6 +202,7 @@ class UserApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -210,8 +214,8 @@ class UserApi {
   ///
   /// * [String] username (required):
   ///   The name that needs to be deleted
-  Future<void> deleteUser(String username,) async {
-    final response = await deleteUserWithHttpInfo(username,);
+  Future<void> deleteUser(String username, { Future<void>? abortTrigger, }) async {
+    final response = await deleteUserWithHttpInfo(username, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -227,7 +231,7 @@ class UserApi {
   ///
   /// * [String] username (required):
   ///   The name that needs to be fetched. Use user1 for testing.
-  Future<Response> getUserByNameWithHttpInfo(String username,) async {
+  Future<Response> getUserByNameWithHttpInfo(String username, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/user/{username}'
       .replaceAll('{username}', username);
@@ -250,6 +254,7 @@ class UserApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -261,8 +266,8 @@ class UserApi {
   ///
   /// * [String] username (required):
   ///   The name that needs to be fetched. Use user1 for testing.
-  Future<User?> getUserByName(String username,) async {
-    final response = await getUserByNameWithHttpInfo(username,);
+  Future<User?> getUserByName(String username, { Future<void>? abortTrigger, }) async {
+    final response = await getUserByNameWithHttpInfo(username, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -289,7 +294,7 @@ class UserApi {
   ///
   /// * [String] password (required):
   ///   The password for login in clear text
-  Future<Response> loginUserWithHttpInfo(String username, String password,) async {
+  Future<Response> loginUserWithHttpInfo(String username, String password, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/user/login';
 
@@ -314,6 +319,7 @@ class UserApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -328,8 +334,8 @@ class UserApi {
   ///
   /// * [String] password (required):
   ///   The password for login in clear text
-  Future<String?> loginUser(String username, String password,) async {
-    final response = await loginUserWithHttpInfo(username, password,);
+  Future<String?> loginUser(String username, String password, { Future<void>? abortTrigger, }) async {
+    final response = await loginUserWithHttpInfo(username, password, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -348,7 +354,7 @@ class UserApi {
   /// 
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> logoutUserWithHttpInfo() async {
+  Future<Response> logoutUserWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/user/logout';
 
@@ -370,14 +376,15 @@ class UserApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Logs out current logged in user session
   ///
   /// 
-  Future<void> logoutUser() async {
-    final response = await logoutUserWithHttpInfo();
+  Future<void> logoutUser({ Future<void>? abortTrigger, }) async {
+    final response = await logoutUserWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -396,7 +403,7 @@ class UserApi {
   ///
   /// * [User] user (required):
   ///   Updated user object
-  Future<Response> updateUserWithHttpInfo(String username, User user,) async {
+  Future<Response> updateUserWithHttpInfo(String username, User user, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final path = r'/user/{username}'
       .replaceAll('{username}', username);
@@ -419,6 +426,7 @@ class UserApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -433,8 +441,8 @@ class UserApi {
   ///
   /// * [User] user (required):
   ///   Updated user object
-  Future<void> updateUser(String username, User user,) async {
-    final response = await updateUserWithHttpInfo(username, user,);
+  Future<void> updateUser(String username, User user, { Future<void>? abortTrigger, }) async {
+    final response = await updateUserWithHttpInfo(username, user, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_client.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_client.dart
@@ -97,9 +97,9 @@ class ApiClient {
       if (nullableHeaderParams != null) {
         request.headers.addAll(nullableHeaderParams);
       }
-      if (msgBody is String) {
+      if (msgBody is String && msgBody.isNotEmpty) {
         request.body = msgBody;
-      } else if (msgBody is List<int>) {
+      } else if (msgBody is List<int> && msgBody.isNotEmpty) {
         request.bodyBytes = msgBody;
       } else if (msgBody is Map<String, String>) {
         request.bodyFields = msgBody;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_client.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_client.dart
@@ -44,8 +44,9 @@ class ApiClient {
     Object? body,
     Map<String, String> headerParams,
     Map<String, String> formParams,
-    String? contentType,
-  ) async {
+    String? contentType, {
+    Future<void>? abortTrigger,
+  }) async {
     await authentication?.applyToParams(queryParams, headerParams);
 
     headerParams.addAll(_defaultHeaderMap);
@@ -63,7 +64,7 @@ class ApiClient {
         body is MultipartFile && (contentType == null ||
         !contentType.toLowerCase().startsWith('multipart/form-data'))
       ) {
-        final request = StreamedRequest(method, uri);
+        final request = AbortableStreamedRequest(method, uri, abortTrigger: abortTrigger);
         request.headers.addAll(headerParams);
         request.contentLength = body.length;
         body.finalize().listen(
@@ -78,7 +79,7 @@ class ApiClient {
       }
 
       if (body is MultipartRequest) {
-        final request = MultipartRequest(method, uri);
+        final request = AbortableMultipartRequest(method, uri, abortTrigger: abortTrigger);
         request.fields.addAll(body.fields);
         request.files.addAll(body.files);
         request.headers.addAll(body.headers);
@@ -92,14 +93,19 @@ class ApiClient {
         : await serializeAsync(body);
       final nullableHeaderParams = headerParams.isEmpty ? null : headerParams;
 
-      switch(method) {
-        case 'POST': return await _client.post(uri, headers: nullableHeaderParams, body: msgBody,);
-        case 'PUT': return await _client.put(uri, headers: nullableHeaderParams, body: msgBody,);
-        case 'DELETE': return await _client.delete(uri, headers: nullableHeaderParams, body: msgBody,);
-        case 'PATCH': return await _client.patch(uri, headers: nullableHeaderParams, body: msgBody,);
-        case 'HEAD': return await _client.head(uri, headers: nullableHeaderParams,);
-        case 'GET': return await _client.get(uri, headers: nullableHeaderParams,);
+      final request = AbortableRequest(method, uri, abortTrigger: abortTrigger);
+      if (nullableHeaderParams != null) {
+        request.headers.addAll(nullableHeaderParams);
       }
+      if (msgBody is String) {
+        request.body = msgBody;
+      } else if (msgBody is List<int>) {
+        request.bodyBytes = msgBody;
+      } else if (msgBody is Map<String, String>) {
+        request.bodyFields = msgBody;
+      }
+      final response = await _client.send(request);
+      return Response.fromStream(response);
     } on SocketException catch (error, trace) {
       throw ApiException.withInner(
         HttpStatus.badRequest,
@@ -136,11 +142,6 @@ class ApiClient {
         trace,
       );
     }
-
-    throw ApiException(
-      HttpStatus.badRequest,
-      'Invalid HTTP operation: $method $path',
-    );
   }
 
   Future<dynamic> deserializeAsync(String value, String targetType, {bool growable = false,}) async =>


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

allows using the standard http.Client mechanism to abort requests, which is useful for both teardown and overall responsiveness.

port of https://github.com/immich-app/immich/pull/28692

cc @mertalev

Dart: @yissachar
Dart (refactor): @joernahrens
Dart 2: @swipesight
Dart (Jaguar): @jaumard
Dart (Dio): @josh-burton

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
