### PR TITLE
[Go] Honor generateUnmarshalJSON=false for oneOf models

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/model_oneof.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_oneof.mustache
@@ -15,6 +15,7 @@ func {{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}}As{{classname}}(v *{
 
 {{/oneOf}}
 
+{{#vendorExtensions.x-go-generate-unmarshal-json}}
 // Unmarshal JSON data into one of the pointers in the struct
 func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 	var err error
@@ -119,6 +120,7 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 	{{/useOneOfDiscriminatorLookup}}
 }
 
+{{/vendorExtensions.x-go-generate-unmarshal-json}}
 // Marshal data from the first non-nil pointers in the struct to JSON
 func (src {{classname}}) MarshalJSON() ([]byte, error) {
 {{#oneOf}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
@@ -515,4 +515,51 @@ public class GoClientCodegenTest {
         // Verify that quotes are properly escaped in email parameter examples
         TestUtils.assertFileContains(docPath, "emailWithQuotes := \"test\\\"user@example.com\"");
     }
+
+    @Test(description = "generateUnmarshalJSON=false must also suppress the oneOf UnmarshalJSON so the generated code does not reference the validator import that is no longer added (#24053)")
+    public void testOneOfUnmarshalJSONHonorsGenerateUnmarshalJSONFlag() throws IOException {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(CodegenConstants.GENERATE_UNMARSHAL_JSON, false);
+
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("go")
+                .setAdditionalProperties(properties)
+                .setInputSpec("src/test/resources/3_0/go/spec-with-oneof-anyof-required.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        // With the flag disabled the validator import is not added, so the oneOf model must not
+        // emit UnmarshalJSON (which would reference the missing validator package and fail to compile).
+        Path oneOfModel = Paths.get(output + "/model_object.go");
+        TestUtils.assertFileNotContains(oneOfModel, "func (dst *Object) UnmarshalJSON");
+        TestUtils.assertFileNotContains(oneOfModel, "validator.Validate");
+        TestUtils.assertFileNotContains(oneOfModel, "gopkg.in/validator.v2");
+    }
+
+    @Test(description = "with the default generateUnmarshalJSON=true the oneOf UnmarshalJSON and the validator import are still generated")
+    public void testOneOfUnmarshalJSONGeneratedByDefault() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("go")
+                .setInputSpec("src/test/resources/3_0/go/spec-with-oneof-anyof-required.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        Path oneOfModel = Paths.get(output + "/model_object.go");
+        TestUtils.assertFileContains(oneOfModel,
+                "func (dst *Object) UnmarshalJSON",
+                "validator.Validate",
+                "gopkg.in/validator.v2");
+    }
 }


### PR DESCRIPTION
Fixes #24053

## Problem

When generating a Go client with `--additional-properties=generateUnmarshalJSON=false`, oneOf models produce code that does not compile.

`GoClientCodegen` only adds the `gopkg.in/validator.v2` import when `generateUnmarshalJSON` is `true`:

```java
if (generateUnmarshalJSON && !useOneOfDiscriminatorLookup) {
    imports.add(createMapping("import", "gopkg.in/validator.v2"));
    ...
}
```

However `model_oneof.mustache` emitted the custom `UnmarshalJSON` method **unconditionally**, and that method calls `validator.Validate(...)` for non-discriminator-lookup oneOf schemas. So with the flag disabled the import is (correctly) dropped while the usage remains:

```go
if err = validator.Validate(dst.ConnectorHTTP); err != nil { // undefined: validator
```

## Fix

Wrap the oneOf `UnmarshalJSON` method in the `x-go-generate-unmarshal-json` vendor extension, exactly as `model_simple.mustache` already does for regular structs. This makes `generateUnmarshalJSON` consistently control `UnmarshalJSON` generation across model kinds, so when it is disabled neither the method nor the import is emitted.

With the default (`generateUnmarshalJSON=true`) the vendor extension is set, so the generated output is **unchanged** — no committed samples are affected (no sample config uses `generateUnmarshalJSON=false`).

> Note on direction: the alternative would be to always add the validator import for oneOf and keep `UnmarshalJSON` regardless of the flag. I went with honoring the flag because it matches the existing `model_simple.mustache` behavior and the existing import logic (which already keys the import on `generateUnmarshalJSON`). Happy to switch to the import-always approach if the team prefers that semantics.

## Tests

Added two tests in `GoClientCodegenTest` using `spec-with-oneof-anyof-required.yaml`:

- `testOneOfUnmarshalJSONHonorsGenerateUnmarshalJSONFlag` — with the flag disabled, the oneOf model emits neither `UnmarshalJSON`, `validator.Validate`, nor the validator import. (Fails before the change, passes after.)
- `testOneOfUnmarshalJSONGeneratedByDefault` — with the default flag the method and import are still generated.

Verification done: built and ran `GoClientCodegenTest` on JDK 21 — all 27 tests pass; the new "honors flag" test fails on the unmodified template (reproducing the bug) and passes after the fix. `git diff` is limited to the template and the test; no sample regeneration is required because default output is byte-identical.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a compile error in generated Go clients when `--additional-properties=generateUnmarshalJSON=false` is used with oneOf models. We now skip emitting `UnmarshalJSON` and validator usage/import for oneOf types when the flag is disabled; default output is unchanged.

- **Bug Fixes**
  - Wrapped the oneOf `UnmarshalJSON` in `x-go-generate-unmarshal-json` within `model_oneof.mustache`, aligning behavior with regular structs.
  - When `generateUnmarshalJSON=false`: no `UnmarshalJSON`, no `validator.Validate`, no `gopkg.in/validator.v2` import. When true (default): unchanged output.

<sup>Written for commit c51ab181ba858b3c7a4e702bdc1de0fd69069d80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

