### PR TITLE
[openapi, openapi-yaml] feature - add sortOutput option to deterministically sort paths and schemas, http methods, etc...

### DIFF
--- a/docs/generators/openapi-yaml.md
+++ b/docs/generators/openapi-yaml.md
@@ -17,15 +17,8 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 
 | Option | Description | Values | Default |
 | ------ | ----------- | ------ | ------- |
-|allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
-|disallowAdditionalPropertiesIfNotPresent|If false, the 'additionalProperties' implementation (set to true by default) is compliant with the OAS and JSON schema specifications. If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.|<dl><dt>**false**</dt><dd>The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.</dd><dt>**true**</dt><dd>Keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.</dd></dl>|true|
-|ensureUniqueParams|Whether to ensure parameter names are unique in an operation (rename parameters that are not).| |true|
-|enumUnknownDefaultCase|If the server adds new enum cases, that are unknown by an old spec/client, the client will fail to parse the network response. With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the server sends an enum case that is not known by the client/spec, they can safely fallback to this case.|<dl><dt>**false**</dt><dd>No changes to the enums are made, this is the default option.</dd><dt>**true**</dt><dd>With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the enum case sent by the server is not known by the client/spec, can safely be decoded to this case.</dd></dl>|false|
-|legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
 |outputFile|Output filename| |openapi/openapi.yaml|
-|prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
-|sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
-|sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
+|sortOutput|Sort paths alphabetically, schemas/parameters by name, and HTTP methods in classical order (GET, PUT, POST, DELETE, OPTIONS, HEAD, PATCH, TRACE).| |false|
 
 ## IMPORT MAPPING
 

--- a/docs/generators/openapi-yaml.md
+++ b/docs/generators/openapi-yaml.md
@@ -18,7 +18,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | Option | Description | Values | Default |
 | ------ | ----------- | ------ | ------- |
 |outputFile|Output filename| |openapi/openapi.yaml|
-|sortOutput|Sort paths alphabetically, schemas/parameters by name, and HTTP methods in classical order (GET, PUT, POST, DELETE, OPTIONS, HEAD, PATCH, TRACE).| |false|
+|sortOutput|Sort paths alphabetically, component maps (schemas, parameters, requestBodies, responses, headers, examples, links, callbacks, securitySchemes) by name, and HTTP methods in classical order (GET, PUT, POST, DELETE, OPTIONS, HEAD, PATCH, TRACE).| |false|
 
 ## IMPORT MAPPING
 

--- a/docs/generators/openapi.md
+++ b/docs/generators/openapi.md
@@ -17,15 +17,8 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 
 | Option | Description | Values | Default |
 | ------ | ----------- | ------ | ------- |
-|allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
-|disallowAdditionalPropertiesIfNotPresent|If false, the 'additionalProperties' implementation (set to true by default) is compliant with the OAS and JSON schema specifications. If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.|<dl><dt>**false**</dt><dd>The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.</dd><dt>**true**</dt><dd>Keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.</dd></dl>|true|
-|ensureUniqueParams|Whether to ensure parameter names are unique in an operation (rename parameters that are not).| |true|
-|enumUnknownDefaultCase|If the server adds new enum cases, that are unknown by an old spec/client, the client will fail to parse the network response. With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the server sends an enum case that is not known by the client/spec, they can safely fallback to this case.|<dl><dt>**false**</dt><dd>No changes to the enums are made, this is the default option.</dd><dt>**true**</dt><dd>With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the enum case sent by the server is not known by the client/spec, can safely be decoded to this case.</dd></dl>|false|
-|legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
 |outputFileName|Output file name| |openapi.json|
-|prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
-|sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
-|sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
+|sortOutput|Sort paths alphabetically, schemas/parameters by name, and HTTP methods in classical order (GET, PUT, POST, DELETE, OPTIONS, HEAD, PATCH, TRACE).| |false|
 
 ## IMPORT MAPPING
 

--- a/docs/generators/openapi.md
+++ b/docs/generators/openapi.md
@@ -18,7 +18,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | Option | Description | Values | Default |
 | ------ | ----------- | ------ | ------- |
 |outputFileName|Output file name| |openapi.json|
-|sortOutput|Sort paths alphabetically, schemas/parameters by name, and HTTP methods in classical order (GET, PUT, POST, DELETE, OPTIONS, HEAD, PATCH, TRACE).| |false|
+|sortOutput|Sort paths alphabetically, component maps (schemas, parameters, requestBodies, responses, headers, examples, links, callbacks, securitySchemes) by name, and HTTP methods in classical order (GET, PUT, POST, DELETE, OPTIONS, HEAD, PATCH, TRACE).| |false|
 
 ## IMPORT MAPPING
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/OpenAPIGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/OpenAPIGenerator.java
@@ -22,6 +22,7 @@ import org.apache.commons.io.FileUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.features.*;
 import org.openapitools.codegen.serializer.SerializerUtils;
+import org.openapitools.codegen.utils.OpenAPISorter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,10 +32,12 @@ import java.util.EnumSet;
 
 public class OpenAPIGenerator extends DefaultCodegen implements CodegenConfig {
     public static final String OUTPUT_NAME = "outputFileName";
+    public static final String SORT_OUTPUT = "sortOutput";
 
     private final Logger LOGGER = LoggerFactory.getLogger(OpenAPIGenerator.class);
 
     protected String outputFileName = "openapi.json";
+    protected boolean sortOutput = false;
 
     public OpenAPIGenerator() {
         super();
@@ -55,6 +58,10 @@ public class OpenAPIGenerator extends DefaultCodegen implements CodegenConfig {
         supportingFiles.add(new SupportingFile("README.md", "", "README.md"));
 
         cliOptions.add(CliOption.newString(OUTPUT_NAME, "Output file name").defaultValue(outputFileName));
+        cliOptions.add(CliOption.newBoolean(SORT_OUTPUT,
+                "Sort paths alphabetically, schemas/parameters by name, and HTTP methods in classical order "
+                        + "(GET, PUT, POST, DELETE, OPTIONS, HEAD, PATCH, TRACE).")
+                .defaultValue(Boolean.FALSE.toString()));
     }
 
     @Override
@@ -80,11 +87,18 @@ public class OpenAPIGenerator extends DefaultCodegen implements CodegenConfig {
             outputFileName = additionalProperties.get(OUTPUT_NAME).toString();
         }
         LOGGER.info("Output file name [outputFileName={}]", outputFileName);
+
+        if (additionalProperties.containsKey(SORT_OUTPUT)) {
+            sortOutput = Boolean.parseBoolean(additionalProperties.get(SORT_OUTPUT).toString());
+        }
     }
 
     @Override
     public void processOpenAPI(OpenAPI openAPI) {
-        String jsonOpenAPI = SerializerUtils.toJsonString(openAPI);
+        if (sortOutput) {
+            OpenAPISorter.sort(openAPI);
+        }
+        String jsonOpenAPI = SerializerUtils.toJsonString(openAPI, sortOutput);
 
         try {
             String outputFile = outputFolder + File.separator + outputFileName;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/OpenAPIGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/OpenAPIGenerator.java
@@ -57,6 +57,7 @@ public class OpenAPIGenerator extends DefaultCodegen implements CodegenConfig {
 
         supportingFiles.add(new SupportingFile("README.md", "", "README.md"));
 
+        cliOptions.clear();
         cliOptions.add(CliOption.newString(OUTPUT_NAME, "Output file name").defaultValue(outputFileName));
         cliOptions.add(CliOption.newBoolean(SORT_OUTPUT,
                 "Sort paths alphabetically, schemas/parameters by name, and HTTP methods in classical order "

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/OpenAPIGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/OpenAPIGenerator.java
@@ -60,8 +60,9 @@ public class OpenAPIGenerator extends DefaultCodegen implements CodegenConfig {
         cliOptions.clear();
         cliOptions.add(CliOption.newString(OUTPUT_NAME, "Output file name").defaultValue(outputFileName));
         cliOptions.add(CliOption.newBoolean(SORT_OUTPUT,
-                "Sort paths alphabetically, schemas/parameters by name, and HTTP methods in classical order "
-                        + "(GET, PUT, POST, DELETE, OPTIONS, HEAD, PATCH, TRACE).")
+                        "Sort paths alphabetically, component maps (schemas, parameters, requestBodies, responses, " +
+                                "headers, examples, links, callbacks, securitySchemes) by name, and HTTP methods in classical " +
+                                "order (GET, PUT, POST, DELETE, OPTIONS, HEAD, PATCH, TRACE).")
                 .defaultValue(Boolean.FALSE.toString()));
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/OpenAPIYamlGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/OpenAPIYamlGenerator.java
@@ -19,10 +19,13 @@ package org.openapitools.codegen.languages;
 
 import com.google.common.collect.ImmutableMap;
 import com.samskivert.mustache.Mustache.Lambda;
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.features.*;
+import org.openapitools.codegen.serializer.SerializerUtils;
 import org.openapitools.codegen.templating.mustache.OnChangeLambda;
+import org.openapitools.codegen.utils.OpenAPISorter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,10 +36,12 @@ import java.util.Map;
 
 public class OpenAPIYamlGenerator extends DefaultCodegen implements CodegenConfig {
     public static final String OUTPUT_NAME = "outputFile";
+    public static final String SORT_OUTPUT = "sortOutput";
 
     private final Logger LOGGER = LoggerFactory.getLogger(OpenAPIYamlGenerator.class);
 
     protected String outputFile = "openapi/openapi.yaml";
+    protected boolean sortOutput = false;
 
     public OpenAPIYamlGenerator() {
         super();
@@ -54,6 +59,10 @@ public class OpenAPIYamlGenerator extends DefaultCodegen implements CodegenConfi
         embeddedTemplateDir = templateDir = "openapi-yaml";
         outputFolder = "generated-code/openapi-yaml";
         cliOptions.add(CliOption.newString(OUTPUT_NAME, "Output filename").defaultValue(outputFile));
+        cliOptions.add(CliOption.newBoolean(SORT_OUTPUT,
+                "Sort paths alphabetically, schemas/parameters by name, and HTTP methods in classical order "
+                        + "(GET, PUT, POST, DELETE, OPTIONS, HEAD, PATCH, TRACE).")
+                .defaultValue(Boolean.FALSE.toString()));
         supportingFiles.add(new SupportingFile("README.md", "", "README.md"));
     }
 
@@ -80,6 +89,17 @@ public class OpenAPIYamlGenerator extends DefaultCodegen implements CodegenConfi
         }
         LOGGER.info("Output file [outputFile={}]", outputFile);
         supportingFiles.add(new SupportingFile("openapi.mustache", outputFile));
+
+        if (additionalProperties.containsKey(SORT_OUTPUT)) {
+            sortOutput = Boolean.parseBoolean(additionalProperties.get(SORT_OUTPUT).toString());
+        }
+    }
+
+    @Override
+    public void processOpenAPI(OpenAPI openAPI) {
+        if (sortOutput) {
+            OpenAPISorter.sort(openAPI);
+        }
     }
 
     @Override
@@ -98,6 +118,15 @@ public class OpenAPIYamlGenerator extends DefaultCodegen implements CodegenConfi
         List<CodegenOperation> opList = operations.computeIfAbsent(resourcePath,
                 k -> new ArrayList<>());
         opList.add(co);
+    }
+
+    @Override
+    public void generateYAMLSpecFile(Map<String, Object> objs) {
+        OpenAPI openAPI = (OpenAPI) objs.get("openAPI");
+        String yaml = SerializerUtils.toYamlString(openAPI, sortOutput);
+        if (yaml != null) {
+            objs.put("openapi-yaml", yaml);
+        }
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/OpenAPIYamlGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/OpenAPIYamlGenerator.java
@@ -58,6 +58,8 @@ public class OpenAPIYamlGenerator extends DefaultCodegen implements CodegenConfi
 
         embeddedTemplateDir = templateDir = "openapi-yaml";
         outputFolder = "generated-code/openapi-yaml";
+
+        cliOptions.clear();
         cliOptions.add(CliOption.newString(OUTPUT_NAME, "Output filename").defaultValue(outputFile));
         cliOptions.add(CliOption.newBoolean(SORT_OUTPUT,
                 "Sort paths alphabetically, schemas/parameters by name, and HTTP methods in classical order "

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/OpenAPIYamlGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/OpenAPIYamlGenerator.java
@@ -62,8 +62,9 @@ public class OpenAPIYamlGenerator extends DefaultCodegen implements CodegenConfi
         cliOptions.clear();
         cliOptions.add(CliOption.newString(OUTPUT_NAME, "Output filename").defaultValue(outputFile));
         cliOptions.add(CliOption.newBoolean(SORT_OUTPUT,
-                "Sort paths alphabetically, schemas/parameters by name, and HTTP methods in classical order "
-                        + "(GET, PUT, POST, DELETE, OPTIONS, HEAD, PATCH, TRACE).")
+                "Sort paths alphabetically, component maps (schemas, parameters, requestBodies, responses, " +
+                        "headers, examples, links, callbacks, securitySchemes) by name, and HTTP methods in classical " +
+                        "order (GET, PUT, POST, DELETE, OPTIONS, HEAD, PATCH, TRACE).")
                 .defaultValue(Boolean.FALSE.toString()));
         supportingFiles.add(new SupportingFile("README.md", "", "README.md"));
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/serializer/PathItemSerializer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/serializer/PathItemSerializer.java
@@ -1,0 +1,65 @@
+package org.openapitools.codegen.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import io.swagger.v3.oas.models.PathItem;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Serializes a {@link PathItem} with HTTP methods written in classical OpenAPI spec order:
+ * GET, PUT, POST, DELETE, OPTIONS, HEAD, PATCH, TRACE — instead of Jackson's default
+ * alphabetical order (which would put DELETE before GET).
+ */
+public class PathItemSerializer extends JsonSerializer<PathItem> {
+
+    @Override
+    public void serialize(PathItem value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeStartObject();
+        if (value.getSummary() != null) {
+            gen.writeStringField("summary", value.getSummary());
+        }
+        if (value.getDescription() != null) {
+            gen.writeStringField("description", value.getDescription());
+        }
+        // HTTP methods in classical OpenAPI spec order
+        if (value.getGet() != null) {
+            gen.writeObjectField("get", value.getGet());
+        }
+        if (value.getPut() != null) {
+            gen.writeObjectField("put", value.getPut());
+        }
+        if (value.getPost() != null) {
+            gen.writeObjectField("post", value.getPost());
+        }
+        if (value.getDelete() != null) {
+            gen.writeObjectField("delete", value.getDelete());
+        }
+        if (value.getOptions() != null) {
+            gen.writeObjectField("options", value.getOptions());
+        }
+        if (value.getHead() != null) {
+            gen.writeObjectField("head", value.getHead());
+        }
+        if (value.getPatch() != null) {
+            gen.writeObjectField("patch", value.getPatch());
+        }
+        if (value.getTrace() != null) {
+            gen.writeObjectField("trace", value.getTrace());
+        }
+        if (value.getServers() != null) {
+            gen.writeObjectField("servers", value.getServers());
+        }
+        if (value.getParameters() != null) {
+            gen.writeObjectField("parameters", value.getParameters());
+        }
+        if (value.getExtensions() != null) {
+            for (Map.Entry<String, Object> e : value.getExtensions().entrySet()) {
+                gen.writeObjectField(e.getKey(), e.getValue());
+            }
+        }
+        gen.writeEndObject();
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/serializer/SerializerUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/serializer/SerializerUtils.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.PathItem;
 import org.openapitools.codegen.config.GlobalSettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,10 +20,14 @@ public class SerializerUtils {
     private static final boolean minimizeYamlQuotes = Boolean.parseBoolean(GlobalSettings.getProperty(YAML_MINIMIZE_QUOTES_PROPERTY, "true"));
 
     public static String toYamlString(OpenAPI openAPI) {
+        return toYamlString(openAPI, false);
+    }
+
+    public static String toYamlString(OpenAPI openAPI, boolean sortOutput) {
         if (openAPI == null) {
             return null;
         }
-        SimpleModule module = createModule();
+        SimpleModule module = createModule(sortOutput);
         try {
             ObjectMapper yamlMapper = Yaml.mapper().copy();
             // there is an unfortunate YAML condition where user inputs should be treated as strings (e.g. "1234_1234"), but in yaml this is a valid number and
@@ -44,11 +49,15 @@ public class SerializerUtils {
     }
 
     public static String toJsonString(OpenAPI openAPI) {
+        return toJsonString(openAPI, false);
+    }
+
+    public static String toJsonString(OpenAPI openAPI, boolean sortOutput) {
         if (openAPI == null) {
             return null;
         }
 
-        SimpleModule module = createModule();
+        SimpleModule module = createModule(sortOutput);
         try {
             return Json.mapper()
                     .copy()
@@ -63,10 +72,13 @@ public class SerializerUtils {
         return null;
     }
 
-    private static SimpleModule createModule() {
+    private static SimpleModule createModule(boolean sortOutput) {
         SimpleModule module = new SimpleModule("OpenAPIModule");
         module.addSerializer(OpenAPI.class, new OpenAPISerializer());
         module.addSerializer(byte[].class, new ByteArraySerializer());
+        if (sortOutput) {
+            module.addSerializer(PathItem.class, new PathItemSerializer());
+        }
         return module;
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/OpenAPISorter.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/OpenAPISorter.java
@@ -1,0 +1,80 @@
+package org.openapitools.codegen.utils;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Paths;
+
+import java.util.TreeMap;
+
+/**
+ * Utility for sorting an {@link OpenAPI} model in-place before serialization.
+ *
+ * <ul>
+ *   <li>Paths are sorted alphabetically by path string.</li>
+ *   <li>All component maps (schemas, parameters, requestBodies, responses, headers,
+ *       securitySchemes, examples, links, callbacks) are sorted alphabetically by name.</li>
+ *   <li>HTTP method ordering within a path is handled by {@link org.openapitools.codegen.serializer.PathItemSerializer},
+ *       which writes operations in classical spec order: GET, PUT, POST, DELETE, OPTIONS, HEAD, PATCH, TRACE.</li>
+ * </ul>
+ */
+public class OpenAPISorter {
+
+    private OpenAPISorter() {
+    }
+
+    public static void sort(OpenAPI openAPI) {
+        if (openAPI == null) {
+            return;
+        }
+        sortPaths(openAPI);
+        sortComponents(openAPI);
+    }
+
+    private static void sortPaths(OpenAPI openAPI) {
+        if (openAPI.getPaths() == null || openAPI.getPaths().isEmpty()) {
+            return;
+        }
+        Paths sorted = new Paths();
+        openAPI.getPaths().entrySet().stream()
+                .sorted(java.util.Map.Entry.comparingByKey())
+                .forEach(e -> sorted.addPathItem(e.getKey(), e.getValue()));
+        if (openAPI.getPaths().getExtensions() != null) {
+            openAPI.getPaths().getExtensions().forEach(sorted::addExtension);
+        }
+        openAPI.setPaths(sorted);
+    }
+
+    private static void sortComponents(OpenAPI openAPI) {
+        Components c = openAPI.getComponents();
+        if (c == null) {
+            return;
+        }
+        if (c.getSchemas() != null) {
+            c.setSchemas(new TreeMap<>(c.getSchemas()));
+        }
+        if (c.getParameters() != null) {
+            c.setParameters(new TreeMap<>(c.getParameters()));
+        }
+        if (c.getRequestBodies() != null) {
+            c.setRequestBodies(new TreeMap<>(c.getRequestBodies()));
+        }
+        if (c.getResponses() != null) {
+            c.setResponses(new TreeMap<>(c.getResponses()));
+        }
+        if (c.getHeaders() != null) {
+            c.setHeaders(new TreeMap<>(c.getHeaders()));
+        }
+        if (c.getSecuritySchemes() != null) {
+            c.setSecuritySchemes(new TreeMap<>(c.getSecuritySchemes()));
+        }
+        if (c.getExamples() != null) {
+            c.setExamples(new TreeMap<>(c.getExamples()));
+        }
+        if (c.getLinks() != null) {
+            c.setLinks(new TreeMap<>(c.getLinks()));
+        }
+        if (c.getCallbacks() != null) {
+            c.setCallbacks(new TreeMap<>(c.getCallbacks()));
+        }
+    }
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/json/JsonGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/json/JsonGeneratorTest.java
@@ -91,33 +91,40 @@ public class JsonGeneratorTest {
         // Paths alphabetical: /animals, /mammals, /zebra
         int idxAnimals = json.indexOf("\"/animals\"");
         int idxMammals = json.indexOf("\"/mammals\"");
-        int idxZebra   = json.indexOf("\"/zebra\"");
+        int idxZebra = json.indexOf("\"/zebra\"");
+        Assert.assertTrue(idxAnimals != -1 && idxMammals != -1 && idxZebra != -1, "Expected paths must be present in output");
         Assert.assertTrue(idxAnimals < idxMammals, "/animals must come before /mammals");
-        Assert.assertTrue(idxMammals < idxZebra,   "/mammals must come before /zebra");
+        Assert.assertTrue(idxMammals < idxZebra, "/mammals must come before /zebra");
 
         // Schemas alphabetical: AnimalModel, MammalModel, ZebraModel
         int idxAnimal = json.indexOf("\"AnimalModel\"");
         int idxMammal = json.indexOf("\"MammalModel\"");
         int idxZebraM = json.indexOf("\"ZebraModel\"");
+        Assert.assertTrue(idxAnimal != -1 && idxMammal != -1 && idxZebraM != -1, "Expected schemas must be present in output");
         Assert.assertTrue(idxAnimal < idxMammal, "AnimalModel must come before MammalModel");
         Assert.assertTrue(idxMammal < idxZebraM, "MammalModel must come before ZebraModel");
 
         // Parameters alphabetical: aFilter, mPage, zLimit
         int idxAFilter = json.indexOf("\"aFilter\"");
-        int idxMPage   = json.indexOf("\"mPage\"");
-        int idxZLimit  = json.indexOf("\"zLimit\"");
-        Assert.assertTrue(idxAFilter < idxMPage,  "aFilter must come before mPage");
-        Assert.assertTrue(idxMPage   < idxZLimit, "mPage must come before zLimit");
+        int idxMPage = json.indexOf("\"mPage\"");
+        int idxZLimit = json.indexOf("\"zLimit\"");
+        Assert.assertTrue(idxAFilter != -1 && idxMPage != -1 && idxZLimit != -1, "Expected parameters must be present in output");
+        Assert.assertTrue(idxAFilter < idxMPage, "aFilter must come before mPage");
+        Assert.assertTrue(idxMPage < idxZLimit, "mPage must come before zLimit");
 
         // HTTP method order — GET before POST in /zebra (spec has POST first)
         int zebraBlock = json.indexOf("\"/zebra\"");
-        Assert.assertTrue(json.indexOf("\"get\"",  zebraBlock) < json.indexOf("\"post\"", zebraBlock),
-                "GET must appear before POST within /zebra");
+        int zebraGet = json.indexOf("\"get\"", zebraBlock);
+        int zebraPost = json.indexOf("\"post\"", zebraBlock);
+        Assert.assertTrue(zebraGet != -1 && zebraPost != -1, "Expected HTTP methods must be present in output");
+        Assert.assertTrue(zebraGet < zebraPost, "GET must appear before POST within /zebra");
 
         // HTTP method order — GET before DELETE in /mammals (spec has DELETE first)
         int mammalsBlock = json.indexOf("\"/mammals\"");
-        Assert.assertTrue(json.indexOf("\"get\"", mammalsBlock) < json.indexOf("\"delete\"", mammalsBlock),
-                "GET must appear before DELETE within /mammals");
+        int mammalsGet = json.indexOf("\"get\"", mammalsBlock);
+        int mammalsDelete = json.indexOf("\"delete\"", mammalsBlock);
+        Assert.assertTrue(mammalsGet != -1 && mammalsDelete != -1, "Expected HTTP methods must be present in output");
+        Assert.assertTrue(mammalsGet < mammalsDelete, "GET must appear before DELETE within /mammals");
     }
 
     @Test
@@ -136,7 +143,7 @@ public class JsonGeneratorTest {
         String json = new String(Files.readAllBytes(Paths.get(output.getAbsolutePath(), "openapi.json")));
 
         // Without sortOutput, paths are in spec order: /zebra first, then /mammals, then /animals
-        int idxZebra   = json.indexOf("\"/zebra\"");
+        int idxZebra = json.indexOf("\"/zebra\"");
         int idxMammals = json.indexOf("\"/mammals\"");
         int idxAnimals = json.indexOf("\"/animals\"");
         Assert.assertTrue(idxZebra < idxMammals, "Without sortOutput /zebra must come before /mammals (spec order)");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/json/JsonGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/json/JsonGeneratorTest.java
@@ -8,6 +8,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -86,7 +87,7 @@ public class JsonGeneratorTest {
 
         new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
 
-        String json = new String(Files.readAllBytes(Paths.get(output.getAbsolutePath(), "openapi.json")));
+        String json = Files.readString(Paths.get(output.getAbsolutePath(), "openapi.json"));
 
         // Paths alphabetical: /animals, /mammals, /zebra
         int idxAnimals = json.indexOf("\"/animals\"");
@@ -140,7 +141,7 @@ public class JsonGeneratorTest {
 
         new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
 
-        String json = new String(Files.readAllBytes(Paths.get(output.getAbsolutePath(), "openapi.json")));
+        String json = new String(Files.readAllBytes(Paths.get(output.getAbsolutePath(), "openapi.json")), StandardCharsets.UTF_8);
 
         // Without sortOutput, paths are in spec order: /zebra first, then /mammals, then /animals
         int idxZebra = json.indexOf("\"/zebra\"");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/json/JsonGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/json/JsonGeneratorTest.java
@@ -4,6 +4,7 @@ import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.DefaultGenerator;
 import org.openapitools.codegen.config.CodegenConfigurator;
 import org.openapitools.codegen.languages.OpenAPIGenerator;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -66,5 +67,79 @@ public class JsonGeneratorTest {
         assertFileContains(Paths.get(outputPath + "/.openapi-generator/VERSION"));
 
         output.deleteOnExit();
+    }
+
+
+    @Test
+    public void testSortOutput() throws Exception {
+        File output = Files.createTempDirectory("test-sort-json").toFile();
+        output.deleteOnExit();
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(OpenAPIGenerator.SORT_OUTPUT, "true");
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("openapi")
+                .setAdditionalProperties(properties)
+                .setInputSpec("src/test/resources/3_0/sort-output-test.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+
+        String json = new String(Files.readAllBytes(Paths.get(output.getAbsolutePath(), "openapi.json")));
+
+        // Paths alphabetical: /animals, /mammals, /zebra
+        int idxAnimals = json.indexOf("\"/animals\"");
+        int idxMammals = json.indexOf("\"/mammals\"");
+        int idxZebra   = json.indexOf("\"/zebra\"");
+        Assert.assertTrue(idxAnimals < idxMammals, "/animals must come before /mammals");
+        Assert.assertTrue(idxMammals < idxZebra,   "/mammals must come before /zebra");
+
+        // Schemas alphabetical: AnimalModel, MammalModel, ZebraModel
+        int idxAnimal = json.indexOf("\"AnimalModel\"");
+        int idxMammal = json.indexOf("\"MammalModel\"");
+        int idxZebraM = json.indexOf("\"ZebraModel\"");
+        Assert.assertTrue(idxAnimal < idxMammal, "AnimalModel must come before MammalModel");
+        Assert.assertTrue(idxMammal < idxZebraM, "MammalModel must come before ZebraModel");
+
+        // Parameters alphabetical: aFilter, mPage, zLimit
+        int idxAFilter = json.indexOf("\"aFilter\"");
+        int idxMPage   = json.indexOf("\"mPage\"");
+        int idxZLimit  = json.indexOf("\"zLimit\"");
+        Assert.assertTrue(idxAFilter < idxMPage,  "aFilter must come before mPage");
+        Assert.assertTrue(idxMPage   < idxZLimit, "mPage must come before zLimit");
+
+        // HTTP method order — GET before POST in /zebra (spec has POST first)
+        int zebraBlock = json.indexOf("\"/zebra\"");
+        Assert.assertTrue(json.indexOf("\"get\"",  zebraBlock) < json.indexOf("\"post\"", zebraBlock),
+                "GET must appear before POST within /zebra");
+
+        // HTTP method order — GET before DELETE in /mammals (spec has DELETE first)
+        int mammalsBlock = json.indexOf("\"/mammals\"");
+        Assert.assertTrue(json.indexOf("\"get\"", mammalsBlock) < json.indexOf("\"delete\"", mammalsBlock),
+                "GET must appear before DELETE within /mammals");
+    }
+
+    @Test
+    public void testSortOutputDisabledPreservesOriginalOrder() throws Exception {
+        File output = Files.createTempDirectory("test-nosort-json").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("openapi")
+                .setAdditionalProperties(new HashMap<>())
+                .setInputSpec("src/test/resources/3_0/sort-output-test.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+
+        String json = new String(Files.readAllBytes(Paths.get(output.getAbsolutePath(), "openapi.json")));
+
+        // Without sortOutput, paths are in spec order: /zebra first, then /mammals, then /animals
+        int idxZebra   = json.indexOf("\"/zebra\"");
+        int idxMammals = json.indexOf("\"/mammals\"");
+        int idxAnimals = json.indexOf("\"/animals\"");
+        Assert.assertTrue(idxZebra < idxMammals, "Without sortOutput /zebra must come before /mammals (spec order)");
+        Assert.assertTrue(idxMammals < idxAnimals, "Without sortOutput /mammals must come before /animals (spec order)");
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/yaml/YamlGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/yaml/YamlGeneratorTest.java
@@ -203,7 +203,7 @@ public class YamlGeneratorTest {
 
         new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
 
-        String yaml = new String(Files.readAllBytes(Path.of(output.getAbsolutePath(), "sorted.yaml")), StandardCharsets.UTF_8);
+        String yaml = Files.readString(Path.of(output.getAbsolutePath(), "sorted.yaml"));
 
         // Paths alphabetical: /animals, /mammals, /zebra
         int idxAnimals = yaml.indexOf("/animals:");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/yaml/YamlGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/yaml/YamlGeneratorTest.java
@@ -185,4 +185,55 @@ public class YamlGeneratorTest {
         byte[] exampleBytes = (byte[]) dataSchema.getExample();
         Assert.assertEquals(new String(exampleBytes, StandardCharsets.UTF_8), "aGVsbG8K");
     }
+
+    @Test
+    public void testSortOutput() throws Exception {
+        File output = Files.createTempDirectory("test-sort-yaml").toFile();
+        output.deleteOnExit();
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(OpenAPIYamlGenerator.OUTPUT_NAME, "sorted.yaml");
+        properties.put(OpenAPIYamlGenerator.SORT_OUTPUT, "true");
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("openapi-yaml")
+                .setAdditionalProperties(properties)
+                .setInputSpec("src/test/resources/3_0/sort-output-test.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+
+        String yaml = new String(Files.readAllBytes(Path.of(output.getAbsolutePath(), "sorted.yaml")), StandardCharsets.UTF_8);
+
+        // Paths alphabetical: /animals, /mammals, /zebra
+        int idxAnimals = yaml.indexOf("/animals:");
+        int idxMammals = yaml.indexOf("/mammals:");
+        int idxZebra   = yaml.indexOf("/zebra:");
+        Assert.assertTrue(idxAnimals < idxMammals, "/animals must come before /mammals");
+        Assert.assertTrue(idxMammals < idxZebra,   "/mammals must come before /zebra");
+
+        // Schemas alphabetical: AnimalModel, MammalModel, ZebraModel
+        int idxAnimal = yaml.indexOf("AnimalModel:");
+        int idxMammal = yaml.indexOf("MammalModel:");
+        int idxZebraM = yaml.indexOf("ZebraModel:");
+        Assert.assertTrue(idxAnimal < idxMammal, "AnimalModel must come before MammalModel");
+        Assert.assertTrue(idxMammal < idxZebraM, "MammalModel must come before ZebraModel");
+
+        // Parameters alphabetical: aFilter, mPage, zLimit
+        int idxAFilter = yaml.indexOf("aFilter:");
+        int idxMPage   = yaml.indexOf("mPage:");
+        int idxZLimit  = yaml.indexOf("zLimit:");
+        Assert.assertTrue(idxAFilter < idxMPage,  "aFilter must come before mPage");
+        Assert.assertTrue(idxMPage   < idxZLimit, "mPage must come before zLimit");
+
+        // HTTP method order — GET before POST in /zebra (spec has POST first)
+        int zebraBlock = yaml.indexOf("/zebra:");
+        Assert.assertTrue(yaml.indexOf("get:", zebraBlock) < yaml.indexOf("post:", zebraBlock),
+                "GET must appear before POST within /zebra");
+
+        // HTTP method order — GET before DELETE in /mammals (spec has DELETE first)
+        int mammalsBlock = yaml.indexOf("/mammals:");
+        Assert.assertTrue(yaml.indexOf("get:", mammalsBlock) < yaml.indexOf("delete:", mammalsBlock),
+                "GET must appear before DELETE within /mammals");
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/yaml/YamlGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/yaml/YamlGeneratorTest.java
@@ -208,32 +208,39 @@ public class YamlGeneratorTest {
         // Paths alphabetical: /animals, /mammals, /zebra
         int idxAnimals = yaml.indexOf("/animals:");
         int idxMammals = yaml.indexOf("/mammals:");
-        int idxZebra   = yaml.indexOf("/zebra:");
+        int idxZebra = yaml.indexOf("/zebra:");
+        Assert.assertTrue(idxAnimals != -1 && idxMammals != -1 && idxZebra != -1, "Expected schemas must be present in output");
         Assert.assertTrue(idxAnimals < idxMammals, "/animals must come before /mammals");
-        Assert.assertTrue(idxMammals < idxZebra,   "/mammals must come before /zebra");
+        Assert.assertTrue(idxMammals < idxZebra, "/mammals must come before /zebra");
 
         // Schemas alphabetical: AnimalModel, MammalModel, ZebraModel
         int idxAnimal = yaml.indexOf("AnimalModel:");
         int idxMammal = yaml.indexOf("MammalModel:");
         int idxZebraM = yaml.indexOf("ZebraModel:");
+        Assert.assertTrue(idxAnimal != -1 && idxMammal != -1 && idxZebraM != -1, "Expected schemas must be present in output");
         Assert.assertTrue(idxAnimal < idxMammal, "AnimalModel must come before MammalModel");
         Assert.assertTrue(idxMammal < idxZebraM, "MammalModel must come before ZebraModel");
 
         // Parameters alphabetical: aFilter, mPage, zLimit
         int idxAFilter = yaml.indexOf("aFilter:");
-        int idxMPage   = yaml.indexOf("mPage:");
-        int idxZLimit  = yaml.indexOf("zLimit:");
-        Assert.assertTrue(idxAFilter < idxMPage,  "aFilter must come before mPage");
-        Assert.assertTrue(idxMPage   < idxZLimit, "mPage must come before zLimit");
+        int idxMPage = yaml.indexOf("mPage:");
+        int idxZLimit = yaml.indexOf("zLimit:");
+        Assert.assertTrue(idxAFilter != -1 && idxMPage != -1 && idxZLimit != -1, "Expected parameters must be present in output");
+        Assert.assertTrue(idxAFilter < idxMPage, "aFilter must come before mPage");
+        Assert.assertTrue(idxMPage < idxZLimit, "mPage must come before zLimit");
 
         // HTTP method order — GET before POST in /zebra (spec has POST first)
         int zebraBlock = yaml.indexOf("/zebra:");
-        Assert.assertTrue(yaml.indexOf("get:", zebraBlock) < yaml.indexOf("post:", zebraBlock),
-                "GET must appear before POST within /zebra");
+        int zebraGet = yaml.indexOf("get:", zebraBlock);
+        int zebraPost = yaml.indexOf("post:", zebraBlock);
+        Assert.assertTrue(zebraGet != -1 && zebraPost != -1, "Expected HTTP methods must be present within /zebra");
+        Assert.assertTrue(zebraGet < zebraPost, "GET must appear before POST within /zebra");
 
         // HTTP method order — GET before DELETE in /mammals (spec has DELETE first)
         int mammalsBlock = yaml.indexOf("/mammals:");
-        Assert.assertTrue(yaml.indexOf("get:", mammalsBlock) < yaml.indexOf("delete:", mammalsBlock),
-                "GET must appear before DELETE within /mammals");
+        int mammalsGet = yaml.indexOf("get:", mammalsBlock);
+        int mammalsDelete = yaml.indexOf("delete:", mammalsBlock);
+        Assert.assertTrue(mammalsGet != -1 && mammalsDelete != -1, "Expected HTTP methods must be present within /mammals");
+        Assert.assertTrue(mammalsGet < mammalsDelete, "GET must appear before DELETE within /mammals");
     }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/sort-output-test.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/sort-output-test.yaml
@@ -1,0 +1,102 @@
+openapi: 3.0.0
+info:
+  title: Sort Output Test
+  version: 1.0.0
+servers:
+  - url: http://localhost:8080
+paths:
+  /zebra:
+    post:
+      operationId: createZebra
+      summary: Create a zebra
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ZebraModel'
+      responses:
+        '201':
+          description: Created
+    get:
+      operationId: listZebras
+      summary: List zebras
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZebraModel'
+  /mammals:
+    delete:
+      operationId: deleteMammal
+      summary: Delete a mammal
+      responses:
+        '204':
+          description: No Content
+    get:
+      operationId: getMammal
+      summary: Get a mammal
+      parameters:
+        - $ref: '#/components/parameters/zLimit'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MammalModel'
+  /animals:
+    get:
+      operationId: listAnimals
+      summary: List animals
+      parameters:
+        - $ref: '#/components/parameters/mPage'
+        - $ref: '#/components/parameters/aFilter'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnimalModel'
+components:
+  schemas:
+    ZebraModel:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+    MammalModel:
+      type: object
+      properties:
+        id:
+          type: integer
+        species:
+          type: string
+    AnimalModel:
+      type: object
+      properties:
+        id:
+          type: integer
+        type:
+          type: string
+  parameters:
+    zLimit:
+      name: limit
+      in: query
+      schema:
+        type: integer
+    mPage:
+      name: page
+      in: query
+      schema:
+        type: integer
+    aFilter:
+      name: filter
+      in: query
+      schema:
+        type: string


### PR DESCRIPTION
Add a new 'sortOutput' generator option to the 'openapi' (JSON) and 'openapi-yaml' (YAML) documentation generators that produces a deterministically ordered spec:

- Paths are sorted alphabetically by URL
- Schemas, parameters, requestBodies, responses, headers, examples, links, callbacks and securitySchemes are sorted alphabetically by name
- HTTP methods within each path are ordered by the classical convention: GET, PUT, POST, DELETE, OPTIONS, HEAD, PATCH, TRACE

Implementation details:
- OpenAPISorter: replaces Paths and all Components maps with TreeMaps
- PathItemSerializer: custom Jackson serializer writing operations in classical HTTP method order (only registered when sortOutput=true)
- SerializerUtils: overloaded toJsonString/toYamlString with sortOutput flag; createModule(boolean) registers PathItemSerializer when true
- OpenAPIGenerator / OpenAPIYamlGenerator: wire the new option through to the serializer

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `sortOutput` option to `openapi` and `openapi-yaml` for deterministic JSON/YAML output (sorted paths, components, and HTTP method order) to reduce noisy diffs. Docs were refined, forbidden method calls removed, and tests added.

- **New Features**
  - `sortOutput` (default: false) in both generators.
  - Paths sorted A–Z; component maps by key; HTTP methods ordered: GET, PUT, POST, DELETE, OPTIONS, HEAD, PATCH, TRACE.
  - Implemented via `OpenAPISorter` and a custom `PathItemSerializer`; CLI option added; docs updated and clarified; tests verify JSON and YAML ordering.

- **Migration**
  - Disabled by default. Enable with `-p sortOutput=true`.
  - No functional spec changes; only output ordering.

<sup>Written for commit 20333484f5e335648c1a26e8c101367d7753f7f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

