### PR TITLE
[kotlin] Add @get:JsonValue to nested Jackson enums (#23886)

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
@@ -22,6 +22,9 @@ import com.squareup.moshi.JsonClass
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 {{/enumUnknownDefaultCase}}
 import com.fasterxml.jackson.annotation.JsonProperty
+{{#hasEnums}}
+import com.fasterxml.jackson.annotation.JsonValue
+{{/hasEnums}}
 {{#discriminator}}
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonSubTypes
@@ -146,7 +149,7 @@ import {{packageName}}.infrastructure.ITransformForStorage
     {{#multiplatform}}
     @Serializable
     {{/multiplatform}}
-    {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}enum class {{{nameInPascalCase}}}({{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val value: {{^isContainer}}{{dataType}}{{/isContainer}}{{#isContainer}}{{#mostInnerItems}}{{dataType}}{{/mostInnerItems}}{{/isContainer}}) {
+    {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}enum class {{{nameInPascalCase}}}({{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}{{#jackson}}@get:JsonValue {{/jackson}}val value: {{^isContainer}}{{dataType}}{{/isContainer}}{{#isContainer}}{{#mostInnerItems}}{{dataType}}{{/mostInnerItems}}{{/isContainer}}) {
     {{#allowableValues}}
     {{#enumVars}}
         {{^multiplatform}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
@@ -815,7 +815,7 @@ public class KotlinClientCodegenModelTest {
 
       final Path modelKt = Paths.get(output + "/src/main/kotlin/model/ModelWithIntArrayEnum.kt");
 
-      TestUtils.assertFileContains(modelKt, "enum class DaysOfWeek(val value: kotlin.Int)");
+      TestUtils.assertFileContains(modelKt, "enum class DaysOfWeek(@get:JsonValue val value: kotlin.Int)");
   }
 
   @Test
@@ -842,7 +842,7 @@ public class KotlinClientCodegenModelTest {
       final Path modelKt = Paths.get(output + "/src/main/kotlin/model/ExceptionState.kt");
 
       TestUtils.assertFileContains(modelKt,
-              "enum class ExceptionPeriodIsClosed(val value: kotlin.Boolean)",
+              "enum class ExceptionPeriodIsClosed(@get:JsonValue val value: kotlin.Boolean)",
               "@JsonProperty(value = \"true\")",
               "`true`(true);");
       TestUtils.assertFileNotContains(modelKt, "`true`(\"true\")");
@@ -872,6 +872,34 @@ public class KotlinClientCodegenModelTest {
 
       TestUtils.assertFileContains(enumKt, "@get:JsonValue");
       TestUtils.assertFileContains(enumKt, "@JsonCreator");
+  }
+
+  @Test
+  public void testJacksonNestedEnumsUseJsonValue() throws IOException {
+      File output = Files.createTempDirectory("test").toFile();
+      output.deleteOnExit();
+
+      final CodegenConfigurator configurator = new CodegenConfigurator()
+              .setGeneratorName("kotlin")
+              .setLibrary("jvm-retrofit2")
+              .setAdditionalProperties(new HashMap<>() {{
+                put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
+                put(CodegenConstants.MODEL_PACKAGE, "model");
+              }})
+              .setInputSpec("src/test/resources/3_0/kotlin/issue23886-kotlin-nested-numeric-enum.yaml")
+              .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+      final ClientOptInput clientOptInput = configurator.toClientOptInput();
+      DefaultGenerator generator = new DefaultGenerator();
+
+      generator.opts(clientOptInput).generate();
+
+      final Path modelKt = Paths.get(output + "/src/main/kotlin/model/ExampleModel.kt");
+
+      // Without @get:JsonValue, Jackson serializes the Int-valued nested enum by its name instead
+      // of its numeric value. The import must be present so the generated code compiles.
+      TestUtils.assertFileContains(modelKt, "import com.fasterxml.jackson.annotation.JsonValue");
+      TestUtils.assertFileContains(modelKt, "enum class Source(@get:JsonValue val value: kotlin.Int)");
   }
 
   @Test

--- a/modules/openapi-generator/src/test/resources/3_0/kotlin/issue23886-kotlin-nested-numeric-enum.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/kotlin/issue23886-kotlin-nested-numeric-enum.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.0
+info:
+  title: 'Issue 23886 Jackson nested numeric enum'
+  version: latest
+paths:
+  '/example':
+    get:
+      operationId: getExample
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExampleModel'
+components:
+  schemas:
+    ExampleModel:
+      type: object
+      properties:
+        source:
+          type: integer
+          format: int32
+          enum:
+            - -1
+            - 0
+            - 1

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/DefaultValue.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/DefaultValue.kt
@@ -27,6 +27,7 @@ import org.openapitools.client.models.StringEnumRef
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * to test the default value of properties
@@ -83,7 +84,7 @@ data class DefaultValue (
      *
      * Values: success,failure,unclassified,unknown_default_open_api
      */
-    enum class ArrayStringEnumDefault(val value: kotlin.String) {
+    enum class ArrayStringEnumDefault(@get:JsonValue val value: kotlin.String) {
         @JsonProperty(value = "success") success("success"),
         @JsonProperty(value = "failure") failure("failure"),
         @JsonProperty(value = "unclassified") unclassified("unclassified"),

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -28,6 +28,7 @@ import org.openapitools.client.models.Tag
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * 
@@ -75,7 +76,7 @@ data class Pet (
      *
      * Values: available,pending,sold,unknown_default_open_api
      */
-    enum class Status(val value: kotlin.String) {
+    enum class Status(@get:JsonValue val value: kotlin.String) {
         @JsonProperty(value = "available") available("available"),
         @JsonProperty(value = "pending") pending("pending"),
         @JsonProperty(value = "sold") sold("sold"),

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Query.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Query.kt
@@ -26,6 +26,7 @@ package org.openapitools.client.models
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * 
@@ -53,7 +54,7 @@ data class Query (
      *
      * Values: SUCCESS,FAILURE,SKIPPED,unknown_default_open_api
      */
-    enum class Outcomes(val value: kotlin.String) {
+    enum class Outcomes(@get:JsonValue val value: kotlin.String) {
         @JsonProperty(value = "SUCCESS") SUCCESS("SUCCESS"),
         @JsonProperty(value = "FAILURE") FAILURE("FAILURE"),
         @JsonProperty(value = "SKIPPED") SKIPPED("SKIPPED"),

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/DefaultValue.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/DefaultValue.kt
@@ -27,6 +27,7 @@ import org.openapitools.client.models.StringEnumRef
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * to test the default value of properties
@@ -83,7 +84,7 @@ data class DefaultValue (
      *
      * Values: success,failure,unclassified,unknown_default_open_api
      */
-    enum class ArrayStringEnumDefault(val value: kotlin.String) {
+    enum class ArrayStringEnumDefault(@get:JsonValue val value: kotlin.String) {
         @JsonProperty(value = "success") success("success"),
         @JsonProperty(value = "failure") failure("failure"),
         @JsonProperty(value = "unclassified") unclassified("unclassified"),

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -28,6 +28,7 @@ import org.openapitools.client.models.Tag
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * 
@@ -75,7 +76,7 @@ data class Pet (
      *
      * Values: available,pending,sold,unknown_default_open_api
      */
-    enum class Status(val value: kotlin.String) {
+    enum class Status(@get:JsonValue val value: kotlin.String) {
         @JsonProperty(value = "available") available("available"),
         @JsonProperty(value = "pending") pending("pending"),
         @JsonProperty(value = "sold") sold("sold"),

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Query.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Query.kt
@@ -26,6 +26,7 @@ package org.openapitools.client.models
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * 
@@ -53,7 +54,7 @@ data class Query (
      *
      * Values: SUCCESS,FAILURE,SKIPPED,unknown_default_open_api
      */
-    enum class Outcomes(val value: kotlin.String) {
+    enum class Outcomes(@get:JsonValue val value: kotlin.String) {
         @JsonProperty(value = "SUCCESS") SUCCESS("SUCCESS"),
         @JsonProperty(value = "FAILURE") FAILURE("FAILURE"),
         @JsonProperty(value = "SKIPPED") SKIPPED("SKIPPED"),

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -26,6 +26,7 @@ package org.openapitools.client.models
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * An order for a pets from the pet store
@@ -73,7 +74,7 @@ data class Order (
      *
      * Values: PLACED,APPROVED,DELIVERED,UNKNOWN_DEFAULT_OPEN_API
      */
-    enum class Status(val value: kotlin.String) {
+    enum class Status(@get:JsonValue val value: kotlin.String) {
         @JsonProperty(value = "placed") PLACED("placed"),
         @JsonProperty(value = "approved") APPROVED("approved"),
         @JsonProperty(value = "delivered") DELIVERED("delivered"),

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -28,6 +28,7 @@ import org.openapitools.client.models.Tag
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * A pet for sale in the pet store
@@ -75,7 +76,7 @@ data class Pet (
      *
      * Values: AVAILABLE,PENDING,SOLD,UNKNOWN_DEFAULT_OPEN_API
      */
-    enum class Status(val value: kotlin.String) {
+    enum class Status(@get:JsonValue val value: kotlin.String) {
         @JsonProperty(value = "available") AVAILABLE("available"),
         @JsonProperty(value = "pending") PENDING("pending"),
         @JsonProperty(value = "sold") SOLD("sold"),

--- a/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -26,6 +26,7 @@ package org.openapitools.client.models
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * An order for a pets from the pet store
@@ -73,7 +74,7 @@ data class Order (
      *
      * Values: placed,approved,delivered,unknown_default_open_api
      */
-    enum class Status(val value: kotlin.String) {
+    enum class Status(@get:JsonValue val value: kotlin.String) {
         @JsonProperty(value = "placed") placed("placed"),
         @JsonProperty(value = "approved") approved("approved"),
         @JsonProperty(value = "delivered") delivered("delivered"),

--- a/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -28,6 +28,7 @@ import org.openapitools.client.models.Tag
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * A pet for sale in the pet store
@@ -76,7 +77,7 @@ data class Pet (
      *
      * Values: available,pending,sold,unknown_default_open_api
      */
-    enum class Status(val value: kotlin.String) {
+    enum class Status(@get:JsonValue val value: kotlin.String) {
         @JsonProperty(value = "available") available("available"),
         @JsonProperty(value = "pending") pending("pending"),
         @JsonProperty(value = "sold") sold("sold"),

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -26,6 +26,7 @@ package org.openapitools.client.models
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * An order for a pets from the pet store
@@ -73,7 +74,7 @@ data class Order (
      *
      * Values: placed,approved,delivered,unknown_default_open_api
      */
-    enum class Status(val value: kotlin.String) {
+    enum class Status(@get:JsonValue val value: kotlin.String) {
         @JsonProperty(value = "placed") placed("placed"),
         @JsonProperty(value = "approved") approved("approved"),
         @JsonProperty(value = "delivered") delivered("delivered"),

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -28,6 +28,7 @@ import org.openapitools.client.models.Tag
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * A pet for sale in the pet store
@@ -75,7 +76,7 @@ data class Pet (
      *
      * Values: available,pending,sold,unknown_default_open_api
      */
-    enum class Status(val value: kotlin.String) {
+    enum class Status(@get:JsonValue val value: kotlin.String) {
         @JsonProperty(value = "available") available("available"),
         @JsonProperty(value = "pending") pending("pending"),
         @JsonProperty(value = "sold") sold("sold"),

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -26,6 +26,7 @@ package org.openapitools.client.models
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * An order for a pets from the pet store
@@ -73,7 +74,7 @@ data class Order (
      *
      * Values: placed,approved,delivered,unknown_default_open_api
      */
-    enum class Status(val value: kotlin.String) {
+    enum class Status(@get:JsonValue val value: kotlin.String) {
         @JsonProperty(value = "placed") placed("placed"),
         @JsonProperty(value = "approved") approved("approved"),
         @JsonProperty(value = "delivered") delivered("delivered"),

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -28,6 +28,7 @@ import org.openapitools.client.models.Tag
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * A pet for sale in the pet store
@@ -76,7 +77,7 @@ data class Pet (
      *
      * Values: available,pending,sold,unknown_default_open_api
      */
-    enum class Status(val value: kotlin.String) {
+    enum class Status(@get:JsonValue val value: kotlin.String) {
         @JsonProperty(value = "available") available("available"),
         @JsonProperty(value = "pending") pending("pending"),
         @JsonProperty(value = "sold") sold("sold"),

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -26,6 +26,7 @@ package org.openapitools.client.models
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * An order for a pets from the pet store
@@ -73,7 +74,7 @@ data class Order (
      *
      * Values: placed,approved,delivered,unknown_default_open_api
      */
-    enum class Status(val value: kotlin.String) {
+    enum class Status(@get:JsonValue val value: kotlin.String) {
         @JsonProperty(value = "placed") placed("placed"),
         @JsonProperty(value = "approved") approved("approved"),
         @JsonProperty(value = "delivered") delivered("delivered"),

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -28,6 +28,7 @@ import org.openapitools.client.models.Tag
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * A pet for sale in the pet store
@@ -76,7 +77,7 @@ data class Pet (
      *
      * Values: available,pending,sold,unknown_default_open_api
      */
-    enum class Status(val value: kotlin.String) {
+    enum class Status(@get:JsonValue val value: kotlin.String) {
         @JsonProperty(value = "available") available("available"),
         @JsonProperty(value = "pending") pending("pending"),
         @JsonProperty(value = "sold") sold("sold"),

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -26,6 +26,7 @@ package org.openapitools.client.models
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * An order for a pets from the pet store
@@ -73,7 +74,7 @@ data class Order (
      *
      * Values: placed,approved,delivered,unknown_default_open_api
      */
-    enum class Status(val value: kotlin.String) {
+    enum class Status(@get:JsonValue val value: kotlin.String) {
         @JsonProperty(value = "placed") placed("placed"),
         @JsonProperty(value = "approved") approved("approved"),
         @JsonProperty(value = "delivered") delivered("delivered"),

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -28,6 +28,7 @@ import org.openapitools.client.models.Tag
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * A pet for sale in the pet store
@@ -76,7 +77,7 @@ data class Pet (
      *
      * Values: available,pending,sold,unknown_default_open_api
      */
-    enum class Status(val value: kotlin.String) {
+    enum class Status(@get:JsonValue val value: kotlin.String) {
         @JsonProperty(value = "available") available("available"),
         @JsonProperty(value = "pending") pending("pending"),
         @JsonProperty(value = "sold") sold("sold"),

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -25,6 +25,7 @@ package org.openapitools.client.models
 
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * An order for a pets from the pet store
@@ -72,7 +73,7 @@ data class Order (
      *
      * Values: placed,approved,delivered
      */
-    enum class Status(val value: kotlin.String) {
+    enum class Status(@get:JsonValue val value: kotlin.String) {
         @JsonProperty(value = "placed") placed("placed"),
         @JsonProperty(value = "approved") approved("approved"),
         @JsonProperty(value = "delivered") delivered("delivered");

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -27,6 +27,7 @@ import org.openapitools.client.models.Category
 import org.openapitools.client.models.Tag
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * A pet for sale in the pet store
@@ -75,7 +76,7 @@ data class Pet (
      *
      * Values: available,pending,sold
      */
-    enum class Status(val value: kotlin.String) {
+    enum class Status(@get:JsonValue val value: kotlin.String) {
         @JsonProperty(value = "available") available("available"),
         @JsonProperty(value = "pending") pending("pending"),
         @JsonProperty(value = "sold") sold("sold");

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -25,6 +25,7 @@ package org.openapitools.client.models
 
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * An order for a pets from the pet store
@@ -72,7 +73,7 @@ data class Order (
      *
      * Values: placed,approved,delivered
      */
-    enum class Status(val value: kotlin.String) {
+    enum class Status(@get:JsonValue val value: kotlin.String) {
         @JsonProperty(value = "placed") placed("placed"),
         @JsonProperty(value = "approved") approved("approved"),
         @JsonProperty(value = "delivered") delivered("delivered");

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -27,6 +27,7 @@ import org.openapitools.client.models.Category
 import org.openapitools.client.models.Tag
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * A pet for sale in the pet store
@@ -75,7 +76,7 @@ data class Pet (
      *
      * Values: available,pending,sold
      */
-    enum class Status(val value: kotlin.String) {
+    enum class Status(@get:JsonValue val value: kotlin.String) {
         @JsonProperty(value = "available") available("available"),
         @JsonProperty(value = "pending") pending("pending"),
         @JsonProperty(value = "sold") sold("sold");

--- a/samples/client/petstore/kotlin-retrofit2-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-retrofit2-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -25,6 +25,7 @@ package org.openapitools.client.models
 
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 import java.io.Serializable
 
 /**
@@ -76,7 +77,7 @@ data class Order (
      *
      * Values: PLACED,APPROVED,DELIVERED
      */
-    enum class Status(val value: kotlin.String) {
+    enum class Status(@get:JsonValue val value: kotlin.String) {
         @JsonProperty(value = "placed") PLACED("placed"),
         @JsonProperty(value = "approved") APPROVED("approved"),
         @JsonProperty(value = "delivered") DELIVERED("delivered");

--- a/samples/client/petstore/kotlin-retrofit2-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-retrofit2-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -27,6 +27,7 @@ import org.openapitools.client.models.Category
 import org.openapitools.client.models.Tag
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 import java.io.Serializable
 
 /**
@@ -79,7 +80,7 @@ data class Pet (
      *
      * Values: AVAILABLE,PENDING,SOLD
      */
-    enum class Status(val value: kotlin.String) {
+    enum class Status(@get:JsonValue val value: kotlin.String) {
         @JsonProperty(value = "available") AVAILABLE("available"),
         @JsonProperty(value = "pending") PENDING("pending"),
         @JsonProperty(value = "sold") SOLD("sold");


### PR DESCRIPTION
Fixes #23886

### Problem

For the Kotlin client generator with `serializationLibrary=jackson`, **nested** (inline) enum classes generated into a model's data class are missing the `@get:JsonValue` annotation that **top-level** enum classes already carry (`enum_class.mustache`). Without it, Jackson serializes an `Int`-valued nested enum by its constant **name** instead of its numeric **value**, producing wrong JSON output (a string where a number is expected).

### Change

- `kotlin-client/data_class.mustache`: add `{{#jackson}}@get:JsonValue {{/jackson}}` to the nested `enum class` declaration, mirroring `enum_class.mustache`, and import `com.fasterxml.jackson.annotation.JsonValue` (guarded by `{{#hasEnums}}`) so the generated code compiles.
- Added regression test `KotlinClientCodegenModelTest#testJacksonNestedEnumsUseJsonValue` with spec `issue23886-kotlin-nested-numeric-enum.yaml`.
- Regenerated the affected Kotlin Jackson client samples (`./bin/generate-samples.sh` for the `kotlin-client` jackson configs). All sample changes are limited to the added `@get:JsonValue` and the `JsonValue` import.

### Test evidence

```
./mvnw -pl modules/openapi-generator test -Dtest='KotlinClientCodegenModelTest#testJacksonNestedEnumsUseJsonValue'
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Verification done: confirmed the gap on `master` (top-level `enum_class.mustache` emits `@get:JsonValue` while nested enums in `data_class.mustache` did not); confirmed no in-flight PR / claim on #23886; the diff across all 24 regenerated sample files contains only the new annotation/import lines.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran `./bin/generate-samples.sh` for the affected `kotlin-client` jackson configs and committed all changed files.
- [x] File the PR against the `master` branch.

@jimschubert @stefankoppier — Kotlin technical committee, this touches the `kotlin-client` enum template and the `jvm-spring-webclient`/`jvm-spring-restclient` samples.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@get:JsonValue` to nested enum value parameters in Kotlin Jackson client models so Jackson serializes by value (e.g., numbers) instead of enum name. Aligns nested enums with top‑level behavior and fixes #23886.

- **Bug Fixes**
  - `kotlin-client/data_class.mustache`: add `@get:JsonValue` to nested enum `value`; import `com.fasterxml.jackson.annotation.JsonValue` guarded by `{{#hasEnums}}`.
  - Tests: updated assertions to expect the annotation; added regression test `KotlinClientCodegenModelTest#testJacksonNestedEnumsUseJsonValue` using `issue23886-kotlin-nested-numeric-enum.yaml`.
  - Regenerated Kotlin Jackson client samples; changes limited to the new annotation and import.

<sup>Written for commit 675af998dc69d01957e49c2345338ff3a7fbc53f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

