### PR TITLE
build: migrate to OSS Community Develocity Instance

### DIFF
--- a/.github/workflows/gradle-plugin-tests.yaml
+++ b/.github/workflows/gradle-plugin-tests.yaml
@@ -40,7 +40,7 @@ jobs:
           ./mvnw clean --no-snapshot-updates --batch-mode --quiet install -DskipTests -Dorg.slf4j.simpleLogger.defaultLogLevel=error
       - name: Run tests with wrapper
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |
           (cd modules/openapi-generator-gradle-plugin/samples/local-spec && ./gradlew buildGoSdk) # using gradle-6.8.3 via wrapper
           (cd modules/openapi-generator-gradle-plugin/samples/local-spec && ./gradlew openApiGenerate)
@@ -51,6 +51,6 @@ jobs:
           gradle-version: '8.14.3'
       - name: Run tests without wrapper
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |
           (cd modules/openapi-generator-gradle-plugin/samples/local-spec && gradle buildJavaResttemplateSdk) # not using gradle wrapper

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -60,7 +60,7 @@ jobs:
         shell: bash
         run: ./mvnw clean -nsu -B --quiet -Dorg.slf4j.simpleLogger.defaultLogLevel=error --no-transfer-progress install --file pom.xml
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Upload Maven build artifact
         uses: actions/upload-artifact@v7
@@ -77,7 +77,7 @@ jobs:
         if: matrix.java == '11'
         shell: bash
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |
           cd modules/openapi-generator-maven-plugin
           mvn clean verify -Pintegration

--- a/.github/workflows/maven-plugin-tests-jdk17.yaml
+++ b/.github/workflows/maven-plugin-tests-jdk17.yaml
@@ -35,7 +35,7 @@ jobs:
             ${{ runner.os }}-test-maven-plugin-
       - name: Run tests
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |
           ./mvnw clean install -DskipTests -Dmaven.javadoc.skip=true
           ./mvnw --no-snapshot-updates --quiet clean compile -f modules/openapi-generator-maven-plugin/examples/java-client.xml -Dorg.slf4j.simpleLogger.defaultLogLevel=error

--- a/.github/workflows/maven-plugin-tests.yaml
+++ b/.github/workflows/maven-plugin-tests.yaml
@@ -35,7 +35,7 @@ jobs:
             ${{ runner.os }}-test-maven-plugin-
       - name: Run tests
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |
           ./mvnw clean install -DskipTests -Dmaven.javadoc.skip=true
           ./mvnw --no-snapshot-updates --quiet clean compile -f modules/openapi-generator-maven-plugin/examples/java-client.xml -Dorg.slf4j.simpleLogger.defaultLogLevel=error

--- a/.github/workflows/mill-plugin-tests.yaml
+++ b/.github/workflows/mill-plugin-tests.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Maven Clean Install
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |
           ./mvnw clean install -DskipTests -Dmaven.javadoc.skip=true
 
@@ -51,19 +51,19 @@ jobs:
 
       - name: Mill Example - Test Validation Command
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |
           (cd modules/openapi-generator-mill-plugin/example/ && ./mill validateOpenapiSpec $(pwd)/api/petstore-invalid.yaml)
 
       - name: Mill Example - Test Validation Task
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |
           (cd modules/openapi-generator-mill-plugin/example/ && ./mill openapi.validate)
 
       - name: Mill Example - Test Compile Task
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |
           (cd modules/openapi-generator-mill-plugin/example/ && ./mill __.compile)
           

--- a/.github/workflows/openapi-generator.yaml
+++ b/.github/workflows/openapi-generator.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Run maven
         run: ./mvnw clean --no-snapshot-updates --batch-mode --quiet install -DskipTests -Dorg.slf4j.simpleLogger.defaultLogLevel=error
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - run: ls -la  modules/openapi-generator-cli/target
       - name: Upload openapi-generator-cli.jar artifact
         uses: actions/upload-artifact@v7
@@ -78,7 +78,7 @@ jobs:
       - name: Run unit tests
         run: ./mvnw clean --no-snapshot-updates --batch-mode --quiet --fail-at-end test -Dorg.slf4j.simpleLogger.defaultLogLevel=error
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: Publish unit test reports
         if: ${{ always() }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Run maven
         run: ./mvnw clean --no-snapshot-updates --batch-mode --quiet install
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: Test Template Retrieval
         run: |
           cd modules/openapi-generator-cli/target

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,45 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-
-<!-- Common develocity.xml configuration for Maven shared between CI agents and developers building locally.
-
-     The build cache credentials required for CI builds to write to the remote build cache are read from environment variables.
-     Possibly, the credentials are configured in Jenkins via Credentials plugin (https://plugins.jenkins.io/credentials/) and
-     Credentials Binding plugin (https://plugins.jenkins.io/credentials-binding/), or the credentials are injected using the
-     vendor-specific mechanism of the CI server running the build.
-
-     Note: In the XML configuration below, you need to adjust
-
-             - the server url of your Develocity server
-             - the name of the environment variable that reveals the build is running in a CI environment
-             - the names of the environment variables holding the build cache credentials
-
-           to the specifics of your CI server settings. -->
-
 <develocity
     xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
+  <projectId>OpenAPITools</projectId>
   <server>
-    <url>https://ge.openapi-generator.tech/</url>
-    <allowUntrusted>false</allowUntrusted>
+    <url>https://community.develocity.cloud</url>
   </server>
   <buildScan>
-    <backgroundBuildScanUpload>#{isFalse(env['CI'])}</backgroundBuildScanUpload> <!-- adjust to your CI provider -->
+    <backgroundBuildScanUpload>#{isFalse(env['CI'])}</backgroundBuildScanUpload>
     <publishing>
       <onlyIf>authenticated</onlyIf>
     </publishing>
     <obfuscation>
-      <!-- Use a redacted value.-->
       <ipAddresses>#{{'0.0.0.0'}}</ipAddresses>
     </obfuscation>
   </buildScan>
   <buildCache>
-    <local>
-      <enabled>true</enabled>
-    </local>
     <remote>
-      <enabled>true</enabled>
-      <!-- Check credentials presence to avoid build cache errors on PR builds when credentials are not present -->
-      <storeEnabled>#{isTrue(env['CI']) and isTrue(env['GRADLE_ENTERPRISE_ACCESS_KEY'])}</storeEnabled>
+      <storeEnabled>#{isTrue(env['CI']) and isTrue(env['DEVELOCITY_ACCESS_KEY'])}</storeEnabled>
     </remote>
   </buildCache>
 </develocity>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,11 +3,11 @@
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>develocity-maven-extension</artifactId>
-        <version>1.23.2</version>
+        <version>2.4.1</version>
     </extension>
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>common-custom-user-data-maven-extension</artifactId>
-        <version>2.0.2</version>
+        <version>2.2.0</version>
     </extension>
 </extensions>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Follow OpenAPI Generator Twitter account to get the latest update](https://img.shields.io/twitter/follow/oas_generator.svg?style=social&label=Follow)](https://twitter.com/oas_generator)
 [![Contribute with Gitpod](https://img.shields.io/badge/Contribute%20with-Gitpod-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/OpenAPITools/openapi-generator)
 [![Conan Center](https://shields.io/conan/v/openapi-generator)](https://conan.io/center/recipes/openapi-generator)
-[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.openapi-generator.tech/scans)
+[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://community.develocity.cloud/scans?search.rootProjectNames=openapi-generator-project)
 </div>
 
 <div align="center">


### PR DESCRIPTION
# Migrate to the OSS Community Develocity Instance

This PR migrates [Develocity](https://gradle.com/develocity) Build Scan® and Build Cache support
for this project to the **OSS Community Develocity Instance** at
<https://community.develocity.cloud> under project ID `OpenAPITools`.

## What this PR changes

- Updates `.mvn/develocity.xml` to point at `https://community.develocity.cloud` with project ID `OpenAPITools`, trimming keys that carry default values
- Upgrades `develocity-maven-extension` to `2.4.1` and `common-custom-user-data-maven-extension` to `2.2.0` in `.mvn/extensions.xml`
- Renames `GRADLE_ENTERPRISE_ACCESS_KEY` → `DEVELOCITY_ACCESS_KEY` in all GitHub Actions workflow files
- Updates the "Revved up by Develocity" badge in the README to link to the filtered Build Scan list for this project on the community instance

## Step 1 — Get an access key for `community.develocity.cloud`

Build Scan publishing **and** Build Cache writes from CI need a Develocity access key.

1. Visit <https://community.develocity.cloud>.
2. **Sign in as the CI service account that the Develocity Solutions team has provisioned
   for your project** — that account's project memberships and permissions are already set up
   for this migration. The access key inherits those memberships and permissions.
3. From the user menu in the top-right, open **My settings** → **Access keys**.
4. Click **Generate access key**, give it a description (e.g. `GitHub Actions`), and copy
   the generated key. Keep this tab open until you complete Step 2 — the key is only shown once.

## Step 2 — Set the GitHub Actions secret on this repository

CI uses a repository secret named `DEVELOCITY_ACCESS_KEY` to authenticate to
`community.develocity.cloud`.

1. Open this repository on GitHub and click **Settings**.
2. In the left sidebar, click **Secrets and variables** → **Actions**.
3. Click **New repository secret** (or update the existing `GRADLE_ENTERPRISE_ACCESS_KEY` if present — but note the name must change to `DEVELOCITY_ACCESS_KEY`).
4. Set **Name** to:

   ```
   DEVELOCITY_ACCESS_KEY
   ```

5. Set **Secret** to the value below, replacing `PASTE_THE_ACCESS_KEY_FROM_STEP_1_HERE`
   with the key you copied in Step 1:

   ```
   community.develocity.cloud=PASTE_THE_ACCESS_KEY_FROM_STEP_1_HERE
   ```

   The `community.develocity.cloud=` prefix is **required** — without the host name, the
   access key is silently ignored. This is the most common point of failure during
   migration, so please double-check the format.
6. Click **Add secret** (or **Update secret**).

## Step 3 — Provision an access key for local builds

Developers building this project locally should provision an access key for
`community.develocity.cloud` so their Build Scans publish and they benefit from
remote Build Cache reads. Run the following Maven command — it opens the browser,
asks the developer to confirm, and writes the key to
`~/.m2/develocity/keys.properties` automatically:

```
./mvnw develocity:provision-access-key
```

## Note on the CI run on this PR

This PR was prepared from a fork. Forks can't read repository secrets, so the workflow
run on this PR cannot publish to `community.develocity.cloud` even after you set the
secret in Step 2.

If you want CI verification before merging, push the branch
`dv/migrate-to-community-develocity-instance` to a temporary branch on **this** repo
(not the fork) and re-run the workflow — it will pick up the secret and publish a Build Scan.

After merging, every CI run **on this repository** will publish a Build Scan to
<https://community.develocity.cloud>. CI runs from forks will not (forks don't have
access to the secret either), and that's expected.

## Optional — CircleCI builds

This repository also runs builds on CircleCI (visible in the README badge). Would you like
CircleCI builds to publish Build Scans to `community.develocity.cloud` as well? If so, the
same `DEVELOCITY_ACCESS_KEY` value (`community.develocity.cloud=<key>`) would need to be
added as an environment variable in your CircleCI project settings, and the CircleCI
workflow configuration would need to expose it to the build steps. Happy to prepare a
follow-up PR for this if it is of interest.