### PR TITLE
fix(python): remove redundant debug setter call in __deepcopy__

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-pydantic-v1/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python-pydantic-v1/configuration.mustache
@@ -289,9 +289,9 @@ conf = {{{packageName}}}.Configuration(
                 setattr(result, k, copy.deepcopy(v, memo))
         # shallow copy of loggers
         result.logger = copy.copy(self.logger)
-        # use setters to configure loggers
+        # use setter to re-create the file handler (excluded from __dict__ copy)
         result.logger_file = self.logger_file
-        result.debug = self.debug
+
         return result
 
     def __setattr__(self, name, value):

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -516,9 +516,9 @@ conf = {{{packageName}}}.Configuration(
                 setattr(result, k, copy.deepcopy(v, memo))
         # shallow copy of loggers
         result.logger = copy.copy(self.logger)
-        # use setters to configure loggers
+        # use setter to re-create the file handler (excluded from __dict__ copy)
         result.logger_file = self.logger_file
-        result.debug = self.debug
+
         return result
 
     def __setattr__(self, name: str, value: Any) -> None:

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/configuration.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/configuration.py
@@ -364,9 +364,9 @@ conf = openapi_client.Configuration(
                 setattr(result, k, copy.deepcopy(v, memo))
         # shallow copy of loggers
         result.logger = copy.copy(self.logger)
-        # use setters to configure loggers
+        # use setter to re-create the file handler (excluded from __dict__ copy)
         result.logger_file = self.logger_file
-        result.debug = self.debug
+
         return result
 
     def __setattr__(self, name: str, value: Any) -> None:

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/configuration.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/configuration.py
@@ -209,9 +209,9 @@ conf = openapi_client.Configuration(
                 setattr(result, k, copy.deepcopy(v, memo))
         # shallow copy of loggers
         result.logger = copy.copy(self.logger)
-        # use setters to configure loggers
+        # use setter to re-create the file handler (excluded from __dict__ copy)
         result.logger_file = self.logger_file
-        result.debug = self.debug
+
         return result
 
     def __setattr__(self, name, value):

--- a/samples/client/echo_api/python/openapi_client/configuration.py
+++ b/samples/client/echo_api/python/openapi_client/configuration.py
@@ -364,9 +364,9 @@ conf = openapi_client.Configuration(
                 setattr(result, k, copy.deepcopy(v, memo))
         # shallow copy of loggers
         result.logger = copy.copy(self.logger)
-        # use setters to configure loggers
+        # use setter to re-create the file handler (excluded from __dict__ copy)
         result.logger_file = self.logger_file
-        result.debug = self.debug
+
         return result
 
     def __setattr__(self, name: str, value: Any) -> None:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/configuration.py
@@ -453,9 +453,9 @@ conf = petstore_api.Configuration(
                 setattr(result, k, copy.deepcopy(v, memo))
         # shallow copy of loggers
         result.logger = copy.copy(self.logger)
-        # use setters to configure loggers
+        # use setter to re-create the file handler (excluded from __dict__ copy)
         result.logger_file = self.logger_file
-        result.debug = self.debug
+
         return result
 
     def __setattr__(self, name: str, value: Any) -> None:

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/configuration.py
@@ -432,9 +432,9 @@ conf = petstore_api.Configuration(
                 setattr(result, k, copy.deepcopy(v, memo))
         # shallow copy of loggers
         result.logger = copy.copy(self.logger)
-        # use setters to configure loggers
+        # use setter to re-create the file handler (excluded from __dict__ copy)
         result.logger_file = self.logger_file
-        result.debug = self.debug
+
         return result
 
     def __setattr__(self, name: str, value: Any) -> None:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/configuration.py
@@ -434,9 +434,9 @@ conf = petstore_api.Configuration(
                 setattr(result, k, copy.deepcopy(v, memo))
         # shallow copy of loggers
         result.logger = copy.copy(self.logger)
-        # use setters to configure loggers
+        # use setter to re-create the file handler (excluded from __dict__ copy)
         result.logger_file = self.logger_file
-        result.debug = self.debug
+
         return result
 
     def __setattr__(self, name: str, value: Any) -> None:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/configuration.py
@@ -270,9 +270,9 @@ conf = petstore_api.Configuration(
                 setattr(result, k, copy.deepcopy(v, memo))
         # shallow copy of loggers
         result.logger = copy.copy(self.logger)
-        # use setters to configure loggers
+        # use setter to re-create the file handler (excluded from __dict__ copy)
         result.logger_file = self.logger_file
-        result.debug = self.debug
+
         return result
 
     def __setattr__(self, name, value):

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/configuration.py
@@ -274,9 +274,9 @@ conf = petstore_api.Configuration(
                 setattr(result, k, copy.deepcopy(v, memo))
         # shallow copy of loggers
         result.logger = copy.copy(self.logger)
-        # use setters to configure loggers
+        # use setter to re-create the file handler (excluded from __dict__ copy)
         result.logger_file = self.logger_file
-        result.debug = self.debug
+
         return result
 
     def __setattr__(self, name, value):

--- a/samples/openapi3/client/petstore/python-pydantic-v1/tests/test_configuration.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/tests/test_configuration.py
@@ -76,5 +76,20 @@ class TestConfiguration(unittest.TestCase):
         self.assertEqual("http://petstore.swagger.io:8080/v2", self.config.get_host_from_settings(0, {'port': '8080'}))
         self.assertEqual("http://dev-petstore.swagger.io:8080/v2", self.config.get_host_from_settings(0, {'server': 'dev-petstore', 'port': '8080'}))
 
+    def testDeepcopyPreservesDebugValue(self):
+        """Verify deepcopy preserves debug=True without calling the setter."""
+        import copy
+        c1 = petstore_api.Configuration()
+        c1.debug = True
+        c2 = copy.deepcopy(c1)
+        self.assertTrue(c2.debug)
+
+    def testDeepcopyPreservesDebugFalse(self):
+        """Verify deepcopy preserves debug=False (the default)."""
+        import copy
+        c1 = petstore_api.Configuration()
+        c2 = copy.deepcopy(c1)
+        self.assertFalse(c2.debug)
+
 if __name__ == '__main__':
     unittest.main()

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -434,9 +434,9 @@ conf = petstore_api.Configuration(
                 setattr(result, k, copy.deepcopy(v, memo))
         # shallow copy of loggers
         result.logger = copy.copy(self.logger)
-        # use setters to configure loggers
+        # use setter to re-create the file handler (excluded from __dict__ copy)
         result.logger_file = self.logger_file
-        result.debug = self.debug
+
         return result
 
     def __setattr__(self, name: str, value: Any) -> None:

--- a/samples/openapi3/client/petstore/python/tests/test_configuration.py
+++ b/samples/openapi3/client/petstore/python/tests/test_configuration.py
@@ -97,5 +97,20 @@ class TestConfiguration(unittest.TestCase):
             c = petstore_api.Configuration()
             self.assertFalse(c.debug)
 
+    def testDeepcopyPreservesDebugValue(self):
+        """Verify deepcopy preserves debug=True without calling the setter."""
+        import copy
+        c1 = petstore_api.Configuration()
+        c1.debug = True
+        c2 = copy.deepcopy(c1)
+        self.assertTrue(c2.debug)
+
+    def testDeepcopyPreservesDebugFalse(self):
+        """Verify deepcopy preserves debug=False (the default)."""
+        import copy
+        c1 = petstore_api.Configuration()
+        c2 = copy.deepcopy(c1)
+        self.assertFalse(c2.debug)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi! It seems I'm hitting an extremely pathological case during the creation of many openapi-generated objects in a very large (many registered loggers) codebase.

The `__deepcopy__` method on the `Configuration` copies all `__dict__` items (including `_Configuration__debug`) and then loggers are shallow-copied over. After that, we call `result.debug = self.debug` which fires the property setter with the same value already present. On Python 3.12+ (actually maybe earlier, just what im using here) , the setter's `logger.setLevel()` call triggers `logging.Manager._clear_cache()` which iterates every registered logger — O(n_loggers) per deepcopy.

In applications with many loggers, this causes severe performance degradation when Configuration objects are deepcopied frequently (e.g., per-request in API clients).

I let my friendly bot create an example perf bechmmark to showcase the issue and fix:
https://gist.github.com/markjm/bb5805505d9dfddc5d595cadd0beaff1

```bash
$ python3 scripts/python_debug_setter_repro.py
Python 3.12.3
Registered loggers: 20,000
deepcopy() calls:   1,000

  Before fix: 1.744s
  After fix:  0.004s
  Speedup:    413.2x
```

The redundant debug setter in __deepcopy__ causes measurable overhead that scales with the number of registered loggers (O(n_loggers) per copy).

Because we already copy over the parts we want (and explicitly configure loggers how we want on copy), I believe this change to be essentially a noop except for the perf improvement.


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
🫡  @cbornet @tomplus  @krjakbrjak @fa0311  @multani 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove a redundant debug setter call in Python clients’ `Configuration.__deepcopy__`. This avoids O(n_loggers) logger cache clears on Python 3.12+ and significantly speeds up deepcopy in apps with many loggers.

- **Bug Fixes**
  - Stop calling `result.debug = self.debug` in `__deepcopy__`; the value is already copied from `__dict__`.
  - Keep the `logger_file` setter to re-create the file handler excluded from the dict copy.
  - Update Python templates and regenerated samples; add tests ensuring deepcopy preserves `debug` True/False.

<sup>Written for commit b83efd1e6ca100c1eb3e7c393b34529d0982b66f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

