### PR TITLE
[Rust-Axum] Fix generating error upon special model name

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-axum/lib.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-axum/lib.mustache
@@ -14,6 +14,8 @@
     clippy::too_many_arguments
 )]
 
+extern crate futures_util;
+
 pub const BASE_PATH: &str = "{{{basePathWithoutHost}}}";
 {{#appVersion}}
 pub const API_VERSION: &str = "{{{.}}}";

--- a/modules/openapi-generator/src/main/resources/rust-axum/models.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-axum/models.mustache
@@ -8,7 +8,7 @@ use crate::header;
 use crate::{models, types::*};
 
 #[allow(dead_code)]
-pub type SSE = std::pin::Pin<std::boxed::Box<dyn futures_util::Stream<Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>> + Send + Sync>>;
+pub type SSE = std::pin::Pin<std::boxed::Box<dyn futures_util::Stream<Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>> + std::marker::Send + std::marker::Sync>>;
 
 #[allow(dead_code)]
 fn from_validation_error(e: validator::ValidationError) -> validator::ValidationErrors {

--- a/modules/openapi-generator/src/main/resources/rust-axum/models.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-axum/models.mustache
@@ -8,7 +8,7 @@ use crate::header;
 use crate::{models, types::*};
 
 #[allow(dead_code)]
-pub type SSE = std::pin::Pin<Box<dyn futures_util::Stream<Item = Result<axum::response::sse::Event, std::convert::Infallible>> + Send + Sync>>;
+pub type SSE = std::pin::Pin<std::boxed::Box<dyn futures_util::Stream<Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>> + Send + Sync>>;
 
 #[allow(dead_code)]
 fn from_validation_error(e: validator::ValidationError) -> validator::ValidationErrors {

--- a/samples/server/petstore/rust-axum/output/apikey-authorization/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/apikey-authorization/src/lib.rs
@@ -14,6 +14,8 @@
     clippy::too_many_arguments
 )]
 
+extern crate futures_util;
+
 pub const BASE_PATH: &str = "/v71";
 pub const API_VERSION: &str = "1.0.0";
 

--- a/samples/server/petstore/rust-axum/output/apikey-authorization/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/apikey-authorization/src/models.rs
@@ -8,6 +8,16 @@ use crate::header;
 use crate::{models, types::*};
 
 #[allow(dead_code)]
+pub type SSE = std::pin::Pin<
+    std::boxed::Box<
+        dyn futures_util::Stream<
+                Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
+            > + Send
+            + Sync,
+    >,
+>;
+
+#[allow(dead_code)]
 fn from_validation_error(e: validator::ValidationError) -> validator::ValidationErrors {
     let mut errs = validator::ValidationErrors::new();
     errs.add("na", e);

--- a/samples/server/petstore/rust-axum/output/apikey-authorization/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/apikey-authorization/src/models.rs
@@ -12,8 +12,8 @@ pub type SSE = std::pin::Pin<
     std::boxed::Box<
         dyn futures_util::Stream<
                 Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
-            > + Send
-            + Sync,
+            > + std::marker::Send
+            + std::marker::Sync,
     >,
 >;
 

--- a/samples/server/petstore/rust-axum/output/apikey-auths/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/apikey-auths/src/lib.rs
@@ -14,6 +14,8 @@
     clippy::too_many_arguments
 )]
 
+extern crate futures_util;
+
 pub const BASE_PATH: &str = "/v71";
 pub const API_VERSION: &str = "1.0.0";
 

--- a/samples/server/petstore/rust-axum/output/apikey-auths/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/apikey-auths/src/models.rs
@@ -8,6 +8,16 @@ use crate::header;
 use crate::{models, types::*};
 
 #[allow(dead_code)]
+pub type SSE = std::pin::Pin<
+    std::boxed::Box<
+        dyn futures_util::Stream<
+                Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
+            > + Send
+            + Sync,
+    >,
+>;
+
+#[allow(dead_code)]
 fn from_validation_error(e: validator::ValidationError) -> validator::ValidationErrors {
     let mut errs = validator::ValidationErrors::new();
     errs.add("na", e);

--- a/samples/server/petstore/rust-axum/output/apikey-auths/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/apikey-auths/src/models.rs
@@ -12,8 +12,8 @@ pub type SSE = std::pin::Pin<
     std::boxed::Box<
         dyn futures_util::Stream<
                 Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
-            > + Send
-            + Sync,
+            > + std::marker::Send
+            + std::marker::Sync,
     >,
 >;
 

--- a/samples/server/petstore/rust-axum/output/multipart-v3/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/multipart-v3/src/lib.rs
@@ -14,6 +14,8 @@
     clippy::too_many_arguments
 )]
 
+extern crate futures_util;
+
 pub const BASE_PATH: &str = "";
 pub const API_VERSION: &str = "1.0.7";
 

--- a/samples/server/petstore/rust-axum/output/multipart-v3/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/multipart-v3/src/models.rs
@@ -8,6 +8,16 @@ use crate::header;
 use crate::{models, types::*};
 
 #[allow(dead_code)]
+pub type SSE = std::pin::Pin<
+    std::boxed::Box<
+        dyn futures_util::Stream<
+                Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
+            > + Send
+            + Sync,
+    >,
+>;
+
+#[allow(dead_code)]
 fn from_validation_error(e: validator::ValidationError) -> validator::ValidationErrors {
     let mut errs = validator::ValidationErrors::new();
     errs.add("na", e);

--- a/samples/server/petstore/rust-axum/output/multipart-v3/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/multipart-v3/src/models.rs
@@ -12,8 +12,8 @@ pub type SSE = std::pin::Pin<
     std::boxed::Box<
         dyn futures_util::Stream<
                 Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
-            > + Send
-            + Sync,
+            > + std::marker::Send
+            + std::marker::Sync,
     >,
 >;
 

--- a/samples/server/petstore/rust-axum/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/openapi-v3/src/lib.rs
@@ -14,6 +14,8 @@
     clippy::too_many_arguments
 )]
 
+extern crate futures_util;
+
 pub const BASE_PATH: &str = "";
 pub const API_VERSION: &str = "1.0.7";
 

--- a/samples/server/petstore/rust-axum/output/openapi-v3/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/openapi-v3/src/models.rs
@@ -8,6 +8,16 @@ use crate::header;
 use crate::{models, types::*};
 
 #[allow(dead_code)]
+pub type SSE = std::pin::Pin<
+    std::boxed::Box<
+        dyn futures_util::Stream<
+                Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
+            > + Send
+            + Sync,
+    >,
+>;
+
+#[allow(dead_code)]
 fn from_validation_error(e: validator::ValidationError) -> validator::ValidationErrors {
     let mut errs = validator::ValidationErrors::new();
     errs.add("na", e);

--- a/samples/server/petstore/rust-axum/output/openapi-v3/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/openapi-v3/src/models.rs
@@ -12,8 +12,8 @@ pub type SSE = std::pin::Pin<
     std::boxed::Box<
         dyn futures_util::Stream<
                 Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
-            > + Send
-            + Sync,
+            > + std::marker::Send
+            + std::marker::Sync,
     >,
 >;
 

--- a/samples/server/petstore/rust-axum/output/ops-v3/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/ops-v3/src/lib.rs
@@ -14,6 +14,8 @@
     clippy::too_many_arguments
 )]
 
+extern crate futures_util;
+
 pub const BASE_PATH: &str = "";
 pub const API_VERSION: &str = "0.0.1";
 

--- a/samples/server/petstore/rust-axum/output/ops-v3/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/ops-v3/src/models.rs
@@ -8,6 +8,16 @@ use crate::header;
 use crate::{models, types::*};
 
 #[allow(dead_code)]
+pub type SSE = std::pin::Pin<
+    std::boxed::Box<
+        dyn futures_util::Stream<
+                Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
+            > + Send
+            + Sync,
+    >,
+>;
+
+#[allow(dead_code)]
 fn from_validation_error(e: validator::ValidationError) -> validator::ValidationErrors {
     let mut errs = validator::ValidationErrors::new();
     errs.add("na", e);

--- a/samples/server/petstore/rust-axum/output/ops-v3/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/ops-v3/src/models.rs
@@ -12,8 +12,8 @@ pub type SSE = std::pin::Pin<
     std::boxed::Box<
         dyn futures_util::Stream<
                 Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
-            > + Send
-            + Sync,
+            > + std::marker::Send
+            + std::marker::Sync,
     >,
 >;
 

--- a/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
@@ -14,6 +14,8 @@
     clippy::too_many_arguments
 )]
 
+extern crate futures_util;
+
 pub const BASE_PATH: &str = "/v2";
 pub const API_VERSION: &str = "1.0.0";
 

--- a/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
@@ -8,6 +8,16 @@ use crate::header;
 use crate::{models, types::*};
 
 #[allow(dead_code)]
+pub type SSE = std::pin::Pin<
+    std::boxed::Box<
+        dyn futures_util::Stream<
+                Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
+            > + Send
+            + Sync,
+    >,
+>;
+
+#[allow(dead_code)]
 fn from_validation_error(e: validator::ValidationError) -> validator::ValidationErrors {
     let mut errs = validator::ValidationErrors::new();
     errs.add("na", e);

--- a/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
@@ -12,8 +12,8 @@ pub type SSE = std::pin::Pin<
     std::boxed::Box<
         dyn futures_util::Stream<
                 Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
-            > + Send
-            + Sync,
+            > + std::marker::Send
+            + std::marker::Sync,
     >,
 >;
 

--- a/samples/server/petstore/rust-axum/output/petstore/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/petstore/src/lib.rs
@@ -14,6 +14,8 @@
     clippy::too_many_arguments
 )]
 
+extern crate futures_util;
+
 pub const BASE_PATH: &str = "/v2";
 pub const API_VERSION: &str = "1.0.0";
 

--- a/samples/server/petstore/rust-axum/output/petstore/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/petstore/src/models.rs
@@ -8,6 +8,16 @@ use crate::header;
 use crate::{models, types::*};
 
 #[allow(dead_code)]
+pub type SSE = std::pin::Pin<
+    std::boxed::Box<
+        dyn futures_util::Stream<
+                Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
+            > + Send
+            + Sync,
+    >,
+>;
+
+#[allow(dead_code)]
 fn from_validation_error(e: validator::ValidationError) -> validator::ValidationErrors {
     let mut errs = validator::ValidationErrors::new();
     errs.add("na", e);

--- a/samples/server/petstore/rust-axum/output/petstore/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/petstore/src/models.rs
@@ -12,8 +12,8 @@ pub type SSE = std::pin::Pin<
     std::boxed::Box<
         dyn futures_util::Stream<
                 Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
-            > + Send
-            + Sync,
+            > + std::marker::Send
+            + std::marker::Sync,
     >,
 >;
 

--- a/samples/server/petstore/rust-axum/output/ping-bearer-auth/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/ping-bearer-auth/src/lib.rs
@@ -14,6 +14,8 @@
     clippy::too_many_arguments
 )]
 
+extern crate futures_util;
+
 pub const BASE_PATH: &str = "";
 pub const API_VERSION: &str = "1.0";
 

--- a/samples/server/petstore/rust-axum/output/ping-bearer-auth/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/ping-bearer-auth/src/models.rs
@@ -8,6 +8,16 @@ use crate::header;
 use crate::{models, types::*};
 
 #[allow(dead_code)]
+pub type SSE = std::pin::Pin<
+    std::boxed::Box<
+        dyn futures_util::Stream<
+                Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
+            > + Send
+            + Sync,
+    >,
+>;
+
+#[allow(dead_code)]
 fn from_validation_error(e: validator::ValidationError) -> validator::ValidationErrors {
     let mut errs = validator::ValidationErrors::new();
     errs.add("na", e);

--- a/samples/server/petstore/rust-axum/output/ping-bearer-auth/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/ping-bearer-auth/src/models.rs
@@ -12,8 +12,8 @@ pub type SSE = std::pin::Pin<
     std::boxed::Box<
         dyn futures_util::Stream<
                 Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
-            > + Send
-            + Sync,
+            > + std::marker::Send
+            + std::marker::Sync,
     >,
 >;
 

--- a/samples/server/petstore/rust-axum/output/rust-axum-array-params-test/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-array-params-test/src/lib.rs
@@ -14,6 +14,8 @@
     clippy::too_many_arguments
 )]
 
+extern crate futures_util;
+
 pub const BASE_PATH: &str = "";
 pub const API_VERSION: &str = "0.0.1";
 

--- a/samples/server/petstore/rust-axum/output/rust-axum-array-params-test/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-array-params-test/src/models.rs
@@ -8,6 +8,16 @@ use crate::header;
 use crate::{models, types::*};
 
 #[allow(dead_code)]
+pub type SSE = std::pin::Pin<
+    std::boxed::Box<
+        dyn futures_util::Stream<
+                Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
+            > + Send
+            + Sync,
+    >,
+>;
+
+#[allow(dead_code)]
 fn from_validation_error(e: validator::ValidationError) -> validator::ValidationErrors {
     let mut errs = validator::ValidationErrors::new();
     errs.add("na", e);

--- a/samples/server/petstore/rust-axum/output/rust-axum-array-params-test/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-array-params-test/src/models.rs
@@ -12,8 +12,8 @@ pub type SSE = std::pin::Pin<
     std::boxed::Box<
         dyn futures_util::Stream<
                 Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
-            > + Send
-            + Sync,
+            > + std::marker::Send
+            + std::marker::Sync,
     >,
 >;
 

--- a/samples/server/petstore/rust-axum/output/rust-axum-header-uuid/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-header-uuid/src/lib.rs
@@ -14,6 +14,8 @@
     clippy::too_many_arguments
 )]
 
+extern crate futures_util;
+
 pub const BASE_PATH: &str = "";
 pub const API_VERSION: &str = "0.1.9";
 

--- a/samples/server/petstore/rust-axum/output/rust-axum-header-uuid/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-header-uuid/src/models.rs
@@ -8,6 +8,16 @@ use crate::header;
 use crate::{models, types::*};
 
 #[allow(dead_code)]
+pub type SSE = std::pin::Pin<
+    std::boxed::Box<
+        dyn futures_util::Stream<
+                Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
+            > + Send
+            + Sync,
+    >,
+>;
+
+#[allow(dead_code)]
 fn from_validation_error(e: validator::ValidationError) -> validator::ValidationErrors {
     let mut errs = validator::ValidationErrors::new();
     errs.add("na", e);

--- a/samples/server/petstore/rust-axum/output/rust-axum-header-uuid/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-header-uuid/src/models.rs
@@ -12,8 +12,8 @@ pub type SSE = std::pin::Pin<
     std::boxed::Box<
         dyn futures_util::Stream<
                 Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
-            > + Send
-            + Sync,
+            > + std::marker::Send
+            + std::marker::Sync,
     >,
 >;
 

--- a/samples/server/petstore/rust-axum/output/rust-axum-integer-types-test/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-integer-types-test/src/lib.rs
@@ -14,6 +14,8 @@
     clippy::too_many_arguments
 )]
 
+extern crate futures_util;
+
 pub const BASE_PATH: &str = "";
 pub const API_VERSION: &str = "1.0.0";
 

--- a/samples/server/petstore/rust-axum/output/rust-axum-integer-types-test/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-integer-types-test/src/models.rs
@@ -8,6 +8,16 @@ use crate::header;
 use crate::{models, types::*};
 
 #[allow(dead_code)]
+pub type SSE = std::pin::Pin<
+    std::boxed::Box<
+        dyn futures_util::Stream<
+                Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
+            > + Send
+            + Sync,
+    >,
+>;
+
+#[allow(dead_code)]
 fn from_validation_error(e: validator::ValidationError) -> validator::ValidationErrors {
     let mut errs = validator::ValidationErrors::new();
     errs.add("na", e);

--- a/samples/server/petstore/rust-axum/output/rust-axum-integer-types-test/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-integer-types-test/src/models.rs
@@ -12,8 +12,8 @@ pub type SSE = std::pin::Pin<
     std::boxed::Box<
         dyn futures_util::Stream<
                 Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
-            > + Send
-            + Sync,
+            > + std::marker::Send
+            + std::marker::Sync,
     >,
 >;
 

--- a/samples/server/petstore/rust-axum/output/rust-axum-oneof/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-oneof/src/lib.rs
@@ -14,6 +14,8 @@
     clippy::too_many_arguments
 )]
 
+extern crate futures_util;
+
 pub const BASE_PATH: &str = "";
 pub const API_VERSION: &str = "0.0.1";
 

--- a/samples/server/petstore/rust-axum/output/rust-axum-oneof/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-oneof/src/models.rs
@@ -8,6 +8,16 @@ use crate::header;
 use crate::{models, types::*};
 
 #[allow(dead_code)]
+pub type SSE = std::pin::Pin<
+    std::boxed::Box<
+        dyn futures_util::Stream<
+                Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
+            > + Send
+            + Sync,
+    >,
+>;
+
+#[allow(dead_code)]
 fn from_validation_error(e: validator::ValidationError) -> validator::ValidationErrors {
     let mut errs = validator::ValidationErrors::new();
     errs.add("na", e);

--- a/samples/server/petstore/rust-axum/output/rust-axum-oneof/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-oneof/src/models.rs
@@ -12,8 +12,8 @@ pub type SSE = std::pin::Pin<
     std::boxed::Box<
         dyn futures_util::Stream<
                 Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
-            > + Send
-            + Sync,
+            > + std::marker::Send
+            + std::marker::Sync,
     >,
 >;
 

--- a/samples/server/petstore/rust-axum/output/rust-axum-sse/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-sse/src/lib.rs
@@ -14,6 +14,8 @@
     clippy::too_many_arguments
 )]
 
+extern crate futures_util;
+
 pub const BASE_PATH: &str = "";
 pub const API_VERSION: &str = "1.0.0";
 

--- a/samples/server/petstore/rust-axum/output/rust-axum-sse/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-sse/src/models.rs
@@ -9,9 +9,9 @@ use crate::{models, types::*};
 
 #[allow(dead_code)]
 pub type SSE = std::pin::Pin<
-    Box<
+    std::boxed::Box<
         dyn futures_util::Stream<
-                Item = Result<axum::response::sse::Event, std::convert::Infallible>,
+                Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
             > + Send
             + Sync,
     >,

--- a/samples/server/petstore/rust-axum/output/rust-axum-sse/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-sse/src/models.rs
@@ -12,8 +12,8 @@ pub type SSE = std::pin::Pin<
     std::boxed::Box<
         dyn futures_util::Stream<
                 Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
-            > + Send
-            + Sync,
+            > + std::marker::Send
+            + std::marker::Sync,
     >,
 >;
 

--- a/samples/server/petstore/rust-axum/output/rust-axum-test/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-test/src/lib.rs
@@ -14,6 +14,8 @@
     clippy::too_many_arguments
 )]
 
+extern crate futures_util;
+
 pub const BASE_PATH: &str = "";
 pub const API_VERSION: &str = "2.3.4";
 

--- a/samples/server/petstore/rust-axum/output/rust-axum-test/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-test/src/models.rs
@@ -8,6 +8,16 @@ use crate::header;
 use crate::{models, types::*};
 
 #[allow(dead_code)]
+pub type SSE = std::pin::Pin<
+    std::boxed::Box<
+        dyn futures_util::Stream<
+                Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
+            > + Send
+            + Sync,
+    >,
+>;
+
+#[allow(dead_code)]
 fn from_validation_error(e: validator::ValidationError) -> validator::ValidationErrors {
     let mut errs = validator::ValidationErrors::new();
     errs.add("na", e);

--- a/samples/server/petstore/rust-axum/output/rust-axum-test/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-test/src/models.rs
@@ -12,8 +12,8 @@ pub type SSE = std::pin::Pin<
     std::boxed::Box<
         dyn futures_util::Stream<
                 Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
-            > + Send
-            + Sync,
+            > + std::marker::Send
+            + std::marker::Sync,
     >,
 >;
 

--- a/samples/server/petstore/rust-axum/output/rust-axum-validation-test/src/lib.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-validation-test/src/lib.rs
@@ -14,6 +14,8 @@
     clippy::too_many_arguments
 )]
 
+extern crate futures_util;
+
 pub const BASE_PATH: &str = "";
 pub const API_VERSION: &str = "0.0.1";
 

--- a/samples/server/petstore/rust-axum/output/rust-axum-validation-test/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-validation-test/src/models.rs
@@ -8,6 +8,16 @@ use crate::header;
 use crate::{models, types::*};
 
 #[allow(dead_code)]
+pub type SSE = std::pin::Pin<
+    std::boxed::Box<
+        dyn futures_util::Stream<
+                Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
+            > + Send
+            + Sync,
+    >,
+>;
+
+#[allow(dead_code)]
 fn from_validation_error(e: validator::ValidationError) -> validator::ValidationErrors {
     let mut errs = validator::ValidationErrors::new();
     errs.add("na", e);

--- a/samples/server/petstore/rust-axum/output/rust-axum-validation-test/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-validation-test/src/models.rs
@@ -12,8 +12,8 @@ pub type SSE = std::pin::Pin<
     std::boxed::Box<
         dyn futures_util::Stream<
                 Item = std::result::Result<axum::response::sse::Event, std::convert::Infallible>,
-            > + Send
-            + Sync,
+            > + std::marker::Send
+            + std::marker::Sync,
     >,
 >;
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Kindly ping @wing328 to review and merge. Thank you

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Rust `axum` server generation failures when a model name shadows `Result`, `Box`, `Send`, or `Sync` by fully qualifying the `SSE` alias and linking `futures_util`. This removes name-collision compile errors for SSE-enabled projects.

- **Bug Fixes**
  - `rust-axum/models.mustache`: `SSE` alias now uses `std::boxed::Box`, `std::result::Result`, and `std::marker::{Send, Sync}` to avoid collisions.
  - `rust-axum/lib.mustache`: added `extern crate futures_util;` so the generated crate links `futures_util` consistently.

<sup>Written for commit 8348a21a4dec8662e00c9ddb133c69d60ad503b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

