### PR TITLE
[typescript-fetch] Fix TS2590 in instanceOf guards for wide sanitized-name models (#23980)

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -26,7 +26,7 @@ export function instanceOf{{classname}}(value: object): value is {{classname}} {
     {{#vars}}
     {{#required}}
     {{#hasSanitizedName}}
-    if ((!('{{name}}' in value) && !('{{baseName}}' in value)) || (value['{{name}}'] === undefined && value['{{baseName}}'] === undefined)) return false;
+    if ((!('{{name}}' in (value as Record<string, any>)) && !('{{baseName}}' in (value as Record<string, any>))) || ((value as Record<string, any>)['{{name}}'] === undefined && (value as Record<string, any>)['{{baseName}}'] === undefined)) return false;
     {{/hasSanitizedName}}
     {{^hasSanitizedName}}
     if (!('{{name}}' in value) || value['{{name}}'] === undefined) return false;
@@ -37,8 +37,8 @@ export function instanceOf{{classname}}(value: object): value is {{classname}} {
     {{#-first}}
     {{#-last}}
     {{#hasSanitizedName}}
-    {{#isString}}if (value['{{name}}'] !== '{{.}}' && value['{{baseName}}'] !== '{{.}}') return false;{{/isString}}
-    {{^isString}}if (value['{{name}}'] !== {{.}} && value['{{baseName}}'] !== {{.}}) return false;{{/isString}}
+    {{#isString}}if ((value as Record<string, any>)['{{name}}'] !== '{{.}}' && (value as Record<string, any>)['{{baseName}}'] !== '{{.}}') return false;{{/isString}}
+    {{^isString}}if ((value as Record<string, any>)['{{name}}'] !== {{.}} && (value as Record<string, any>)['{{baseName}}'] !== {{.}}) return false;{{/isString}}
     {{/hasSanitizedName}}
     {{^hasSanitizedName}}
     {{#isString}}if (value['{{name}}'] !== '{{.}}') return false;{{/isString}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -466,25 +466,26 @@ public class TypeScriptFetchClientCodegenTest {
 
         // SnakeOptionOne: discriminator_field (snake_case baseName) vs discriminatorField (camelCase name)
         // instanceOf should check both casings for field presence and discriminator value
+        // (the value is widened to Record<string, any> to avoid TS2590 on wide models)
         Path snakeOptionOne = Paths.get(output + "/models/SnakeOptionOne.ts");
         TestUtils.assertFileExists(snakeOptionOne);
-        TestUtils.assertFileContains(snakeOptionOne, "'discriminatorField' in value");
-        TestUtils.assertFileContains(snakeOptionOne, "'discriminator_field' in value");
-        TestUtils.assertFileContains(snakeOptionOne, "value['discriminatorField'] !== 'snakeOptionOne'");
-        TestUtils.assertFileContains(snakeOptionOne, "value['discriminator_field'] !== 'snakeOptionOne'");
+        TestUtils.assertFileContains(snakeOptionOne, "'discriminatorField' in (value as Record<string, any>)");
+        TestUtils.assertFileContains(snakeOptionOne, "'discriminator_field' in (value as Record<string, any>)");
+        TestUtils.assertFileContains(snakeOptionOne, "(value as Record<string, any>)['discriminatorField'] !== 'snakeOptionOne'");
+        TestUtils.assertFileContains(snakeOptionOne, "(value as Record<string, any>)['discriminator_field'] !== 'snakeOptionOne'");
         // Also verify the non-enum required field checks both casings
-        TestUtils.assertFileContains(snakeOptionOne, "'someProperty' in value");
-        TestUtils.assertFileContains(snakeOptionOne, "'some_property' in value");
+        TestUtils.assertFileContains(snakeOptionOne, "'someProperty' in (value as Record<string, any>)");
+        TestUtils.assertFileContains(snakeOptionOne, "'some_property' in (value as Record<string, any>)");
 
         // DashedOptionOne: discriminator-field (dashed baseName) vs discriminatorField (camelCase name)
         Path dashedOptionOne = Paths.get(output + "/models/DashedOptionOne.ts");
         TestUtils.assertFileExists(dashedOptionOne);
-        TestUtils.assertFileContains(dashedOptionOne, "'discriminatorField' in value");
-        TestUtils.assertFileContains(dashedOptionOne, "'discriminator-field' in value");
-        TestUtils.assertFileContains(dashedOptionOne, "value['discriminatorField'] !== 'dashedOptionOne'");
-        TestUtils.assertFileContains(dashedOptionOne, "value['discriminator-field'] !== 'dashedOptionOne'");
-        TestUtils.assertFileContains(dashedOptionOne, "'someProperty' in value");
-        TestUtils.assertFileContains(dashedOptionOne, "'some-property' in value");
+        TestUtils.assertFileContains(dashedOptionOne, "'discriminatorField' in (value as Record<string, any>)");
+        TestUtils.assertFileContains(dashedOptionOne, "'discriminator-field' in (value as Record<string, any>)");
+        TestUtils.assertFileContains(dashedOptionOne, "(value as Record<string, any>)['discriminatorField'] !== 'dashedOptionOne'");
+        TestUtils.assertFileContains(dashedOptionOne, "(value as Record<string, any>)['discriminator-field'] !== 'dashedOptionOne'");
+        TestUtils.assertFileContains(dashedOptionOne, "'someProperty' in (value as Record<string, any>)");
+        TestUtils.assertFileContains(dashedOptionOne, "'some-property' in (value as Record<string, any>)");
 
         // Numeric singleton enum: value check must NOT quote the literal
         Path numericModel = Paths.get(output + "/models/NumericSingletonEnumModel.ts");

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
@@ -142,7 +142,7 @@ export type EnumTestEnumNumberEnum = typeof EnumTestEnumNumberEnum[keyof typeof 
  * Check if a given object implements the EnumTest interface.
  */
 export function instanceOfEnumTest(value: object): value is EnumTest {
-    if ((!('enumStringRequired' in value) && !('enum_string_required' in value)) || (value['enumStringRequired'] === undefined && value['enum_string_required'] === undefined)) return false;
+    if ((!('enumStringRequired' in (value as Record<string, any>)) && !('enum_string_required' in (value as Record<string, any>))) || ((value as Record<string, any>)['enumStringRequired'] === undefined && (value as Record<string, any>)['enum_string_required'] === undefined)) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
@@ -122,7 +122,7 @@ export interface FormatTest {
  */
 export function instanceOfFormatTest(value: object): value is FormatTest {
     if (!('number' in value) || value['number'] === undefined) return false;
-    if ((!('_byte' in value) && !('byte' in value)) || (value['_byte'] === undefined && value['byte'] === undefined)) return false;
+    if ((!('_byte' in (value as Record<string, any>)) && !('byte' in (value as Record<string, any>))) || ((value as Record<string, any>)['_byte'] === undefined && (value as Record<string, any>)['byte'] === undefined)) return false;
     if (!('date' in value) || value['date'] === undefined) return false;
     if (!('password' in value) || value['password'] === undefined) return false;
     return true;

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/DashedOptionOne.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/DashedOptionOne.ts
@@ -47,10 +47,10 @@ export type DashedOptionOneDiscriminatorFieldEnum = typeof DashedOptionOneDiscri
  * Check if a given object implements the DashedOptionOne interface.
  */
 export function instanceOfDashedOptionOne(value: object): value is DashedOptionOne {
-    if ((!('discriminatorField' in value) && !('discriminator-field' in value)) || (value['discriminatorField'] === undefined && value['discriminator-field'] === undefined)) return false;
-    if (value['discriminatorField'] !== 'dashedOptionOne' && value['discriminator-field'] !== 'dashedOptionOne') return false;
+    if ((!('discriminatorField' in (value as Record<string, any>)) && !('discriminator-field' in (value as Record<string, any>))) || ((value as Record<string, any>)['discriminatorField'] === undefined && (value as Record<string, any>)['discriminator-field'] === undefined)) return false;
+    if ((value as Record<string, any>)['discriminatorField'] !== 'dashedOptionOne' && (value as Record<string, any>)['discriminator-field'] !== 'dashedOptionOne') return false;
     
-    if ((!('someProperty' in value) && !('some-property' in value)) || (value['someProperty'] === undefined && value['some-property'] === undefined)) return false;
+    if ((!('someProperty' in (value as Record<string, any>)) && !('some-property' in (value as Record<string, any>))) || ((value as Record<string, any>)['someProperty'] === undefined && (value as Record<string, any>)['some-property'] === undefined)) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/DashedOptionTwo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/DashedOptionTwo.ts
@@ -47,10 +47,10 @@ export type DashedOptionTwoDiscriminatorFieldEnum = typeof DashedOptionTwoDiscri
  * Check if a given object implements the DashedOptionTwo interface.
  */
 export function instanceOfDashedOptionTwo(value: object): value is DashedOptionTwo {
-    if ((!('discriminatorField' in value) && !('discriminator-field' in value)) || (value['discriminatorField'] === undefined && value['discriminator-field'] === undefined)) return false;
-    if (value['discriminatorField'] !== 'dashedOptionTwo' && value['discriminator-field'] !== 'dashedOptionTwo') return false;
+    if ((!('discriminatorField' in (value as Record<string, any>)) && !('discriminator-field' in (value as Record<string, any>))) || ((value as Record<string, any>)['discriminatorField'] === undefined && (value as Record<string, any>)['discriminator-field'] === undefined)) return false;
+    if ((value as Record<string, any>)['discriminatorField'] !== 'dashedOptionTwo' && (value as Record<string, any>)['discriminator-field'] !== 'dashedOptionTwo') return false;
     
-    if ((!('someProperty' in value) && !('some-property' in value)) || (value['someProperty'] === undefined && value['some-property'] === undefined)) return false;
+    if ((!('someProperty' in (value as Record<string, any>)) && !('some-property' in (value as Record<string, any>))) || ((value as Record<string, any>)['someProperty'] === undefined && (value as Record<string, any>)['some-property'] === undefined)) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/SnakeOptionOne.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/SnakeOptionOne.ts
@@ -47,10 +47,10 @@ export type SnakeOptionOneDiscriminatorFieldEnum = typeof SnakeOptionOneDiscrimi
  * Check if a given object implements the SnakeOptionOne interface.
  */
 export function instanceOfSnakeOptionOne(value: object): value is SnakeOptionOne {
-    if ((!('discriminatorField' in value) && !('discriminator_field' in value)) || (value['discriminatorField'] === undefined && value['discriminator_field'] === undefined)) return false;
-    if (value['discriminatorField'] !== 'snakeOptionOne' && value['discriminator_field'] !== 'snakeOptionOne') return false;
+    if ((!('discriminatorField' in (value as Record<string, any>)) && !('discriminator_field' in (value as Record<string, any>))) || ((value as Record<string, any>)['discriminatorField'] === undefined && (value as Record<string, any>)['discriminator_field'] === undefined)) return false;
+    if ((value as Record<string, any>)['discriminatorField'] !== 'snakeOptionOne' && (value as Record<string, any>)['discriminator_field'] !== 'snakeOptionOne') return false;
     
-    if ((!('someProperty' in value) && !('some_property' in value)) || (value['someProperty'] === undefined && value['some_property'] === undefined)) return false;
+    if ((!('someProperty' in (value as Record<string, any>)) && !('some_property' in (value as Record<string, any>))) || ((value as Record<string, any>)['someProperty'] === undefined && (value as Record<string, any>)['some_property'] === undefined)) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/SnakeOptionTwo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/SnakeOptionTwo.ts
@@ -47,10 +47,10 @@ export type SnakeOptionTwoDiscriminatorFieldEnum = typeof SnakeOptionTwoDiscrimi
  * Check if a given object implements the SnakeOptionTwo interface.
  */
 export function instanceOfSnakeOptionTwo(value: object): value is SnakeOptionTwo {
-    if ((!('discriminatorField' in value) && !('discriminator_field' in value)) || (value['discriminatorField'] === undefined && value['discriminator_field'] === undefined)) return false;
-    if (value['discriminatorField'] !== 'snakeOptionTwo' && value['discriminator_field'] !== 'snakeOptionTwo') return false;
+    if ((!('discriminatorField' in (value as Record<string, any>)) && !('discriminator_field' in (value as Record<string, any>))) || ((value as Record<string, any>)['discriminatorField'] === undefined && (value as Record<string, any>)['discriminator_field'] === undefined)) return false;
+    if ((value as Record<string, any>)['discriminatorField'] !== 'snakeOptionTwo' && (value as Record<string, any>)['discriminator_field'] !== 'snakeOptionTwo') return false;
     
-    if ((!('someProperty' in value) && !('some_property' in value)) || (value['someProperty'] === undefined && value['some_property'] === undefined)) return false;
+    if ((!('someProperty' in (value as Record<string, any>)) && !('some_property' in (value as Record<string, any>))) || ((value as Record<string, any>)['someProperty'] === undefined && (value as Record<string, any>)['some_property'] === undefined)) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Animal.ts
@@ -39,7 +39,7 @@ export interface Animal {
  * Check if a given object implements the Animal interface.
  */
 export function instanceOfAnimal(value: object): value is Animal {
-    if ((!('className' in value) && !('class_name' in value)) || (value['className'] === undefined && value['class_name'] === undefined)) return false;
+    if ((!('className' in (value as Record<string, any>)) && !('class_name' in (value as Record<string, any>))) || ((value as Record<string, any>)['className'] === undefined && (value as Record<string, any>)['class_name'] === undefined)) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
@@ -142,7 +142,7 @@ export type EnumTestEnumNumberEnum = typeof EnumTestEnumNumberEnum[keyof typeof 
  * Check if a given object implements the EnumTest interface.
  */
 export function instanceOfEnumTest(value: object): value is EnumTest {
-    if ((!('enumStringRequired' in value) && !('enum_string_required' in value)) || (value['enumStringRequired'] === undefined && value['enum_string_required'] === undefined)) return false;
+    if ((!('enumStringRequired' in (value as Record<string, any>)) && !('enum_string_required' in (value as Record<string, any>))) || ((value as Record<string, any>)['enumStringRequired'] === undefined && (value as Record<string, any>)['enum_string_required'] === undefined)) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FormatTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FormatTest.ts
@@ -122,7 +122,7 @@ export interface FormatTest {
  */
 export function instanceOfFormatTest(value: object): value is FormatTest {
     if (!('number' in value) || value['number'] === undefined) return false;
-    if ((!('_byte' in value) && !('byte' in value)) || (value['_byte'] === undefined && value['byte'] === undefined)) return false;
+    if ((!('_byte' in (value as Record<string, any>)) && !('byte' in (value as Record<string, any>))) || ((value as Record<string, any>)['_byte'] === undefined && (value as Record<string, any>)['byte'] === undefined)) return false;
     if (!('date' in value) || value['date'] === undefined) return false;
     if (!('password' in value) || value['password'] === undefined) return false;
     return true;


### PR DESCRIPTION
Fixes #23980

### Problem

As of 7.23.0 the `typescript-fetch` generator emits `instanceOf<Model>` type guards that fail to compile with **TS2590: "Expression produces a union type that is too complex to represent"** when a model has many required properties whose sanitized TS name differs from the JSON `baseName` (e.g. any snake_case API).

The dual `name`/`baseName` membership check added in #23497 reads through the `value` parameter (typed `object`) on every clause:

```ts
if ((!('awsRegion' in value) && !('aws_region' in value)) || (value['awsRegion'] === undefined && value['aws_region'] === undefined)) return false;
```

Because the function is a type predicate (`value is Model`), each `in`/index-access against `value` narrows the parameter, and the candidate union grows on every clause. With ~15+ sanitized required fields the union crosses the compiler's internal limit and trips TS2590. Skinny models stay under the threshold, which is why it was not caught by existing samples.

### Fix

Read the membership and index-access checks in the `hasSanitizedName` branch through `value as Record<string, any>` so TypeScript no longer narrows the predicate on each clause. This keeps the dual-key (name + baseName) behavior introduced by #23497 while restoring compilable guards. The non-sanitized branch (single-key) is unchanged — it never accumulated the cross-product union and already compiles for wide models.

Only `modelGeneric.mustache` changed; the regenerated samples are a mechanical consequence.

### Verification

- **Reproduced** the failure: a model with 18 required snake_case properties generated on `master` produces a guard that fails `tsc --noEmit` with TS2590.
- **After the fix**, the same spec generates a guard that compiles cleanly (`tsc --noEmit --strict`, exit 0).
- Regenerated all `typescript-fetch` samples (`./bin/generate-samples.sh ./bin/configs/typescript-fetch-*.yaml`) — 9 model files updated; the changed `snakecase-discriminator` build's models type-check cleanly under `--strict`.

Verification done: 1 (no in-flight PR — `gh pr list`/code-search), 2 (no claims on the issue), 3 (fix is in the `.mustache` template + generated `.ts`), 4 (grepped the dual-key pattern on master, confirmed present), end-to-end repro before/after with `tsc`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TS2590 (“union type too complex”) in `typescript-fetch` when generating `instanceOf<Model>` guards for models with many required fields whose TS names differ from their JSON `baseName`. Guards now compile while preserving dual-key checks.

- **Bug Fixes**
  - Cast `value` to `Record<string, any>` for dual `name`/`baseName` membership and discriminator checks to stop type predicate narrowing.
  - Retains behavior from #23497; single-key path unchanged.
  - Updated `modelGeneric.mustache`; regenerated affected samples; updated `TypeScriptFetchClientCodegenTest` assertions to expect the casts.

<sup>Written for commit 3b1d30a8ac68c4502a4cc262ab4a053ef2e71c81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

