### PR TITLE
[JAVA] Add logic and test case to avoid stackOverflow exception for circular allOf

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/examples/ExampleGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/examples/ExampleGenerator.java
@@ -406,6 +406,10 @@ public class ExampleGenerator {
      */
     private void resolveAllOfSchemaProperties(String mediaType, Schema schema, Set<String> processedModels, Map<String, Object> values) {
         List<Schema> interfaces = schema.getAllOf();
+        if (interfaces == null) {
+            return;
+        }
+
         for (Schema composed : interfaces) {
             if (composed.get$ref() != null) {
                 String ref = ModelUtils.getSimpleRef(composed.get$ref());
@@ -419,6 +423,7 @@ public class ExampleGenerator {
                 if (resolved != null) {
                     processedModels.add(ref);
                     traverseSchemaProperties(mediaType, resolved, processedModels, values);
+                    processedModels.remove(ref);
                 }
             } else {
                 traverseSchemaProperties(mediaType, composed, processedModels, values);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/examples/ExampleGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/examples/ExampleGenerator.java
@@ -407,13 +407,21 @@ public class ExampleGenerator {
     private void resolveAllOfSchemaProperties(String mediaType, Schema schema, Set<String> processedModels, Map<String, Object> values) {
         List<Schema> interfaces = schema.getAllOf();
         for (Schema composed : interfaces) {
-            traverseSchemaProperties(mediaType, composed, processedModels, values);
             if (composed.get$ref() != null) {
                 String ref = ModelUtils.getSimpleRef(composed.get$ref());
+
+                if (processedModels.contains(ref)) {
+                    LOGGER.warn("Circular reference detected in allOf for $ref: {}. Skipping.", ref);
+                    continue;
+                }
+
                 Schema resolved = ModelUtils.getSchema(openAPI, ref);
                 if (resolved != null) {
+                    processedModels.add(ref);
                     traverseSchemaProperties(mediaType, resolved, processedModels, values);
                 }
+            } else {
+                traverseSchemaProperties(mediaType, composed, processedModels, values);
             }
         }
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ExampleGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ExampleGeneratorTest.java
@@ -8,7 +8,6 @@ import org.testng.annotations.Test;
 
 import java.util.*;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.testng.AssertJUnit.assertEquals;
@@ -246,6 +245,37 @@ public class ExampleGeneratorTest {
         assertEquals(1, examples.size());
         assertEquals("application/json", examples.get(0).get("contentType"));
         assertEquals(mapper.readTree(String.format(Locale.ROOT, "{%n  \"example_schema_property_composed\" : \"example schema property value composed\",%n  \"example_schema_property\" : \"example schema property value\"%n}")), mapper.readTree(examples.get(0).get("example")));
+        assertEquals("200", examples.get(0).get("statusCode"));
+    }
+
+    @Test
+    public void generateFromResponseSchemaWithAllOfRecursionSchema() throws Exception{
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/example_generator_test.yaml");
+
+        new InlineModelResolver().flatten(openAPI);
+
+        ExampleGenerator exampleGenerator = new ExampleGenerator(openAPI.getComponents().getSchemas(), openAPI);
+        Set<String> mediaTypeKeys = new TreeSet<>();
+        mediaTypeKeys.add("application/json");
+        List<Map<String, String>> examples = exampleGenerator.generateFromResponseSchema(
+                "200",
+                openAPI
+                        .getPaths()
+                        .get("/generate_from_response_schema_with_allOf_circular_model")
+                        .getGet()
+                        .getResponses()
+                        .get("200")
+                        .getContent()
+                        .get("application/json")
+                        .getSchema(),
+                mediaTypeKeys
+        );
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        assertEquals(1, examples.size());
+        assertEquals("application/json", examples.get(0).get("contentType"));
+        assertEquals(mapper.readTree(String.format(Locale.ROOT, "{%n  \"example_schema_property_alloff_circular\" : \"example schema property allOff circular\"%n}")), mapper.readTree(examples.get(0).get("example")));
         assertEquals("200", examples.get(0).get("statusCode"));
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ExampleGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ExampleGeneratorTest.java
@@ -249,7 +249,7 @@ public class ExampleGeneratorTest {
     }
 
     @Test
-    public void generateFromResponseSchemaWithAllOfRecursionSchema() throws Exception{
+    public void generateFromResponseSchemaWithAllOfCircularSchema() throws Exception{
         OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/example_generator_test.yaml");
 
         new InlineModelResolver().flatten(openAPI);
@@ -276,6 +276,37 @@ public class ExampleGeneratorTest {
         assertEquals(1, examples.size());
         assertEquals("application/json", examples.get(0).get("contentType"));
         assertEquals(mapper.readTree(String.format(Locale.ROOT, "{%n  \"example_schema_property_alloff_circular\" : \"example schema property allOff circular\"%n}")), mapper.readTree(examples.get(0).get("example")));
+        assertEquals("200", examples.get(0).get("statusCode"));
+    }
+
+    @Test
+    public void generateFromResponseSchemaWithAllOfSiblingSchema() throws Exception{
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/example_generator_test.yaml");
+
+        new InlineModelResolver().flatten(openAPI);
+
+        ExampleGenerator exampleGenerator = new ExampleGenerator(openAPI.getComponents().getSchemas(), openAPI);
+        Set<String> mediaTypeKeys = new TreeSet<>();
+        mediaTypeKeys.add("application/json");
+        List<Map<String, String>> examples = exampleGenerator.generateFromResponseSchema(
+                "200",
+                openAPI
+                        .getPaths()
+                        .get("/generate_from_response_schema_with_allOf_sibling_model")
+                        .getGet()
+                        .getResponses()
+                        .get("200")
+                        .getContent()
+                        .get("application/json")
+                        .getSchema(),
+                mediaTypeKeys
+        );
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        assertEquals(1, examples.size());
+        assertEquals("application/json", examples.get(0).get("contentType"));
+        assertEquals(mapper.readTree(String.format(Locale.ROOT, "{%n \"base\":{\"example_schema_property\":\"example schema property value\",\"example_schema_property_composed\":\"example schema property value composed\"}, \"sibling\":{\"example_schema_property\":\"example schema property value\",\"example_schema_property_composed\":\"example schema property value composed\"} %n}")), mapper.readTree(examples.get(0).get("example")));
         assertEquals("200", examples.get(0).get("statusCode"));
     }
 

--- a/modules/openapi-generator/src/test/resources/3_0/example_generator_test.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/example_generator_test.yaml
@@ -101,6 +101,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ExampleAllOfParentSchema'
+  /generate_from_response_schema_with_allOf_circular_model:
+    get:
+      operationId: generateFromResponseSchemaWithAllOfCircularModel
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExampleAllOfCircularSchema'
   /generate_from_response_schema_with_anyOf_composed_model:
     get:
       operationId: generateFromResponseSchemaWithAnyOfModel
@@ -160,6 +170,15 @@ components:
             example_schema_property_composed_parent:
               type: string
               example: example schema property value composed parent
+    ExampleAllOfCircularSchema:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/ExampleAllOfCircularSchema'
+        - type: object
+          properties:
+            example_schema_property_alloff_circular:
+              type: string
+              example: example schema property allOff circular
     ExampleAnyOfSchema:
       type: object
       anyOf:

--- a/modules/openapi-generator/src/test/resources/3_0/example_generator_test.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/example_generator_test.yaml
@@ -111,6 +111,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ExampleAllOfCircularSchema'
+  /generate_from_response_schema_with_allOf_sibling_model:
+    get:
+      operationId: generateFromResponseSchemaWithAllOfSiblingModel
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExampleAllOfSiblingContainerSchema'
   /generate_from_response_schema_with_anyOf_composed_model:
     get:
       operationId: generateFromResponseSchemaWithAnyOfModel
@@ -161,6 +171,15 @@ components:
             example_schema_property_composed:
               type: string
               example: example schema property value composed
+    ExampleAllOfSiblingSchema:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/ExampleSchema'
+        - type: object
+          properties:
+            example_schema_property_composed:
+              type: string
+              example: example schema property value composed
     ExampleAllOfParentSchema:
       type: object
       allOf:
@@ -179,6 +198,13 @@ components:
             example_schema_property_alloff_circular:
               type: string
               example: example schema property allOff circular
+    ExampleAllOfSiblingContainerSchema:
+      type: object
+      properties:
+        base:
+          $ref: '#/components/schemas/ExampleAllOfSchema'
+        sibling:
+          $ref: '#/components/schemas/ExampleAllOfSiblingSchema'
     ExampleAnyOfSchema:
       type: object
       anyOf:


### PR DESCRIPTION
To fix issue #23966 

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents StackOverflow for circular allOf and fixes sibling allOf handling in example generation. Examples now generate correctly without infinite recursion.

- **Bug Fixes**
  - Detect circular $ref in allOf within `ExampleGenerator` and skip revisiting processed models (warn instead of recursing); correctly traverse non-$ref allOf entries and isolate processed tracking per $ref.
  - Added tests: generateFromResponseSchemaWithAllOfCircularSchema and generateFromResponseSchemaWithAllOfSiblingSchema, plus schemas ExampleAllOfCircularSchema, ExampleAllOfSiblingSchema, ExampleAllOfSiblingContainerSchema and new paths to validate behavior.
  - Fixes #23966.

<sup>Written for commit d60cec524ccf6e37763a12935fe82b9d2b132f27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

