### PR TITLE
fix(kotlin-spring): skip @field:Valid on Map container properties (HV000271)

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-spring/beanValidation.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/beanValidation.mustache
@@ -1,4 +1,4 @@
-{{#isContainer}}{{^isPrimitiveType}}{{^isEnum}}
-    @field:Valid{{/isEnum}}{{/isPrimitiveType}}{{/isContainer}}{{!
+{{#isContainer}}{{^isMap}}{{^isPrimitiveType}}{{^isEnum}}
+    @field:Valid{{/isEnum}}{{/isPrimitiveType}}{{/isMap}}{{/isContainer}}{{!
 }}{{^isContainer}}{{^isPrimitiveType}}{{^isNumber}}{{^isUuid}}{{^isDateTime}}
     @field:Valid{{/isDateTime}}{{/isUuid}}{{/isNumber}}{{/isPrimitiveType}}{{/isContainer}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
@@ -6777,4 +6777,26 @@ public class KotlinSpringServerCodegenTest {
         String content = Files.readString(myObjectFile.toPath());
         assertThat(content).contains("com.example.ExternalModel?");
     }
+
+    @Test
+    public void mapPropertiesDoNotGetFieldValidAnnotation_HV000271() throws IOException {
+        // Hibernate Validator deprecated @Valid on Map containers (HV000271).
+        // @field:Valid must not be emitted for Map properties; it must still be emitted for List properties.
+        Map<String, File> files = generateFromContract(
+                "src/test/resources/3_0/spring/map-field-valid-hv000271.yaml",
+                new HashMap<>(Map.of(KotlinSpringServerCodegen.USE_BEANVALIDATION, "true"))
+        );
+
+        File containerFile = files.get("Container.kt");
+        assertThat(containerFile).isNotNull();
+
+        String content = Files.readString(containerFile.toPath());
+        assertThat(content).contains("val mapProp:");
+        assertThat(content).contains("val listProp:");
+
+        long fieldValidCount = content.lines().filter(line -> line.contains("@field:Valid")).count();
+        assertThat(fieldValidCount)
+                .as("@field:Valid must appear only on the list property, not on the map property (HV000271)")
+                .isEqualTo(1);
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/spring/map-field-valid-hv000271.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/spring/map-field-valid-hv000271.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  version: "1.0.0"
+  title: map-field-valid-hv000271
+paths: {}
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+    Container:
+      type: object
+      properties:
+        mapProp:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/Item'
+        listProp:
+          type: array
+          items:
+            $ref: '#/components/schemas/Item'


### PR DESCRIPTION
## Description

Hibernate Validator 9.1 deprecated placing `@Valid` directly on a `Map` container, emitting a `HV000271` warning at startup:

> Using `@Valid` on a container (java.util.Map) is deprecated. You should apply the annotation on the type argument(s).

The `beanValidation.mustache` template adds `@field:Valid` to all container properties (`List`, `Map`, …) whose items are not primitives. For `Map` properties the correct fix is to omit `@field:Valid` entirely — annotating a type argument of `Map<K, Any>` or `Map<K, SomeModel>` with `@Valid` would require type-use annotations, which the current codegen does not support, and for untyped maps (`Any` values) there is nothing to validate anyway.

## Change

Add a `{{^isMap}}` guard to the container branch of `beanValidation.mustache` so that only `List`/`Set`/array-typed properties still get `@field:Valid`. Map-typed properties are left unannotated.

## Testing

- Added a new `@Test` in `KotlinSpringServerCodegenTest`: generates a model with one `Map<String, Item>` property and one `List<Item>` property, then asserts that exactly **one** `@field:Valid` annotation is present in the generated file (for the list only).
- All existing kotlin-spring sample outputs regenerated — **no diff** (none of the petstore samples have `Map<String, ComplexType>` properties).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip emitting `@field:Valid` on Map properties in Kotlin Spring codegen to prevent HV000271 warnings with Hibernate Validator 9.1. Lists/Sets/arrays are unchanged.

- **Bug Fixes**
  - Updated `kotlin-spring/beanValidation.mustache` to apply `@field:Valid` only when `isContainer && !isMap`.
  - Added a test to ensure only the list property gets `@field:Valid`; regenerated samples with no changes.

<sup>Written for commit b959b17df5d1f2a47fa9abc475e433428c9903e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

