### PR TITLE
[BUG][TYPESCRIPT-FETCH] Fix #23998: Form data requests with mime type parameters use URLSearchParams instead of FormData

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -361,7 +361,7 @@ export function mapValues(data: any, fn: (item: any) => any) {
 
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
+        if (consume.contentType?.startsWith('multipart/form-data') == true) {
             return true;
         }
     }

--- a/samples/client/others/typescript-fetch/additional-properties-in-multipart-issue/runtime.ts
+++ b/samples/client/others/typescript-fetch/additional-properties-in-multipart-issue/runtime.ts
@@ -369,7 +369,7 @@ export function mapValues(data: any, fn: (item: any) => any) {
 
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
+        if (consume.contentType?.startsWith('multipart/form-data') == true) {
             return true;
         }
     }

--- a/samples/client/others/typescript-fetch/infinite-recursion-issue/runtime.ts
+++ b/samples/client/others/typescript-fetch/infinite-recursion-issue/runtime.ts
@@ -369,7 +369,7 @@ export function mapValues(data: any, fn: (item: any) => any) {
 
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
+        if (consume.contentType?.startsWith('multipart/form-data') == true) {
             return true;
         }
     }

--- a/samples/client/others/typescript-fetch/self-import-issue/runtime.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/runtime.ts
@@ -369,7 +369,7 @@ export function mapValues(data: any, fn: (item: any) => any) {
 
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
+        if (consume.contentType?.startsWith('multipart/form-data') == true) {
             return true;
         }
     }

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/runtime.ts
@@ -369,7 +369,7 @@ export function mapValues(data: any, fn: (item: any) => any) {
 
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
+        if (consume.contentType?.startsWith('multipart/form-data') == true) {
             return true;
         }
     }

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/runtime.ts
@@ -369,7 +369,7 @@ export function mapValues(data: any, fn: (item: any) => any) {
 
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
+        if (consume.contentType?.startsWith('multipart/form-data') == true) {
             return true;
         }
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
@@ -369,7 +369,7 @@ export function mapValues(data: any, fn: (item: any) => any) {
 
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
+        if (consume.contentType?.startsWith('multipart/form-data') == true) {
             return true;
         }
     }

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -369,7 +369,7 @@ export function mapValues(data: any, fn: (item: any) => any) {
 
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
+        if (consume.contentType?.startsWith('multipart/form-data') == true) {
             return true;
         }
     }

--- a/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
@@ -369,7 +369,7 @@ export function mapValues(data: any, fn: (item: any) => any) {
 
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
+        if (consume.contentType?.startsWith('multipart/form-data') == true) {
             return true;
         }
     }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -369,7 +369,7 @@ export function mapValues(data: any, fn: (item: any) => any) {
 
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
+        if (consume.contentType?.startsWith('multipart/form-data') == true) {
             return true;
         }
     }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -369,7 +369,7 @@ export function mapValues(data: any, fn: (item: any) => any) {
 
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
+        if (consume.contentType?.startsWith('multipart/form-data') == true) {
             return true;
         }
     }

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/runtime.ts
@@ -369,7 +369,7 @@ export function mapValues(data: any, fn: (item: any) => any) {
 
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
+        if (consume.contentType?.startsWith('multipart/form-data') == true) {
             return true;
         }
     }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
@@ -369,7 +369,7 @@ export function mapValues(data: any, fn: (item: any) => any) {
 
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
+        if (consume.contentType?.startsWith('multipart/form-data') == true) {
             return true;
         }
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
@@ -369,7 +369,7 @@ export function mapValues(data: any, fn: (item: any) => any) {
 
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
+        if (consume.contentType?.startsWith('multipart/form-data') == true) {
             return true;
         }
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/runtime.ts
@@ -369,7 +369,7 @@ export function mapValues(data: any, fn: (item: any) => any) {
 
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
+        if (consume.contentType?.startsWith('multipart/form-data') == true) {
             return true;
         }
     }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/runtime.ts
@@ -369,7 +369,7 @@ export function mapValues(data: any, fn: (item: any) => any) {
 
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
+        if (consume.contentType?.startsWith('multipart/form-data') == true) {
             return true;
         }
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -369,7 +369,7 @@ export function mapValues(data: any, fn: (item: any) => any) {
 
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
+        if (consume.contentType?.startsWith('multipart/form-data') == true) {
             return true;
         }
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -369,7 +369,7 @@ export function mapValues(data: any, fn: (item: any) => any) {
 
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
+        if (consume.contentType?.startsWith('multipart/form-data') == true) {
             return true;
         }
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
@@ -369,7 +369,7 @@ export function mapValues(data: any, fn: (item: any) => any) {
 
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
+        if (consume.contentType?.startsWith('multipart/form-data') == true) {
             return true;
         }
     }

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
@@ -362,7 +362,7 @@ export function exists(json: any, key: string) {
 
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
+        if (consume.contentType?.startsWith('multipart/form-data') == true) {
             return true;
         }
     }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Fixes #23998. A description and a guide on how to reproduce the issue can be found there.

@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka @joscha @dennisameling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect detection of multipart form data in `typescript-fetch` when MIME parameters are present, so requests now use FormData instead of URLSearchParams. Fixes #23998.

- **Bug Fixes**
  - In `canConsumeForm`, replace strict equality with `startsWith('multipart/form-data')` to handle content types like `multipart/form-data; charset=UTF-8`.

<sup>Written for commit 9a9ca47dbd79d41d7116d0417dd63938ca87b8dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

