### PR TITLE
[kotlin] Fix boolean const enum literal generation

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -1052,7 +1052,8 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
 
     @Override
     public String toEnumValue(String value, String datatype) {
-        if ("kotlin.Int".equals(datatype) || "kotlin.Long".equals(datatype)) {
+        if ("kotlin.Int".equals(datatype) || "kotlin.Long".equals(datatype)
+                || "kotlin.Boolean".equals(datatype)) {
             return value;
         } else if ("kotlin.Double".equals(datatype)) {
             if (value.contains(".")) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
@@ -172,6 +172,7 @@ public class AbstractKotlinCodegenTest {
         assertEquals(codegen.toEnumValue("1", "kotlin.Double"), "1.0");
         assertEquals(codegen.toEnumValue("1.3", "kotlin.Double"), "1.3");
         assertEquals(codegen.toEnumValue("1337", "kotlin.Long"), "1337");
+        assertEquals(codegen.toEnumValue("true", "kotlin.Boolean"), "true");
         assertEquals(codegen.toEnumValue("5", "kotlin.Float"), "5f");
         assertEquals(codegen.toEnumValue("1.0", "kotlin.Float"), "1.0f");
         assertEquals(codegen.toEnumValue("data", "Something"), "\"data\"");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
@@ -819,6 +819,36 @@ public class KotlinClientCodegenModelTest {
   }
 
   @Test
+  public void testBooleanConstEnumUsesBooleanLiteral() throws IOException {
+      File output = Files.createTempDirectory("test").toFile();
+      output.deleteOnExit();
+
+      final CodegenConfigurator configurator = new CodegenConfigurator()
+              .setGeneratorName("kotlin")
+              .setLibrary("jvm-ktor")
+              .setAdditionalProperties(new HashMap<>() {{
+                put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
+                put(CodegenConstants.MODEL_PACKAGE, "model");
+                put(ENUM_PROPERTY_NAMING, "original");
+              }})
+              .setInputSpec("src/test/resources/3_1/kotlin/issue23550-boolean-const.yaml")
+              .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+      final ClientOptInput clientOptInput = configurator.toClientOptInput();
+      DefaultGenerator generator = new DefaultGenerator();
+
+      generator.opts(clientOptInput).generate();
+
+      final Path modelKt = Paths.get(output + "/src/main/kotlin/model/ExceptionState.kt");
+
+      TestUtils.assertFileContains(modelKt,
+              "enum class ExceptionPeriodIsClosed(val value: kotlin.Boolean)",
+              "@JsonProperty(value = \"true\")",
+              "`true`(true);");
+      TestUtils.assertFileNotContains(modelKt, "`true`(\"true\")");
+  }
+
+  @Test
   public void testJacksonEnumsUseJsonCreator() throws IOException {
       File output = Files.createTempDirectory("test").toFile();
       output.deleteOnExit();

--- a/modules/openapi-generator/src/test/resources/3_1/kotlin/issue23550-boolean-const.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/kotlin/issue23550-boolean-const.yaml
@@ -1,0 +1,13 @@
+openapi: 3.1.0
+info:
+  title: Boolean const regression
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    ExceptionState:
+      type: object
+      properties:
+        exceptionPeriodIsClosed:
+          type: boolean
+          const: true


### PR DESCRIPTION
Fixes #23550.

This keeps Kotlin boolean enum/const values as boolean literals when rendering enum values. Before this change, `const: true` could generate a Kotlin enum entry with `"true"` even though the enum value type is `kotlin.Boolean`.

I added a focused `toEnumValue` assertion and a generated-output regression fixture for the reported OpenAPI 3.1 boolean `const: true` case.

Tests:
- `./mvnw clean package`
- `./bin/generate-samples.sh ./bin/configs/*.yaml`
- `./bin/utils/export_docs_generators.sh`

Kotlin technical committee: @karismann @Zomzog @andrewemery @4brunu @yutaka0m @stefankoppier @e5l @dennisameling


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure Kotlin boolean const enums are generated as boolean literals, not strings. Fixes #23550.

- **Bug Fixes**
  - Updated `toEnumValue` to pass through values for `kotlin.Boolean` (like `kotlin.Int`/`kotlin.Long`).
  - Added unit and generator tests for OpenAPI 3.1 `const: true` with `jvm-ktor` and `jackson`, plus a regression fixture (`issue23550-boolean-const.yaml`).

<sup>Written for commit a9e10a142d44ff3af29f7b1332c357e2ff81e315. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

