### PR TITLE
fix(cpp-httplib-server): handle missing optional JSON properties

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-httplib-server/model-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-httplib-server/model-header.mustache
@@ -225,9 +225,27 @@ public:
 
 {{/isArray}}{{/isEnum}}{{/vars}}
 
-    // JSON serialization using NLOHMANN INTRUSIVE macro (must be inside class to access private members)
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE({{vendorExtensions.modelClassName}},
-        {{#vars}} {{nameInCamelCase}}{{^-last}},{{/-last}}{{/vars}})
+friend void to_json(nlohmann::json& j, const {{vendorExtensions.modelClassName}}& o)
+{
+    {{#vars}}
+    j["{{baseName}}"] = o.{{nameInCamelCase}};
+    {{/vars}}
+}
+
+friend void from_json(const nlohmann::json& j, {{vendorExtensions.modelClassName}}& o)
+{
+    {{#requiredVars}}
+    j.at("{{baseName}}").get_to(o.{{nameInCamelCase}});
+    {{/requiredVars}}
+
+    {{#optionalVars}}
+    if (j.contains("{{baseName}}") && !j.at("{{baseName}}").is_null())
+    {
+        j.at("{{baseName}}").get_to(o.{{nameInCamelCase}});
+    }
+    {{/optionalVars}}
+}
+
 
 private:
     {{#vars}}


### PR DESCRIPTION
Fixes #23991

This fixes a crash in cpp-httplib-server generator when optional JSON properties
are missing in the request payload.

Previously, NLOHMANN_DEFINE_TYPE_INTRUSIVE was used which does not safely handle
missing fields.

Now replaced with custom to_json/from_json using:
- j.at() for required fields
- j.contains() check for optional fields

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents crashes in the `cpp-httplib-server` generator when request JSON omits optional fields by switching to explicit `to_json`/`from_json` handling. Generated servers now safely ignore missing optional properties.

- **Bug Fixes**
  - Replaced `NLOHMANN_DEFINE_TYPE_INTRUSIVE` with friend `to_json`/`from_json` in model headers.
  - Required fields use `j.at(...).get_to(...)`.
  - Optional fields use `j.contains(...)` and null check before `get_to(...)`.

<sup>Written for commit 3eeffcda8749aea4b7129c8ceb7b967ba9b6a319. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

