### PR TITLE
update python-fastapi multipart dep to newer version

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-fastapi/requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python-fastapi/requirements.mustache
@@ -22,7 +22,7 @@ orjson==3.11.6
 promise==2.3
 pydantic>=2
 python-dotenv==1.2.2
-python-multipart==0.0.27
+python-multipart==0.0.31
 PyYAML>=5.4.1,<6.1.0
 requests==2.33.0
 Rx==1.6.1

--- a/samples/server/petstore/python-fastapi/requirements.txt
+++ b/samples/server/petstore/python-fastapi/requirements.txt
@@ -22,7 +22,7 @@ orjson==3.11.6
 promise==2.3
 pydantic>=2
 python-dotenv==1.2.2
-python-multipart==0.0.27
+python-multipart==0.0.31
 PyYAML>=5.4.1,<6.1.0
 requests==2.33.0
 Rx==1.6.1


### PR DESCRIPTION
to close https://github.com/OpenAPITools/openapi-generator/pull/24040

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `python-multipart` from 0.0.27 to 0.0.31 in the Python FastAPI generator template and the petstore sample. This keeps the dependency current and aligns generated projects with the latest package version.

<sup>Written for commit a9baade5625b931dbafc6252a8b43fa22b025cf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

