### PR TITLE
[Core] bug - fix OAS 3.1 nullable validation when using older "nullable: true" syntax instead of type: [null, ...]

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
@@ -120,13 +120,7 @@ class OpenApiSchemaValidations extends GenericValidator<SchemaWrapper> {
         if (schemaWrapper.getOpenAPI() != null) {
             SemVer version = new SemVer(schemaWrapper.getOpenAPI().getOpenapi());
             if (version.atLeast("3.1")) {
-                // ModelUtils.isNullable checks schema.getNullable(), but swagger-parser does not populate
-                // that field when parsing OAS 3.1 documents — 'nullable' is not a valid 3.1 keyword, so
-                // the parser stores it as a raw extension under the key "nullable" instead.
-                // We must check both paths to catch the deprecated usage in either case.
-                boolean hasNullableExtension = schema.getExtensions() != null
-                        && Boolean.TRUE.equals(schema.getExtensions().get("nullable"));
-                if (ModelUtils.isNullable(schema) || hasNullableExtension) {
+                if (ModelUtils.isNullable(schema)) {
                     result = new ValidationRule.Fail();
                     result.setDetails(String.format(Locale.ROOT,
                             "OAS document is version '%s'. Schema '%s' uses 'nullable' attribute, which has been deprecated in OAS 3.1.",

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
@@ -120,7 +120,13 @@ class OpenApiSchemaValidations extends GenericValidator<SchemaWrapper> {
         if (schemaWrapper.getOpenAPI() != null) {
             SemVer version = new SemVer(schemaWrapper.getOpenAPI().getOpenapi());
             if (version.atLeast("3.1")) {
-                if (ModelUtils.isNullable(schema)) {
+                // ModelUtils.isNullable checks schema.getNullable(), but swagger-parser does not populate
+                // that field when parsing OAS 3.1 documents — 'nullable' is not a valid 3.1 keyword, so
+                // the parser stores it as a raw extension under the key "nullable" instead.
+                // We must check both paths to catch the deprecated usage in either case.
+                boolean hasNullableExtension = schema.getExtensions() != null
+                        && Boolean.TRUE.equals(schema.getExtensions().get("nullable"));
+                if (ModelUtils.isNullable(schema) || hasNullableExtension) {
                     result = new ValidationRule.Fail();
                     result.setDetails(String.format(Locale.ROOT,
                             "OAS document is version '%s'. Schema '%s' uses 'nullable' attribute, which has been deprecated in OAS 3.1.",

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
@@ -123,10 +123,11 @@ class OpenApiSchemaValidations extends GenericValidator<SchemaWrapper> {
                 // ModelUtils.isNullable checks schema.getNullable(), but swagger-parser does not populate
                 // that field when parsing OAS 3.1 documents — 'nullable' is not a valid 3.1 keyword, so
                 // the parser stores it as a raw extension under the key "nullable" instead.
-                // We must check both paths to catch the deprecated usage in either case.
+                // We must check both paths to catch the deprecated usage in either case,
+                // regardless of whether the value is true or false.
                 boolean hasNullableExtension = schema.getExtensions() != null
-                        && Boolean.TRUE.equals(schema.getExtensions().get("nullable"));
-                if (ModelUtils.isNullable(schema) || hasNullableExtension) {
+                        && schema.getExtensions().containsKey("nullable");
+                if (ModelUtils.isNullable(schema) || schema.getNullable() != null || hasNullableExtension) {
                     result = new ValidationRule.Fail();
                     result.setDetails(String.format(Locale.ROOT,
                             "OAS document is version '%s'. Schema '%s' uses 'nullable' attribute, which has been deprecated in OAS 3.1.",

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidationsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidationsTest.java
@@ -1,6 +1,8 @@
 package org.openapitools.codegen.validations.oas;
 
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.*;
+import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.validation.Invalid;
 import org.openapitools.codegen.validation.ValidationResult;
 import org.testng.Assert;
@@ -65,6 +67,75 @@ public class OpenApiSchemaValidationsTest {
 
         Assert.assertNotNull(warnings);
         Assert.assertEquals(warnings.size(), 0, "Expected rule to be disabled.");
+    }
+
+    /**
+     * Probe: verify where swagger-parser stores `nullable: true` when parsing an OAS 3.1 spec.
+     * In OAS 3.1, `nullable` is not a recognized keyword — it may be stored in schema.getExtensions()
+     * under the raw key "nullable", or it may be silently dropped.
+     * This test documents the actual parser behavior so the fix in checkNullableAttribute
+     * knows which field to check.
+     */
+    @Test(description = "Probe: where does swagger-parser store 'nullable: true' in an OAS 3.1 spec?")
+    public void probe_nullableInOas31_parserStorageLocation() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/nullable-deprecated-in-oas31.yaml");
+        Schema<?> proxyUrl = (Schema<?>) openAPI.getComponents().getSchemas().get("TestModel").getProperties().get("proxyUrl");
+
+        // Document actual parser behavior — at least one of these must be non-null for the fix to work.
+        // If both are null, the parser silently drops 'nullable: true' and a different approach is needed.
+        Boolean getNullable = proxyUrl.getNullable();
+        Object extensionNullable = proxyUrl.getExtensions() != null ? proxyUrl.getExtensions().get("nullable") : null;
+
+        // swagger-parser stores it in extensions["nullable"] (not in getNullable() which stays null for 3.1)
+        Assert.assertNull(getNullable,
+                "In OAS 3.1, getNullable() should be null because 'nullable' is not a valid 3.1 keyword");
+        Assert.assertEquals(extensionNullable, Boolean.TRUE,
+                "In OAS 3.1, swagger-parser stores 'nullable: true' in schema.getExtensions()[\"nullable\"]");
+    }
+
+    /**
+     * The validation warning for 'nullable: true' in an OAS 3.1 spec must fire.
+     * The existing checkNullableAttribute only checked ModelUtils.isNullable(schema) which relies on
+     * schema.getNullable() — but swagger-parser does not populate that field for 3.1 specs (it stores
+     * the value in extensions["nullable"] instead). The fix must also check extensions["nullable"].
+     */
+    @Test(description = "nullable: true in OAS 3.1 spec must trigger the nullable-deprecated warning")
+    public void testNullableAttributeInOas31_triggerWarning() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/nullable-deprecated-in-oas31.yaml");
+        Schema<?> proxyUrl = (Schema<?>) openAPI.getComponents().getSchemas().get("TestModel").getProperties().get("proxyUrl");
+
+        RuleConfiguration config = new RuleConfiguration();
+        config.setEnableRecommendations(true);
+        OpenApiSchemaValidations validator = new OpenApiSchemaValidations(config);
+
+        ValidationResult result = validator.validate(new SchemaWrapper(openAPI, proxyUrl));
+        List<Invalid> nullableWarnings = result.getWarnings().stream()
+                .filter(invalid -> "Schema uses the 'nullable' attribute.".equals(invalid.getRule().getDescription()))
+                .collect(Collectors.toList());
+
+        Assert.assertEquals(nullableWarnings.size(), 1,
+                "Expected exactly one 'nullable attribute deprecated' warning for a 3.1 spec using nullable: true");
+    }
+
+    /**
+     * The nullable-deprecated warning must NOT fire for an OAS 3.1 spec using the correct 3.1 null type syntax.
+     */
+    @Test(description = "correct OAS 3.1 null type syntax (type: [string, null]) must NOT trigger the nullable-deprecated warning")
+    public void testNullTypeInOas31_noWarning() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/null-types-simple.yaml");
+        Schema<?> stringDataOrNull = (Schema<?>) openAPI.getComponents().getSchemas().get("WithNullableType").getProperties().get("stringDataOrNull");
+
+        RuleConfiguration config = new RuleConfiguration();
+        config.setEnableRecommendations(true);
+        OpenApiSchemaValidations validator = new OpenApiSchemaValidations(config);
+
+        ValidationResult result = validator.validate(new SchemaWrapper(openAPI, stringDataOrNull));
+        List<Invalid> nullableWarnings = result.getWarnings().stream()
+                .filter(invalid -> "Schema uses the 'nullable' attribute.".equals(invalid.getRule().getDescription()))
+                .collect(Collectors.toList());
+
+        Assert.assertEquals(nullableWarnings.size(), 0,
+                "OAS 3.1 with type:[string,null] must not trigger the nullable-deprecated warning");
     }
 
     @DataProvider(name = "apacheNginxRecommendationExpectations")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidationsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidationsTest.java
@@ -70,30 +70,6 @@ public class OpenApiSchemaValidationsTest {
     }
 
     /**
-     * Probe: verify where swagger-parser stores `nullable: true` when parsing an OAS 3.1 spec.
-     * In OAS 3.1, `nullable` is not a recognized keyword — it may be stored in schema.getExtensions()
-     * under the raw key "nullable", or it may be silently dropped.
-     * This test documents the actual parser behavior so the fix in checkNullableAttribute
-     * knows which field to check.
-     */
-    @Test(description = "Probe: where does swagger-parser store 'nullable: true' in an OAS 3.1 spec?")
-    public void probe_nullableInOas31_parserStorageLocation() {
-        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/nullable-deprecated-in-oas31.yaml");
-        Schema<?> proxyUrl = (Schema<?>) openAPI.getComponents().getSchemas().get("TestModel").getProperties().get("proxyUrl");
-
-        // Document actual parser behavior — at least one of these must be non-null for the fix to work.
-        // If both are null, the parser silently drops 'nullable: true' and a different approach is needed.
-        Boolean getNullable = proxyUrl.getNullable();
-        Object extensionNullable = proxyUrl.getExtensions() != null ? proxyUrl.getExtensions().get("nullable") : null;
-
-        // swagger-parser stores it in extensions["nullable"] (not in getNullable() which stays null for 3.1)
-        Assert.assertNull(getNullable,
-                "In OAS 3.1, getNullable() should be null because 'nullable' is not a valid 3.1 keyword");
-        Assert.assertEquals(extensionNullable, Boolean.TRUE,
-                "In OAS 3.1, swagger-parser stores 'nullable: true' in schema.getExtensions()[\"nullable\"]");
-    }
-
-    /**
      * The validation warning for 'nullable: true' in an OAS 3.1 spec must fire.
      * The existing checkNullableAttribute only checked ModelUtils.isNullable(schema) which relies on
      * schema.getNullable() — but swagger-parser does not populate that field for 3.1 specs (it stores

--- a/modules/openapi-generator/src/test/resources/3_1/nullable-deprecated-in-oas31.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/nullable-deprecated-in-oas31.yaml
@@ -1,0 +1,14 @@
+openapi: 3.1.0
+info:
+  title: Nullable deprecated in OAS 3.1 test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    TestModel:
+      type: object
+      properties:
+        # OAS 3.0 'nullable: true' used in a 3.1 spec — deprecated and should trigger a warning
+        proxyUrl:
+          type: string
+          nullable: true


### PR DESCRIPTION
There is a preexisting validation in place that is supposed to log warning when someone tries to use `nullable: true` in OAS 3.1.0 type spec. However the functionality does not actually work. I was bitten by this recently hence this fix to robustly enable the warning trigger.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix OAS 3.1 nullable validation and add tests to lock behavior. The validator now warns on any use of `nullable` in 3.1 (even if false, or when `swagger-parser` stores it in `extensions['nullable']`) and does not warn for `type: [string, null]`.

<sup>Written for commit 02cfaa7fcfd2b8d7e8464329bcaea4277cdfe9db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

