### PR TITLE
better caching in kotlin server workflows

### DIFF
--- a/.github/workflows/samples-kotlin-server.yaml
+++ b/.github/workflows/samples-kotlin-server.yaml
@@ -68,4 +68,4 @@ jobs:
 
       - name: Build
         working-directory: ${{ matrix.sample }}
-        run: ./gradlew build -x test
+        run: gradle build -x test --no-daemon

--- a/.github/workflows/samples-kotlin-server.yaml
+++ b/.github/workflows/samples-kotlin-server.yaml
@@ -60,21 +60,12 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 11
-          cache: gradle
-      - name: Cache maven dependencies
-        uses: actions/cache@v5
-        env:
-          cache-name: maven-repository
-        with:
-          path: |
-            ~/.gradle
-          key: ${{ runner.os }}-${{ github.job }}-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
-      - name: Install Gradle wrapper
-        uses: eskatos/gradle-command-action@v3
-        with:
-          gradle-version: ${{ env.GRADLE_VERSION }}
-          build-root-directory: ${{ matrix.sample }}
-          arguments: wrapper
+          cache: maven
+
+      # The official action automatically handles the Gradle cache
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       - name: Build
         working-directory: ${{ matrix.sample }}
         run: ./gradlew build -x test

--- a/samples/server/petstore/kotlin-server/ktor2/.openapi-generator-ignore
+++ b/samples/server/petstore/kotlin-server/ktor2/.openapi-generator-ignore
@@ -21,3 +21,5 @@
 #docs/*.md
 # Then explicitly reverse the ignore rule for a single file:
 #!docs/README.md
+#
+#


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve caching for Kotlin server sample builds in CI by using the official Gradle setup action. This speeds up builds and simplifies the workflow.

- **Refactors**
  - Switched `actions/setup-java` cache to `maven`.
  - Adopted `gradle/actions/setup-gradle@v4` for automatic Gradle caching and switched builds to `gradle build -x test --no-daemon`.
  - Removed manual `actions/cache@v5` and the Gradle wrapper install step.

<sup>Written for commit e46cceff31b16909358591038f29bcdaa7fb48e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

