### PR TITLE
[Kotlin][Spring] fix option `useSpringBuiltInValidation` not implemented

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
@@ -98,6 +98,7 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
 
     public static final String USE_SPRING_BOOT3 = "useSpringBoot3";
     public static final String USE_SPRING_BOOT4 = "useSpringBoot4";
+    public static final String USE_SPRING_BUILT_IN_VALIDATION = "useSpringBuiltInValidation";
     public static final String INCLUDE_HTTP_REQUEST_CONTEXT = "includeHttpRequestContext";
     public static final String USE_FLOW_FOR_ARRAY_RETURN_TYPE = "useFlowForArrayReturnType";
     public static final String REQUEST_MAPPING_OPTION = "requestMappingMode";
@@ -190,6 +191,8 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
     protected boolean useSpringBoot3 = false;
     @Getter @Setter
     protected boolean useSpringBoot4 = false;
+    @Getter @Setter
+    protected boolean useSpringBuiltInValidation = false;
     protected RequestMappingMode requestMappingMode = RequestMappingMode.controller;
     private DocumentationProvider documentationProvider;
     private AnnotationLibrary annotationLibrary;
@@ -286,6 +289,7 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
                 " (contexts) added to single project.", beanQualifiers);
         addSwitch(USE_SPRING_BOOT3, "Generate code and provide dependencies for use with Spring Boot ≥ 3 (use jakarta instead of javax in imports). Enabling this option will also enable `useJakartaEe`.", useSpringBoot3);
         addSwitch(USE_SPRING_BOOT4, "Generate code and provide dependencies for use with Spring Boot 4.x. Enabling this option will also enable `useJakartaEe`.", useSpringBoot4);
+        addSwitch(USE_SPRING_BUILT_IN_VALIDATION, "Disable `@Validated` at the class level when using built-in validation.", useSpringBuiltInValidation);
         addSwitch(USE_JACKSON_3, "Use Jackson 3 dependencies (tools.jackson package). Only available with `useSpringBoot4`. Defaults to true when `useSpringBoot4` is enabled.", useJackson3);
         addSwitch(USE_FLOW_FOR_ARRAY_RETURN_TYPE, "Whether to use Flow for array/collection return types when reactive is enabled. If false, will use List instead.", useFlowForArrayReturnType);
         addSwitch(INCLUDE_HTTP_REQUEST_CONTEXT, "Whether to include HttpServletRequest (blocking) or ServerWebExchange (reactive) as additional parameter in generated methods.", includeHttpRequestContext);
@@ -520,6 +524,9 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
         }
         if (additionalProperties.containsKey(USE_SPRING_BOOT4)) {
             this.setUseSpringBoot4(convertPropertyToBoolean(USE_SPRING_BOOT4));
+        }
+        if (additionalProperties.containsKey(USE_SPRING_BUILT_IN_VALIDATION)) {
+            this.setUseSpringBuiltInValidation(convertPropertyToBoolean(USE_SPRING_BUILT_IN_VALIDATION));
         }
         if (additionalProperties.containsKey(INCLUDE_HTTP_REQUEST_CONTEXT)) {
             this.setIncludeHttpRequestContext(convertPropertyToBoolean(INCLUDE_HTTP_REQUEST_CONTEXT));

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/api.mustache
@@ -29,9 +29,7 @@ import org.springframework.http.ResponseEntity
 {{/useResponseEntity}}
 
 import org.springframework.web.bind.annotation.*
-{{#useBeanValidation}}
-import org.springframework.validation.annotation.Validated
-{{/useBeanValidation}}
+{{#useBeanValidation}}{{^useSpringBuiltInValidation}}import org.springframework.validation.annotation.Validated{{/useSpringBuiltInValidation}}{{/useBeanValidation}}
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -54,9 +52,7 @@ import kotlin.collections.List
 import kotlin.collections.Map
 
 @RestController{{#beanQualifiers}}("{{package}}.{{classname}}Controller"){{/beanQualifiers}}
-{{#useBeanValidation}}
-@Validated
-{{/useBeanValidation}}
+{{#useBeanValidation}}{{^useSpringBuiltInValidation}}@Validated{{/useSpringBuiltInValidation}}{{/useBeanValidation}}
 {{#swagger1AnnotationLibrary}}
 @Api(value = "{{{baseName}}}", description = "The {{{baseName}}} API")
 {{/swagger1AnnotationLibrary}}

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/apiInterface.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/apiInterface.mustache
@@ -34,9 +34,7 @@ import org.springframework.http.ResponseEntity
 {{/useResponseEntity}}
 
 import org.springframework.web.bind.annotation.*
-{{#useBeanValidation}}
-import org.springframework.validation.annotation.Validated
-{{/useBeanValidation}}
+{{#useBeanValidation}}{{^useSpringBuiltInValidation}}import org.springframework.validation.annotation.Validated{{/useSpringBuiltInValidation}}{{/useBeanValidation}}
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -61,9 +59,7 @@ import kotlin.collections.Map
 {{^useFeignClient}}
 @RestController
 {{/useFeignClient}}
-{{#useBeanValidation}}
-@Validated
-{{/useBeanValidation}}
+{{#useBeanValidation}}{{^useSpringBuiltInValidation}}@Validated{{/useSpringBuiltInValidation}}{{/useBeanValidation}}
 {{#swagger1AnnotationLibrary}}
 @Api(value = "{{{baseName}}}", description = "The {{{baseName}}} API")
 {{/swagger1AnnotationLibrary}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinSpringServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinSpringServerCodegenTest.java
@@ -105,4 +105,101 @@ public class KotlinSpringServerCodegenTest {
         // derived doesn't contain disciminator
         TestUtils.assertFileNotContains(birdKt, "val discriminator");
     }
+
+    @Test(description = "should not generate @Validated annotation on interface when built-in validation option is set to true")
+    public void shouldEnableBuiltInValidationOptionWhenSetToTrueInterface() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        KotlinSpringServerCodegen codegen = new KotlinSpringServerCodegen() ;
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        codegen.setUseSpringBoot3(true);
+        codegen.additionalProperties().put(KotlinSpringServerCodegen.USE_BEANVALIDATION, true);
+        codegen.additionalProperties().put(KotlinSpringServerCodegen.USE_SPRING_BUILT_IN_VALIDATION, true);
+        codegen.additionalProperties().put(KotlinSpringServerCodegen.INTERFACE_ONLY, true);
+
+        new DefaultGenerator().opts(
+                new ClientOptInput()
+                        .openAPI(TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml"))
+                        .config(codegen)
+        ).generate();
+
+        final Path userApiKt = Paths.get(output + "/src/main/kotlin/org/openapitools/api/UserApi.kt");
+        TestUtils.assertFileNotContains(userApiKt, "import org.springframework.validation.annotation.Validated");
+        TestUtils.assertFileNotContains(userApiKt, "@org.springframework.validation.annotation.Validated");
+        TestUtils.assertFileNotContains(userApiKt, "@Validated");
+    }
+
+    @Test(description = "should not generate @Validated annotation on controller when built-in validation option is set to true")
+    public void shouldEnableBuiltInValidationOptionWhenSetToTrueController() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        KotlinSpringServerCodegen codegen = new KotlinSpringServerCodegen() ;
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        codegen.setUseSpringBoot3(true);
+        codegen.additionalProperties().put(KotlinSpringServerCodegen.USE_BEANVALIDATION, true);
+        codegen.additionalProperties().put(KotlinSpringServerCodegen.USE_SPRING_BUILT_IN_VALIDATION, true);
+
+        new DefaultGenerator().opts(
+                new ClientOptInput()
+                        .openAPI(TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml"))
+                        .config(codegen)
+        ).generate();
+
+        final Path userApiKt = Paths.get(output + "/src/main/kotlin/org/openapitools/api/UserApiController.kt");
+        TestUtils.assertFileNotContains(userApiKt, "import org.springframework.validation.annotation.Validated");
+        TestUtils.assertFileNotContains(userApiKt, "@org.springframework.validation.annotation.Validated");
+        TestUtils.assertFileNotContains(userApiKt, "@Validated");
+    }
+
+    @Test(description = "should generate @Validated annotation when built-in validation option is set to false")
+    public void shouldDisableBuiltInValidationOptionWhenSetToFalse() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        KotlinSpringServerCodegen codegen = new KotlinSpringServerCodegen() ;
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        codegen.setUseSpringBoot3(true);
+        codegen.additionalProperties().put(KotlinSpringServerCodegen.USE_BEANVALIDATION, true);
+        codegen.additionalProperties().put(KotlinSpringServerCodegen.USE_SPRING_BUILT_IN_VALIDATION, false);
+        codegen.additionalProperties().put(KotlinSpringServerCodegen.INTERFACE_ONLY, true);
+
+        new DefaultGenerator().opts(
+                new ClientOptInput()
+                        .openAPI(TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml"))
+                        .config(codegen)
+        ).generate();
+
+        final Path userApiKt = Paths.get(output + "/src/main/kotlin/org/openapitools/api/UserApi.kt");
+        TestUtils.assertFileContains(userApiKt, "import org.springframework.validation.annotation.Validated");
+        TestUtils.assertFileContains(userApiKt, "@Validated");
+    }
+
+    @Test(description = "should generate @Validated annotation when built-in validation option has default value")
+    public void shouldDisableBuiltInValidationOptionByDefault() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        KotlinSpringServerCodegen codegen = new KotlinSpringServerCodegen() ;
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        codegen.additionalProperties().put(KotlinSpringServerCodegen.INTERFACE_ONLY, true);
+
+        codegen.setUseSpringBoot3(true);
+
+        new DefaultGenerator().opts(
+                new ClientOptInput()
+                        .openAPI(TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml"))
+                        .config(codegen)
+        ).generate();
+
+        final Path userApiKt = Paths.get(output + "/src/main/kotlin/org/openapitools/api/UserApi.kt");
+        TestUtils.assertFileContains(userApiKt, "import org.springframework.validation.annotation.Validated");
+        TestUtils.assertFileContains(userApiKt, "@Validated");
+    }
+
 }


### PR DESCRIPTION
fixes #23950

Java Spring generator introduced option `useSpringBuiltInValidation` to address new Spring Framework 6.1+ controller argument validation mechanism. 

This option is also present in Kotlin Spring generator documentation, however it seems like it **has never been implemented** and has no effect.

This PR ports the mechanism used in Java Spring generator:
The `@Validated` annotation on api class/interface is not rendered when `useSpringBuiltInValidation` is `true`.
This removes AOT aspect that is bypassing the built-in handler.

@martin-mfg, @dennisameling this PR targets Kotlin Spring server generator specifically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the `useSpringBuiltInValidation` option in the Kotlin Spring generator to use Spring 6.1+ built-in validation by skipping class-level `@Validated`. Aligns Kotlin with the Java Spring generator and keeps default behavior unchanged.

- **Bug Fixes**
  - Add `useSpringBuiltInValidation` switch to `KotlinSpringServerCodegen`.
  - Update `api.mustache` and `apiInterface.mustache` to conditionally omit `@Validated` and its import when the option is true.
  - Add tests for interface and controller outputs, true/false cases, and default behavior.

<sup>Written for commit 6c06df4959ab52654fec43aeda992668f213f61d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

