### PR TITLE
[php-nextgen] Check for $openApiType === "string" instead of "\DateTime" in ObjectSerializer

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
@@ -233,7 +233,7 @@ class ObjectSerializer
         }
 
         // Handle DateTime objects in query
-        if ($openApiType === "\\DateTime" && $value instanceof DateTime) {
+        if ($openApiType === "string" && $value instanceof DateTime) {
             return ["{$paramName}" => $value->format(self::$dateTimeFormat)];
         }
 

--- a/samples/client/echo_api/php-nextgen-streaming/src/ObjectSerializer.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/ObjectSerializer.php
@@ -242,7 +242,7 @@ class ObjectSerializer
         }
 
         // Handle DateTime objects in query
-        if ($openApiType === "\\DateTime" && $value instanceof DateTime) {
+        if ($openApiType === "string" && $value instanceof DateTime) {
             return ["{$paramName}" => $value->format(self::$dateTimeFormat)];
         }
 

--- a/samples/client/echo_api/php-nextgen/src/ObjectSerializer.php
+++ b/samples/client/echo_api/php-nextgen/src/ObjectSerializer.php
@@ -242,7 +242,7 @@ class ObjectSerializer
         }
 
         // Handle DateTime objects in query
-        if ($openApiType === "\\DateTime" && $value instanceof DateTime) {
+        if ($openApiType === "string" && $value instanceof DateTime) {
             return ["{$paramName}" => $value->format(self::$dateTimeFormat)];
         }
 

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ObjectSerializer.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ObjectSerializer.php
@@ -241,7 +241,7 @@ class ObjectSerializer
         }
 
         // Handle DateTime objects in query
-        if ($openApiType === "\\DateTime" && $value instanceof DateTime) {
+        if ($openApiType === "string" && $value instanceof DateTime) {
             return ["{$paramName}" => $value->format(self::$dateTimeFormat)];
         }
 


### PR DESCRIPTION
ObjectSerializer incorretly validates the `$openApiType` equals `\DateTime`. This is not a valid OpenAPI type, instead, it should validate the type to be `string`.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
