### PR TITLE
[kotlin-server] Update vertx core to newer version

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-vertx-server/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-vertx-server/pom.mustache
@@ -21,7 +21,7 @@
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         {{/useJakartaEe}}
         <junit.version>4.13.2</junit.version>
-        <vertx.version>4.5.24</vertx.version>
+        <vertx.version>4.5.27</vertx.version>
         <maven-compiler-plugin.version>3.10.0</maven-compiler-plugin.version>
         <vertx-openapi-router.version>1.0.2</vertx-openapi-router.version>
         <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>

--- a/samples/server/petstore/kotlin-vertx-modelMutable/pom.xml
+++ b/samples/server/petstore/kotlin-vertx-modelMutable/pom.xml
@@ -16,7 +16,7 @@
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <junit.version>4.13.2</junit.version>
-        <vertx.version>4.5.24</vertx.version>
+        <vertx.version>4.5.27</vertx.version>
         <maven-compiler-plugin.version>3.10.0</maven-compiler-plugin.version>
         <vertx-openapi-router.version>1.0.2</vertx-openapi-router.version>
         <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>

--- a/samples/server/petstore/kotlin/vertx/pom.xml
+++ b/samples/server/petstore/kotlin/vertx/pom.xml
@@ -16,7 +16,7 @@
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <junit.version>4.13.2</junit.version>
-        <vertx.version>4.5.24</vertx.version>
+        <vertx.version>4.5.27</vertx.version>
         <maven-compiler-plugin.version>3.10.0</maven-compiler-plugin.version>
         <vertx-openapi-router.version>1.0.2</vertx-openapi-router.version>
         <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>


### PR DESCRIPTION
to close https://github.com/OpenAPITools/openapi-generator/pull/new/update-vertx-cor

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `vertx-core` from 4.5.24 to 4.5.27 in the Kotlin Vert.x server generator and petstore samples to pull in the latest patch fixes.

<sup>Written for commit b44a120d8567c82233ec1717bfe5ab4895948c42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

