### PR TITLE
[php-nextgen] Remove request body handling if no request body exists

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
@@ -23,7 +23,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -773,7 +772,7 @@ use {{invokerPackage}}\ObjectSerializer;
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters

--- a/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
@@ -747,6 +747,7 @@ use {{invokerPackage}}\ObjectSerializer;
             $multipart
         );
 
+        {{#hasBodyOrFormParams}}
         // for model (json/xml)
         {{#bodyParams}}
         if (isset(${{paramName}})) {
@@ -783,6 +784,7 @@ use {{invokerPackage}}\ObjectSerializer;
                 $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
+        {{/hasBodyOrFormParams}}
 
         {{#authMethods}}
         {{#isApiKey}}

--- a/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
@@ -629,7 +629,8 @@ use {{invokerPackage}}\ObjectSerializer;
         $variables = array_key_exists('variables', $associative_array) ? $associative_array['variables'] : [];
 {{/servers.0}}
         $contentType = $associative_array['contentType'] ?? self::contentTypes['{{{operationId}}}'][0];
-        {{/exts.x-group-parameters}}{{#allParams}}
+        {{/exts.x-group-parameters}}
+        {{#allParams}}
         {{#required}}
         // verify the required parameter '{{paramName}}' is set
         if (${{paramName}} === null || (is_array(${{paramName}}) && count(${{paramName}}) === 0)) {
@@ -674,7 +675,8 @@ use {{invokerPackage}}\ObjectSerializer;
             throw new InvalidArgumentException('invalid value for "${{paramName}}" when calling {{classname}}.{{operationId}}, number of items must be greater than or equal to {{minItems}}.');
         }
         {{/minItems}}
-        {{/hasValidation}}{{/allParams}}
+        {{/hasValidation}}
+        {{/allParams}}
 
         $resourcePath = '{{{path}}}';
         $formParams = [];

--- a/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
@@ -32,7 +32,6 @@ use Psr\Http\Message\ResponseInterface;
 use {{invokerPackage}}\ApiException;
 use {{invokerPackage}}\Configuration;
 use {{invokerPackage}}\HeaderSelector;
-use {{invokerPackage}}\FormDataProcessor;
 use {{invokerPackage}}\ObjectSerializer;
 
 /**
@@ -728,7 +727,7 @@ use {{invokerPackage}}\ObjectSerializer;
         {{#formParams}}
         {{#-first}}
         // form params
-        $formDataProcessor = new FormDataProcessor();
+        $formDataProcessor = new \{{invokerPackage}}\FormDataProcessor();
 
         $formData = $formDataProcessor->prepare([
         {{/-first}}

--- a/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
@@ -679,8 +679,12 @@ use {{invokerPackage}}\ObjectSerializer;
         {{/allParams}}
 
         $resourcePath = '{{{path}}}';
+        {{#hasBodyOrFormParams}}
         $formParams = [];
+        {{/hasBodyOrFormParams}}
+        {{#hasQueryParams}}
         $queryParams = [];
+        {{/hasQueryParams}}
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpNextgenClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpNextgenClientCodegenTest.java
@@ -215,4 +215,63 @@ public class PhpNextgenClientCodegenTest {
         Assert.assertListContains(modelContent, a -> a.equals("): int|string|null"), "Expected to find nullable return type declaration.");
         Assert.assertListNotContains(modelContent, a -> a.equals("): ?int|string"), "Expected to not find invalid union type with '?'.");
     }
+
+    @Test
+    public void testFormParamsBlockOnlyEmittedWhenBodyOrFormParamsExist() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/php-nextgen/form-body-params.yaml", null, new ParseOptions())
+                .getOpenAPI();
+
+        codegen.setOutputDir(output.getAbsolutePath());
+        ClientOptInput input = new ClientOptInput()
+                .openAPI(openAPI)
+                .config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        Map<String, File> files = generator.opts(input).generate().stream()
+                .collect(Collectors.toMap(File::getName, Function.identity()));
+
+        String apiContent = Files.readString(files.get("DefaultApi.php").toPath());
+
+        // Each operation produces a "*Request" helper holding its own httpBody handling.
+        String noBodyNoForm = extractMethod(apiContent, "noBodyNoFormRequest");
+        String bodyParam = extractMethod(apiContent, "bodyParamRequest");
+        String formParam = extractMethod(apiContent, "formParamRequest");
+
+        // No body, no form: the dead form-params block must not be generated at all.
+        Assert.assertFalse(noBodyNoForm.contains("if (count($formParams) > 0)"),
+                "Operation without body or form params must not emit the form-params block");
+        Assert.assertFalse(noBodyNoForm.contains("// for model (json/xml)"),
+                "Operation without body or form params must not emit the json/xml comment");
+
+        // Body param: emits the body block followed by the elseif form-params branch.
+        Assert.assertTrue(bodyParam.contains("if (isset($thing)) {"),
+                "Body param operation must emit the body serialization block");
+        Assert.assertTrue(bodyParam.contains("} elseif (count($formParams) > 0) {"),
+                "Body param operation must keep the elseif form-params branch");
+
+        // Form param: emits the standalone form-params block.
+        Assert.assertTrue(formParam.contains("if (count($formParams) > 0) {"),
+                "Form param operation must emit the standalone form-params block");
+        Assert.assertFalse(formParam.contains("} elseif (count($formParams) > 0) {"),
+                "Form-only operation must not have an elseif (no body branch precedes it)");
+    }
+
+    /**
+     * Extracts the source of a single PHP method (from its declaration up to, but not
+     * including, the next method declaration) so per-operation assertions don't leak
+     * across operations sharing the same generated file.
+     */
+    private static String extractMethod(String content, String methodName) {
+        int start = content.indexOf("function " + methodName + "(");
+        Assert.assertTrue(start >= 0, "Expected to find method " + methodName + " in generated API");
+        int next = content.indexOf("\n    public function ", start + 1);
+        if (next < 0) {
+            next = content.indexOf("\n    protected function ", start + 1);
+        }
+        return next < 0 ? content.substring(start) : content.substring(start, next);
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/php-nextgen/form-body-params.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/php-nextgen/form-body-params.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.0
+info:
+  title: Form and body params test
+  version: 1.0.0
+paths:
+  /no-body-no-form:
+    get:
+      operationId: noBodyNoForm
+      parameters:
+        - name: filter
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+  /body-param:
+    post:
+      operationId: bodyParam
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Thing'
+      responses:
+        '200':
+          description: OK
+  /form-param:
+    post:
+      operationId: formParam
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                count:
+                  type: integer
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/AuthApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/AuthApi.php
@@ -317,7 +317,6 @@ class AuthApi
     ): Request
     {
 
-
         $resourcePath = '/auth/http/basic';
         $formParams = [];
         $queryParams = [];
@@ -551,7 +550,6 @@ class AuthApi
         string $contentType = self::contentTypes['testAuthHttpBearer'][0]
     ): Request
     {
-
 
         $resourcePath = '/auth/http/bearer';
         $formParams = [];

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/AuthApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/AuthApi.php
@@ -41,7 +41,6 @@ use Psr\Http\Message\ResponseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
-use OpenAPI\Client\FormDataProcessor;
 use OpenAPI\Client\ObjectSerializer;
 
 /**

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/AuthApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/AuthApi.php
@@ -337,30 +337,6 @@ class AuthApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         // this endpoint requires HTTP basic authentication
         if (!empty($this->config->getUsername()) || !(empty($this->config->getPassword()))) {
@@ -596,30 +572,6 @@ class AuthApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         // this endpoint requires Bearer authentication (access token)
         if (!empty($this->config->getAccessToken())) {

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/AuthApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/AuthApi.php
@@ -318,8 +318,6 @@ class AuthApi
     {
 
         $resourcePath = '/auth/http/basic';
-        $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -552,8 +550,6 @@ class AuthApi
     {
 
         $resourcePath = '/auth/http/bearer';
-        $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/AuthApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/AuthApi.php
@@ -32,7 +32,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Promise\PromiseInterface;

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/BodyApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/BodyApi.php
@@ -361,30 +361,6 @@ class BodyApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/BodyApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/BodyApi.php
@@ -32,7 +32,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -622,7 +621,7 @@ class BodyApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -902,7 +901,7 @@ class BodyApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -1176,7 +1175,7 @@ class BodyApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -1448,7 +1447,7 @@ class BodyApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -1720,7 +1719,7 @@ class BodyApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -1992,7 +1991,7 @@ class BodyApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -2264,7 +2263,7 @@ class BodyApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -2536,7 +2535,7 @@ class BodyApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -2808,7 +2807,7 @@ class BodyApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/BodyApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/BodyApi.php
@@ -41,7 +41,6 @@ use Psr\Http\Message\ResponseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
-use OpenAPI\Client\FormDataProcessor;
 use OpenAPI\Client\ObjectSerializer;
 
 /**
@@ -874,7 +873,7 @@ class BodyApi
 
 
         // form params
-        $formDataProcessor = new FormDataProcessor();
+        $formDataProcessor = new \OpenAPI\Client\FormDataProcessor();
 
         $formData = $formDataProcessor->prepare([
             'files' => $files,
@@ -1148,7 +1147,7 @@ class BodyApi
 
 
         // form params
-        $formDataProcessor = new FormDataProcessor();
+        $formDataProcessor = new \OpenAPI\Client\FormDataProcessor();
 
         $formData = $formDataProcessor->prepare([
             'my-file' => $my_file,

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/BodyApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/BodyApi.php
@@ -342,8 +342,6 @@ class BodyApi
     {
 
         $resourcePath = '/binary/gif';
-        $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -582,7 +580,6 @@ class BodyApi
 
         $resourcePath = '/body/application/octetstream/binary';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -858,7 +855,6 @@ class BodyApi
 
         $resourcePath = '/body/application/octetstream/array_of_binary';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1130,7 +1126,6 @@ class BodyApi
 
         $resourcePath = '/body/application/octetstream/single_binary';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1402,7 +1397,6 @@ class BodyApi
 
         $resourcePath = '/echo/body/allOf/Pet';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1672,7 +1666,6 @@ class BodyApi
 
         $resourcePath = '/echo/body/FreeFormObject/response_string';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1942,7 +1935,6 @@ class BodyApi
 
         $resourcePath = '/echo/body/Pet';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2212,7 +2204,6 @@ class BodyApi
 
         $resourcePath = '/echo/body/Pet/response_string';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2482,7 +2473,6 @@ class BodyApi
 
         $resourcePath = '/echo/body/string_enum';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2752,7 +2742,6 @@ class BodyApi
 
         $resourcePath = '/echo/body/Tag/response_string';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/BodyApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/BodyApi.php
@@ -341,7 +341,6 @@ class BodyApi
     ): Request
     {
 
-
         $resourcePath = '/binary/gif';
         $formParams = [];
         $queryParams = [];
@@ -580,8 +579,6 @@ class BodyApi
         string $contentType = self::contentTypes['testBodyApplicationOctetstreamBinary'][0]
     ): Request
     {
-
-
 
         $resourcePath = '/body/application/octetstream/binary';
         $formParams = [];
@@ -852,14 +849,12 @@ class BodyApi
         string $contentType = self::contentTypes['testBodyMultipartFormdataArrayOfBinary'][0]
     ): Request
     {
-
         // verify the required parameter 'files' is set
         if ($files === null || (is_array($files) && count($files) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $files when calling testBodyMultipartFormdataArrayOfBinary'
             );
         }
-
 
         $resourcePath = '/body/application/octetstream/array_of_binary';
         $formParams = [];
@@ -1133,8 +1128,6 @@ class BodyApi
     ): Request
     {
 
-
-
         $resourcePath = '/body/application/octetstream/single_binary';
         $formParams = [];
         $queryParams = [];
@@ -1407,8 +1400,6 @@ class BodyApi
     ): Request
     {
 
-
-
         $resourcePath = '/echo/body/allOf/Pet';
         $formParams = [];
         $queryParams = [];
@@ -1678,8 +1669,6 @@ class BodyApi
         string $contentType = self::contentTypes['testEchoBodyFreeFormObjectResponseString'][0]
     ): Request
     {
-
-
 
         $resourcePath = '/echo/body/FreeFormObject/response_string';
         $formParams = [];
@@ -1951,8 +1940,6 @@ class BodyApi
     ): Request
     {
 
-
-
         $resourcePath = '/echo/body/Pet';
         $formParams = [];
         $queryParams = [];
@@ -2222,8 +2209,6 @@ class BodyApi
         string $contentType = self::contentTypes['testEchoBodyPetResponseString'][0]
     ): Request
     {
-
-
 
         $resourcePath = '/echo/body/Pet/response_string';
         $formParams = [];
@@ -2495,8 +2480,6 @@ class BodyApi
     ): Request
     {
 
-
-
         $resourcePath = '/echo/body/string_enum';
         $formParams = [];
         $queryParams = [];
@@ -2766,8 +2749,6 @@ class BodyApi
         string $contentType = self::contentTypes['testEchoBodyTagResponseString'][0]
     ): Request
     {
-
-
 
         $resourcePath = '/echo/body/Tag/response_string';
         $formParams = [];

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/FormApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/FormApi.php
@@ -350,10 +350,6 @@ class FormApi
     ): Request
     {
 
-
-
-
-
         $resourcePath = '/form/integer/boolean/string';
         $formParams = [];
         $queryParams = [];
@@ -627,14 +623,12 @@ class FormApi
         string $contentType = self::contentTypes['testFormObjectMultipart'][0]
     ): Request
     {
-
         // verify the required parameter 'marker' is set
         if ($marker === null || (is_array($marker) && count($marker) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $marker when calling testFormObjectMultipart'
             );
         }
-
 
         $resourcePath = '/form/object/multipart';
         $formParams = [];
@@ -957,13 +951,6 @@ class FormApi
         string $contentType = self::contentTypes['testFormOneof'][0]
     ): Request
     {
-
-
-
-
-
-
-
 
         $resourcePath = '/form/oneof';
         $formParams = [];

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/FormApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/FormApi.php
@@ -32,7 +32,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -397,7 +396,7 @@ class FormApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -677,7 +676,7 @@ class FormApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -1011,7 +1010,7 @@ class FormApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/FormApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/FormApi.php
@@ -352,7 +352,6 @@ class FormApi
 
         $resourcePath = '/form/integer/boolean/string';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -632,7 +631,6 @@ class FormApi
 
         $resourcePath = '/form/object/multipart';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -954,7 +952,6 @@ class FormApi
 
         $resourcePath = '/form/oneof';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/FormApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/FormApi.php
@@ -41,7 +41,6 @@ use Psr\Http\Message\ResponseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
-use OpenAPI\Client\FormDataProcessor;
 use OpenAPI\Client\ObjectSerializer;
 
 /**
@@ -367,7 +366,7 @@ class FormApi
 
 
         // form params
-        $formDataProcessor = new FormDataProcessor();
+        $formDataProcessor = new \OpenAPI\Client\FormDataProcessor();
 
         $formData = $formDataProcessor->prepare([
             'integer_form' => $integer_form,
@@ -649,7 +648,7 @@ class FormApi
 
 
         // form params
-        $formDataProcessor = new FormDataProcessor();
+        $formDataProcessor = new \OpenAPI\Client\FormDataProcessor();
 
         $formData = $formDataProcessor->prepare([
             'marker' => $marker,
@@ -978,7 +977,7 @@ class FormApi
 
 
         // form params
-        $formDataProcessor = new FormDataProcessor();
+        $formDataProcessor = new \OpenAPI\Client\FormDataProcessor();
 
         $formData = $formDataProcessor->prepare([
             'form1' => $form1,

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/HeaderApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/HeaderApi.php
@@ -41,7 +41,6 @@ use Psr\Http\Message\ResponseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
-use OpenAPI\Client\FormDataProcessor;
 use OpenAPI\Client\ObjectSerializer;
 
 /**

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/HeaderApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/HeaderApi.php
@@ -409,30 +409,6 @@ class HeaderApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/HeaderApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/HeaderApi.php
@@ -32,7 +32,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Promise\PromiseInterface;

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/HeaderApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/HeaderApi.php
@@ -365,8 +365,6 @@ class HeaderApi
     {
 
         $resourcePath = '/header/integer/boolean/string/enums';
-        $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/HeaderApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/HeaderApi.php
@@ -364,12 +364,6 @@ class HeaderApi
     ): Request
     {
 
-
-
-
-
-
-
         $resourcePath = '/header/integer/boolean/string/enums';
         $formParams = [];
         $queryParams = [];

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/PathApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/PathApi.php
@@ -379,8 +379,6 @@ class PathApi
         }
 
         $resourcePath = '/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}';
-        $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/PathApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/PathApi.php
@@ -41,7 +41,6 @@ use Psr\Http\Message\ResponseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
-use OpenAPI\Client\FormDataProcessor;
 use OpenAPI\Client\ObjectSerializer;
 
 /**

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/PathApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/PathApi.php
@@ -353,35 +353,30 @@ class PathApi
         string $contentType = self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'][0]
     ): Request
     {
-
         // verify the required parameter 'path_string' is set
         if ($path_string === null || (is_array($path_string) && count($path_string) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $path_string when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'
             );
         }
-
         // verify the required parameter 'path_integer' is set
         if ($path_integer === null || (is_array($path_integer) && count($path_integer) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $path_integer when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'
             );
         }
-
         // verify the required parameter 'enum_nonref_string_path' is set
         if ($enum_nonref_string_path === null || (is_array($enum_nonref_string_path) && count($enum_nonref_string_path) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $enum_nonref_string_path when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'
             );
         }
-
         // verify the required parameter 'enum_ref_string_path' is set
         if ($enum_ref_string_path === null || (is_array($enum_ref_string_path) && count($enum_ref_string_path) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $enum_ref_string_path when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'
             );
         }
-
 
         $resourcePath = '/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}';
         $formParams = [];

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/PathApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/PathApi.php
@@ -32,7 +32,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Promise\PromiseInterface;

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/PathApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/PathApi.php
@@ -434,30 +434,6 @@ class PathApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
@@ -365,7 +365,6 @@ class QueryApi
     {
 
         $resourcePath = '/query/enum_ref_string';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -642,7 +641,6 @@ class QueryApi
     {
 
         $resourcePath = '/query/datetime/date/string';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -928,7 +926,6 @@ class QueryApi
     {
 
         $resourcePath = '/query/integer/boolean/string';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -1194,7 +1191,6 @@ class QueryApi
     {
 
         $resourcePath = '/query/style_deepObject/explode_true/object';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -1442,7 +1438,6 @@ class QueryApi
     {
 
         $resourcePath = '/query/style_deepObject/explode_true/object/allOf';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -1690,7 +1685,6 @@ class QueryApi
     {
 
         $resourcePath = '/query/style_form/explode_false/array_integer';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -1938,7 +1932,6 @@ class QueryApi
     {
 
         $resourcePath = '/query/style_form/explode_false/array_string';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -2186,7 +2179,6 @@ class QueryApi
     {
 
         $resourcePath = '/query/style_form/explode_true/array_string';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -2434,7 +2426,6 @@ class QueryApi
     {
 
         $resourcePath = '/query/style_form/explode_true/object';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -2682,7 +2673,6 @@ class QueryApi
     {
 
         $resourcePath = '/query/style_form/explode_true/object/allOf';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -2940,7 +2930,6 @@ class QueryApi
     {
 
         $resourcePath = '/query/style_jsonSerialization/object';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
@@ -41,7 +41,6 @@ use Psr\Http\Message\ResponseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
-use OpenAPI\Client\FormDataProcessor;
 use OpenAPI\Client\ObjectSerializer;
 
 /**

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
@@ -364,9 +364,6 @@ class QueryApi
     ): Request
     {
 
-
-
-
         $resourcePath = '/query/enum_ref_string';
         $formParams = [];
         $queryParams = [];
@@ -643,10 +640,6 @@ class QueryApi
         string $contentType = self::contentTypes['testQueryDatetimeDateString'][0]
     ): Request
     {
-
-
-
-
 
         $resourcePath = '/query/datetime/date/string';
         $formParams = [];
@@ -934,10 +927,6 @@ class QueryApi
     ): Request
     {
 
-
-
-
-
         $resourcePath = '/query/integer/boolean/string';
         $formParams = [];
         $queryParams = [];
@@ -1204,8 +1193,6 @@ class QueryApi
     ): Request
     {
 
-
-
         $resourcePath = '/query/style_deepObject/explode_true/object';
         $formParams = [];
         $queryParams = [];
@@ -1453,8 +1440,6 @@ class QueryApi
         string $contentType = self::contentTypes['testQueryStyleDeepObjectExplodeTrueObjectAllOf'][0]
     ): Request
     {
-
-
 
         $resourcePath = '/query/style_deepObject/explode_true/object/allOf';
         $formParams = [];
@@ -1704,8 +1689,6 @@ class QueryApi
     ): Request
     {
 
-
-
         $resourcePath = '/query/style_form/explode_false/array_integer';
         $formParams = [];
         $queryParams = [];
@@ -1953,8 +1936,6 @@ class QueryApi
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayString'][0]
     ): Request
     {
-
-
 
         $resourcePath = '/query/style_form/explode_false/array_string';
         $formParams = [];
@@ -2204,8 +2185,6 @@ class QueryApi
     ): Request
     {
 
-
-
         $resourcePath = '/query/style_form/explode_true/array_string';
         $formParams = [];
         $queryParams = [];
@@ -2454,8 +2433,6 @@ class QueryApi
     ): Request
     {
 
-
-
         $resourcePath = '/query/style_form/explode_true/object';
         $formParams = [];
         $queryParams = [];
@@ -2703,8 +2680,6 @@ class QueryApi
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueObjectAllOf'][0]
     ): Request
     {
-
-
 
         $resourcePath = '/query/style_form/explode_true/object/allOf';
         $formParams = [];
@@ -2963,9 +2938,6 @@ class QueryApi
         string $contentType = self::contentTypes['testQueryStyleJsonSerializationObject'][0]
     ): Request
     {
-
-
-
 
         $resourcePath = '/query/style_jsonSerialization/object';
         $formParams = [];

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
@@ -32,7 +32,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Promise\PromiseInterface;

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
@@ -404,30 +404,6 @@ class QueryApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -718,30 +694,6 @@ class QueryApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -1032,30 +984,6 @@ class QueryApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -1306,30 +1234,6 @@ class QueryApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -1580,30 +1484,6 @@ class QueryApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -1854,30 +1734,6 @@ class QueryApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -2128,30 +1984,6 @@ class QueryApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -2402,30 +2234,6 @@ class QueryApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -2676,30 +2484,6 @@ class QueryApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -2950,30 +2734,6 @@ class QueryApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -3244,30 +3004,6 @@ class QueryApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {

--- a/samples/client/echo_api/php-nextgen/src/Api/AuthApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/AuthApi.php
@@ -317,7 +317,6 @@ class AuthApi
     ): Request
     {
 
-
         $resourcePath = '/auth/http/basic';
         $formParams = [];
         $queryParams = [];
@@ -551,7 +550,6 @@ class AuthApi
         string $contentType = self::contentTypes['testAuthHttpBearer'][0]
     ): Request
     {
-
 
         $resourcePath = '/auth/http/bearer';
         $formParams = [];

--- a/samples/client/echo_api/php-nextgen/src/Api/AuthApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/AuthApi.php
@@ -41,7 +41,6 @@ use Psr\Http\Message\ResponseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
-use OpenAPI\Client\FormDataProcessor;
 use OpenAPI\Client\ObjectSerializer;
 
 /**

--- a/samples/client/echo_api/php-nextgen/src/Api/AuthApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/AuthApi.php
@@ -337,30 +337,6 @@ class AuthApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         // this endpoint requires HTTP basic authentication
         if (!empty($this->config->getUsername()) || !(empty($this->config->getPassword()))) {
@@ -596,30 +572,6 @@ class AuthApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         // this endpoint requires Bearer authentication (access token)
         if (!empty($this->config->getAccessToken())) {

--- a/samples/client/echo_api/php-nextgen/src/Api/AuthApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/AuthApi.php
@@ -318,8 +318,6 @@ class AuthApi
     {
 
         $resourcePath = '/auth/http/basic';
-        $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -552,8 +550,6 @@ class AuthApi
     {
 
         $resourcePath = '/auth/http/bearer';
-        $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/echo_api/php-nextgen/src/Api/AuthApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/AuthApi.php
@@ -32,7 +32,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Promise\PromiseInterface;

--- a/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
@@ -361,30 +361,6 @@ class BodyApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {

--- a/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
@@ -32,7 +32,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -622,7 +621,7 @@ class BodyApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -902,7 +901,7 @@ class BodyApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -1176,7 +1175,7 @@ class BodyApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -1448,7 +1447,7 @@ class BodyApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -1720,7 +1719,7 @@ class BodyApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -1992,7 +1991,7 @@ class BodyApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -2264,7 +2263,7 @@ class BodyApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -2536,7 +2535,7 @@ class BodyApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -2808,7 +2807,7 @@ class BodyApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters

--- a/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
@@ -41,7 +41,6 @@ use Psr\Http\Message\ResponseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
-use OpenAPI\Client\FormDataProcessor;
 use OpenAPI\Client\ObjectSerializer;
 
 /**
@@ -874,7 +873,7 @@ class BodyApi
 
 
         // form params
-        $formDataProcessor = new FormDataProcessor();
+        $formDataProcessor = new \OpenAPI\Client\FormDataProcessor();
 
         $formData = $formDataProcessor->prepare([
             'files' => $files,
@@ -1148,7 +1147,7 @@ class BodyApi
 
 
         // form params
-        $formDataProcessor = new FormDataProcessor();
+        $formDataProcessor = new \OpenAPI\Client\FormDataProcessor();
 
         $formData = $formDataProcessor->prepare([
             'my-file' => $my_file,

--- a/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
@@ -342,8 +342,6 @@ class BodyApi
     {
 
         $resourcePath = '/binary/gif';
-        $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -582,7 +580,6 @@ class BodyApi
 
         $resourcePath = '/body/application/octetstream/binary';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -858,7 +855,6 @@ class BodyApi
 
         $resourcePath = '/body/application/octetstream/array_of_binary';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1130,7 +1126,6 @@ class BodyApi
 
         $resourcePath = '/body/application/octetstream/single_binary';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1402,7 +1397,6 @@ class BodyApi
 
         $resourcePath = '/echo/body/allOf/Pet';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1672,7 +1666,6 @@ class BodyApi
 
         $resourcePath = '/echo/body/FreeFormObject/response_string';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1942,7 +1935,6 @@ class BodyApi
 
         $resourcePath = '/echo/body/Pet';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2212,7 +2204,6 @@ class BodyApi
 
         $resourcePath = '/echo/body/Pet/response_string';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2482,7 +2473,6 @@ class BodyApi
 
         $resourcePath = '/echo/body/string_enum';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2752,7 +2742,6 @@ class BodyApi
 
         $resourcePath = '/echo/body/Tag/response_string';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
@@ -341,7 +341,6 @@ class BodyApi
     ): Request
     {
 
-
         $resourcePath = '/binary/gif';
         $formParams = [];
         $queryParams = [];
@@ -580,8 +579,6 @@ class BodyApi
         string $contentType = self::contentTypes['testBodyApplicationOctetstreamBinary'][0]
     ): Request
     {
-
-
 
         $resourcePath = '/body/application/octetstream/binary';
         $formParams = [];
@@ -852,14 +849,12 @@ class BodyApi
         string $contentType = self::contentTypes['testBodyMultipartFormdataArrayOfBinary'][0]
     ): Request
     {
-
         // verify the required parameter 'files' is set
         if ($files === null || (is_array($files) && count($files) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $files when calling testBodyMultipartFormdataArrayOfBinary'
             );
         }
-
 
         $resourcePath = '/body/application/octetstream/array_of_binary';
         $formParams = [];
@@ -1133,8 +1128,6 @@ class BodyApi
     ): Request
     {
 
-
-
         $resourcePath = '/body/application/octetstream/single_binary';
         $formParams = [];
         $queryParams = [];
@@ -1407,8 +1400,6 @@ class BodyApi
     ): Request
     {
 
-
-
         $resourcePath = '/echo/body/allOf/Pet';
         $formParams = [];
         $queryParams = [];
@@ -1678,8 +1669,6 @@ class BodyApi
         string $contentType = self::contentTypes['testEchoBodyFreeFormObjectResponseString'][0]
     ): Request
     {
-
-
 
         $resourcePath = '/echo/body/FreeFormObject/response_string';
         $formParams = [];
@@ -1951,8 +1940,6 @@ class BodyApi
     ): Request
     {
 
-
-
         $resourcePath = '/echo/body/Pet';
         $formParams = [];
         $queryParams = [];
@@ -2222,8 +2209,6 @@ class BodyApi
         string $contentType = self::contentTypes['testEchoBodyPetResponseString'][0]
     ): Request
     {
-
-
 
         $resourcePath = '/echo/body/Pet/response_string';
         $formParams = [];
@@ -2495,8 +2480,6 @@ class BodyApi
     ): Request
     {
 
-
-
         $resourcePath = '/echo/body/string_enum';
         $formParams = [];
         $queryParams = [];
@@ -2766,8 +2749,6 @@ class BodyApi
         string $contentType = self::contentTypes['testEchoBodyTagResponseString'][0]
     ): Request
     {
-
-
 
         $resourcePath = '/echo/body/Tag/response_string';
         $formParams = [];

--- a/samples/client/echo_api/php-nextgen/src/Api/FormApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/FormApi.php
@@ -350,10 +350,6 @@ class FormApi
     ): Request
     {
 
-
-
-
-
         $resourcePath = '/form/integer/boolean/string';
         $formParams = [];
         $queryParams = [];
@@ -627,14 +623,12 @@ class FormApi
         string $contentType = self::contentTypes['testFormObjectMultipart'][0]
     ): Request
     {
-
         // verify the required parameter 'marker' is set
         if ($marker === null || (is_array($marker) && count($marker) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $marker when calling testFormObjectMultipart'
             );
         }
-
 
         $resourcePath = '/form/object/multipart';
         $formParams = [];
@@ -957,13 +951,6 @@ class FormApi
         string $contentType = self::contentTypes['testFormOneof'][0]
     ): Request
     {
-
-
-
-
-
-
-
 
         $resourcePath = '/form/oneof';
         $formParams = [];

--- a/samples/client/echo_api/php-nextgen/src/Api/FormApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/FormApi.php
@@ -32,7 +32,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -397,7 +396,7 @@ class FormApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -677,7 +676,7 @@ class FormApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -1011,7 +1010,7 @@ class FormApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters

--- a/samples/client/echo_api/php-nextgen/src/Api/FormApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/FormApi.php
@@ -352,7 +352,6 @@ class FormApi
 
         $resourcePath = '/form/integer/boolean/string';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -632,7 +631,6 @@ class FormApi
 
         $resourcePath = '/form/object/multipart';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -954,7 +952,6 @@ class FormApi
 
         $resourcePath = '/form/oneof';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/echo_api/php-nextgen/src/Api/FormApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/FormApi.php
@@ -41,7 +41,6 @@ use Psr\Http\Message\ResponseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
-use OpenAPI\Client\FormDataProcessor;
 use OpenAPI\Client\ObjectSerializer;
 
 /**
@@ -367,7 +366,7 @@ class FormApi
 
 
         // form params
-        $formDataProcessor = new FormDataProcessor();
+        $formDataProcessor = new \OpenAPI\Client\FormDataProcessor();
 
         $formData = $formDataProcessor->prepare([
             'integer_form' => $integer_form,
@@ -649,7 +648,7 @@ class FormApi
 
 
         // form params
-        $formDataProcessor = new FormDataProcessor();
+        $formDataProcessor = new \OpenAPI\Client\FormDataProcessor();
 
         $formData = $formDataProcessor->prepare([
             'marker' => $marker,
@@ -978,7 +977,7 @@ class FormApi
 
 
         // form params
-        $formDataProcessor = new FormDataProcessor();
+        $formDataProcessor = new \OpenAPI\Client\FormDataProcessor();
 
         $formData = $formDataProcessor->prepare([
             'form1' => $form1,

--- a/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
@@ -41,7 +41,6 @@ use Psr\Http\Message\ResponseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
-use OpenAPI\Client\FormDataProcessor;
 use OpenAPI\Client\ObjectSerializer;
 
 /**

--- a/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
@@ -409,30 +409,6 @@ class HeaderApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {

--- a/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
@@ -32,7 +32,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Promise\PromiseInterface;

--- a/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
@@ -365,8 +365,6 @@ class HeaderApi
     {
 
         $resourcePath = '/header/integer/boolean/string/enums';
-        $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
@@ -364,12 +364,6 @@ class HeaderApi
     ): Request
     {
 
-
-
-
-
-
-
         $resourcePath = '/header/integer/boolean/string/enums';
         $formParams = [];
         $queryParams = [];

--- a/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
@@ -379,8 +379,6 @@ class PathApi
         }
 
         $resourcePath = '/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}';
-        $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
@@ -41,7 +41,6 @@ use Psr\Http\Message\ResponseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
-use OpenAPI\Client\FormDataProcessor;
 use OpenAPI\Client\ObjectSerializer;
 
 /**

--- a/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
@@ -353,35 +353,30 @@ class PathApi
         string $contentType = self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'][0]
     ): Request
     {
-
         // verify the required parameter 'path_string' is set
         if ($path_string === null || (is_array($path_string) && count($path_string) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $path_string when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'
             );
         }
-
         // verify the required parameter 'path_integer' is set
         if ($path_integer === null || (is_array($path_integer) && count($path_integer) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $path_integer when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'
             );
         }
-
         // verify the required parameter 'enum_nonref_string_path' is set
         if ($enum_nonref_string_path === null || (is_array($enum_nonref_string_path) && count($enum_nonref_string_path) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $enum_nonref_string_path when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'
             );
         }
-
         // verify the required parameter 'enum_ref_string_path' is set
         if ($enum_ref_string_path === null || (is_array($enum_ref_string_path) && count($enum_ref_string_path) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $enum_ref_string_path when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'
             );
         }
-
 
         $resourcePath = '/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}';
         $formParams = [];

--- a/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
@@ -32,7 +32,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Promise\PromiseInterface;

--- a/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
@@ -434,30 +434,6 @@ class PathApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {

--- a/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
@@ -365,7 +365,6 @@ class QueryApi
     {
 
         $resourcePath = '/query/enum_ref_string';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -642,7 +641,6 @@ class QueryApi
     {
 
         $resourcePath = '/query/datetime/date/string';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -928,7 +926,6 @@ class QueryApi
     {
 
         $resourcePath = '/query/integer/boolean/string';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -1194,7 +1191,6 @@ class QueryApi
     {
 
         $resourcePath = '/query/style_deepObject/explode_true/object';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -1442,7 +1438,6 @@ class QueryApi
     {
 
         $resourcePath = '/query/style_deepObject/explode_true/object/allOf';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -1690,7 +1685,6 @@ class QueryApi
     {
 
         $resourcePath = '/query/style_form/explode_false/array_integer';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -1938,7 +1932,6 @@ class QueryApi
     {
 
         $resourcePath = '/query/style_form/explode_false/array_string';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -2186,7 +2179,6 @@ class QueryApi
     {
 
         $resourcePath = '/query/style_form/explode_true/array_string';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -2434,7 +2426,6 @@ class QueryApi
     {
 
         $resourcePath = '/query/style_form/explode_true/object';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -2682,7 +2673,6 @@ class QueryApi
     {
 
         $resourcePath = '/query/style_form/explode_true/object/allOf';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -2940,7 +2930,6 @@ class QueryApi
     {
 
         $resourcePath = '/query/style_jsonSerialization/object';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';

--- a/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
@@ -41,7 +41,6 @@ use Psr\Http\Message\ResponseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
-use OpenAPI\Client\FormDataProcessor;
 use OpenAPI\Client\ObjectSerializer;
 
 /**

--- a/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
@@ -364,9 +364,6 @@ class QueryApi
     ): Request
     {
 
-
-
-
         $resourcePath = '/query/enum_ref_string';
         $formParams = [];
         $queryParams = [];
@@ -643,10 +640,6 @@ class QueryApi
         string $contentType = self::contentTypes['testQueryDatetimeDateString'][0]
     ): Request
     {
-
-
-
-
 
         $resourcePath = '/query/datetime/date/string';
         $formParams = [];
@@ -934,10 +927,6 @@ class QueryApi
     ): Request
     {
 
-
-
-
-
         $resourcePath = '/query/integer/boolean/string';
         $formParams = [];
         $queryParams = [];
@@ -1204,8 +1193,6 @@ class QueryApi
     ): Request
     {
 
-
-
         $resourcePath = '/query/style_deepObject/explode_true/object';
         $formParams = [];
         $queryParams = [];
@@ -1453,8 +1440,6 @@ class QueryApi
         string $contentType = self::contentTypes['testQueryStyleDeepObjectExplodeTrueObjectAllOf'][0]
     ): Request
     {
-
-
 
         $resourcePath = '/query/style_deepObject/explode_true/object/allOf';
         $formParams = [];
@@ -1704,8 +1689,6 @@ class QueryApi
     ): Request
     {
 
-
-
         $resourcePath = '/query/style_form/explode_false/array_integer';
         $formParams = [];
         $queryParams = [];
@@ -1953,8 +1936,6 @@ class QueryApi
         string $contentType = self::contentTypes['testQueryStyleFormExplodeFalseArrayString'][0]
     ): Request
     {
-
-
 
         $resourcePath = '/query/style_form/explode_false/array_string';
         $formParams = [];
@@ -2204,8 +2185,6 @@ class QueryApi
     ): Request
     {
 
-
-
         $resourcePath = '/query/style_form/explode_true/array_string';
         $formParams = [];
         $queryParams = [];
@@ -2454,8 +2433,6 @@ class QueryApi
     ): Request
     {
 
-
-
         $resourcePath = '/query/style_form/explode_true/object';
         $formParams = [];
         $queryParams = [];
@@ -2703,8 +2680,6 @@ class QueryApi
         string $contentType = self::contentTypes['testQueryStyleFormExplodeTrueObjectAllOf'][0]
     ): Request
     {
-
-
 
         $resourcePath = '/query/style_form/explode_true/object/allOf';
         $formParams = [];
@@ -2963,9 +2938,6 @@ class QueryApi
         string $contentType = self::contentTypes['testQueryStyleJsonSerializationObject'][0]
     ): Request
     {
-
-
-
 
         $resourcePath = '/query/style_jsonSerialization/object';
         $formParams = [];

--- a/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
@@ -32,7 +32,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Promise\PromiseInterface;

--- a/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
@@ -404,30 +404,6 @@ class QueryApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -718,30 +694,6 @@ class QueryApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -1032,30 +984,6 @@ class QueryApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -1306,30 +1234,6 @@ class QueryApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -1580,30 +1484,6 @@ class QueryApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -1854,30 +1734,6 @@ class QueryApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -2128,30 +1984,6 @@ class QueryApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -2402,30 +2234,6 @@ class QueryApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -2676,30 +2484,6 @@ class QueryApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -2950,30 +2734,6 @@ class QueryApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -3244,30 +3004,6 @@ class QueryApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
@@ -322,14 +322,12 @@ class AnotherFakeApi
         string $contentType = self::contentTypes['call123TestSpecialTags'][0]
     ): Request
     {
-
         // verify the required parameter 'client' is set
         if ($client === null || (is_array($client) && count($client) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $client when calling call123TestSpecialTags'
             );
         }
-
 
         $resourcePath = '/another-fake/dummy';
         $formParams = [];

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
@@ -40,7 +40,6 @@ use Psr\Http\Message\ResponseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
-use OpenAPI\Client\FormDataProcessor;
 use OpenAPI\Client\ObjectSerializer;
 
 /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
@@ -331,7 +331,6 @@ class AnotherFakeApi
 
         $resourcePath = '/another-fake/dummy';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
@@ -31,7 +31,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -370,7 +369,7 @@ class AnotherFakeApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
@@ -321,30 +321,6 @@ class DefaultApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -567,30 +543,6 @@ class DefaultApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
@@ -40,7 +40,6 @@ use Psr\Http\Message\ResponseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
-use OpenAPI\Client\FormDataProcessor;
 use OpenAPI\Client\ObjectSerializer;
 
 /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
@@ -31,7 +31,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Promise\PromiseInterface;

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
@@ -301,7 +301,6 @@ class DefaultApi
     ): Request
     {
 
-
         $resourcePath = '/error';
         $formParams = [];
         $queryParams = [];
@@ -522,7 +521,6 @@ class DefaultApi
         string $contentType = self::contentTypes['fooGet'][0]
     ): Request
     {
-
 
         $resourcePath = '/foo';
         $formParams = [];

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
@@ -302,8 +302,6 @@ class DefaultApi
     {
 
         $resourcePath = '/error';
-        $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -523,8 +521,6 @@ class DefaultApi
     {
 
         $resourcePath = '/foo';
-        $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
@@ -396,8 +396,6 @@ class FakeApi
     {
 
         $resourcePath = '/fake/BigDecimalMap';
-        $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -618,8 +616,6 @@ class FakeApi
         }
 
         $resourcePath = '/fake/pet/{pet_id}';
-        $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -903,7 +899,6 @@ class FakeApi
         }
 
         $resourcePath = '/fake/enum/endpoint';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -1159,8 +1154,6 @@ class FakeApi
     {
 
         $resourcePath = '/fake/health';
-        $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1652,7 +1645,6 @@ class FakeApi
 
         $resourcePath = '/fake/outer/boolean';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1914,7 +1906,6 @@ class FakeApi
 
         $resourcePath = '/fake/outer/composite';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2176,7 +2167,6 @@ class FakeApi
 
         $resourcePath = '/fake/outer/number';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2438,7 +2428,6 @@ class FakeApi
 
         $resourcePath = '/fake/outer/string';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2706,7 +2695,6 @@ class FakeApi
 
         $resourcePath = '/fake/property/enum-int';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -3014,7 +3002,6 @@ class FakeApi
 
         $resourcePath = '/fake/with_400_and_4xx_range_response/endpoint';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -3290,7 +3277,6 @@ class FakeApi
 
         $resourcePath = '/fake/with_400_and_4xx_range_response_no_4xx_datatype/endpoint';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -3580,7 +3566,6 @@ class FakeApi
 
         $resourcePath = '/fake/with_400_response/endpoint';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -3874,7 +3859,6 @@ class FakeApi
 
         $resourcePath = '/fake/with_4xx_range_response/endpoint';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -4150,7 +4134,6 @@ class FakeApi
 
         $resourcePath = '/fake/with_4xx_range_response_no_4xx_datatype/endpoint';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -4378,7 +4361,6 @@ class FakeApi
 
         $resourcePath = '/fake/additionalProperties-reference';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -4598,7 +4580,6 @@ class FakeApi
 
         $resourcePath = '/fake/body-with-binary';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -4818,7 +4799,6 @@ class FakeApi
 
         $resourcePath = '/fake/body-with-file-schema';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -5339,7 +5319,6 @@ class FakeApi
 
         $resourcePath = '/fake';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -5754,7 +5733,6 @@ class FakeApi
 
         $resourcePath = '/fake';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -6412,7 +6390,6 @@ class FakeApi
         }
 
         $resourcePath = '/fake';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -6659,7 +6636,6 @@ class FakeApi
 
         $resourcePath = '/fake/inline-additionalProperties';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -6887,7 +6863,6 @@ class FakeApi
 
         $resourcePath = '/fake/inline-freeform-additionalProperties';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -7131,7 +7106,6 @@ class FakeApi
 
         $resourcePath = '/fake/jsonFormData';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -7362,7 +7336,6 @@ class FakeApi
 
         $resourcePath = '/fake/nullable';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -7671,7 +7644,6 @@ class FakeApi
         }
 
         $resourcePath = '/fake/test-query-parameters';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -7932,7 +7904,6 @@ class FakeApi
 
         $resourcePath = '/fake/stringMap-reference';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
@@ -415,30 +415,6 @@ class FakeApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -671,30 +647,6 @@ class FakeApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -1003,30 +955,6 @@ class FakeApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -1257,30 +1185,6 @@ class FakeApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -6645,30 +6549,6 @@ class FakeApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         // this endpoint requires Bearer (JWT) authentication (access token)
         if (!empty($this->config->getAccessToken())) {
@@ -7964,30 +7844,6 @@ class FakeApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
@@ -40,7 +40,6 @@ use Psr\Http\Message\ResponseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
-use OpenAPI\Client\FormDataProcessor;
 use OpenAPI\Client\ObjectSerializer;
 
 /**
@@ -5823,7 +5822,7 @@ class FakeApi
 
 
         // form params
-        $formDataProcessor = new FormDataProcessor();
+        $formDataProcessor = new \OpenAPI\Client\FormDataProcessor();
 
         $formData = $formDataProcessor->prepare([
             'integer' => $integer,
@@ -6211,7 +6210,7 @@ class FakeApi
 
 
         // form params
-        $formDataProcessor = new FormDataProcessor();
+        $formDataProcessor = new \OpenAPI\Client\FormDataProcessor();
 
         $formData = $formDataProcessor->prepare([
             'enum_form_string_array' => $enum_form_string_array,
@@ -7224,7 +7223,7 @@ class FakeApi
 
 
         // form params
-        $formDataProcessor = new FormDataProcessor();
+        $formDataProcessor = new \OpenAPI\Client\FormDataProcessor();
 
         $formData = $formDataProcessor->prepare([
             'param' => $param,

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
@@ -31,7 +31,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -1439,7 +1438,7 @@ class FakeApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -1703,7 +1702,7 @@ class FakeApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -1967,7 +1966,7 @@ class FakeApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -2231,7 +2230,7 @@ class FakeApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -2495,7 +2494,7 @@ class FakeApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -2765,7 +2764,7 @@ class FakeApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -3075,7 +3074,7 @@ class FakeApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -3353,7 +3352,7 @@ class FakeApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -3645,7 +3644,7 @@ class FakeApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -3941,7 +3940,7 @@ class FakeApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -4219,7 +4218,7 @@ class FakeApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -4449,7 +4448,7 @@ class FakeApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -4671,7 +4670,7 @@ class FakeApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -4893,7 +4892,7 @@ class FakeApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -5141,7 +5140,7 @@ class FakeApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -5419,7 +5418,7 @@ class FakeApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -5864,7 +5863,7 @@ class FakeApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -6240,7 +6239,7 @@ class FakeApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -6773,7 +6772,7 @@ class FakeApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -7003,7 +7002,7 @@ class FakeApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -7253,7 +7252,7 @@ class FakeApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -7483,7 +7482,7 @@ class FakeApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -8063,7 +8062,7 @@ class FakeApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
@@ -395,7 +395,6 @@ class FakeApi
     ): Request
     {
 
-
         $resourcePath = '/fake/BigDecimalMap';
         $formParams = [];
         $queryParams = [];
@@ -611,14 +610,12 @@ class FakeApi
         string $contentType = self::contentTypes['fakeDeletePet'][0]
     ): Request
     {
-
         // verify the required parameter 'pet_id' is set
         if ($pet_id === null || (is_array($pet_id) && count($pet_id) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $pet_id when calling fakeDeletePet'
             );
         }
-
 
         $resourcePath = '/fake/pet/{pet_id}';
         $formParams = [];
@@ -886,28 +883,24 @@ class FakeApi
         string $contentType = self::contentTypes['fakeEnumEndpoint'][0]
     ): Request
     {
-
         // verify the required parameter 'enum_class' is set
         if ($enum_class === null || (is_array($enum_class) && count($enum_class) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $enum_class when calling fakeEnumEndpoint'
             );
         }
-
         // verify the required parameter 'enum_class_array' is set
         if ($enum_class_array === null || (is_array($enum_class_array) && count($enum_class_array) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $enum_class_array when calling fakeEnumEndpoint'
             );
         }
-
         // verify the required parameter 'enum_class_map' is set
         if ($enum_class_map === null || (is_array($enum_class_map) && count($enum_class_map) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $enum_class_map when calling fakeEnumEndpoint'
             );
         }
-
 
         $resourcePath = '/fake/enum/endpoint';
         $formParams = [];
@@ -1165,7 +1158,6 @@ class FakeApi
     ): Request
     {
 
-
         $resourcePath = '/fake/health';
         $formParams = [];
         $queryParams = [];
@@ -1376,16 +1368,12 @@ class FakeApi
         string $contentType = self::contentTypes['fakeHttpSignatureTest'][0]
     ): Request
     {
-
         // verify the required parameter 'pet' is set
         if ($pet === null || (is_array($pet) && count($pet) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $pet when calling fakeHttpSignatureTest'
             );
         }
-
-
-
 
         $resourcePath = '/fake/http-signature-test';
         $formParams = [];
@@ -1662,8 +1650,6 @@ class FakeApi
     ): Request
     {
 
-
-
         $resourcePath = '/fake/outer/boolean';
         $formParams = [];
         $queryParams = [];
@@ -1925,8 +1911,6 @@ class FakeApi
         string $contentType = self::contentTypes['fakeOuterCompositeSerialize'][0]
     ): Request
     {
-
-
 
         $resourcePath = '/fake/outer/composite';
         $formParams = [];
@@ -2190,8 +2174,6 @@ class FakeApi
     ): Request
     {
 
-
-
         $resourcePath = '/fake/outer/number';
         $formParams = [];
         $queryParams = [];
@@ -2454,8 +2436,6 @@ class FakeApi
     ): Request
     {
 
-
-
         $resourcePath = '/fake/outer/string';
         $formParams = [];
         $queryParams = [];
@@ -2717,14 +2697,12 @@ class FakeApi
         string $contentType = self::contentTypes['fakePropertyEnumIntegerSerialize'][0]
     ): Request
     {
-
         // verify the required parameter 'outer_object_with_enum_property' is set
         if ($outer_object_with_enum_property === null || (is_array($outer_object_with_enum_property) && count($outer_object_with_enum_property) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $outer_object_with_enum_property when calling fakePropertyEnumIntegerSerialize'
             );
         }
-
 
         $resourcePath = '/fake/property/enum-int';
         $formParams = [];
@@ -3027,14 +3005,12 @@ class FakeApi
         string $contentType = self::contentTypes['fakeWith400And4xxRangeResponseEndpoint'][0]
     ): Request
     {
-
         // verify the required parameter 'pet' is set
         if ($pet === null || (is_array($pet) && count($pet) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $pet when calling fakeWith400And4xxRangeResponseEndpoint'
             );
         }
-
 
         $resourcePath = '/fake/with_400_and_4xx_range_response/endpoint';
         $formParams = [];
@@ -3305,14 +3281,12 @@ class FakeApi
         string $contentType = self::contentTypes['fakeWith400And4xxRangeResponseNo4xxDatatypeEndpoint'][0]
     ): Request
     {
-
         // verify the required parameter 'pet' is set
         if ($pet === null || (is_array($pet) && count($pet) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $pet when calling fakeWith400And4xxRangeResponseNo4xxDatatypeEndpoint'
             );
         }
-
 
         $resourcePath = '/fake/with_400_and_4xx_range_response_no_4xx_datatype/endpoint';
         $formParams = [];
@@ -3597,14 +3571,12 @@ class FakeApi
         string $contentType = self::contentTypes['fakeWith400ResponseEndpoint'][0]
     ): Request
     {
-
         // verify the required parameter 'pet' is set
         if ($pet === null || (is_array($pet) && count($pet) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $pet when calling fakeWith400ResponseEndpoint'
             );
         }
-
 
         $resourcePath = '/fake/with_400_response/endpoint';
         $formParams = [];
@@ -3893,14 +3865,12 @@ class FakeApi
         string $contentType = self::contentTypes['fakeWith4xxRangeResponseEndpoint'][0]
     ): Request
     {
-
         // verify the required parameter 'pet' is set
         if ($pet === null || (is_array($pet) && count($pet) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $pet when calling fakeWith4xxRangeResponseEndpoint'
             );
         }
-
 
         $resourcePath = '/fake/with_4xx_range_response/endpoint';
         $formParams = [];
@@ -4171,14 +4141,12 @@ class FakeApi
         string $contentType = self::contentTypes['fakeWith4xxRangeResponseNo4xxDatatypeEndpoint'][0]
     ): Request
     {
-
         // verify the required parameter 'pet' is set
         if ($pet === null || (is_array($pet) && count($pet) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $pet when calling fakeWith4xxRangeResponseNo4xxDatatypeEndpoint'
             );
         }
-
 
         $resourcePath = '/fake/with_4xx_range_response_no_4xx_datatype/endpoint';
         $formParams = [];
@@ -4401,14 +4369,12 @@ class FakeApi
         string $contentType = self::contentTypes['testAdditionalPropertiesReference'][0]
     ): Request
     {
-
         // verify the required parameter 'request_body' is set
         if ($request_body === null || (is_array($request_body) && count($request_body) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $request_body when calling testAdditionalPropertiesReference'
             );
         }
-
 
         $resourcePath = '/fake/additionalProperties-reference';
         $formParams = [];
@@ -4623,14 +4589,12 @@ class FakeApi
         string $contentType = self::contentTypes['testBodyWithBinary'][0]
     ): Request
     {
-
         // verify the required parameter 'body' is set
         if ($body === null || (is_array($body) && count($body) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $body when calling testBodyWithBinary'
             );
         }
-
 
         $resourcePath = '/fake/body-with-binary';
         $formParams = [];
@@ -4845,14 +4809,12 @@ class FakeApi
         string $contentType = self::contentTypes['testBodyWithFileSchema'][0]
     ): Request
     {
-
         // verify the required parameter 'file_schema_test_class' is set
         if ($file_schema_test_class === null || (is_array($file_schema_test_class) && count($file_schema_test_class) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $file_schema_test_class when calling testBodyWithFileSchema'
             );
         }
-
 
         $resourcePath = '/fake/body-with-file-schema';
         $formParams = [];
@@ -5077,21 +5039,18 @@ class FakeApi
         string $contentType = self::contentTypes['testBodyWithQueryParams'][0]
     ): Request
     {
-
         // verify the required parameter 'query' is set
         if ($query === null || (is_array($query) && count($query) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $query when calling testBodyWithQueryParams'
             );
         }
-
         // verify the required parameter 'user' is set
         if ($user === null || (is_array($user) && count($user) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $user when calling testBodyWithQueryParams'
             );
         }
-
 
         $resourcePath = '/fake/body-with-query-params';
         $formParams = [];
@@ -5371,14 +5330,12 @@ class FakeApi
         string $contentType = self::contentTypes['testClientModel'][0]
     ): Request
     {
-
         // verify the required parameter 'client' is set
         if ($client === null || (is_array($client) && count($client) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $client when calling testClientModel'
             );
         }
-
 
         $resourcePath = '/fake';
         $formParams = [];
@@ -5731,7 +5688,6 @@ class FakeApi
         string $contentType = self::contentTypes['testEndpointParameters'][0]
     ): Request
     {
-
         // verify the required parameter 'number' is set
         if ($number === null || (is_array($number) && count($number) === 0)) {
             throw new InvalidArgumentException(
@@ -5744,7 +5700,6 @@ class FakeApi
         if ($number < 32.1) {
             throw new InvalidArgumentException('invalid value for "$number" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 32.1.');
         }
-        
         // verify the required parameter 'double' is set
         if ($double === null || (is_array($double) && count($double) === 0)) {
             throw new InvalidArgumentException(
@@ -5757,7 +5712,6 @@ class FakeApi
         if ($double < 67.8) {
             throw new InvalidArgumentException('invalid value for "$double" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 67.8.');
         }
-        
         // verify the required parameter 'pattern_without_delimiter' is set
         if ($pattern_without_delimiter === null || (is_array($pattern_without_delimiter) && count($pattern_without_delimiter) === 0)) {
             throw new InvalidArgumentException(
@@ -5767,48 +5721,36 @@ class FakeApi
         if (!preg_match("/^[A-Z].*/", $pattern_without_delimiter)) {
             throw new InvalidArgumentException("invalid value for \"pattern_without_delimiter\" when calling FakeApi.testEndpointParameters, must conform to the pattern /^[A-Z].*/.");
         }
-        
         // verify the required parameter 'byte' is set
         if ($byte === null || (is_array($byte) && count($byte) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $byte when calling testEndpointParameters'
             );
         }
-
         if ($integer !== null && $integer > 100) {
             throw new InvalidArgumentException('invalid value for "$integer" when calling FakeApi.testEndpointParameters, must be smaller than or equal to 100.');
         }
         if ($integer !== null && $integer < 10) {
             throw new InvalidArgumentException('invalid value for "$integer" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 10.');
         }
-        
         if ($int32 !== null && $int32 > 200) {
             throw new InvalidArgumentException('invalid value for "$int32" when calling FakeApi.testEndpointParameters, must be smaller than or equal to 200.');
         }
         if ($int32 !== null && $int32 < 20) {
             throw new InvalidArgumentException('invalid value for "$int32" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 20.');
         }
-        
-
         if ($float !== null && $float > 987.6) {
             throw new InvalidArgumentException('invalid value for "$float" when calling FakeApi.testEndpointParameters, must be smaller than or equal to 987.6.');
         }
-        
         if ($string !== null && !preg_match("/[a-z]/i", $string)) {
             throw new InvalidArgumentException("invalid value for \"string\" when calling FakeApi.testEndpointParameters, must conform to the pattern /[a-z]/i.");
         }
-        
-
-
-
         if ($password !== null && strlen($password) > 64) {
             throw new InvalidArgumentException('invalid length for "$password" when calling FakeApi.testEndpointParameters, must be smaller than or equal to 64.');
         }
         if ($password !== null && strlen($password) < 10) {
             throw new InvalidArgumentException('invalid length for "$password" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 10.');
         }
-        
-
 
         $resourcePath = '/fake';
         $formParams = [];
@@ -6132,16 +6074,6 @@ class FakeApi
     ): Request
     {
 
-
-
-
-
-
-
-
-
-
-
         $resourcePath = '/fake';
         $formParams = [];
         $queryParams = [];
@@ -6460,31 +6392,24 @@ class FakeApi
         $boolean_group = array_key_exists('boolean_group', $associative_array) ? $associative_array['boolean_group'] : null;
         $int64_group = array_key_exists('int64_group', $associative_array) ? $associative_array['int64_group'] : null;
         $contentType = $associative_array['contentType'] ?? self::contentTypes['testGroupParameters'][0];
-        
         // verify the required parameter 'required_string_group' is set
         if ($required_string_group === null || (is_array($required_string_group) && count($required_string_group) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $required_string_group when calling testGroupParameters'
             );
         }
-
         // verify the required parameter 'required_boolean_group' is set
         if ($required_boolean_group === null || (is_array($required_boolean_group) && count($required_boolean_group) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $required_boolean_group when calling testGroupParameters'
             );
         }
-
         // verify the required parameter 'required_int64_group' is set
         if ($required_int64_group === null || (is_array($required_int64_group) && count($required_int64_group) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $required_int64_group when calling testGroupParameters'
             );
         }
-
-
-
-
 
         $resourcePath = '/fake';
         $formParams = [];
@@ -6725,14 +6650,12 @@ class FakeApi
         string $contentType = self::contentTypes['testInlineAdditionalProperties'][0]
     ): Request
     {
-
         // verify the required parameter 'request_body' is set
         if ($request_body === null || (is_array($request_body) && count($request_body) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $request_body when calling testInlineAdditionalProperties'
             );
         }
-
 
         $resourcePath = '/fake/inline-additionalProperties';
         $formParams = [];
@@ -6955,14 +6878,12 @@ class FakeApi
         string $contentType = self::contentTypes['testInlineFreeformAdditionalProperties'][0]
     ): Request
     {
-
         // verify the required parameter 'test_inline_freeform_additional_properties_request' is set
         if ($test_inline_freeform_additional_properties_request === null || (is_array($test_inline_freeform_additional_properties_request) && count($test_inline_freeform_additional_properties_request) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $test_inline_freeform_additional_properties_request when calling testInlineFreeformAdditionalProperties'
             );
         }
-
 
         $resourcePath = '/fake/inline-freeform-additionalProperties';
         $formParams = [];
@@ -7195,21 +7116,18 @@ class FakeApi
         string $contentType = self::contentTypes['testJsonFormData'][0]
     ): Request
     {
-
         // verify the required parameter 'param' is set
         if ($param === null || (is_array($param) && count($param) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $param when calling testJsonFormData'
             );
         }
-
         // verify the required parameter 'param2' is set
         if ($param2 === null || (is_array($param2) && count($param2) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $param2 when calling testJsonFormData'
             );
         }
-
 
         $resourcePath = '/fake/jsonFormData';
         $formParams = [];
@@ -7435,14 +7353,12 @@ class FakeApi
         string $contentType = self::contentTypes['testNullable'][0]
     ): Request
     {
-
         // verify the required parameter 'child_with_nullable' is set
         if ($child_with_nullable === null || (is_array($child_with_nullable) && count($child_with_nullable) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $child_with_nullable when calling testNullable'
             );
         }
-
 
         $resourcePath = '/fake/nullable';
         $formParams = [];
@@ -7717,50 +7633,42 @@ class FakeApi
         string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0]
     ): Request
     {
-
         // verify the required parameter 'pipe' is set
         if ($pipe === null || (is_array($pipe) && count($pipe) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $pipe when calling testQueryParameterCollectionFormat'
             );
         }
-
         // verify the required parameter 'ioutil' is set
         if ($ioutil === null || (is_array($ioutil) && count($ioutil) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $ioutil when calling testQueryParameterCollectionFormat'
             );
         }
-
         // verify the required parameter 'http' is set
         if ($http === null || (is_array($http) && count($http) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $http when calling testQueryParameterCollectionFormat'
             );
         }
-
         // verify the required parameter 'url' is set
         if ($url === null || (is_array($url) && count($url) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $url when calling testQueryParameterCollectionFormat'
             );
         }
-
         // verify the required parameter 'context' is set
         if ($context === null || (is_array($context) && count($context) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $context when calling testQueryParameterCollectionFormat'
             );
         }
-
         // verify the required parameter 'allow_empty' is set
         if ($allow_empty === null || (is_array($allow_empty) && count($allow_empty) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $allow_empty when calling testQueryParameterCollectionFormat'
             );
         }
-
-
 
         $resourcePath = '/fake/test-query-parameters';
         $formParams = [];
@@ -8015,14 +7923,12 @@ class FakeApi
         string $contentType = self::contentTypes['testStringMapReference'][0]
     ): Request
     {
-
         // verify the required parameter 'request_body' is set
         if ($request_body === null || (is_array($request_body) && count($request_body) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $request_body when calling testStringMapReference'
             );
         }
-
 
         $resourcePath = '/fake/stringMap-reference';
         $formParams = [];

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
@@ -31,7 +31,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -370,7 +369,7 @@ class FakeClassnameTags123Api
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
@@ -40,7 +40,6 @@ use Psr\Http\Message\ResponseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
-use OpenAPI\Client\FormDataProcessor;
 use OpenAPI\Client\ObjectSerializer;
 
 /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
@@ -331,7 +331,6 @@ class FakeClassnameTags123Api
 
         $resourcePath = '/fake_classname_test';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
@@ -322,14 +322,12 @@ class FakeClassnameTags123Api
         string $contentType = self::contentTypes['testClassname'][0]
     ): Request
     {
-
         // verify the required parameter 'client' is set
         if ($client === null || (is_array($client) && count($client) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $client when calling testClassname'
             );
         }
-
 
         $resourcePath = '/fake_classname_test';
         $formParams = [];

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
@@ -414,7 +414,6 @@ class PetApi
 
         $resourcePath = '/pet';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -712,8 +711,6 @@ class PetApi
         }
 
         $resourcePath = '/pet/{petId}';
-        $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -974,7 +971,6 @@ class PetApi
         }
 
         $resourcePath = '/pet/findByStatus';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -1238,7 +1234,6 @@ class PetApi
         }
 
         $resourcePath = '/pet/findByTags';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -1497,8 +1492,6 @@ class PetApi
         }
 
         $resourcePath = '/pet/{petId}';
-        $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1814,7 +1807,6 @@ class PetApi
 
         $resourcePath = '/pet';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2123,7 +2115,6 @@ class PetApi
 
         $resourcePath = '/pet/{petId}';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2435,7 +2426,6 @@ class PetApi
 
         $resourcePath = '/pet/{petId}/uploadImage';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2753,7 +2743,6 @@ class PetApi
 
         $resourcePath = '/fake/{petId}/uploadImageWithRequiredFile';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
@@ -31,7 +31,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -453,7 +452,7 @@ class PetApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -1864,7 +1863,7 @@ class PetApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -2188,7 +2187,7 @@ class PetApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -2504,7 +2503,7 @@ class PetApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -2826,7 +2825,7 @@ class PetApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
@@ -405,14 +405,12 @@ class PetApi
         string $contentType = self::contentTypes['addPet'][0]
     ): Request
     {
-
         // verify the required parameter 'pet' is set
         if ($pet === null || (is_array($pet) && count($pet) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $pet when calling addPet'
             );
         }
-
 
         $resourcePath = '/pet';
         $formParams = [];
@@ -706,15 +704,12 @@ class PetApi
         string $contentType = self::contentTypes['deletePet'][0]
     ): Request
     {
-
         // verify the required parameter 'pet_id' is set
         if ($pet_id === null || (is_array($pet_id) && count($pet_id) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $pet_id when calling deletePet'
             );
         }
-
-
 
         $resourcePath = '/pet/{petId}';
         $formParams = [];
@@ -971,14 +966,12 @@ class PetApi
         string $contentType = self::contentTypes['findPetsByStatus'][0]
     ): Request
     {
-
         // verify the required parameter 'status' is set
         if ($status === null || (is_array($status) && count($status) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $status when calling findPetsByStatus'
             );
         }
-
 
         $resourcePath = '/pet/findByStatus';
         $formParams = [];
@@ -1237,14 +1230,12 @@ class PetApi
         string $contentType = self::contentTypes['findPetsByTags'][0]
     ): Request
     {
-
         // verify the required parameter 'tags' is set
         if ($tags === null || (is_array($tags) && count($tags) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $tags when calling findPetsByTags'
             );
         }
-        
 
         $resourcePath = '/pet/findByTags';
         $formParams = [];
@@ -1498,14 +1489,12 @@ class PetApi
         string $contentType = self::contentTypes['getPetById'][0]
     ): Request
     {
-
         // verify the required parameter 'pet_id' is set
         if ($pet_id === null || (is_array($pet_id) && count($pet_id) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $pet_id when calling getPetById'
             );
         }
-
 
         $resourcePath = '/pet/{petId}';
         $formParams = [];
@@ -1816,14 +1805,12 @@ class PetApi
         string $contentType = self::contentTypes['updatePet'][0]
     ): Request
     {
-
         // verify the required parameter 'pet' is set
         if ($pet === null || (is_array($pet) && count($pet) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $pet when calling updatePet'
             );
         }
-
 
         $resourcePath = '/pet';
         $formParams = [];
@@ -2127,16 +2114,12 @@ class PetApi
         string $contentType = self::contentTypes['updatePetWithForm'][0]
     ): Request
     {
-
         // verify the required parameter 'pet_id' is set
         if ($pet_id === null || (is_array($pet_id) && count($pet_id) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $pet_id when calling updatePetWithForm'
             );
         }
-
-
-
 
         $resourcePath = '/pet/{petId}';
         $formParams = [];
@@ -2443,16 +2426,12 @@ class PetApi
         string $contentType = self::contentTypes['uploadFile'][0]
     ): Request
     {
-
         // verify the required parameter 'pet_id' is set
         if ($pet_id === null || (is_array($pet_id) && count($pet_id) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $pet_id when calling uploadFile'
             );
         }
-
-
-
 
         $resourcePath = '/pet/{petId}/uploadImage';
         $formParams = [];
@@ -2759,22 +2738,18 @@ class PetApi
         string $contentType = self::contentTypes['uploadFileWithRequiredFile'][0]
     ): Request
     {
-
         // verify the required parameter 'pet_id' is set
         if ($pet_id === null || (is_array($pet_id) && count($pet_id) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $pet_id when calling uploadFileWithRequiredFile'
             );
         }
-
         // verify the required parameter 'required_file' is set
         if ($required_file === null || (is_array($required_file) && count($required_file) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $required_file when calling uploadFileWithRequiredFile'
             );
         }
-
-
 
         $resourcePath = '/fake/{petId}/uploadImageWithRequiredFile';
         $formParams = [];

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
@@ -747,30 +747,6 @@ class PetApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         // this endpoint requires OAuth (access token)
         if (!empty($this->config->getAccessToken())) {
@@ -1032,30 +1008,6 @@ class PetApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         // this endpoint requires OAuth (access token)
         if (!empty($this->config->getAccessToken())) {
@@ -1322,30 +1274,6 @@ class PetApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         // this endpoint requires OAuth (access token)
         if (!empty($this->config->getAccessToken())) {
@@ -1606,30 +1534,6 @@ class PetApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         // this endpoint requires API key authentication
         $apiKey = $this->config->getApiKeyWithPrefix('api_key');

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
@@ -40,7 +40,6 @@ use Psr\Http\Message\ResponseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
-use OpenAPI\Client\FormDataProcessor;
 use OpenAPI\Client\ObjectSerializer;
 
 /**
@@ -2159,7 +2158,7 @@ class PetApi
         }
 
         // form params
-        $formDataProcessor = new FormDataProcessor();
+        $formDataProcessor = new \OpenAPI\Client\FormDataProcessor();
 
         $formData = $formDataProcessor->prepare([
             'name' => $name,
@@ -2475,7 +2474,7 @@ class PetApi
         }
 
         // form params
-        $formDataProcessor = new FormDataProcessor();
+        $formDataProcessor = new \OpenAPI\Client\FormDataProcessor();
 
         $formData = $formDataProcessor->prepare([
             'additionalMetadata' => $additional_metadata,
@@ -2797,7 +2796,7 @@ class PetApi
         }
 
         // form params
-        $formDataProcessor = new FormDataProcessor();
+        $formDataProcessor = new \OpenAPI\Client\FormDataProcessor();
 
         $formData = $formDataProcessor->prepare([
             'additionalMetadata' => $additional_metadata,

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
@@ -40,7 +40,6 @@ use Psr\Http\Message\ResponseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
-use OpenAPI\Client\FormDataProcessor;
 use OpenAPI\Client\ObjectSerializer;
 
 /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
@@ -283,14 +283,12 @@ class StoreApi
         string $contentType = self::contentTypes['deleteOrder'][0]
     ): Request
     {
-
         // verify the required parameter 'order_id' is set
         if ($order_id === null || (is_array($order_id) && count($order_id) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $order_id when calling deleteOrder'
             );
         }
-
 
         $resourcePath = '/store/order/{order_id}';
         $formParams = [];
@@ -528,7 +526,6 @@ class StoreApi
         string $contentType = self::contentTypes['getInventory'][0]
     ): Request
     {
-
 
         $resourcePath = '/store/inventory';
         $formParams = [];
@@ -774,7 +771,6 @@ class StoreApi
         string $contentType = self::contentTypes['getOrderById'][0]
     ): Request
     {
-
         // verify the required parameter 'order_id' is set
         if ($order_id === null || (is_array($order_id) && count($order_id) === 0)) {
             throw new InvalidArgumentException(
@@ -787,7 +783,6 @@ class StoreApi
         if ($order_id < 1) {
             throw new InvalidArgumentException('invalid value for "$order_id" when calling StoreApi.getOrderById, must be bigger than or equal to 1.');
         }
-        
 
         $resourcePath = '/store/order/{order_id}';
         $formParams = [];
@@ -1035,14 +1030,12 @@ class StoreApi
         string $contentType = self::contentTypes['placeOrder'][0]
     ): Request
     {
-
         // verify the required parameter 'order' is set
         if ($order === null || (is_array($order) && count($order) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $order when calling placeOrder'
             );
         }
-
 
         $resourcePath = '/store/order';
         $formParams = [];

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
@@ -291,8 +291,6 @@ class StoreApi
         }
 
         $resourcePath = '/store/order/{order_id}';
-        $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -528,8 +526,6 @@ class StoreApi
     {
 
         $resourcePath = '/store/inventory';
-        $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -785,8 +781,6 @@ class StoreApi
         }
 
         $resourcePath = '/store/order/{order_id}';
-        $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1039,7 +1033,6 @@ class StoreApi
 
         $resourcePath = '/store/order';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
@@ -31,7 +31,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -1083,7 +1082,7 @@ class StoreApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
@@ -319,30 +319,6 @@ class StoreApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -573,30 +549,6 @@ class StoreApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         // this endpoint requires API key authentication
         $apiKey = $this->config->getApiKeyWithPrefix('api_key');
@@ -864,30 +816,6 @@ class StoreApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
@@ -40,7 +40,6 @@ use Psr\Http\Message\ResponseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
-use OpenAPI\Client\FormDataProcessor;
 use OpenAPI\Client\ObjectSerializer;
 
 /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
@@ -1021,30 +1021,6 @@ class UserApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -1300,30 +1276,6 @@ class UserApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -1606,30 +1558,6 @@ class UserApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {
@@ -1812,30 +1740,6 @@ class UserApi
             $multipart
         );
 
-        // for model (json/xml)
-        if (count($formParams) > 0) {
-            if ($multipart) {
-                $multipartContents = [];
-                foreach ($formParams as $formParamName => $formParamValue) {
-                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
-                    foreach ($formParamValueItems as $formParamValueItem) {
-                        $multipartContents[] = [
-                            'name' => $formParamName,
-                            'contents' => $formParamValueItem
-                        ];
-                    }
-                }
-                // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
-
-            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
-                # if Content-Type contains "application/json", json_encode the form parameters
-                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
-            } else {
-                // for HTTP post (form)
-                $httpBody = ObjectSerializer::buildQuery($formParams);
-            }
-        }
 
         $defaultHeaders = [];
         if ($this->config->getUserAgent()) {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
@@ -295,14 +295,12 @@ class UserApi
         string $contentType = self::contentTypes['createUser'][0]
     ): Request
     {
-
         // verify the required parameter 'user' is set
         if ($user === null || (is_array($user) && count($user) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $user when calling createUser'
             );
         }
-
 
         $resourcePath = '/user';
         $formParams = [];
@@ -525,14 +523,12 @@ class UserApi
         string $contentType = self::contentTypes['createUsersWithArrayInput'][0]
     ): Request
     {
-
         // verify the required parameter 'user' is set
         if ($user === null || (is_array($user) && count($user) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $user when calling createUsersWithArrayInput'
             );
         }
-
 
         $resourcePath = '/user/createWithArray';
         $formParams = [];
@@ -755,14 +751,12 @@ class UserApi
         string $contentType = self::contentTypes['createUsersWithListInput'][0]
     ): Request
     {
-
         // verify the required parameter 'user' is set
         if ($user === null || (is_array($user) && count($user) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $user when calling createUsersWithListInput'
             );
         }
-
 
         $resourcePath = '/user/createWithList';
         $formParams = [];
@@ -985,14 +979,12 @@ class UserApi
         string $contentType = self::contentTypes['deleteUser'][0]
     ): Request
     {
-
         // verify the required parameter 'username' is set
         if ($username === null || (is_array($username) && count($username) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $username when calling deleteUser'
             );
         }
-
 
         $resourcePath = '/user/{username}';
         $formParams = [];
@@ -1240,14 +1232,12 @@ class UserApi
         string $contentType = self::contentTypes['getUserByName'][0]
     ): Request
     {
-
         // verify the required parameter 'username' is set
         if ($username === null || (is_array($username) && count($username) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $username when calling getUserByName'
             );
         }
-
 
         $resourcePath = '/user/{username}';
         $formParams = [];
@@ -1505,21 +1495,18 @@ class UserApi
         string $contentType = self::contentTypes['loginUser'][0]
     ): Request
     {
-
         // verify the required parameter 'username' is set
         if ($username === null || (is_array($username) && count($username) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $username when calling loginUser'
             );
         }
-
         // verify the required parameter 'password' is set
         if ($password === null || (is_array($password) && count($password) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $password when calling loginUser'
             );
         }
-
 
         $resourcePath = '/user/login';
         $formParams = [];
@@ -1719,7 +1706,6 @@ class UserApi
         string $contentType = self::contentTypes['logoutUser'][0]
     ): Request
     {
-
 
         $resourcePath = '/user/logout';
         $formParams = [];
@@ -1921,21 +1907,18 @@ class UserApi
         string $contentType = self::contentTypes['updateUser'][0]
     ): Request
     {
-
         // verify the required parameter 'username' is set
         if ($username === null || (is_array($username) && count($username) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $username when calling updateUser'
             );
         }
-
         // verify the required parameter 'user' is set
         if ($user === null || (is_array($user) && count($user) === 0)) {
             throw new InvalidArgumentException(
                 'Missing the required parameter $user when calling updateUser'
             );
         }
-
 
         $resourcePath = '/user/{username}';
         $formParams = [];

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
@@ -304,7 +304,6 @@ class UserApi
 
         $resourcePath = '/user';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -532,7 +531,6 @@ class UserApi
 
         $resourcePath = '/user/createWithArray';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -760,7 +758,6 @@ class UserApi
 
         $resourcePath = '/user/createWithList';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -987,8 +984,6 @@ class UserApi
         }
 
         $resourcePath = '/user/{username}';
-        $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1240,8 +1235,6 @@ class UserApi
         }
 
         $resourcePath = '/user/{username}';
-        $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1509,7 +1502,6 @@ class UserApi
         }
 
         $resourcePath = '/user/login';
-        $formParams = [];
         $queryParams = [];
         $headerParams = [];
         $httpBody = '';
@@ -1708,8 +1700,6 @@ class UserApi
     {
 
         $resourcePath = '/user/logout';
-        $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1922,7 +1912,6 @@ class UserApi
 
         $resourcePath = '/user/{username}';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
@@ -31,7 +31,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -343,7 +342,7 @@ class UserApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -573,7 +572,7 @@ class UserApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -803,7 +802,7 @@ class UserApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters
@@ -1984,7 +1983,7 @@ class UserApi
                     }
                 }
                 // for HTTP post (form)
-                $httpBody = new MultipartStream($multipartContents);
+                $httpBody = new \GuzzleHttp\Psr7\MultipartStream($multipartContents);
 
             } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
                 # if Content-Type contains "application/json", json_encode the form parameters


### PR DESCRIPTION
- Remove request processing if there is no body (unused code)
- Change imports of FormProcessor and MultipartStream so no unused imports exist

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove request body/form handling and related variables/imports from generated `php-nextgen` APIs when operations have no body. This cleans up dead code and avoids unused imports in generated clients.

- **Refactors**
  - Update `api.mustache` to emit body/form blocks only when needed; remove unused `FormDataProcessor` import and inline `MultipartStream` usage.
  - Regenerate PHP samples to drop empty `$formParams`, `$queryParams`, and body-processing code where not applicable.
  - Add test and fixture to ensure no form/body blocks are generated without body/form params.

<sup>Written for commit c8962bda000e6230b9da318dcb7562b905e356bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/23995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

