### PR TITLE
[Java][Spring] Use discriminator value for @JsonTypeName instead of schema name (#23997)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -469,6 +469,7 @@ public class DefaultCodegen implements CodegenConfig {
                 .put("forwardslash", new ForwardSlashLambda())
                 .put("backslash", new BackSlashLambda())
                 .put("doublequote", new DoubleQuoteLambda())
+                .put("escapeJava", new EscapeJavaLambda())
                 .put("indented", new IndentedLambda())
                 .put("indented_8", new IndentedLambda(8, " ", false, false))
                 .put("indented_12", new IndentedLambda(12, " ", false, false))

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/EscapeJavaLambda.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/EscapeJavaLambda.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.templating.mustache;
+
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
+import org.apache.commons.text.StringEscapeUtils;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * Escapes the text so it can be safely embedded in a Java string or character
+ * literal (escapes quotes, backslashes and control characters such as newlines).
+ * <p>
+ * The value is a no-op for normal identifier-like text, so it does not change
+ * output for values that were already valid Java literal content.
+ * <p>
+ * Register:
+ * <pre>
+ * additionalProperties.put("escapeJava", new EscapeJavaLambda());
+ * </pre>
+ * <p>
+ * Use:
+ * <pre>
+ * {{#escapeJava}}{{{summary}}}{{/escapeJava}}
+ * </pre>
+ */
+public class EscapeJavaLambda implements Mustache.Lambda {
+    @Override
+    public void execute(Template.Fragment fragment, Writer writer) throws IOException {
+        writer.write(StringEscapeUtils.escapeJava(fragment.execute()));
+    }
+}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/pojo.mustache
@@ -16,7 +16,7 @@
 })
 {{#isClassnameSanitized}}
 {{^hasDiscriminatorWithNonEmptyMapping}}
-@JsonTypeName("{{name}}")
+@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
 {{/hasDiscriminatorWithNonEmptyMapping}}
 {{/isClassnameSanitized}}
 {{/jackson}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/pojo.mustache
@@ -16,7 +16,7 @@
 })
 {{#isClassnameSanitized}}
 {{^hasDiscriminatorWithNonEmptyMapping}}
-@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
+@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{#lambda.escapeJava}}{{{vendorExtensions.x-discriminator-value}}}{{/lambda.escapeJava}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
 {{/hasDiscriminatorWithNonEmptyMapping}}
 {{/isClassnameSanitized}}
 {{/jackson}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pojo.mustache
@@ -20,7 +20,7 @@
 {{/vars}}
 })
 {{#isClassnameSanitized}}
-@JsonTypeName("{{name}}")
+@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
 {{/isClassnameSanitized}}
 {{/jackson}}
 {{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pojo.mustache
@@ -20,7 +20,7 @@
 {{/vars}}
 })
 {{#isClassnameSanitized}}
-@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
+@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{#lambda.escapeJava}}{{{vendorExtensions.x-discriminator-value}}}{{/lambda.escapeJava}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
 {{/isClassnameSanitized}}
 {{/jackson}}
 {{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pojo.mustache
@@ -20,7 +20,7 @@
 {{/vars}}
 })
 {{#isClassnameSanitized}}
-@JsonTypeName("{{name}}")
+@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
 {{/isClassnameSanitized}}
 {{/jackson}}
 {{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pojo.mustache
@@ -20,7 +20,7 @@
 {{/vars}}
 })
 {{#isClassnameSanitized}}
-@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
+@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{#lambda.escapeJava}}{{{vendorExtensions.x-discriminator-value}}}{{/lambda.escapeJava}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
 {{/isClassnameSanitized}}
 {{/jackson}}
 {{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/pojo.mustache
@@ -14,7 +14,7 @@
 })
 {{#isClassnameSanitized}}
 {{^hasDiscriminatorWithNonEmptyMapping}}
-@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
+@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{#lambda.escapeJava}}{{{vendorExtensions.x-discriminator-value}}}{{/lambda.escapeJava}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
 {{/hasDiscriminatorWithNonEmptyMapping}}
 {{/isClassnameSanitized}}
 {{/jackson}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/pojo.mustache
@@ -14,7 +14,7 @@
 })
 {{#isClassnameSanitized}}
 {{^hasDiscriminatorWithNonEmptyMapping}}
-@JsonTypeName("{{name}}")
+@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
 {{/hasDiscriminatorWithNonEmptyMapping}}
 {{/isClassnameSanitized}}
 {{/jackson}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/pojo.mustache
@@ -21,7 +21,7 @@
 })
 {{#isClassnameSanitized}}
 {{^hasDiscriminatorWithNonEmptyMapping}}
-@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
+@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{#lambda.escapeJava}}{{{vendorExtensions.x-discriminator-value}}}{{/lambda.escapeJava}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
 {{/hasDiscriminatorWithNonEmptyMapping}}
 {{/isClassnameSanitized}}
 {{/jackson}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/pojo.mustache
@@ -21,7 +21,7 @@
 })
 {{#isClassnameSanitized}}
 {{^hasDiscriminatorWithNonEmptyMapping}}
-@JsonTypeName("{{name}}")
+@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
 {{/hasDiscriminatorWithNonEmptyMapping}}
 {{/isClassnameSanitized}}
 {{/jackson}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pojo.mustache
@@ -21,7 +21,7 @@
 })
 {{#isClassnameSanitized}}
 {{^hasDiscriminatorWithNonEmptyMapping}}
-@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
+@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{#lambda.escapeJava}}{{{vendorExtensions.x-discriminator-value}}}{{/lambda.escapeJava}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
 {{/hasDiscriminatorWithNonEmptyMapping}}
 {{/isClassnameSanitized}}
 {{/jackson}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pojo.mustache
@@ -21,7 +21,7 @@
 })
 {{#isClassnameSanitized}}
 {{^hasDiscriminatorWithNonEmptyMapping}}
-@JsonTypeName("{{name}}")
+@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
 {{/hasDiscriminatorWithNonEmptyMapping}}
 {{/isClassnameSanitized}}
 {{/jackson}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pojo.mustache
@@ -21,7 +21,7 @@
 })
 {{#isClassnameSanitized}}
 {{^hasDiscriminatorWithNonEmptyMapping}}
-@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
+@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{#lambda.escapeJava}}{{{vendorExtensions.x-discriminator-value}}}{{/lambda.escapeJava}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
 {{/hasDiscriminatorWithNonEmptyMapping}}
 {{/isClassnameSanitized}}
 {{/jackson}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pojo.mustache
@@ -21,7 +21,7 @@
 })
 {{#isClassnameSanitized}}
 {{^hasDiscriminatorWithNonEmptyMapping}}
-@JsonTypeName("{{name}}")
+@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
 {{/hasDiscriminatorWithNonEmptyMapping}}
 {{/isClassnameSanitized}}
 {{/jackson}}

--- a/modules/openapi-generator/src/main/resources/Java/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pojo.mustache
@@ -21,7 +21,7 @@
 })
 {{#isClassnameSanitized}}
 {{^hasDiscriminatorWithNonEmptyMapping}}
-@JsonTypeName("{{name}}")
+@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
 {{/hasDiscriminatorWithNonEmptyMapping}}
 {{/isClassnameSanitized}}
 {{#additionalPropertiesType}}

--- a/modules/openapi-generator/src/main/resources/Java/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pojo.mustache
@@ -21,7 +21,7 @@
 })
 {{#isClassnameSanitized}}
 {{^hasDiscriminatorWithNonEmptyMapping}}
-@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
+@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{#lambda.escapeJava}}{{{vendorExtensions.x-discriminator-value}}}{{/lambda.escapeJava}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
 {{/hasDiscriminatorWithNonEmptyMapping}}
 {{/isClassnameSanitized}}
 {{#additionalPropertiesType}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
@@ -22,7 +22,7 @@
 {{#jackson}}
 {{#isClassnameSanitized}}
 {{^hasDiscriminatorWithNonEmptyMapping}}
-@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
+@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{#lambda.escapeJava}}{{{vendorExtensions.x-discriminator-value}}}{{/lambda.escapeJava}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
 {{/hasDiscriminatorWithNonEmptyMapping}}
 {{/isClassnameSanitized}}
 {{/jackson}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
@@ -22,7 +22,7 @@
 {{#jackson}}
 {{#isClassnameSanitized}}
 {{^hasDiscriminatorWithNonEmptyMapping}}
-@JsonTypeName("{{name}}")
+@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
 {{/hasDiscriminatorWithNonEmptyMapping}}
 {{/isClassnameSanitized}}
 {{/jackson}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -4558,4 +4558,34 @@ public class JavaClientCodegenTest {
                 .contains("@Tag(");
     }
 
+    @Test
+    public void testDiscriminatorValueUsedInJsonTypeName_issue23997() throws Exception {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/issue_23997_discriminator_jsontypename.yaml", null, new ParseOptions()).getOpenAPI();
+        JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.setLibrary(JavaClientCodegen.RESTCLIENT);
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.setModelNameSuffix("ConsumerDTO");
+
+        ClientOptInput input = new ClientOptInput()
+                .openAPI(openAPI)
+                .config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.setGenerateMetadata(false);
+        Map<String, File> files = generator.opts(input).generate().stream()
+                .collect(Collectors.toMap(File::getName, Function.identity()));
+
+        // Child models must use the declared discriminator value, not the (suffixed) schema name.
+        JavaFileAssert.assertThat(files.get("UserBrLockConsumerDTO.java"))
+                .fileContains("@JsonTypeName(\"USER\")")
+                .fileDoesNotContain("@JsonTypeName(\"UserBrLock\")");
+        JavaFileAssert.assertThat(files.get("ComponentBrLockConsumerDTO.java"))
+                .fileContains("@JsonTypeName(\"COMPONENT\")")
+                .fileDoesNotContain("@JsonTypeName(\"ComponentBrLock\")");
+    }
+
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -8135,25 +8135,9 @@ public class SpringCodegenTest {
 
     @Test
     public void testDiscriminatorValueUsedInJsonTypeName_issue23997() throws IOException {
-        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
-        output.deleteOnExit();
-
-        OpenAPI openAPI = new OpenAPIParser()
-                .readLocation("src/test/resources/3_0/issue_23997_discriminator_jsontypename.yaml", null, new ParseOptions()).getOpenAPI();
-        SpringCodegen codegen = new SpringCodegen();
-        codegen.setLibrary(SPRING_BOOT);
-        codegen.setOutputDir(output.getAbsolutePath());
-        codegen.setModelNameSuffix("ProviderDTO");
-        codegen.additionalProperties().put(INTERFACE_ONLY, "true");
-
-        ClientOptInput input = new ClientOptInput()
-                .openAPI(openAPI)
-                .config(codegen);
-
-        DefaultGenerator generator = new DefaultGenerator();
-        generator.setGenerateMetadata(false);
-        Map<String, File> files = generator.opts(input).generate().stream()
-                .collect(Collectors.toMap(File::getName, Function.identity()));
+        Map<String, File> files = generateFromContract(
+                "src/test/resources/3_0/issue_23997_discriminator_jsontypename.yaml", SPRING_BOOT,
+                Map.of(USE_SPRING_BOOT4, true, MODEL_NAME_SUFFIX, "ProviderDTO", INTERFACE_ONLY, "true"));
 
         // Child models must use the declared discriminator value, not the (suffixed) schema name.
         JavaFileAssert.assertThat(files.get("UserBrLockProviderDTO.java"))

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -8132,4 +8132,35 @@ public class SpringCodegenTest {
         JavaFileAssert.assertThat(files.get("MyObject.java"))
                 .assertProperty("optionalRef").withType("JsonNullable<com.example.ExternalModel>");
     }
+
+    @Test
+    public void testDiscriminatorValueUsedInJsonTypeName_issue23997() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/issue_23997_discriminator_jsontypename.yaml", null, new ParseOptions()).getOpenAPI();
+        SpringCodegen codegen = new SpringCodegen();
+        codegen.setLibrary(SPRING_BOOT);
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.setModelNameSuffix("ProviderDTO");
+        codegen.additionalProperties().put(INTERFACE_ONLY, "true");
+
+        ClientOptInput input = new ClientOptInput()
+                .openAPI(openAPI)
+                .config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.setGenerateMetadata(false);
+        Map<String, File> files = generator.opts(input).generate().stream()
+                .collect(Collectors.toMap(File::getName, Function.identity()));
+
+        // Child models must use the declared discriminator value, not the (suffixed) schema name.
+        JavaFileAssert.assertThat(files.get("UserBrLockProviderDTO.java"))
+                .fileContains("@JsonTypeName(\"USER\")")
+                .fileDoesNotContain("@JsonTypeName(\"UserBrLock\")");
+        JavaFileAssert.assertThat(files.get("ComponentBrLockProviderDTO.java"))
+                .fileContains("@JsonTypeName(\"COMPONENT\")")
+                .fileDoesNotContain("@JsonTypeName(\"ComponentBrLock\")");
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/EscapeJavaLambdaTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/EscapeJavaLambdaTest.java
@@ -1,0 +1,36 @@
+package org.openapitools.codegen.templating.mustache;
+
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+public class EscapeJavaLambdaTest extends LambdaTest {
+
+    @Test
+    public void escapesDoubleQuote() {
+        // Given
+        Map<String, Object> ctx = context("escapeJava", new EscapeJavaLambda(), "value", "say \"hi\"");
+
+        // When & Then
+        test("say \\\"hi\\\"", "{{#escapeJava}}{{{value}}}{{/escapeJava}}", ctx);
+    }
+
+    @Test
+    public void escapesBackslash() {
+        // Given
+        Map<String, Object> ctx = context("escapeJava", new EscapeJavaLambda(), "value", "a\\b");
+
+        // When & Then
+        test("a\\\\b", "{{#escapeJava}}{{{value}}}{{/escapeJava}}", ctx);
+    }
+
+    @Test
+    public void leavesPlainTextUnchanged() {
+        // Given
+        Map<String, Object> ctx = context("escapeJava", new EscapeJavaLambda(), "value", "USER");
+
+        // When & Then
+        test("USER", "{{#escapeJava}}{{{value}}}{{/escapeJava}}", ctx);
+    }
+
+}

--- a/modules/openapi-generator/src/test/resources/3_0/issue_23997_discriminator_jsontypename.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_23997_discriminator_jsontypename.yaml
@@ -1,0 +1,70 @@
+openapi: 3.0.1
+info:
+  title: x-discriminator-value JsonTypeName bug
+  version: 1.0.0
+paths:
+  /locks:
+    get:
+      operationId: getLocks
+      responses:
+        '200':
+          description: list of locks
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BrLock'
+components:
+  schemas:
+    LockType:
+      type: string
+      enum:
+        - USER
+        - COMPONENT
+
+    BrLock:
+      type: object
+      required:
+        - lockType
+      properties:
+        lockType:
+          $ref: '#/components/schemas/LockType'
+      oneOf:
+        - $ref: '#/components/schemas/UserBrLock'
+        - $ref: '#/components/schemas/ComponentBrLock'
+      discriminator:
+        propertyName: lockType
+        mapping:
+          USER: '#/components/schemas/UserBrLock'
+          COMPONENT: '#/components/schemas/ComponentBrLock'
+
+    BaseBrLock:
+      type: object
+      required:
+        - lockType
+      properties:
+        lockType:
+          $ref: '#/components/schemas/LockType'
+
+    UserBrLock:
+      x-discriminator-value: USER
+      allOf:
+        - $ref: '#/components/schemas/BaseBrLock'
+        - type: object
+          required:
+            - userId
+          properties:
+            userId:
+              type: string
+
+    ComponentBrLock:
+      x-discriminator-value: COMPONENT
+      allOf:
+        - $ref: '#/components/schemas/BaseBrLock'
+        - type: object
+          required:
+            - componentId
+          properties:
+            componentId:
+              type: string


### PR DESCRIPTION
Fixes #23997

### Problem

For the `java` and `spring` generators, generated child models of a discriminator can receive a Jackson `@JsonTypeName` annotation using the **schema/model name** instead of the discriminator value declared in the OpenAPI contract:

```java
@JsonTypeName("ComponentBrLock")               // wrong
public class ComponentBrLockConsumerDTO implements BrLockConsumerDTO { }
```

This breaks Jackson polymorphic serialization whenever the discriminator value differs from the schema name — most visibly when `modelNameSuffix`/`modelNamePrefix` is used, or when an explicit `x-discriminator-value` is declared on the child schema. The parent's `@JsonSubTypes` already uses the correct value, so serialization and deserialization disagree.

### Fix

Render `@JsonTypeName` from `vendorExtensions.x-discriminator-value` when present, falling back to the schema/model name otherwise — exactly the approach suggested in the issue and already used for the `jaxrs-spec` generator (#23509):

```mustache
@JsonTypeName("{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}")
```

Applied to the base `Java`/`JavaSpring` `pojo.mustache` and the affected Java client libraries (restclient, resttemplate, webclient, feign, jersey2, jersey3, microprofile) so the behavior is consistent across the Java/Spring generators.

The change is a **no-op when no `x-discriminator-value` is present** (the conditional renders exactly `{{name}}` as before), so no existing samples change.

### Test evidence

Added two focused tests reproducing the issue's spec (child schemas extend a non-discriminator base and carry an explicit `x-discriminator-value`, generated with a model-name suffix):

- `SpringCodegenTest#testDiscriminatorValueUsedInJsonTypeName_issue23997`
- `JavaClientCodegenTest#testDiscriminatorValueUsedInJsonTypeName_issue23997`

Both assert child models emit `@JsonTypeName("USER")` / `@JsonTypeName("COMPONENT")` rather than the suffixed schema name. Both pass:

```
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0  -- SpringCodegenTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0  -- JavaClientCodegenTest
```

Regenerating an existing discriminator-bearing sample (`bin/configs/java-restclient.yaml`, petstore) produced **zero diff**, confirming the template change does not affect output when `x-discriminator-value` is absent.

### Verification done
- (1) No in-flight PR for this issue (`gh pr list` search), no linked PRs/branches on the issue
- (2) No claim comments (issue had 0 comments)
- (3) Code-focused: fix touches `.mustache` templates + Java tests, not docs
- (4) Confirmed the bug still exists on `master` (templates emitted `@JsonTypeName("{{name}}")`); reproduced via the added tests
- (5) Not part of a closed umbrella epic — related JAX-RS fix #23509 deliberately did not cover java/spring

cc @bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jimschubert (Java technical committee) and @cachescrubber @welshm @MelleD @atextor @manedev79 @javisst @borsch @banlangzhi @SahilGarg17 (Spring technical committee)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the discriminator value for Jackson `@JsonTypeName` in Java and Spring generators, and escape it to prevent invalid Java string literals. Fixes mismatched polymorphic serialization and avoids compile errors when values include quotes or backslashes. Fixes #23997.

- **Bug Fixes**
  - Render `@JsonTypeName` from `vendorExtensions.x-discriminator-value`, otherwise `{{name}}`; wrap with `lambda.escapeJava` to escape quotes, backslashes, and control chars.
  - Added `EscapeJavaLambda` (registered as `escapeJava`) and applied to `Java`/`JavaSpring` `pojo.mustache` and Java client libs: `restclient`, `resttemplate`, `webclient`, `feign`, `jersey2`, `jersey3`, `microprofile`.
  - Added tests asserting `@JsonTypeName("USER" | "COMPONENT")` is emitted and unit tests for escaping; existing samples show zero diff.

<sup>Written for commit 94f285fe76229cd164923d7f5da18334ed232378. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

