### PR TITLE
[Java] Render object default for composed ($ref + default) schemas (#23795)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1502,92 +1502,138 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             return null;
         } else if (ModelUtils.isObjectSchema(schema)) {
             if (schema.getDefault() != null) {
-                try {
-                    StringBuilder stringBuilder = new StringBuilder();
-                    stringBuilder.append("new " + cp.datatypeWithEnum + "()");
-                    Map<String, Schema> propertySchemas = schema.getProperties();
-                    if(propertySchemas != null) {
-                        // With `parseOptions.setResolve(true)`, objects with 1 key-value pair are LinkedHashMap and objects with more than 1 are ObjectNode
-                        // When not set, objects of any size are ObjectNode
-                        ObjectMapper objectMapper = new ObjectMapper();
-                        ObjectNode objectNode;
-                        if(!(schema.getDefault() instanceof ObjectNode)) {
-                            objectNode = objectMapper.valueToTree(schema.getDefault());
-                        } else {
-                            objectNode = (ObjectNode) schema.getDefault();
-
-                        }
-                        Set<Map.Entry<String, JsonNode>> defaultProperties = objectNode.properties();
-                        for (Map.Entry<String, JsonNode> defaultProperty : defaultProperties) {
-                            String key = defaultProperty.getKey();
-                            JsonNode value = defaultProperty.getValue();
-                            Schema propertySchema = propertySchemas.get(key);
-                            if (!value.isValueNode() || propertySchema == null) { //Skip complex objects for now
-                                continue;
-                            }
-
-                            String defaultPropertyExpression = null;
-                            if(ModelUtils.isLongSchema(propertySchema)) {
-                                defaultPropertyExpression = value.asText()+"l";
-                            } else if(ModelUtils.isIntegerSchema(propertySchema)) {
-                                defaultPropertyExpression = value.asText();
-                            } else if(ModelUtils.isDoubleSchema(propertySchema)) {
-                                defaultPropertyExpression = value.asText()+"d";
-                            } else if(ModelUtils.isFloatSchema(propertySchema)) {
-                                defaultPropertyExpression = value.asText()+"f";
-                            } else if(ModelUtils.isNumberSchema(propertySchema)) {
-                                defaultPropertyExpression = "new java.math.BigDecimal(\"" + value.asText() + "\")";
-                            } else if(ModelUtils.isURISchema(propertySchema)) {
-                                defaultPropertyExpression = "java.net.URI.create(\"" + escapeText(value.asText()) + "\")";
-                            } else if(ModelUtils.isDateSchema(propertySchema)) {
-                                if("java8".equals(getDateLibrary())) {
-                                    defaultPropertyExpression = String.format(Locale.ROOT, "java.time.LocalDate.parse(\"%s\")", value.asText());
-                                }
-                            } else if(ModelUtils.isDateTimeSchema(propertySchema)) {
-                                if("java8".equals(getDateLibrary())) {
-                                    defaultPropertyExpression = String.format(Locale.ROOT, "java.time.OffsetDateTime.parse(\"%s\", %s)",
-                                            value.asText(),
-                                            "java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME.withZone(java.time.ZoneId.systemDefault())");
-                                }
-                            } else if(ModelUtils.isTimeLocalSchema(propertySchema)) {
-                                if("java8".equals(getDateLibrary())) {
-                                    defaultPropertyExpression = String.format(Locale.ROOT, "java.time.LocalTime.parse(\"%s\")", value.asText());
-                                }
-                            } else if(ModelUtils.isDateTimeLocalSchema(propertySchema)) {
-                                if("java8".equals(getDateLibrary())) {
-                                    defaultPropertyExpression = String.format(Locale.ROOT, "java.time.LocalDateTime.parse(\"%s\")", value.asText());
-                                }
-                            } else if(ModelUtils.isUUIDSchema(propertySchema)) {
-                                defaultPropertyExpression = "java.util.UUID.fromString(\"" + value.asText() + "\")";
-                            } else if(ModelUtils.isStringSchema(propertySchema)) {
-                                defaultPropertyExpression = "\"" + value.asText() + "\"";
-                            } else if(ModelUtils.isBooleanSchema(propertySchema)) {
-                                defaultPropertyExpression = value.asText();
-                            }
-                            if(defaultPropertyExpression != null) {
-                                stringBuilder
-//                                        .append(System.lineSeparator())
-                                        .append(".")
-                                        .append(toVarName(key))
-                                        .append("(").append(defaultPropertyExpression).append(")");
-                            }
-                        }
-                    }
-                    return stringBuilder.toString();
-                } catch (ClassCastException e) {
-                    LOGGER.error("Can't resolve default value: "+schema.getDefault(), e);
-                    return null;
-                }
+                return toObjectDefaultValue(cp, schema.getDefault(), schema.getProperties());
             }
             return null;
         } else if (ModelUtils.isComposedSchema(schema)) {
             if (schema.getDefault() != null) {
-                return super.toDefaultValue(schema);
+                // A `$ref` to an object schema combined with a sibling `default` (or an explicit `allOf`)
+                // is parsed as a composed schema, so the object's properties live in the `allOf` members
+                // rather than directly on the schema. Resolve them and render the default the same way as a
+                // plain object schema. Falling through to `super.toDefaultValue(...)` here would emit the raw
+                // default (e.g. `{"one":"one"}`) as Java, which does not compile (see #23795).
+                Map<String, Schema> propertySchemas = getComposedSchemaProperties(schema);
+                if (!propertySchemas.isEmpty()) {
+                    return toObjectDefaultValue(cp, schema.getDefault(), propertySchemas);
+                }
+                return null;
             }
             return null;
         }
 
         return super.toDefaultValue(schema);
+    }
+
+    /**
+     * Renders the default value of an object-typed property as a Java fluent builder expression, e.g.
+     * {@code new Pet().name("doggie").id(1l)}. Only scalar (value node) default properties for which a
+     * matching property schema is known are rendered; nested objects are skipped.
+     *
+     * @param cp              the codegen property carrying the target Java type ({@code datatypeWithEnum})
+     * @param defaultValue    the raw default value from the schema (a {@code Map}/{@code ObjectNode})
+     * @param propertySchemas the resolved property schemas used to type each default entry
+     * @return the Java expression, or {@code null} if it cannot be resolved
+     */
+    private String toObjectDefaultValue(CodegenProperty cp, Object defaultValue, Map<String, Schema> propertySchemas) {
+        try {
+            StringBuilder stringBuilder = new StringBuilder();
+            stringBuilder.append("new " + cp.datatypeWithEnum + "()");
+            if (propertySchemas != null) {
+                // With `parseOptions.setResolve(true)`, objects with 1 key-value pair are LinkedHashMap and objects with more than 1 are ObjectNode
+                // When not set, objects of any size are ObjectNode
+                ObjectMapper objectMapper = new ObjectMapper();
+                ObjectNode objectNode;
+                if(!(defaultValue instanceof ObjectNode)) {
+                    objectNode = objectMapper.valueToTree(defaultValue);
+                } else {
+                    objectNode = (ObjectNode) defaultValue;
+
+                }
+                Set<Map.Entry<String, JsonNode>> defaultProperties = objectNode.properties();
+                for (Map.Entry<String, JsonNode> defaultProperty : defaultProperties) {
+                    String key = defaultProperty.getKey();
+                    JsonNode value = defaultProperty.getValue();
+                    Schema propertySchema = propertySchemas.get(key);
+                    if (!value.isValueNode() || propertySchema == null) { //Skip complex objects for now
+                        continue;
+                    }
+
+                    String defaultPropertyExpression = null;
+                    if(ModelUtils.isLongSchema(propertySchema)) {
+                        defaultPropertyExpression = value.asText()+"l";
+                    } else if(ModelUtils.isIntegerSchema(propertySchema)) {
+                        defaultPropertyExpression = value.asText();
+                    } else if(ModelUtils.isDoubleSchema(propertySchema)) {
+                        defaultPropertyExpression = value.asText()+"d";
+                    } else if(ModelUtils.isFloatSchema(propertySchema)) {
+                        defaultPropertyExpression = value.asText()+"f";
+                    } else if(ModelUtils.isNumberSchema(propertySchema)) {
+                        defaultPropertyExpression = "new java.math.BigDecimal(\"" + value.asText() + "\")";
+                    } else if(ModelUtils.isURISchema(propertySchema)) {
+                        defaultPropertyExpression = "java.net.URI.create(\"" + escapeText(value.asText()) + "\")";
+                    } else if(ModelUtils.isDateSchema(propertySchema)) {
+                        if("java8".equals(getDateLibrary())) {
+                            defaultPropertyExpression = String.format(Locale.ROOT, "java.time.LocalDate.parse(\"%s\")", value.asText());
+                        }
+                    } else if(ModelUtils.isDateTimeSchema(propertySchema)) {
+                        if("java8".equals(getDateLibrary())) {
+                            defaultPropertyExpression = String.format(Locale.ROOT, "java.time.OffsetDateTime.parse(\"%s\", %s)",
+                                    value.asText(),
+                                    "java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME.withZone(java.time.ZoneId.systemDefault())");
+                        }
+                    } else if(ModelUtils.isTimeLocalSchema(propertySchema)) {
+                        if("java8".equals(getDateLibrary())) {
+                            defaultPropertyExpression = String.format(Locale.ROOT, "java.time.LocalTime.parse(\"%s\")", value.asText());
+                        }
+                    } else if(ModelUtils.isDateTimeLocalSchema(propertySchema)) {
+                        if("java8".equals(getDateLibrary())) {
+                            defaultPropertyExpression = String.format(Locale.ROOT, "java.time.LocalDateTime.parse(\"%s\")", value.asText());
+                        }
+                    } else if(ModelUtils.isUUIDSchema(propertySchema)) {
+                        defaultPropertyExpression = "java.util.UUID.fromString(\"" + value.asText() + "\")";
+                    } else if(ModelUtils.isStringSchema(propertySchema)) {
+                        defaultPropertyExpression = "\"" + value.asText() + "\"";
+                    } else if(ModelUtils.isBooleanSchema(propertySchema)) {
+                        defaultPropertyExpression = value.asText();
+                    }
+                    if(defaultPropertyExpression != null) {
+                        stringBuilder
+//                                        .append(System.lineSeparator())
+                                .append(".")
+                                .append(toVarName(key))
+                                .append("(").append(defaultPropertyExpression).append(")");
+                    }
+                }
+            }
+            return stringBuilder.toString();
+        } catch (ClassCastException e) {
+            LOGGER.error("Can't resolve default value: "+defaultValue, e);
+            return null;
+        }
+    }
+
+    /**
+     * Collects the property schemas of a composed schema by merging the schema's own properties with the
+     * properties of every {@code allOf} member (dereferencing {@code $ref}s as needed). This is used to
+     * render object defaults declared via a `$ref` + sibling `default` or an explicit `allOf`.
+     *
+     * @param schema the composed schema
+     * @return the merged property schemas (never {@code null}; empty when none can be resolved)
+     */
+    private Map<String, Schema> getComposedSchemaProperties(Schema schema) {
+        Map<String, Schema> propertySchemas = new LinkedHashMap<>();
+        if (schema.getProperties() != null) {
+            propertySchemas.putAll(schema.getProperties());
+        }
+        if (schema.getAllOf() != null) {
+            for (Object member : schema.getAllOf()) {
+                Schema resolved = ModelUtils.getReferencedSchema(this.openAPI, (Schema) member);
+                if (resolved != null && resolved.getProperties() != null) {
+                    propertySchemas.putAll(resolved.getProperties());
+                }
+            }
+        }
+        return propertySchemas;
     }
 
     private String getDefaultCollectionType(Schema schema) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -28,6 +28,7 @@ import org.mockito.Mockito;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenParameter;
+import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.languages.AbstractJavaCodegen;
 import org.openapitools.codegen.testutils.ConfigAssert;
@@ -622,6 +623,31 @@ public class AbstractJavaCodegenTest {
         dateTimeLocalSchema.setDefault("2007-12-03T10:15:30");
         defaultValue = codegen.toDefaultValue(codegen.fromProperty("", dateTimeLocalSchema), dateTimeLocalSchema);
         Assert.assertEquals(defaultValue, "LocalDateTime.parse(\"2007-12-03T10:15:30\")");
+    }
+
+    @Test
+    public void toDefaultValueForComposedObjectWithDefaultTest() {
+        // A `$ref` to an object schema combined with a sibling `default` is parsed as a composed (allOf)
+        // schema, so the object's properties live in the `allOf` members. The default must still be rendered
+        // as a compilable fluent builder expression rather than the raw JSON object (see #23795).
+        codegen.setDateLibrary("java8");
+        codegen.setOpenAPI(new OpenAPI().components(new Components()
+                .addSchemas("Nested", new ObjectSchema()
+                        .addProperty("one", new StringSchema())
+                        .addProperty("two", new StringSchema()))));
+
+        Map<String, Object> defaultValue = new LinkedHashMap<>();
+        defaultValue.put("one", "one");
+        defaultValue.put("two", "two");
+
+        Schema<?> composed = new ComposedSchema()
+                .addAllOfItem(new Schema<>().$ref("#/components/schemas/Nested"));
+        composed.setDefault(defaultValue);
+
+        CodegenProperty cp = codegen.fromProperty("test", composed);
+        String rendered = codegen.toDefaultValue(cp, composed);
+
+        Assert.assertEquals(rendered, "new " + cp.datatypeWithEnum + "().one(\"one\").two(\"two\")");
     }
 
     @Test


### PR DESCRIPTION
Fixes #23795

### Problem

When a property is declared as a `$ref` to an object schema **with a sibling `default`** (or, equivalently, an explicit `allOf`), the swagger-parser represents it as a *composed* schema — the object's properties live in the `allOf` members rather than directly on the schema.

`AbstractJavaCodegen.toDefaultValue(...)` handled this in the `isComposedSchema(...)` branch by falling through to `super.toDefaultValue(schema)`, which emits the raw default value as Java:

```java
private Nested test = {"one":"one","two":"two"};   // does not compile
```

The semantically-equivalent inline-object spec already rendered correctly:

```java
private DtoTest test = new DtoTest().one("one").two("two");
```

### Change

- Extracted the existing object-default rendering into a private `toObjectDefaultValue(cp, defaultValue, propertySchemas)` helper (behaviour-preserving for the plain `isObjectSchema` path).
- In the composed-schema branch, resolve the effective property schemas from the `allOf` members (dereferencing `$ref`s) via a new `getComposedSchemaProperties(...)` helper, then render the default through the same fluent-builder logic.
- When no object properties can be resolved, return `null` instead of emitting uncompilable output — so the previously broken cases now at worst omit the default rather than producing code that fails to compile.

For the reporter's spec this now generates:

```java
private Nested test = new Nested().one("one").two("two");
```

### Tests

Added `AbstractJavaCodegenTest.toDefaultValueForComposedObjectWithDefaultTest`, which builds a composed (`allOf` → `$ref`) schema with an object default and asserts the rendered fluent-builder expression.

```
Tests run: 66, Failures: 0, Errors: 0, Skipped: 0
  -- in org.openapitools.codegen.java.AbstractJavaCodegenTest
```

Verification done: ran the `modules/openapi-generator` module test class `AbstractJavaCodegenTest` (JDK 21) — all 66 tests pass, including the pre-existing `toDefaultValueTest` that exercises the refactored object-default path, confirming no behaviour change there.

I did not run the full `./bin/generate-samples.sh` regeneration: this code path only triggers for the composed-`$ref`-plus-`default` pattern, which previously produced **uncompilable** output, so no committed sample relies on the old behaviour and a regeneration is not expected to change any sample. Happy to regenerate any specific generator samples if a maintainer would like that included.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran full `./mvnw clean package` + sample regeneration (see note above — targeted module tests run instead).
- [x] Filed against `master`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Java generator to render object defaults for composed (`$ref` + `default` or `allOf`) schemas as fluent builder expressions instead of raw JSON, preventing uncompilable code. Addresses #23795.

- **Bug Fixes**
  - Resolve properties from `allOf` (dereferencing `$ref`) and render defaults via the object builder path; now generates `new Nested().one("one").two("two")`.
  - Extracted `toObjectDefaultValue(...)` and `getComposedSchemaProperties(...)`; plain object behavior unchanged.
  - If no properties are resolved, omit the default (return `null`) instead of emitting invalid Java.
  - Added `AbstractJavaCodegenTest.toDefaultValueForComposedObjectWithDefaultTest`; existing tests remain green.

<sup>Written for commit a279155adbb931a5ff2bb1c1920c0eb464bc5856. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

