### PR TITLE
fix(java): map OpenAPI 3.1 null type to Object to prevent ModelNull generation

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -303,6 +303,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         typeMapping.put("date", "Date");
         typeMapping.put("file", "File");
         typeMapping.put("AnyType", "Object");
+        typeMapping.put("null", "Object");
 
         importMapping.put("BigDecimal", "java.math.BigDecimal");
         importMapping.put("UUID", "java.util.UUID");
@@ -1093,6 +1094,11 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     @Override
     public String getTypeDeclaration(Schema p) {
+        // Intercept "null" explicitly to prevent complex object resolution
+        if (p != null && "null".equalsIgnoreCase(p.getType())) {
+            return "Object";
+        }
+
         Schema<?> schema = unaliasSchema(p);
         Schema<?> target = ModelUtils.isGenerateAliasAsModel() ? p : schema;
         if (ModelUtils.isArraySchema(target)) {
@@ -1866,16 +1872,29 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     @Override
     public String getSchemaType(Schema p) {
+        if (p == null) {
+            LOGGER.error("Schema is null");
+            return "Object";
+        }
+
+        // 1. First, call the parent method to extract the schema type string
         String openAPIType = super.getSchemaType(p);
 
-        // don't apply renaming on types from the typeMapping
+        if (null == openAPIType) {
+            LOGGER.error("No Type defined for Schema {}", p);
+            return "Object"; // Safe fallback to prevent NullPointerException later
+        }
+
+        // 2. Intercept the "null" type string immediately before it routes to typeMapping or toModelName
+        if ("null".equalsIgnoreCase(openAPIType) || "null".equalsIgnoreCase(p.getType())) {
+            return "Object";
+        }
+
+        // 3. Don't apply renaming on types from the typeMapping
         if (typeMapping.containsKey(openAPIType)) {
             return typeMapping.get(openAPIType);
         }
 
-        if (null == openAPIType) {
-            LOGGER.error("No Type defined for Schema {}", p);
-        }
         return toModelName(openAPIType);
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -303,7 +303,6 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         typeMapping.put("date", "Date");
         typeMapping.put("file", "File");
         typeMapping.put("AnyType", "Object");
-        typeMapping.put("null", "Object");
 
         importMapping.put("BigDecimal", "java.math.BigDecimal");
         importMapping.put("UUID", "java.util.UUID");
@@ -1873,24 +1872,27 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     @Override
     public String getSchemaType(Schema p) {
         if (p == null) {
-            LOGGER.error("Schema is null");
+            return super.getSchemaType(p);
+        }
+
+        // Intercept explicit OpenAPI 3.1 type: "null" immediately
+        if ("null".equalsIgnoreCase(p.getType())) {
             return "Object";
         }
 
-        // 1. First, call the parent method to extract the schema type string
         String openAPIType = super.getSchemaType(p);
 
         if (null == openAPIType) {
             LOGGER.error("No Type defined for Schema {}", p);
-            return "Object"; // Safe fallback to prevent NullPointerException later
+            return null;
         }
 
-        // 2. Intercept the "null" type string immediately before it routes to typeMapping or toModelName
-        if ("null".equalsIgnoreCase(openAPIType) || "null".equalsIgnoreCase(p.getType())) {
+        // Intercept if openAPIType resolved to "null"
+        if ("null".equalsIgnoreCase(openAPIType)) {
             return "Object";
         }
 
-        // 3. Don't apply renaming on types from the typeMapping
+        // Don't apply renaming on types from the typeMapping
         if (typeMapping.containsKey(openAPIType)) {
             return typeMapping.get(openAPIType);
         }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -4556,6 +4556,15 @@ public class JavaClientCodegenTest {
         assertThat(content)
                 .contains("import io.swagger.v3.oas.annotations.tags.*;")
                 .contains("@Tag(");
+
+    }
+
+    @Test
+    public void testNullTypeMapsToObject() {
+        final JavaClientCodegen codegen = new JavaClientCodegen();
+        Schema nullSchema = new Schema().type("null");
+        Assert.assertEquals(codegen.getSchemaType(nullSchema), "Object");
+        Assert.assertEquals(codegen.getTypeDeclaration(nullSchema), "Object");
     }
 
 }


### PR DESCRIPTION
### Problem / Context
When processing OpenAPI 3.1 specifications containing schema properties with an explicit `type: 'null'`, the core code generator was failing to capture it as a primitive mapping. Instead, it was treating `"null"` as a custom model class name. This caused the engine to flag it as a language reserved word, fallback to appending "Null", and ultimately generate broken java compilation variables such as `private ModelNull records = null;` (#23908).

### Solution Implemented
- Modified `AbstractJavaCodegen.java` within the core engine translation layers (`getSchemaType` and `getTypeDeclaration`).
- Added an intercept check so that when an explicit `type: 'null'` is resolved, it maps directly back to the standard native Java primitive wrapper type (`Object`).
- Ensured this prevents the downstream factory engine from triggering internal reserved word class sanitization or spinning up unneeded phantom model code files.

### Tests Added / Verification
- Added programmatic coverage inside `JavaClientCodegenTest.java` (`testNullTypeMapsToObject`) to assert that structural schemas defined explicitly with a `null` type correctly declare variable instances as an `Object`.
- Verified locally against target minimal test specs using the Spring `webclient` configuration library—confirming the invalid `ModelNull` import and variable syntax are successfully cleared out.
- Ran the core automated regression suite (`mvn test -pl modules/openapi-generator -Dtest=*CodegenTest`) to ensure all concurrent Java-dependent framework engines build perfectly.

Fixes #23908

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Maps OpenAPI 3.1 `type: "null"` to Java `Object` in the Java code generator to prevent phantom `ModelNull` classes and invalid fields. Fixes #23908.

- **Bug Fixes**
  - Map `"null"` to `Object` in `getSchemaType` and `getTypeDeclaration`, intercepting both `Schema.type` and resolved `openAPIType`, while preserving fail-fast behavior when type is missing.
  - Added `testNullTypeMapsToObject` to ensure schemas with `type: "null"` generate `Object`.

<sup>Written for commit ffac7aab690c674598ef1222e16c7ec57c597137. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

