### PR TITLE
[haskell-http-client] update stack resolver to lts-24.42

### DIFF
--- a/modules/openapi-generator/src/main/resources/haskell-http-client/Client.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-http-client/Client.mustache
@@ -30,6 +30,7 @@ import qualified Data.ByteString.Lazy.Char8 as BCL
 import qualified Data.Proxy as P (Proxy(..))
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
+import qualified Data.Maybe as M
 import qualified Network.HTTP.Client as NH
 import qualified Network.HTTP.Client.MultipartFormData as NH
 import qualified Network.HTTP.Types as NH
@@ -169,7 +170,7 @@ _toInitRequest config req0  =
     req1 <- P.liftIO $ _applyAuthMethods req0 config
     P.when
         (configValidateAuthMethods config && (not . null . rAuthTypes) req1)
-        (E.throw $ AuthMethodException $ "AuthMethod not configured: " <> (show . head . rAuthTypes) req1)
+        (E.throw $ AuthMethodException $ "AuthMethod not configured: " <> (maybe "" show .  M.listToMaybe . rAuthTypes) req1)
     let req2 = req1 & _setContentTypeHeader & _setAcceptHeader
         params = rParams req2
         reqHeaders = ("User-Agent", WH.toHeader (configUserAgent config)) : paramsHeaders params

--- a/modules/openapi-generator/src/main/resources/haskell-http-client/Core.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-http-client/Core.mustache
@@ -61,6 +61,7 @@ import Data.Function ((&))
 import Data.Foldable(foldlM)
 import Data.Monoid ((<>))
 import Data.Text (Text)
+import Data.Type.Equality (type (~))
 import Prelude (($), (.), (&&), (<$>), (<*>), Maybe(..), Bool(..), Char, String, fmap, mempty, pure, return, show, IO, Monad, Functor, maybe)
 
 -- * {{configType}}

--- a/modules/openapi-generator/src/main/resources/haskell-http-client/haskell-http-client.cabal.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-http-client/haskell-http-client.cabal.mustache
@@ -51,7 +51,7 @@ library
     , containers >=0.5.0.0 && <0.8
     , deepseq >= 1.4 && <1.6
     , exceptions >= 0.4
-    , http-api-data >= 0.3.4 && <0.6
+    , http-api-data >= 0.3.4 && <0.7
     , http-client >=0.5 && <0.8
     , http-client-tls
     , http-media >= 0.4 && < 0.9

--- a/modules/openapi-generator/src/main/resources/haskell-http-client/stack.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-http-client/stack.mustache
@@ -1,4 +1,4 @@
-resolver: lts-21.0
+resolver: lts-24.42
 build:
   haddock-arguments:
     haddock-args:

--- a/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/Client.hs
+++ b/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/Client.hs
@@ -39,6 +39,7 @@ import qualified Data.ByteString.Lazy.Char8 as BCL
 import qualified Data.Proxy as P (Proxy(..))
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
+import qualified Data.Maybe as M
 import qualified Network.HTTP.Client as NH
 import qualified Network.HTTP.Client.MultipartFormData as NH
 import qualified Network.HTTP.Types as NH
@@ -178,7 +179,7 @@ _toInitRequest config req0  =
     req1 <- P.liftIO $ _applyAuthMethods req0 config
     P.when
         (configValidateAuthMethods config && (not . null . rAuthTypes) req1)
-        (E.throw $ AuthMethodException $ "AuthMethod not configured: " <> (show . head . rAuthTypes) req1)
+        (E.throw $ AuthMethodException $ "AuthMethod not configured: " <> (maybe "" show .  M.listToMaybe . rAuthTypes) req1)
     let req2 = req1 & _setContentTypeHeader & _setAcceptHeader
         params = rParams req2
         reqHeaders = ("User-Agent", WH.toHeader (configUserAgent config)) : paramsHeaders params

--- a/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/Core.hs
+++ b/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/Core.hs
@@ -70,6 +70,7 @@ import Data.Function ((&))
 import Data.Foldable(foldlM)
 import Data.Monoid ((<>))
 import Data.Text (Text)
+import Data.Type.Equality (type (~))
 import Prelude (($), (.), (&&), (<$>), (<*>), Maybe(..), Bool(..), Char, String, fmap, mempty, pure, return, show, IO, Monad, Functor, maybe)
 
 -- * OpenAPIPetstoreConfig

--- a/samples/client/petstore/haskell-http-client/openapi-petstore.cabal
+++ b/samples/client/petstore/haskell-http-client/openapi-petstore.cabal
@@ -45,7 +45,7 @@ library
     , containers >=0.5.0.0 && <0.8
     , deepseq >= 1.4 && <1.6
     , exceptions >= 0.4
-    , http-api-data >= 0.3.4 && <0.6
+    , http-api-data >= 0.3.4 && <0.7
     , http-client >=0.5 && <0.8
     , http-client-tls
     , http-media >= 0.4 && < 0.9

--- a/samples/client/petstore/haskell-http-client/stack.yaml
+++ b/samples/client/petstore/haskell-http-client/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-21.0
+resolver: lts-24.42
 build:
   haddock-arguments:
     haddock-args:


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `haskell-http-client` to Stack resolver lts-24.42 and make the generator and samples compatible. Also relax `http-api-data` bounds and tighten an auth error path.

- **Dependencies**
  - Bump Stack resolver to lts-24.42 in templates and samples.
  - Relax `http-api-data` upper bound to `<0.7`.
  - Add `Data.Type.Equality` import for `type (~)`.

- **Bug Fixes**
  - Avoid partial `head` when reporting missing auth by using `M.listToMaybe` with `maybe` (safer error message).

<sup>Written for commit c192a5225355e5e2639867d38f8ea56f255e2c04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

