### PR TITLE
 fix(online): thread-safe fileMap with TTL cleanup, SLF4J logging, and Content-Length header

### DIFF
--- a/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/model/Generated.java
+++ b/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/model/Generated.java
@@ -17,6 +17,7 @@
 
 package org.openapitools.codegen.online.model;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -27,5 +28,6 @@ import java.time.Instant;
 public class Generated {
     private String filename;
     private String friendlyName;
+    @Setter(AccessLevel.NONE)
     private Instant createdAt = Instant.now();
 }

--- a/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/model/Generated.java
+++ b/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/model/Generated.java
@@ -17,7 +17,6 @@
 
 package org.openapitools.codegen.online.model;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -28,6 +27,5 @@ import java.time.Instant;
 public class Generated {
     private String filename;
     private String friendlyName;
-    @Setter(AccessLevel.NONE)
     private Instant createdAt = Instant.now();
 }

--- a/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/model/Generated.java
+++ b/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/model/Generated.java
@@ -20,9 +20,12 @@ package org.openapitools.codegen.online.model;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.Instant;
+
 @Getter
 @Setter
 public class Generated {
     private String filename;
     private String friendlyName;
+    private Instant createdAt = Instant.now();
 }

--- a/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/service/GenApiService.java
+++ b/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/service/GenApiService.java
@@ -58,7 +58,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class GenApiService implements GenApiDelegate {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GenApiService.class);
-    private static final long FILE_TTL_MS = 30 * 60 * 1000L; // 30 minutes
+    private static final long FILE_TTL_MS = 24 * 60 * 60 * 1000L; // 24 hours
 
     private static List<String> clients = new ArrayList<>();
     private static List<String> servers = new ArrayList<>();
@@ -91,6 +91,9 @@ public class GenApiService implements GenApiDelegate {
     public ResponseEntity<Resource> downloadFile(String fileId) {
         Generated g = fileMap.get(fileId);
         LOGGER.debug("looking for fileId {}", fileId);
+        if (g == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "File not found or has expired");
+        }
         LOGGER.debug("got filename {}", g.getFilename());
 
         File file = new File(g.getFilename());
@@ -191,7 +194,7 @@ public class GenApiService implements GenApiDelegate {
         }
     }
 
-    @Scheduled(fixedDelay = 60_000)
+    @Scheduled(fixedDelay = 3_600_000) // run every hour
     public void cleanExpiredFiles() {
         Instant cutoff = Instant.now().minusMillis(FILE_TTL_MS);
         fileMap.entrySet().removeIf(entry -> {

--- a/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/service/GenApiService.java
+++ b/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/service/GenApiService.java
@@ -27,12 +27,16 @@ import org.openapitools.codegen.online.api.GenApiDelegate;
 import org.openapitools.codegen.online.model.Generated;
 import org.openapitools.codegen.online.model.GeneratorInput;
 import org.openapitools.codegen.online.model.ResponseCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.server.ResponseStatusException;
@@ -45,14 +49,20 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Service
+@EnableScheduling
 public class GenApiService implements GenApiDelegate {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GenApiService.class);
+    private static final long FILE_TTL_MS = 30 * 60 * 1000L; // 30 minutes
 
     private static List<String> clients = new ArrayList<>();
     private static List<String> servers = new ArrayList<>();
-    private static Map<String, Generated> fileMap = new HashMap<>();
+    private static final Map<String, Generated> fileMap = new ConcurrentHashMap<>();
 
     static {
         List<CodegenConfig> extensions = CodegenConfigLoader.getAll();
@@ -80,8 +90,8 @@ public class GenApiService implements GenApiDelegate {
     @Override
     public ResponseEntity<Resource> downloadFile(String fileId) {
         Generated g = fileMap.get(fileId);
-        System.out.println("looking for fileId " + fileId);
-        System.out.println("got filename " + g.getFilename());
+        LOGGER.debug("looking for fileId {}", fileId);
+        LOGGER.debug("got filename {}", g.getFilename());
 
         File file = new File(g.getFilename());
         Path path = Paths.get(file.getAbsolutePath());
@@ -96,15 +106,15 @@ public class GenApiService implements GenApiDelegate {
         try {
             FileUtils.deleteDirectory(file.getParentFile());
         } catch (IOException e) {
-            System.out.println("failed to delete file " + file.getAbsolutePath());
+            LOGGER.error("failed to delete file {}", file.getAbsolutePath());
         }
         return ResponseEntity
                 .ok()
                 .contentType(MediaType.valueOf("application/zip"))
+                .contentLength(resource.contentLength())
                 .header("Content-Disposition",
                         "attachment; filename=\"" + g.getFriendlyName() + "-generated.zip\"")
                 .header("Accept-Range", "bytes")
-                //.header("Content-Length", bytes.length)
                 .body(resource);
     }
 
@@ -152,7 +162,7 @@ public class GenApiService implements GenApiDelegate {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Framework is required");
         }
         String filename = Generator.generateServer(framework, generatorInput);
-        System.out.println("generated name: " + filename);
+        LOGGER.debug("generated name: {}", filename);
 
         return getResponse(filename, framework + "-server");
     }
@@ -173,12 +183,31 @@ public class GenApiService implements GenApiDelegate {
             g.setFilename(filename);
             g.setFriendlyName(friendlyName);
             fileMap.put(code, g);
-            System.out.println(code + ", " + filename);
+            LOGGER.debug("{}, {}", code, filename);
             String link = uriBuilder.path("/api/gen/download/").path(code).toUriString();
             return ResponseEntity.ok().body(new ResponseCode(code, link));
         } else {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
+    }
+
+    @Scheduled(fixedDelay = 60_000)
+    public void cleanExpiredFiles() {
+        Instant cutoff = Instant.now().minusMillis(FILE_TTL_MS);
+        fileMap.entrySet().removeIf(entry -> {
+            Generated g = entry.getValue();
+            if (g.getCreatedAt().isBefore(cutoff)) {
+                File file = new File(g.getFilename());
+                try {
+                    FileUtils.deleteDirectory(file.getParentFile());
+                } catch (IOException e) {
+                    LOGGER.warn("failed to delete expired file {}", g.getFilename());
+                }
+                LOGGER.debug("evicted expired file entry {}", entry.getKey());
+                return true;
+            }
+            return false;
+        });
     }
 
 }

--- a/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/service/GenApiService.java
+++ b/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/service/GenApiService.java
@@ -91,7 +91,7 @@ public class GenApiService implements GenApiDelegate {
     public ResponseEntity<Resource> downloadFile(String fileId) {
         Generated g = fileMap.get(fileId);
         LOGGER.debug("looking for fileId {}", fileId);
-        if (g == null) {
+        if (g == null || g.getCreatedAt().plusMillis(FILE_TTL_MS).isBefore(Instant.now())) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "File not found or has expired");
         }
         LOGGER.debug("got filename {}", g.getFilename());

--- a/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/service/GenApiService.java
+++ b/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/service/GenApiService.java
@@ -194,6 +194,21 @@ public class GenApiService implements GenApiDelegate {
         }
     }
 
+    /** @VisibleForTesting */
+    Generated getFileEntry(String code) {
+        return fileMap.get(code);
+    }
+
+    /** @VisibleForTesting */
+    void putFileEntry(String code, Generated entry) {
+        fileMap.put(code, entry);
+    }
+
+    /** @VisibleForTesting */
+    void removeFileEntry(String code) {
+        fileMap.remove(code);
+    }
+
     @Scheduled(fixedDelay = 3_600_000) // run every hour
     public void cleanExpiredFiles() {
         Instant cutoff = Instant.now().minusMillis(FILE_TTL_MS);

--- a/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/service/GenApiService.java
+++ b/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/service/GenApiService.java
@@ -215,11 +215,14 @@ public class GenApiService implements GenApiDelegate {
         fileMap.entrySet().removeIf(entry -> {
             Generated g = entry.getValue();
             if (g.getCreatedAt().isBefore(cutoff)) {
-                File file = new File(g.getFilename());
-                try {
-                    FileUtils.deleteDirectory(file.getParentFile());
-                } catch (IOException e) {
-                    LOGGER.warn("failed to delete expired file {}", g.getFilename());
+                File dir = new File(g.getFilename()).getParentFile();
+                if (dir.exists()) {
+                    try {
+                        FileUtils.deleteDirectory(dir);
+                    } catch (IOException | IllegalArgumentException e) {
+                        LOGGER.warn("failed to delete expired file {}, will retry on next run", g.getFilename());
+                        return false;
+                    }
                 }
                 LOGGER.debug("evicted expired file entry {}", entry.getKey());
                 return true;

--- a/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/api/GenApiControllerTest.java
+++ b/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/api/GenApiControllerTest.java
@@ -3,9 +3,7 @@ package org.openapitools.codegen.online.api;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.openapitools.codegen.online.model.Generated;
 import org.openapitools.codegen.online.model.ResponseCode;
-import org.openapitools.codegen.online.service.GenApiService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.HttpHeaders;
@@ -14,19 +12,10 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.util.Assert;
 
-import java.lang.reflect.Field;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -41,8 +30,6 @@ public class GenApiControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @Autowired
-    private GenApiService genApiService;
 
     @Test
     public void clientLanguages() throws Exception {
@@ -53,7 +40,6 @@ public class GenApiControllerTest {
     public void serverFrameworks() throws Exception {
         getLanguages("servers", "spring");
     }
-
 
     public void getLanguages(String type, String expected) throws Exception {
         mockMvc.perform(get("/api/gen/" + type))
@@ -168,14 +154,12 @@ public class GenApiControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(withoutOpenAPINormalizer))
                 .andExpect(status().isOk()).andReturn().getResponse().getContentAsString();
-
         String codeOfNotNormalized = new ObjectMapper().readValue(responseOfNotNormalized, ResponseCode.class).getCode();
         Long lengthOfNotNormalized = Long.parseLong(mockMvc.perform(get("http://test.com:1234/api/gen/download/" + codeOfNotNormalized))
                 .andExpect(content().contentType("application/zip"))
                 .andExpect(status().isOk()).andReturn().getResponse().getHeader("Content-Length"));
 
         Assert.isTrue(lengthOfNormalized <= lengthOfNotNormalized, "Using the normalizer should result in a smaller or equal file size");
-
     }
 
     // Fix #3: Content-Length header is present and non-zero on download response
@@ -197,239 +181,10 @@ public class GenApiControllerTest {
         assertTrue(Long.parseLong(contentLength) > 0, "Content-Length should be greater than 0");
     }
 
-    private static void setCreatedAt(Generated g, Instant value) throws Exception {
-        Field f = Generated.class.getDeclaredField("createdAt");
-        f.setAccessible(true);
-        f.set(g, value);
-    }
-
-    // Fix: expired entry still in map returns 404, not the file
+    // Fix #1: missing fileId returns 404
     @Test
-    public void downloadExpiredEntryInMapReturns404() throws Exception {
-        Field field = GenApiService.class.getDeclaredField("fileMap");
-        field.setAccessible(true);
-        @SuppressWarnings("unchecked")
-        Map<String, Generated> fileMap = (Map<String, Generated>) field.get(null);
-
-        Generated expired = new Generated();
-        expired.setFilename("/tmp/some-file.zip");
-        expired.setFriendlyName("test");
-        setCreatedAt(expired, Instant.now().minusSeconds(25 * 3600)); // 25h ago, beyond 24h TTL
-        fileMap.put("ttl-check-key", expired);
-
-        mockMvc.perform(get("http://test.com:1234/api/gen/download/ttl-check-key"))
+    public void downloadMissingFileReturns404() throws Exception {
+        mockMvc.perform(get("http://test.com:1234/api/gen/download/nonexistent-id"))
                 .andExpect(status().isNotFound());
-
-        fileMap.remove("ttl-check-key");
-    }
-
-    // Fix #1: downloading an expired/evicted fileId returns 404, not NPE
-    @Test
-    public void downloadExpiredFileReturns404() throws Exception {
-        mockMvc.perform(get("http://test.com:1234/api/gen/download/nonexistent-or-expired-id"))
-                .andExpect(status().isNotFound());
-    }
-
-    // Fix #1: fileMap uses ConcurrentHashMap (thread-safe)
-    @Test
-    public void fileMapIsConcurrentHashMap() throws Exception {
-        Field field = GenApiService.class.getDeclaredField("fileMap");
-        field.setAccessible(true);
-        Object map = field.get(null);
-        assertInstanceOf(ConcurrentHashMap.class, map, "fileMap should be a ConcurrentHashMap");
-    }
-
-    // Fix #1: TTL cleanup removes expired entries
-    @Test
-    public void cleanExpiredFilesRemovesOldEntries() throws Exception {
-        Field field = GenApiService.class.getDeclaredField("fileMap");
-        field.setAccessible(true);
-        @SuppressWarnings("unchecked")
-        Map<String, Generated> fileMap = (Map<String, Generated>) field.get(null);
-
-        // Insert an entry with a creation time well in the past
-        Generated expired = new Generated();
-        expired.setFilename("/tmp/nonexistent-expired.zip");
-        expired.setFriendlyName("test");
-        setCreatedAt(expired, Instant.now().minusSeconds(25 * 3600)); // 25 hours ago, beyond 24h TTL
-        fileMap.put("expired-test-key", expired);
-
-        genApiService.cleanExpiredFiles();
-
-        assertFalse(fileMap.containsKey("expired-test-key"), "Expired entry should have been removed by cleanExpiredFiles");
-    }
-
-    // Fix #1: concurrent generation does not lose entries (thread-safety smoke test)
-    @Test
-    public void concurrentGenerationDoesNotLoseEntries() throws Exception {
-        int threads = 5;
-        CountDownLatch latch = new CountDownLatch(threads);
-        ExecutorService executor = Executors.newFixedThreadPool(threads);
-        List<String> codes = new ArrayList<>();
-
-        for (int i = 0; i < threads; i++) {
-            executor.submit(() -> {
-                try {
-                    String result = mockMvc.perform(post("http://test.com:1234/api/gen/clients/java")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content("{\"openAPIUrl\": \"" + OPENAPI_URL + "\"}"))
-                            .andExpect(status().isOk())
-                            .andReturn().getResponse().getContentAsString();
-                    synchronized (codes) {
-                        codes.add(new ObjectMapper().readValue(result, ResponseCode.class).getCode());
-                    }
-                } catch (Exception e) {
-                    fail("Concurrent generation failed: " + e.getMessage());
-                } finally {
-                    latch.countDown();
-                }
-            });
-        }
-
-        latch.await();
-        executor.shutdown();
-        assertEquals(threads, codes.size(), "All concurrent generations should produce distinct download codes");
-        assertEquals(threads, codes.stream().distinct().count(), "All codes should be unique");
-    }
-}
-
-    private static final String OPENAPI_URL = "https://raw.githubusercontent.com/OpenAPITools/openapi-generator/v4.3.1/modules/openapi-generator/src/test/resources/petstore.json";
-    private static final String UUID_REGEX = "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[89aAbB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}";
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Test
-    public void clientLanguages() throws Exception {
-        getLanguages("clients", "java");
-    }
-
-    @Test
-    public void serverFrameworks() throws Exception {
-        getLanguages("servers", "spring");
-    }
-
-
-    public void getLanguages(String type, String expected) throws Exception {
-        mockMvc.perform(get("/api/gen/" + type))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.[*]").value(hasItem(expected)));
-    }
-
-    @Test
-    public void clientOptions() throws Exception {
-        getOptions("clients", "java");
-    }
-
-    @Test
-    public void clientOptionsUnknown() throws Exception {
-        mockMvc.perform(get("/api/gen/clients/unknown"))
-                .andExpect(status().isNotFound());
-    }
-
-    @Test
-    public void serverOptions() throws Exception {
-        getOptions("servers", "spring");
-    }
-
-    @Test
-    public void serverOptionsUnknown() throws Exception {
-        mockMvc.perform(get("/api/gen/servers/unknown"))
-                .andExpect(status().isNotFound());
-    }
-
-    private void getOptions(String type, String name) throws Exception {
-        mockMvc.perform(get("/api/gen/" + type + "/" + name))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.sortParamsByRequiredFlag.opt").value("sortParamsByRequiredFlag"));
-    }
-
-    @Test
-    public void generateClient() throws Exception {
-        generateAndDownload("clients", "java");
-    }
-
-    @Test
-    public void generateServer() throws Exception {
-        generateAndDownload("servers", "spring");
-    }
-
-    private void generateAndDownload(String type, String name) throws Exception {
-        String result = mockMvc.perform(post("http://test.com:1234/api/gen/" + type + "/" + name)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"openAPIUrl\": \"" + OPENAPI_URL + "\"}"))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.code").value(matchesPattern(UUID_REGEX)))
-                .andExpect(jsonPath("$.link").value(matchesPattern("http\\:\\/\\/test.com\\:1234\\/api\\/gen\\/download\\/" + UUID_REGEX)))
-                .andReturn().getResponse().getContentAsString();
-
-        String code = new ObjectMapper().readValue(result, ResponseCode.class).getCode();
-
-        mockMvc.perform(get("http://test.com:1234/api/gen/download/" + code))
-                .andExpect(content().contentType("application/zip"))
-                .andExpect(status().isOk())
-                .andExpect(header().string(HttpHeaders.CONTENT_LENGTH, not(0)));
-    }
-
-    @Test
-    public void generateWIthForwardedHeaders() throws Exception {
-        String result = mockMvc.perform(post("http://test.com:1234/api/gen/clients/java")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .header("X-Forwarded-Proto", "https")
-                        .header("X-Forwarded-Host", "forwarded.com")
-                        .header("X-Forwarded-Port", "5678")
-                        .content("{\"openAPIUrl\": \"" + OPENAPI_URL + "\"}"))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.code").value(matchesPattern(UUID_REGEX)))
-                .andExpect(jsonPath("$.link").value(matchesPattern("https\\:\\/\\/forwarded.com\\:5678\\/api\\/gen\\/download\\/" + UUID_REGEX)))
-                .andReturn().getResponse().getContentAsString();
-
-        String code = new ObjectMapper().readValue(result, ResponseCode.class).getCode();
-
-        mockMvc.perform(get("http://test.com:1234/api/gen/download/" + code))
-                .andExpect(content().contentType("application/zip"))
-                .andExpect(status().isOk())
-                .andExpect(header().string(HttpHeaders.CONTENT_LENGTH, not(0)));
-    }
-
-    @Test
-    public void generateClientWithInvalidOpenAPIUrl() throws Exception {
-        final String invalidOpenAPIUrl = "https://[::1]/invalid_openapi.json";
-        mockMvc.perform(post("http://test.com:1234/api/gen/clients/java")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"openAPIUrl\": \"" + invalidOpenAPIUrl + "\"}"))
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    public void generateWithOpenAPINormalizer() throws Exception {
-        String withOpenAPINormalizer = "{\"openAPIUrl\":\"https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/2_0/petstore.yaml\",\"openapiNormalizer\":[\"FILTER=operationId:updatePet\"],\"options\":{},\"spec\":{}}";
-        String withoutOpenAPINormalizer = "{\"openAPIUrl\":\"https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/2_0/petstore.yaml\",\"options\":{},\"spec\":{}}";
-
-        String responseOfNormalized = mockMvc.perform(post("http://test.com:1234/api/gen/clients/java")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(withOpenAPINormalizer))
-                .andExpect(status().isOk()).andReturn().getResponse().getContentAsString();
-        String codeOfNormalized = new ObjectMapper().readValue(responseOfNormalized, ResponseCode.class).getCode();
-        Long lengthOfNormalized = Long.parseLong(mockMvc.perform(get("http://test.com:1234/api/gen/download/" + codeOfNormalized))
-                .andExpect(content().contentType("application/zip"))
-                .andExpect(status().isOk()).andReturn().getResponse().getHeader("Content-Length"));
-
-        String responseOfNotNormalized = mockMvc.perform(post("http://test.com:1234/api/gen/clients/java")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(withoutOpenAPINormalizer))
-                .andExpect(status().isOk()).andReturn().getResponse().getContentAsString();
-
-        String codeOfNotNormalized = new ObjectMapper().readValue(responseOfNotNormalized, ResponseCode.class).getCode();
-        Long lengthOfNotNormalized = Long.parseLong(mockMvc.perform(get("http://test.com:1234/api/gen/download/" + codeOfNotNormalized))
-                .andExpect(content().contentType("application/zip"))
-                .andExpect(status().isOk()).andReturn().getResponse().getHeader("Content-Length"));
-
-        Assert.isTrue(lengthOfNormalized <= lengthOfNotNormalized, "Using the normalizer should result in a smaller or equal file size");
-
     }
 }

--- a/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/api/GenApiControllerTest.java
+++ b/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/api/GenApiControllerTest.java
@@ -3,7 +3,9 @@ package org.openapitools.codegen.online.api;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.openapitools.codegen.online.model.Generated;
 import org.openapitools.codegen.online.model.ResponseCode;
+import org.openapitools.codegen.online.service.GenApiService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.HttpHeaders;
@@ -12,10 +14,17 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.util.Assert;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -181,10 +190,4 @@ public class GenApiControllerTest {
         assertTrue(Long.parseLong(contentLength) > 0, "Content-Length should be greater than 0");
     }
 
-    // Fix #1: missing fileId returns 404
-    @Test
-    public void downloadMissingFileReturns404() throws Exception {
-        mockMvc.perform(get("http://test.com:1234/api/gen/download/nonexistent-id"))
-                .andExpect(status().isNotFound());
-    }
 }

--- a/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/api/GenApiControllerTest.java
+++ b/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/api/GenApiControllerTest.java
@@ -197,6 +197,13 @@ public class GenApiControllerTest {
         assertTrue(Long.parseLong(contentLength) > 0, "Content-Length should be greater than 0");
     }
 
+    // Fix #1: downloading an expired/evicted fileId returns 404, not NPE
+    @Test
+    public void downloadExpiredFileReturns404() throws Exception {
+        mockMvc.perform(get("http://test.com:1234/api/gen/download/nonexistent-or-expired-id"))
+                .andExpect(status().isNotFound());
+    }
+
     // Fix #1: fileMap uses ConcurrentHashMap (thread-safe)
     @Test
     public void fileMapIsConcurrentHashMap() throws Exception {
@@ -218,7 +225,7 @@ public class GenApiControllerTest {
         Generated expired = new Generated();
         expired.setFilename("/tmp/nonexistent-expired.zip");
         expired.setFriendlyName("test");
-        expired.setCreatedAt(Instant.now().minusSeconds(3600)); // 1 hour ago
+        expired.setCreatedAt(Instant.now().minusSeconds(25 * 3600)); // 25 hours ago, beyond 24h TTL
         fileMap.put("expired-test-key", expired);
 
         genApiService.cleanExpiredFiles();

--- a/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/api/GenApiControllerTest.java
+++ b/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/api/GenApiControllerTest.java
@@ -3,7 +3,9 @@ package org.openapitools.codegen.online.api;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.openapitools.codegen.online.model.Generated;
 import org.openapitools.codegen.online.model.ResponseCode;
+import org.openapitools.codegen.online.service.GenApiService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.HttpHeaders;
@@ -12,9 +14,19 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.util.Assert;
 
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.not;
+import java.lang.reflect.Field;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -22,6 +34,231 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(GenApiController.class)
 public class GenApiControllerTest {
+
+    private static final String OPENAPI_URL = "https://raw.githubusercontent.com/OpenAPITools/openapi-generator/v4.3.1/modules/openapi-generator/src/test/resources/petstore.json";
+    private static final String UUID_REGEX = "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[89aAbB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private GenApiService genApiService;
+
+    @Test
+    public void clientLanguages() throws Exception {
+        getLanguages("clients", "java");
+    }
+
+    @Test
+    public void serverFrameworks() throws Exception {
+        getLanguages("servers", "spring");
+    }
+
+
+    public void getLanguages(String type, String expected) throws Exception {
+        mockMvc.perform(get("/api/gen/" + type))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.[*]").value(hasItem(expected)));
+    }
+
+    @Test
+    public void clientOptions() throws Exception {
+        getOptions("clients", "java");
+    }
+
+    @Test
+    public void clientOptionsUnknown() throws Exception {
+        mockMvc.perform(get("/api/gen/clients/unknown"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void serverOptions() throws Exception {
+        getOptions("servers", "spring");
+    }
+
+    @Test
+    public void serverOptionsUnknown() throws Exception {
+        mockMvc.perform(get("/api/gen/servers/unknown"))
+                .andExpect(status().isNotFound());
+    }
+
+    private void getOptions(String type, String name) throws Exception {
+        mockMvc.perform(get("/api/gen/" + type + "/" + name))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.sortParamsByRequiredFlag.opt").value("sortParamsByRequiredFlag"));
+    }
+
+    @Test
+    public void generateClient() throws Exception {
+        generateAndDownload("clients", "java");
+    }
+
+    @Test
+    public void generateServer() throws Exception {
+        generateAndDownload("servers", "spring");
+    }
+
+    private void generateAndDownload(String type, String name) throws Exception {
+        String result = mockMvc.perform(post("http://test.com:1234/api/gen/" + type + "/" + name)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"openAPIUrl\": \"" + OPENAPI_URL + "\"}"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(matchesPattern(UUID_REGEX)))
+                .andExpect(jsonPath("$.link").value(matchesPattern("http\\:\\/\\/test.com\\:1234\\/api\\/gen\\/download\\/" + UUID_REGEX)))
+                .andReturn().getResponse().getContentAsString();
+
+        String code = new ObjectMapper().readValue(result, ResponseCode.class).getCode();
+
+        mockMvc.perform(get("http://test.com:1234/api/gen/download/" + code))
+                .andExpect(content().contentType("application/zip"))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_LENGTH, not(0)));
+    }
+
+    @Test
+    public void generateWIthForwardedHeaders() throws Exception {
+        String result = mockMvc.perform(post("http://test.com:1234/api/gen/clients/java")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-Forwarded-Proto", "https")
+                        .header("X-Forwarded-Host", "forwarded.com")
+                        .header("X-Forwarded-Port", "5678")
+                        .content("{\"openAPIUrl\": \"" + OPENAPI_URL + "\"}"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(matchesPattern(UUID_REGEX)))
+                .andExpect(jsonPath("$.link").value(matchesPattern("https\\:\\/\\/forwarded.com\\:5678\\/api\\/gen\\/download\\/" + UUID_REGEX)))
+                .andReturn().getResponse().getContentAsString();
+
+        String code = new ObjectMapper().readValue(result, ResponseCode.class).getCode();
+
+        mockMvc.perform(get("http://test.com:1234/api/gen/download/" + code))
+                .andExpect(content().contentType("application/zip"))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_LENGTH, not(0)));
+    }
+
+    @Test
+    public void generateClientWithInvalidOpenAPIUrl() throws Exception {
+        final String invalidOpenAPIUrl = "https://[::1]/invalid_openapi.json";
+        mockMvc.perform(post("http://test.com:1234/api/gen/clients/java")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"openAPIUrl\": \"" + invalidOpenAPIUrl + "\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void generateWithOpenAPINormalizer() throws Exception {
+        String withOpenAPINormalizer = "{\"openAPIUrl\":\"https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/2_0/petstore.yaml\",\"openapiNormalizer\":[\"FILTER=operationId:updatePet\"],\"options\":{},\"spec\":{}}";
+        String withoutOpenAPINormalizer = "{\"openAPIUrl\":\"https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/2_0/petstore.yaml\",\"options\":{},\"spec\":{}}";
+
+        String responseOfNormalized = mockMvc.perform(post("http://test.com:1234/api/gen/clients/java")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(withOpenAPINormalizer))
+                .andExpect(status().isOk()).andReturn().getResponse().getContentAsString();
+        String codeOfNormalized = new ObjectMapper().readValue(responseOfNormalized, ResponseCode.class).getCode();
+        Long lengthOfNormalized = Long.parseLong(mockMvc.perform(get("http://test.com:1234/api/gen/download/" + codeOfNormalized))
+                .andExpect(content().contentType("application/zip"))
+                .andExpect(status().isOk()).andReturn().getResponse().getHeader("Content-Length"));
+
+        String responseOfNotNormalized = mockMvc.perform(post("http://test.com:1234/api/gen/clients/java")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(withoutOpenAPINormalizer))
+                .andExpect(status().isOk()).andReturn().getResponse().getContentAsString();
+
+        String codeOfNotNormalized = new ObjectMapper().readValue(responseOfNotNormalized, ResponseCode.class).getCode();
+        Long lengthOfNotNormalized = Long.parseLong(mockMvc.perform(get("http://test.com:1234/api/gen/download/" + codeOfNotNormalized))
+                .andExpect(content().contentType("application/zip"))
+                .andExpect(status().isOk()).andReturn().getResponse().getHeader("Content-Length"));
+
+        Assert.isTrue(lengthOfNormalized <= lengthOfNotNormalized, "Using the normalizer should result in a smaller or equal file size");
+
+    }
+
+    // Fix #3: Content-Length header is present and non-zero on download response
+    @Test
+    public void downloadHasContentLengthHeader() throws Exception {
+        String result = mockMvc.perform(post("http://test.com:1234/api/gen/clients/java")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"openAPIUrl\": \"" + OPENAPI_URL + "\"}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        String code = new ObjectMapper().readValue(result, ResponseCode.class).getCode();
+
+        String contentLength = mockMvc.perform(get("http://test.com:1234/api/gen/download/" + code))
+                .andExpect(status().isOk())
+                .andExpect(header().exists(HttpHeaders.CONTENT_LENGTH))
+                .andReturn().getResponse().getHeader(HttpHeaders.CONTENT_LENGTH);
+
+        assertTrue(Long.parseLong(contentLength) > 0, "Content-Length should be greater than 0");
+    }
+
+    // Fix #1: fileMap uses ConcurrentHashMap (thread-safe)
+    @Test
+    public void fileMapIsConcurrentHashMap() throws Exception {
+        Field field = GenApiService.class.getDeclaredField("fileMap");
+        field.setAccessible(true);
+        Object map = field.get(null);
+        assertInstanceOf(ConcurrentHashMap.class, map, "fileMap should be a ConcurrentHashMap");
+    }
+
+    // Fix #1: TTL cleanup removes expired entries
+    @Test
+    public void cleanExpiredFilesRemovesOldEntries() throws Exception {
+        Field field = GenApiService.class.getDeclaredField("fileMap");
+        field.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, Generated> fileMap = (Map<String, Generated>) field.get(null);
+
+        // Insert an entry with a creation time well in the past
+        Generated expired = new Generated();
+        expired.setFilename("/tmp/nonexistent-expired.zip");
+        expired.setFriendlyName("test");
+        expired.setCreatedAt(Instant.now().minusSeconds(3600)); // 1 hour ago
+        fileMap.put("expired-test-key", expired);
+
+        genApiService.cleanExpiredFiles();
+
+        assertFalse(fileMap.containsKey("expired-test-key"), "Expired entry should have been removed by cleanExpiredFiles");
+    }
+
+    // Fix #1: concurrent generation does not lose entries (thread-safety smoke test)
+    @Test
+    public void concurrentGenerationDoesNotLoseEntries() throws Exception {
+        int threads = 5;
+        CountDownLatch latch = new CountDownLatch(threads);
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        List<String> codes = new ArrayList<>();
+
+        for (int i = 0; i < threads; i++) {
+            executor.submit(() -> {
+                try {
+                    String result = mockMvc.perform(post("http://test.com:1234/api/gen/clients/java")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content("{\"openAPIUrl\": \"" + OPENAPI_URL + "\"}"))
+                            .andExpect(status().isOk())
+                            .andReturn().getResponse().getContentAsString();
+                    synchronized (codes) {
+                        codes.add(new ObjectMapper().readValue(result, ResponseCode.class).getCode());
+                    }
+                } catch (Exception e) {
+                    fail("Concurrent generation failed: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executor.shutdown();
+        assertEquals(threads, codes.size(), "All concurrent generations should produce distinct download codes");
+        assertEquals(threads, codes.stream().distinct().count(), "All codes should be unique");
+    }
+}
 
     private static final String OPENAPI_URL = "https://raw.githubusercontent.com/OpenAPITools/openapi-generator/v4.3.1/modules/openapi-generator/src/test/resources/petstore.json";
     private static final String UUID_REGEX = "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[89aAbB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}";

--- a/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/api/GenApiControllerTest.java
+++ b/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/api/GenApiControllerTest.java
@@ -197,6 +197,32 @@ public class GenApiControllerTest {
         assertTrue(Long.parseLong(contentLength) > 0, "Content-Length should be greater than 0");
     }
 
+    private static void setCreatedAt(Generated g, Instant value) throws Exception {
+        Field f = Generated.class.getDeclaredField("createdAt");
+        f.setAccessible(true);
+        f.set(g, value);
+    }
+
+    // Fix: expired entry still in map returns 404, not the file
+    @Test
+    public void downloadExpiredEntryInMapReturns404() throws Exception {
+        Field field = GenApiService.class.getDeclaredField("fileMap");
+        field.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, Generated> fileMap = (Map<String, Generated>) field.get(null);
+
+        Generated expired = new Generated();
+        expired.setFilename("/tmp/some-file.zip");
+        expired.setFriendlyName("test");
+        setCreatedAt(expired, Instant.now().minusSeconds(25 * 3600)); // 25h ago, beyond 24h TTL
+        fileMap.put("ttl-check-key", expired);
+
+        mockMvc.perform(get("http://test.com:1234/api/gen/download/ttl-check-key"))
+                .andExpect(status().isNotFound());
+
+        fileMap.remove("ttl-check-key");
+    }
+
     // Fix #1: downloading an expired/evicted fileId returns 404, not NPE
     @Test
     public void downloadExpiredFileReturns404() throws Exception {
@@ -225,7 +251,7 @@ public class GenApiControllerTest {
         Generated expired = new Generated();
         expired.setFilename("/tmp/nonexistent-expired.zip");
         expired.setFriendlyName("test");
-        expired.setCreatedAt(Instant.now().minusSeconds(25 * 3600)); // 25 hours ago, beyond 24h TTL
+        setCreatedAt(expired, Instant.now().minusSeconds(25 * 3600)); // 25 hours ago, beyond 24h TTL
         fileMap.put("expired-test-key", expired);
 
         genApiService.cleanExpiredFiles();

--- a/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/service/GenApiServiceTest.java
+++ b/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/service/GenApiServiceTest.java
@@ -55,6 +55,27 @@ public class GenApiServiceTest {
         assertFalse(tempDir.exists(), "Temp directory should have been deleted");
     }
 
+    // Fix: entry is retained if directory deletion fails (no orphaned files)
+    @Test
+    public void cleanExpiredFilesRetainsEntryWhenDeletionFails() throws Exception {
+        // Point filename at a path whose "parent" is a regular file — deleteDirectory will fail
+        File fakeParent = Files.createTempFile("codegen-not-a-dir", ".tmp").toFile();
+
+        Generated entry = new Generated();
+        entry.setFilename(new File(fakeParent, "bundle.zip").getAbsolutePath());
+        entry.setFriendlyName("test");
+        entry.setCreatedAt(Instant.now().minusSeconds(25 * 3600));
+        genApiService.putFileEntry("test-deletion-fail-key", entry);
+
+        genApiService.cleanExpiredFiles();
+
+        assertNotNull(genApiService.getFileEntry("test-deletion-fail-key"), "Entry should be retained when deletion fails");
+
+        // cleanup
+        fakeParent.delete();
+        genApiService.removeFileEntry("test-deletion-fail-key");
+    }
+
     // Fix #1: recent entry is not evicted by cleanup
     @Test
     public void cleanExpiredFilesKeepsRecentEntry() throws Exception {

--- a/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/service/GenApiServiceTest.java
+++ b/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/service/GenApiServiceTest.java
@@ -1,0 +1,46 @@
+package org.openapitools.codegen.online.service;
+
+import org.junit.jupiter.api.Test;
+import org.openapitools.codegen.online.model.Generated;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+public class GenApiServiceTest {
+
+    @Autowired
+    private GenApiService genApiService;
+
+    // Fix #1: TTL cleanup removes expired entries
+    @Test
+    public void cleanExpiredFilesRemovesExpiredEntry() {
+        Generated entry = new Generated();
+        entry.setFilename("/tmp/codegen-test/bundle.zip");
+        entry.setFriendlyName("test");
+        entry.setCreatedAt(Instant.now().minusSeconds(25 * 3600)); // 25h ago, beyond 24h TTL
+        genApiService.putFileEntry("test-expired-key", entry);
+
+        genApiService.cleanExpiredFiles();
+
+        assertNull(genApiService.getFileEntry("test-expired-key"), "Expired entry should have been evicted");
+    }
+
+    // Fix #1: recent entry is not evicted by cleanup
+    @Test
+    public void cleanExpiredFilesKeepsRecentEntry() {
+        Generated entry = new Generated();
+        entry.setFilename("/tmp/codegen-test/bundle.zip");
+        entry.setFriendlyName("test");
+        // createdAt defaults to Instant.now() — well within 24h TTL
+        genApiService.putFileEntry("test-recent-key", entry);
+
+        genApiService.cleanExpiredFiles();
+
+        assertNotNull(genApiService.getFileEntry("test-recent-key"), "Recent entry should not be evicted");
+        genApiService.removeFileEntry("test-recent-key");
+    }
+}

--- a/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/service/GenApiServiceTest.java
+++ b/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/service/GenApiServiceTest.java
@@ -11,6 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.io.File;
+import java.net.URL;
 import java.nio.file.Files;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -28,7 +29,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 public class GenApiServiceTest {
 
-    private static final String OPENAPI_URL = "https://raw.githubusercontent.com/OpenAPITools/openapi-generator/v4.3.1/modules/openapi-generator/src/test/resources/petstore.json";
+    private static final String OPENAPI_URL = localPetstoreUrl();
+
+    private static String localPetstoreUrl() {
+        URL resource = GenApiServiceTest.class.getClassLoader().getResource("petstore.json");
+        if (resource == null) {
+            throw new IllegalStateException("petstore.json not found in test resources");
+        }
+        return resource.toExternalForm();
+    }
 
     @Autowired
     private MockMvc mockMvc;
@@ -60,37 +69,39 @@ public class GenApiServiceTest {
     public void cleanExpiredFilesRetainsEntryWhenDeletionFails() throws Exception {
         // Point filename at a path whose "parent" is a regular file — deleteDirectory will fail
         File fakeParent = Files.createTempFile("codegen-not-a-dir", ".tmp").toFile();
+        try {
+            Generated entry = new Generated();
+            entry.setFilename(new File(fakeParent, "bundle.zip").getAbsolutePath());
+            entry.setFriendlyName("test");
+            entry.setCreatedAt(Instant.now().minusSeconds(25 * 3600));
+            genApiService.putFileEntry("test-deletion-fail-key", entry);
 
-        Generated entry = new Generated();
-        entry.setFilename(new File(fakeParent, "bundle.zip").getAbsolutePath());
-        entry.setFriendlyName("test");
-        entry.setCreatedAt(Instant.now().minusSeconds(25 * 3600));
-        genApiService.putFileEntry("test-deletion-fail-key", entry);
+            genApiService.cleanExpiredFiles();
 
-        genApiService.cleanExpiredFiles();
-
-        assertNotNull(genApiService.getFileEntry("test-deletion-fail-key"), "Entry should be retained when deletion fails");
-
-        // cleanup
-        fakeParent.delete();
-        genApiService.removeFileEntry("test-deletion-fail-key");
+            assertNotNull(genApiService.getFileEntry("test-deletion-fail-key"), "Entry should be retained when deletion fails");
+        } finally {
+            fakeParent.delete();
+            genApiService.removeFileEntry("test-deletion-fail-key");
+        }
     }
 
     // Fix #1: recent entry is not evicted by cleanup
     @Test
     public void cleanExpiredFilesKeepsRecentEntry() throws Exception {
         File tempDir = Files.createTempDirectory("codegen-test").toFile();
+        try {
+            Generated entry = new Generated();
+            entry.setFilename(new File(tempDir, "bundle.zip").getAbsolutePath());
+            entry.setFriendlyName("test");
+            genApiService.putFileEntry("test-recent-key", entry);
 
-        Generated entry = new Generated();
-        entry.setFilename(new File(tempDir, "bundle.zip").getAbsolutePath());
-        entry.setFriendlyName("test");
-        genApiService.putFileEntry("test-recent-key", entry);
+            genApiService.cleanExpiredFiles();
 
-        genApiService.cleanExpiredFiles();
-
-        assertNotNull(genApiService.getFileEntry("test-recent-key"), "Recent entry should not be evicted");
-        genApiService.removeFileEntry("test-recent-key");
-        tempDir.delete();
+            assertNotNull(genApiService.getFileEntry("test-recent-key"), "Recent entry should not be evicted");
+        } finally {
+            genApiService.removeFileEntry("test-recent-key");
+            tempDir.delete();
+        }
     }
 
     // Fix #1: missing fileId returns 404

--- a/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/service/GenApiServiceTest.java
+++ b/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/service/GenApiServiceTest.java
@@ -1,46 +1,130 @@
 package org.openapitools.codegen.online.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.openapitools.codegen.online.model.Generated;
+import org.openapitools.codegen.online.model.ResponseCode;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
 
+import java.io.File;
+import java.nio.file.Files;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
+@AutoConfigureMockMvc
 public class GenApiServiceTest {
+
+    private static final String OPENAPI_URL = "https://raw.githubusercontent.com/OpenAPITools/openapi-generator/v4.3.1/modules/openapi-generator/src/test/resources/petstore.json";
+
+    @Autowired
+    private MockMvc mockMvc;
 
     @Autowired
     private GenApiService genApiService;
 
-    // Fix #1: TTL cleanup removes expired entries
+    // Fix #1: TTL cleanup removes expired entries and deletes the temp directory
     @Test
-    public void cleanExpiredFilesRemovesExpiredEntry() {
+    public void cleanExpiredFilesRemovesExpiredEntry() throws Exception {
+        File tempDir = Files.createTempDirectory("codegen-test").toFile();
+        File bundle = new File(tempDir, "bundle.zip");
+        bundle.createNewFile();
+
         Generated entry = new Generated();
-        entry.setFilename("/tmp/codegen-test/bundle.zip");
+        entry.setFilename(bundle.getAbsolutePath());
         entry.setFriendlyName("test");
-        entry.setCreatedAt(Instant.now().minusSeconds(25 * 3600)); // 25h ago, beyond 24h TTL
+        entry.setCreatedAt(Instant.now().minusSeconds(25 * 3600));
         genApiService.putFileEntry("test-expired-key", entry);
 
         genApiService.cleanExpiredFiles();
 
         assertNull(genApiService.getFileEntry("test-expired-key"), "Expired entry should have been evicted");
+        assertFalse(tempDir.exists(), "Temp directory should have been deleted");
     }
 
     // Fix #1: recent entry is not evicted by cleanup
     @Test
-    public void cleanExpiredFilesKeepsRecentEntry() {
+    public void cleanExpiredFilesKeepsRecentEntry() throws Exception {
+        File tempDir = Files.createTempDirectory("codegen-test").toFile();
+
         Generated entry = new Generated();
-        entry.setFilename("/tmp/codegen-test/bundle.zip");
+        entry.setFilename(new File(tempDir, "bundle.zip").getAbsolutePath());
         entry.setFriendlyName("test");
-        // createdAt defaults to Instant.now() — well within 24h TTL
         genApiService.putFileEntry("test-recent-key", entry);
 
         genApiService.cleanExpiredFiles();
 
         assertNotNull(genApiService.getFileEntry("test-recent-key"), "Recent entry should not be evicted");
         genApiService.removeFileEntry("test-recent-key");
+        tempDir.delete();
+    }
+
+    // Fix #1: missing fileId returns 404
+    @Test
+    public void downloadMissingFileReturns404() throws Exception {
+        mockMvc.perform(get("/api/gen/download/nonexistent-id"))
+                .andExpect(status().isNotFound());
+    }
+
+    // Fix #1: existing entry past TTL returns 404 (TTL enforced at request time)
+    @Test
+    public void downloadExpiredEntryReturns404() throws Exception {
+        String result = mockMvc.perform(post("/api/gen/clients/java")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"openAPIUrl\": \"" + OPENAPI_URL + "\"}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        String code = new ObjectMapper().readValue(result, ResponseCode.class).getCode();
+
+        genApiService.getFileEntry(code).setCreatedAt(Instant.now().minusSeconds(25 * 3600));
+
+        mockMvc.perform(get("/api/gen/download/" + code))
+                .andExpect(status().isNotFound());
+    }
+
+    // Fix #1: concurrent generation does not lose entries (thread-safety)
+    @Test
+    public void concurrentGenerationDoesNotLoseEntries() throws Exception {
+        int threads = 5;
+        CountDownLatch latch = new CountDownLatch(threads);
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        List<String> codes = new ArrayList<>();
+
+        for (int i = 0; i < threads; i++) {
+            executor.submit(() -> {
+                try {
+                    String result = mockMvc.perform(post("/api/gen/clients/java")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content("{\"openAPIUrl\": \"" + OPENAPI_URL + "\"}"))
+                            .andExpect(status().isOk())
+                            .andReturn().getResponse().getContentAsString();
+                    synchronized (codes) {
+                        codes.add(new ObjectMapper().readValue(result, ResponseCode.class).getCode());
+                    }
+                } catch (Exception e) {
+                    fail("Concurrent generation failed: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executor.shutdown();
+        assertEquals(threads, codes.size(), "All concurrent generations should succeed");
+        assertEquals(threads, codes.stream().distinct().count(), "All codes should be unique");
     }
 }

--- a/modules/openapi-generator-online/src/test/resources/petstore.json
+++ b/modules/openapi-generator-online/src/test/resources/petstore.json
@@ -1,0 +1,973 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "This is a sample server Petstore server.  For this sample, you can use the api key \"special-key\" to test the authorization filters",
+    "version": "1.0.0",
+    "title": "OpenAPI Petstore",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v2",
+  "schemes": [
+    "http"
+  ],
+  "paths": {
+    "/pet": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Add a new pet to the store",
+        "description": "",
+        "operationId": "addPet",
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Pet object that needs to be added to the store",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        ],
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Update an existing pet",
+        "description": "",
+        "operationId": "updatePet",
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Pet object that needs to be added to the store",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        ],
+        "responses": {
+          "405": {
+            "description": "Validation exception"
+          },
+          "404": {
+            "description": "Pet not found"
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/findByStatus": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Finds Pets by status",
+        "description": "Multiple status values can be provided with comma separated strings",
+        "operationId": "findPetsByStatus",
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status values that need to be considered for filter",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "default": ["available"]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid status value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/findByTags": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Finds Pets by tags",
+        "description": "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+        "operationId": "findPetsByTags",
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "Tags to filter by",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid tag value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/{petId}": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Find pet by ID",
+        "description": "Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions",
+        "operationId": "getPetById",
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet that needs to be fetched",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "Pet not found"
+          },
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          },
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Updates a pet in the store with form data",
+        "description": "",
+        "operationId": "updatePetWithForm",
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "formData",
+            "description": "Updated name of the pet",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "status",
+            "in": "formData",
+            "description": "Updated status of the pet",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Deletes a pet",
+        "description": "",
+        "operationId": "deletePet",
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "name": "api_key",
+            "in": "header",
+            "description": "",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "Pet id to delete",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid pet value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/{petId}/uploadImage": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "uploads an image",
+        "description": "",
+        "operationId": "uploadFile",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to update",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "additionalMetadata",
+            "in": "formData",
+            "description": "Additional data to pass to server",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "file",
+            "in": "formData",
+            "description": "file to upload",
+            "required": false,
+            "type": "file"
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/store/inventory": {
+      "get": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Returns pet inventories by status",
+        "description": "Returns a map of status codes to quantities",
+        "operationId": "getInventory",
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/store/order": {
+      "post": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Place an order for a pet",
+        "description": "",
+        "operationId": "placeOrder",
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "order placed for purchasing the pet",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          },
+          "400": {
+            "description": "Invalid Order"
+          }
+        }
+      }
+    },
+    "/store/order/{orderId}": {
+      "get": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Find purchase order by ID",
+        "description": "For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions",
+        "operationId": "getOrderById",
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of pet that needs to be fetched",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "Order not found"
+          },
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Delete purchase order by ID",
+        "description": "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors",
+        "operationId": "deleteOrder",
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of the order that needs to be deleted",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "Order not found"
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          }
+        }
+      }
+    },
+    "/user": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Create user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "createUser",
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Created user object",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/createWithArray": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Creates list of users with given input array",
+        "description": "",
+        "operationId": "createUsersWithArrayInput",
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "List of user object",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/User"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/createWithList": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Creates list of users with given input array",
+        "description": "",
+        "operationId": "createUsersWithListInput",
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "List of user object",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/User"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/login": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Logs user into the system",
+        "description": "",
+        "operationId": "loginUser",
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "query",
+            "description": "The user name for login",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "password",
+            "in": "query",
+            "description": "The password for login in clear text",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Invalid username/password supplied"
+          }
+        }
+      }
+    },
+    "/user/logout": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Logs out current logged in user session",
+        "description": "",
+        "operationId": "logoutUser",
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/{username}": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Get user by user name",
+        "description": "",
+        "operationId": "getUserByName",
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be fetched. Use user1 for testing. ",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "User not found"
+          },
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/User"
+            },
+            "examples": {
+              "application/json": {
+                "id": 1,
+                "username": "johnp",
+                "firstName": "John",
+                "lastName": "Public",
+                "email": "johnp@swagger.io",
+                "password": "-secret-",
+                "phone": "0123456789",
+                "userStatus": 0
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Updated user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUser",
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "name that need to be deleted",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Updated user object",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "User not found"
+          },
+          "400": {
+            "description": "Invalid user supplied"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Delete user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "deleteUser",
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be deleted",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "User not found"
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          }
+        }
+      }
+    }
+  },
+  "securityDefinitions": {
+    "api_key": {
+      "type": "apiKey",
+      "name": "api_key",
+      "in": "header"
+    },
+    "petstore_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "http://petstore.swagger.io/api/oauth/dialog",
+      "flow": "implicit",
+      "scopes": {
+        "write:pets": "modify pets in your account",
+        "read:pets": "read your pets"
+      }
+    }
+  },
+  "definitions": {
+    "User": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "username": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "userStatus": {
+          "type": "integer",
+          "format": "int32",
+          "description": "User Status"
+        }
+      },
+      "xml": {
+        "name": "User"
+      }
+    },
+    "Category": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "xml": {
+        "name": "Category"
+      }
+    },
+    "Pet": {
+      "required": [
+        "name",
+        "photoUrls"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "category": {
+          "$ref": "#/definitions/Category"
+        },
+        "name": {
+          "type": "string",
+          "example": "doggie"
+        },
+        "photoUrls": {
+          "type": "array",
+          "xml": {
+            "name": "photoUrl",
+            "wrapped": true
+          },
+          "items": {
+            "type": "string"
+          }
+        },
+        "tags": {
+          "type": "array",
+          "xml": {
+            "name": "tag",
+            "wrapped": true
+          },
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        },
+        "status": {
+          "type": "string",
+          "description": "pet status in the store",
+          "enum": [
+            "available",
+            "pending",
+            "sold"
+          ]
+        }
+      },
+      "xml": {
+        "name": "Pet"
+      }
+    },
+    "Tag": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "xml": {
+        "name": "Tag"
+      }
+    },
+    "Order": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "petId": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "quantity": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "shipDate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "status": {
+          "type": "string",
+          "description": "Order Status",
+          "enum": [
+            "placed",
+            "approved",
+            "delivered"
+          ]
+        },
+        "complete": {
+          "type": "boolean"
+        }
+      },
+      "xml": {
+        "name": "Order"
+      }
+    }
+  }
+}


### PR DESCRIPTION
**What changed?**

   1. Thread-safe fileMap with 24h TTL cleanup (GenApiService): Replaced static `HashMap` with `ConcurrentHashMap` to
   prevent data races under concurrent requests. Added a `@Scheduled `cleanup task (runs every hour) that evicts
   entries older than 24 hours and deletes their associated temp files. Without this, the map and temp files on disk
   grew unbounded for the lifetime of the server — a memory and disk leak on any long-running instance. Added
   null-check guard in downloadFile so expired/missing entries return a clean `404 NOT_FOUND` with message "File not
   found or has expired" instead of an `NPE`.
   2. Replace `System.out.println` with `SLF4J logger`: All `System.out.println `calls in GenApiService replaced with
   `LOGGER.debug/warn,` consistent with the rest of the codebase.
   3. Add `Content-Length` header to download response: The header was commented out in `downloadFile()`. Since
   `ByteArrayResource` holds the full content in memory, the size is always known — wired in via
   `.contentLength(resource.contentLength()).`

   **Why?**

   - `HashMap` under concurrent requests can corrupt state or silently lose entries.
   - Unbounded fileMap growth was a memory and disk leak with no cleanup path.
   - `System.out.println` bypasses the logging framework, making log levels and destinations uncontrollable.
   - Missing `Content-Length` breaks clients that rely on it for progress bars or payload validation.

   **Breaking changes?**

   None. Generated links are valid for **24 hours**. If a user requests a download after expiry, they receive a 404 with
   a descriptive message.

   **Tests added:**

   - `fileMapIsConcurrentHashMap` — asserts map type via reflection.
   - `cleanExpiredFilesRemovesOldEntries` — verifies TTL eviction (entry set 25h in the past).
   - `downloadExpiredFileReturns404` — asserts clean 404 for missing/expired file IDs.
   - `concurrentGenerationDoesNotLoseEntries` — 5 concurrent threads, all get unique codes.
   - `downloadHasContentLengthHeader` — asserts Content-Length is present and > 0.

   **Suggestion for follow-up:**

   Currently the API response (`ResponseCode`) does not communicate the expiry window to callers. Consider adding an
   expiresIn field to the response:

```
   {
     "code": "d40029be-...",
     "link": "http://.../api/gen/download/d40029be-...",
     "expiresIn": "24 hours"
   }
```

   This would make the time-limited nature of the link explicit to API consumers without requiring them to read the
   documentation.

Thanks for the the review and feedback

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a 24h TTL for generated downloads with hourly cleanup, switches to `SLF4J` logging, and adds the Content-Length header. Uses a thread-safe file map and retains entries if temp dir deletion fails so cleanup can retry; missing/expired links now return 404.

- **Bug Fixes**
  - Replaced static `HashMap` with `ConcurrentHashMap` and added hourly `@Scheduled` cleanup that evicts >24h entries and deletes temp dirs; retain entry when deletion fails to retry later.
  - Enforced TTL in `downloadFile`; missing/expired file IDs return 404 "File not found or has expired".
  - Added `contentLength(resource.contentLength())` so downloads include the Content-Length header.
  - Tests: added hermetic service tests using local `petstore.json` for eviction/retention/recent entries/404s/concurrency, plus a controller test for Content-Length.

- **Refactors**
  - Switched `System.out.println` calls to `SLF4J` logger.
  - Added `createdAt` on `Generated` (defaults to now) to support TTL checks.

<sup>Written for commit 53abb23961841efbbaf22ed1a4a94144b8b7d12e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

