### PR TITLE
[BUG][core] Normalize OAS 3.1 `type: null` map value (additionalProperties) under NORMALIZE_31SPEC

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -995,7 +995,24 @@ public class OpenAPINormalizer {
             normalizeProperties(schema, visitedSchemas);
         } else if (schema.getAdditionalProperties() instanceof Schema) { // map
             normalizeMapSchema(schema);
-            normalizeSchema((Schema) schema.getAdditionalProperties(), visitedSchemas);
+            Schema additionalProperties = (Schema) schema.getAdditionalProperties();
+            if (getRule(NORMALIZE_31SPEC) && ModelUtils.isNullTypeSchema(openAPI, additionalProperties)) {
+                // OAS 3.1 allows a map value schema of `type: "null"` (e.g.
+                // `additionalProperties: { type: "null" }`). There's no OAS 3.0 equivalent type,
+                // so generators emit a fictional `Null` / `ModelNull` value type that fails to
+                // compile. Normalize it to an any-type nullable schema so the map value is
+                // generated as a normal (nullable) object instead.
+                Schema anyTypeNullable = new Schema();
+                anyTypeNullable.setNullable(true);
+                schema.setAdditionalProperties(anyTypeNullable);
+            } else {
+                Schema normalized = normalizeSchema(additionalProperties, visitedSchemas);
+                if (getRule(NORMALIZE_31SPEC)) {
+                    // capture the normalized value schema (e.g. an OAS 3.1 `type: [array, "null"]`
+                    // value is rewritten to a proper array schema), which would otherwise be lost.
+                    schema.setAdditionalProperties(normalized);
+                }
+            }
         } else if (schema instanceof BooleanSchema) {
             normalizeBooleanSchema(schema, visitedSchemas);
         } else if (schema instanceof IntegerSchema) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -1953,5 +1953,30 @@ public class OpenAPINormalizerTest {
                 "ImpliedObject must not be marked nullable (no null type was declared)");
     }
 
+    @Test
+    public void testOpenAPINormalizer31SpecNullMapAdditionalProperties() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/issue_23945.yaml");
+        Map<String, String> inputRules = Map.of("NORMALIZE_31SPEC", "true");
+        OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, inputRules);
+        openAPINormalizer.normalize();
+
+        Schema schema = openAPI.getComponents().getSchemas().get("NullableMaps");
+
+        // `additionalProperties: { type: "null" }` must not keep the OAS 3.1 `null` type (which makes
+        // generators emit a fictional `Null` / `ModelNull` value type); it is normalized to an
+        // any-type nullable schema so the map value generates as a normal (nullable) object.
+        Schema stringMapValue = ModelUtils.getAdditionalProperties((Schema) schema.getProperties().get("stringMap"));
+        assertNull(stringMapValue.getType());
+        assertNull(stringMapValue.getTypes());
+        assertTrue(stringMapValue.getNullable());
+
+        // `additionalProperties: { type: [array, "null"], items: ... }` is normalized to a proper
+        // (nullable) array value schema rather than being left half-converted.
+        Schema errorsValue = ModelUtils.getAdditionalProperties((Schema) schema.getProperties().get("errorsByKey"));
+        assertEquals(errorsValue.getType(), "array");
+        assertTrue(errorsValue.getNullable());
+        assertNotNull(errorsValue.getItems());
+    }
+
 }
 

--- a/modules/openapi-generator/src/test/resources/3_1/issue_23945.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/issue_23945.yaml
@@ -1,0 +1,22 @@
+openapi: 3.1.1
+info:
+  title: Repro
+  version: 1.0.0
+components:
+  schemas:
+    NullableMaps:
+      type: object
+      properties:
+        stringMap:
+          type: [object, "null"]
+          additionalProperties:
+            type: "null"
+        errorsByKey:
+          type: [object, "null"]
+          additionalProperties:
+            type: [array, "null"]
+            items:
+              type: object
+              properties:
+                code:
+                  type: string


### PR DESCRIPTION
Fixes #23945

## Problem

With `--openapi-normalizer NORMALIZE_31SPEC=true`, a nullable map whose `additionalProperties` **value** schema still contains JSON Schema `null` was not normalized to a usable OAS 3.0 value type. Generators emitted a fictional `Null` / `ModelNull` value type that fails to compile, e.g. `Map<String, ModelNull>` (Java) with no `ModelNull` model generated, `Dictionary<string, Null>` (csharp, CS0246), etc.

Two value-schema shapes from the report:

```yaml
stringMap:
  type: [object, "null"]
  additionalProperties:
    type: "null"
errorsByKey:
  type: [object, "null"]
  additionalProperties:
    type: [array, "null"]
    items: { ... }
```

## Root cause

In `OpenAPINormalizer#normalizeSchema`, the map branch recurses into `additionalProperties` but:

1. A pure `type: "null"` value schema is short-circuited by `ModelUtils.isNullTypeSchema(...)` at the top of `normalizeSchema` and returned unchanged, so it keeps its OAS 3.1 `null` type.
2. A `type: [array, "null"]` value schema is converted by `processNormalize31Spec` into a **new** `ArraySchema`, but the map branch discarded the return value (`normalizeSchema(...)` was called without reassigning `additionalProperties`), leaving the value half-converted.

This is the remaining gap after #22056 (which covered `additionalProperties: false` on closed objects, not nullable map **values**).

## Fix

In the map branch, when `NORMALIZE_31SPEC` is enabled:
- rewrite a pure-null `additionalProperties` value to an any-type nullable schema, so the map value generates as a normal (nullable) object; and
- capture the normalized value schema for the other cases (so the `[array, "null"]` rewrite is not lost).

The change is fully gated behind `NORMALIZE_31SPEC`; behavior is unchanged when the rule is off. No committed sample config uses `NORMALIZE_31SPEC`, so no generated samples change.

## Test evidence

Added `OpenAPINormalizerTest#testOpenAPINormalizer31SpecNullMapAdditionalProperties` (spec `src/test/resources/3_1/issue_23945.yaml`) asserting the `stringMap` value loses its `null` type (becomes any-type nullable) and the `errorsByKey` value becomes a nullable array.

```
mvn -pl modules/openapi-generator test -Dtest=OpenAPINormalizerTest
Tests run: 61, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Verification done: (1) confirmed no in-flight PR (`gh pr list` search for NORMALIZE_31SPEC/23945 returned none); (2) no self-claim — issue has 0 comments; (3) code-only change to `.java` + test; (4) reproduced the bug on master with a failing assertion before the fix (`stringMap` value stayed `types=[null]`, `errorsByKey` value stayed `type=null/types=[array]`); (5) full `OpenAPINormalizerTest` (61 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes normalization of OAS 3.1 nullable map value schemas under `NORMALIZE_31SPEC` so generators stop emitting fictional `Null`/`ModelNull` types and maps compile.

- **Bug Fixes**
  - In OpenAPINormalizer#normalizeSchema, if `additionalProperties` is `type: "null"`, rewrite to an any-type nullable schema.
  - Reassign the normalized value schema (e.g., `type: [array, "null"]` → nullable array) so the rewrite isn’t lost.
  - Changes gated behind `NORMALIZE_31SPEC`; default behavior unchanged.
  - Added `OpenAPINormalizerTest#testOpenAPINormalizer31SpecNullMapAdditionalProperties` and `3_1/issue_23945.yaml` to cover both shapes.

<sup>Written for commit 6b8ab05aa122d17582c08fcbb89007ee19be704f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

