### PR TITLE
[Java] Fix uncompilable default value for alias-as-model array/map properties (#23988)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1380,6 +1380,22 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     @Override
     public String toDefaultValue(CodegenProperty cp, Schema schema) {
+        // When generateAliasAsModel is enabled, a property that $refs an array/map alias is typed
+        // as the generated alias model (e.g. "ItemArray extends ArrayList<Item>"), not the inlined
+        // collection. Dereferencing below would otherwise yield a collection default such as
+        // "new ArrayList<>()", which is not assignable to the alias type and does not compile.
+        // Use the alias model's own default instead.
+        // See https://github.com/OpenAPITools/openapi-generator/issues/23988
+        if (schema.get$ref() != null && !cp.isArray && !cp.isMap) {
+            Schema referencedSchema = ModelUtils.getReferencedSchema(this.openAPI, schema);
+            if (ModelUtils.isArraySchema(referencedSchema)
+                    || (ModelUtils.isMapSchema(referencedSchema) && !ModelUtils.isComposedSchema(referencedSchema))) {
+                if (cp.isNullable || containerDefaultToNull) {
+                    return null;
+                }
+                return "new " + cp.datatypeWithEnum + "()";
+            }
+        }
         schema = ModelUtils.getReferencedSchema(this.openAPI, schema);
         if (ModelUtils.isArraySchema(schema)) {
             if (defaultToEmptyContainer) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -6583,6 +6583,39 @@ public class SpringCodegenTest {
     }
 
     @Test
+    public void shouldUseAliasModelDefaultValueForAliasAsModelProperties_issue23988() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/spring/issue_23988.yaml");
+        final SpringCodegen codegen = new SpringCodegen();
+        codegen.setOpenAPI(openAPI);
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(INTERFACE_ONLY, "true");
+        codegen.additionalProperties().put(CodegenConstants.GENERATE_ALIAS_AS_MODEL, "true");
+
+        ClientOptInput input = new ClientOptInput();
+        input.openAPI(openAPI);
+        input.config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.setGenerateMetadata(false);
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+
+        Map<String, File> files = generator.opts(input).generate().stream()
+                .collect(Collectors.toMap(File::getName, Function.identity()));
+
+        // A property that $refs an array/map alias is typed as the generated alias model, so its
+        // default value must instantiate the alias model rather than the inlined collection type
+        // (which is not assignable to the alias and does not compile).
+        JavaFileAssert.assertThat(files.get("MyObject.java"))
+                .fileContains("private ItemArray itemArray = new ItemArray();")
+                .fileContains("private ItemMap itemMap = new ItemMap();");
+    }
+
+    @Test
     public void testClientRegistrationIdAnnotation() throws IOException {
         final SpringCodegen codegen = new SpringCodegen();
         codegen.setLibrary("spring-http-interface");

--- a/modules/openapi-generator/src/test/resources/3_0/spring/issue_23988.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/spring/issue_23988.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.1
+info:
+  title: Test
+  version: 0.0.1
+paths: {}
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        property:
+          type: string
+    ItemArray:
+      type: array
+      items:
+        $ref: '#/components/schemas/Item'
+    ItemMap:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/Item'
+    MyObject:
+      type: object
+      properties:
+        itemArray:
+          $ref: '#/components/schemas/ItemArray'
+        itemMap:
+          $ref: '#/components/schemas/ItemMap'


### PR DESCRIPTION
Fixes #23988

### What

When `generateAliasAsModel=true`, a property that directly `$ref`s an **array or map alias** is typed as the generated alias model (e.g. `ItemArray extends ArrayList<Item>`), but `AbstractJavaCodegen.toDefaultValue(...)` dereferenced the `$ref` first and produced a *collection* default such as `new ArrayList<>()`. That value is not assignable to the alias type, so the generated field does not compile:

```java
private ItemArray itemArray = new ArrayList<>(); // ItemArray extends ArrayList<Item> -> does not compile
```

### Fix

`AbstractJavaCodegen.toDefaultValue(CodegenProperty, Schema)`: when the property is a `$ref` to an array/map alias (so it is neither an inline array nor map itself) and the referenced schema is an array/map (i.e. it is generated as an alias model), instantiate the alias model — or `null` when the property is nullable / `containerDefaultToNull` is set — instead of the inlined collection:

```java
private ItemArray itemArray = new ItemArray();
private ItemMap itemMap = new ItemMap();
```

This matches the maintainer-clarified expectation in the issue thread. When `generateAliasAsModel=false`, the property is inlined to the collection type (`cp.isArray`/`cp.isMap` is `true`), so the guard does not fire and the existing `new ArrayList<>()` behaviour is preserved.

### Test evidence

Added `SpringCodegenTest#shouldUseAliasModelDefaultValueForAliasAsModelProperties_issue23988` (with spec `3_0/spring/issue_23988.yaml`) which generates with `generateAliasAsModel=true` and asserts both the array- and map-alias fields instantiate the alias model.

- New test passes.
- Full `AbstractJavaCodegenTest` (65 tests) passes — including `toDefaultValueTest` and `getTypeDeclarationTest`, which cover the inlined-array/map default paths — so existing behaviour is unchanged.
- Regenerated all `bin/configs/java-*` and `bin/configs/spring*` samples (197 generators): **no diff**, so no committed mature sample changes.

Verification done: reproduced the uncompilable output on master with the issue's spec via the CLI; confirmed the corrected output compiles (`ItemArray`/`ItemMap` have default no-arg constructors); confirmed no in-flight PR referenced #23988.

### PR checklist

- [x] Read the contribution guidelines.
- [x] Ran the build and sample regeneration for the affected generators (Java/Spring); no sample changes resulted.
- [ ] @mention technical committee — deferring to maintainers.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes uncompilable defaults for properties that $ref array/map aliases when `generateAliasAsModel=true`. Defaults now instantiate the alias model (e.g., `new ItemArray()`/`new ItemMap()`), or `null` when nullable or `containerDefaultToNull` is set.

- **Bug Fixes**
  - Updated `AbstractJavaCodegen.toDefaultValue(...)` to detect `$ref` to array/map aliases and return `new <Alias>()`; keeps collection defaults when `generateAliasAsModel=false`.
  - Added a Spring test and spec to assert alias model defaults for array and map properties.
  - No sample diffs; existing tests pass.

<sup>Written for commit 2b405e1a5428dc1fa33757ae20fc0df9ed891e99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

