### PR TITLE
[BUG][CORE] Fix #18963: add SKIP_ANONYMOUS_SCHEMA_REUSE inlineSchemaOption (opt-in, no breaking change)

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -529,6 +529,7 @@ Another useful option is `inlineSchemaOptions`, which allows you to customize ho
 - `ARRAY_ITEM_SUFFIX` sets the array item suffix
 - `MAP_ITEM_SUFFIX` set the map item suffix
 - `SKIP_SCHEMA_REUSE=true` is a special value to skip reusing inline schemas during refactoring
+- `SKIP_ANONYMOUS_SCHEMA_REUSE=true` skips reusing only anonymous (untitled) inline schemas. When two different parent schemas each define a structurally identical inline object without a `title`, they will each get their own named model (e.g. `Item_user` and `Issue_user`) instead of sharing one. Titled inline schemas are still reused. See issue #18963.
 - `REFACTOR_ALLOF_INLINE_SCHEMAS=true` will restore the 6.x (or below) behaviour to refactor allOf inline schemas into $ref. (v7.0.0 will skip the refactoring of these allOf inline schemas by default)
 - `RESOLVE_INLINE_ENUMS=true` will refactor inline enum definitions into $ref. This must be activated to allow the renaming of inline enum definitions using `inlineSchemaNameMappings`.
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/InlineModelResolver.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/InlineModelResolver.java
@@ -69,6 +69,7 @@ public class InlineModelResolver {
     private Set<String> inlineSchemaNameMappingValues = new HashSet<>();
     public boolean resolveInlineEnums = false;
     public boolean skipSchemaReuse = false; // skip reusing inline schema if set to true
+    public boolean skipAnonymousSchemaReuse = false; // skip reusing untitled (anonymous) inline schemas only
     public Boolean refactorAllOfInlineSchemas = null; // refactor allOf inline schemas into $ref
 
     // structure mapper sorts properties alphabetically on write to ensure models are
@@ -161,6 +162,11 @@ public class InlineModelResolver {
         if ("true".equalsIgnoreCase(
                 this.inlineSchemaOptions.getOrDefault("SKIP_SCHEMA_REUSE", "false"))) {
             this.skipSchemaReuse = true;
+        }
+
+        if ("true".equalsIgnoreCase(
+                this.inlineSchemaOptions.getOrDefault("SKIP_ANONYMOUS_SCHEMA_REUSE", "false"))) {
+            this.skipAnonymousSchemaReuse = true;
         }
 
         if (this.inlineSchemaOptions.containsKey("REFACTOR_ALLOF_INLINE_SCHEMAS")) {
@@ -852,6 +858,15 @@ public class InlineModelResolver {
     private String matchGenerated(Schema model) {
         if (skipSchemaReuse) { // skip reusing schema
             return null;
+        }
+        // When skipAnonymousSchemaReuse is set, schemas without a meaningful title are not eligible
+        // for reuse across different parent contexts. "Meaningful title" mirrors the same check in
+        // resolveModelName: non-null and not empty after sanitization.
+        if (skipAnonymousSchemaReuse) {
+            String title = model.getTitle();
+            if (title == null || "".equals(sanitizeName(title).replace("_", ""))) {
+                return null;
+            }
         }
 
         try {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/InlineModelResolverTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/InlineModelResolverTest.java
@@ -1221,6 +1221,83 @@ public class InlineModelResolverTest {
     }
 
     @Test
+    public void testInlineSchemaSkipAnonymousReuseSetToFalse() {
+        // meta_200_response and mega_200_response are anonymous (untitled) inline schemas.
+        // Without SKIP_ANONYMOUS_SCHEMA_REUSE, identical anonymous schemas are reused, so only
+        // meta_200_response is created; mega_200_response reuses the same model.
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/inline_model_resolver.yaml");
+        InlineModelResolver resolver = new InlineModelResolver();
+        resolver.setInlineSchemaOptions(new HashMap<>());
+        resolver.flatten(openAPI);
+
+        Schema schema = openAPI.getComponents().getSchemas().get("meta_200_response");
+        assertTrue(schema.getProperties().get("name") instanceof StringSchema);
+        assertTrue(schema.getProperties().get("id") instanceof IntegerSchema);
+
+        Schema schema2 = openAPI.getComponents().getSchemas().get("mega_200_response");
+        assertNull(schema2);
+    }
+
+    @Test
+    public void testInlineSchemaSkipAnonymousReuseSetToTrue() {
+        // With SKIP_ANONYMOUS_SCHEMA_REUSE=true, anonymous inline schemas under different parents
+        // each receive their own named model even when structurally identical.
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/inline_model_resolver.yaml");
+        InlineModelResolver resolver = new InlineModelResolver();
+        Map<String, String> inlineSchemaOptions = new HashMap<>();
+        inlineSchemaOptions.put("SKIP_ANONYMOUS_SCHEMA_REUSE", "true");
+        resolver.setInlineSchemaOptions(inlineSchemaOptions);
+        resolver.flatten(openAPI);
+
+        Schema schema = openAPI.getComponents().getSchemas().get("meta_200_response");
+        assertTrue(schema.getProperties().get("name") instanceof StringSchema);
+        assertTrue(schema.getProperties().get("id") instanceof IntegerSchema);
+
+        Schema schema2 = openAPI.getComponents().getSchemas().get("mega_200_response");
+        assertTrue(schema2.getProperties().get("name") instanceof StringSchema);
+        assertTrue(schema2.getProperties().get("id") instanceof IntegerSchema);
+    }
+
+    @Test
+    public void resolveTitledInlineSchemaIsReusedAcrossParents() {
+        // A titled inline schema represents a named type that is intentionally shared. When two
+        // different parent schemas each have a property whose inline schema carries the same title
+        // and identical structure, both properties must reference the same named model — only one
+        // entry is created in components, not a numbered variant.
+        OpenAPI openapi = new OpenAPI();
+        openapi.setComponents(new Components());
+
+        openapi.getComponents().addSchemas("Item", new ObjectSchema()
+                .addProperty("id", new StringSchema().format("uuid"))
+                .addProperty("user", new ObjectSchema()
+                        .title("UserSummary")
+                        .addProperty("id", new StringSchema().format("uuid"))
+                        .addProperty("name", new StringSchema())));
+
+        openapi.getComponents().addSchemas("Issue", new ObjectSchema()
+                .addProperty("id", new StringSchema().format("uuid"))
+                .addProperty("user", new ObjectSchema()
+                        .title("UserSummary")
+                        .addProperty("id", new StringSchema().format("uuid"))
+                        .addProperty("name", new StringSchema())));
+
+        new InlineModelResolver().flatten(openapi);
+
+        Map<String, Schema> schemas = openapi.getComponents().getSchemas();
+
+        // Titled inline schema must be deduplicated — no numbered variant
+        assertNotNull("UserSummary schema must exist", schemas.get("UserSummary"));
+        assertNull("Duplicate UserSummary_1 must not exist", schemas.get("UserSummary_1"));
+
+        // Both parents must reference the same shared model
+        Schema itemUser = (Schema) schemas.get("Item").getProperties().get("user");
+        assertEquals("#/components/schemas/UserSummary", itemUser.get$ref());
+
+        Schema issueUser = (Schema) schemas.get("Issue").getProperties().get("user");
+        assertEquals("#/components/schemas/UserSummary", issueUser.get$ref());
+    }
+
+    @Test
     public void resolveInlineRequestBodyAllOf() {
         OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/inline_model_resolver.yaml");
         new InlineModelResolver().flatten(openAPI);


### PR DESCRIPTION
## Summary

Addresses #18963 as an **opt-in, non-breaking alternative**.

When `--inline-schema-options SKIP_ANONYMOUS_SCHEMA_REUSE=true` is set, anonymous (untitled) inline schemas under different parent schemas each get their own named model instead of being deduplicated by structural content.

Example with the issue's spec: `Item.user` and `Issue.user` are structurally identical but untitled. With this flag:
- `ItemDto.user` → `$ref: Item_user`
- `IssueDto.user` → `$ref: Issue_user`

Without the flag (default): current behaviour preserved — `IssueDto.user` reuses `Item_user`.

**This is a finer-grained alternative to the existing `SKIP_SCHEMA_REUSE=true`**, which disables reuse for ALL inline schemas including titled ones. `SKIP_ANONYMOUS_SCHEMA_REUSE=true` only skips anonymous schemas; titled inline schemas (intentionally shared named types) continue to deduplicate.

### Changes
- `InlineModelResolver.java` — new `skipAnonymousSchemaReuse` field; parsed from `SKIP_ANONYMOUS_SCHEMA_REUSE` key in `setInlineSchemaOptions`; conditional guard in `matchGenerated()`
- `InlineModelResolverTest.java` — two new tests: flag off (default reuse preserved) and flag on (separate models per parent)
- `docs/customization.md` — document the new option

### No breaking change
Default is `false` — existing output is unchanged. No sample regeneration needed.

---

**Alternative (default behaviour fix):** #23974 makes the title-guard the default (treats this as a bug fix, requires sample regeneration). Use that PR if a breaking change is acceptable.

## Test plan
- [x] `InlineModelResolverTest#testInlineSchemaSkipAnonymousReuseSetToFalse` — default: anonymous schemas still reused (no change)
- [x] `InlineModelResolverTest#testInlineSchemaSkipAnonymousReuseSetToTrue` — flag on: `meta_200_response` and `mega_200_response` both created
- [x] All existing `resolveInlineModelDeduplicates*` tests — titled-schema dedup unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)