### PR TITLE
[CORE] - Feature: `forcedGenerateSchemas` — Force generation of schema-mapped or import-mapped schemas

### DIFF
--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
@@ -182,6 +182,14 @@ public class Generate extends OpenApiGeneratorCommand {
     private List<String> schemaMappings = new ArrayList<>();
 
     @Option(
+            name = {"--forced-generate-schemas"},
+            title = "forced generate schemas",
+            description = "comma-separated list of schema names that must be generated even when listed "
+                    + "in schemaMappings or importMappings. Example: MyEnum,OtherSchema."
+                    + " You can also have multiple occurrences of this option.")
+    private List<String> forcedGenerateSchemas = new ArrayList<>();
+
+    @Option(
             name = {"--inline-schema-name-mappings"},
             title = "inline schema name mappings",
             description = "specifies mappings between the inline schema name and the new name in the format of inline_object_2=Cat,inline_object_5=Bird."
@@ -508,6 +516,7 @@ public class Generate extends OpenApiGeneratorCommand {
         applyInstantiationTypesKvpList(instantiationTypes, configurator);
         applyImportMappingsKvpList(importMappings, configurator);
         applySchemaMappingsKvpList(schemaMappings, configurator);
+        applyForcedGenerateSchemasKvpList(forcedGenerateSchemas, configurator);
         applyInlineSchemaNameMappingsKvpList(inlineSchemaNameMappings, configurator);
         applyInlineSchemaOptionsKvpList(inlineSchemaOptions, configurator);
         applyNameMappingsKvpList(nameMappings, configurator);

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
@@ -186,6 +186,7 @@ public class Generate extends OpenApiGeneratorCommand {
             title = "forced generate schemas",
             description = "comma-separated list of schema names that must be generated even when listed "
                     + "in schemaMappings or importMappings. Example: MyEnum,OtherSchema."
+                    + " Use the wildcard '*' to force-generate all mapped schemas at once."
                     + " You can also have multiple occurrences of this option.")
     private List<String> forcedGenerateSchemas = new ArrayList<>();
 

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/GeneratorSettings.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/GeneratorSettings.java
@@ -256,6 +256,7 @@ public final class GeneratorSettings implements Serializable {
 
     /**
      * Gets the set of schema names that must be generated even when listed in schemaMappings or importMappings.
+     * Use {@code "*"} as a wildcard to force-generate all mapped schemas at once.
      *
      * @return the forced generate schemas
      */
@@ -956,7 +957,8 @@ public final class GeneratorSettings implements Serializable {
         }
 
         /**
-         * Sets the {@code forcedGenerateSchemas} (schemas to generate even when listed in schemaMappings or importMappings)
+         * Sets the {@code forcedGenerateSchemas} (schemas to generate even when listed in schemaMappings or importMappings).
+         * Use {@code "*"} as a wildcard to force-generate all mapped schemas at once.
          * and returns a reference to this Builder so that the methods can be chained together.
          *
          * @param schemas the {@code forcedGenerateSchemas} to set
@@ -968,8 +970,9 @@ public final class GeneratorSettings implements Serializable {
         }
 
         /**
-         * Adds a single schema name to {@code forcedGenerateSchemas} (schemas to generate even when listed in schemaMappings or importMappings)
-         * and returns a reference to this Builder so that the methods can be chained together.
+         * Adds a single schema name to {@code forcedGenerateSchemas} (schemas to generate even when listed in schemaMappings or importMappings).
+         * Use {@code "*"} as a wildcard to force-generate all mapped schemas at once.
+         * Returns a reference to this Builder so that the methods can be chained together.
          *
          * @param schema the schema name to add
          * @return a reference to this Builder

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/GeneratorSettings.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/GeneratorSettings.java
@@ -51,6 +51,7 @@ public final class GeneratorSettings implements Serializable {
     private final Map<String, Object> additionalProperties;
     private final Map<String, String> importMappings;
     private final Map<String, String> schemaMappings;
+    private final Set<String> forcedGenerateSchemas;
     private final Map<String, String> inlineSchemaNameMappings;
     private final Map<String, String> inlineSchemaOptions;
     private final Map<String, String> nameMappings;
@@ -254,6 +255,15 @@ public final class GeneratorSettings implements Serializable {
     }
 
     /**
+     * Gets the set of schema names that must be generated even when listed in schemaMappings or importMappings.
+     *
+     * @return the forced generate schemas
+     */
+    public Set<String> getForcedGenerateSchemas() {
+        return forcedGenerateSchemas;
+    }
+
+    /**
      * Gets inline schema name mappings between an inline schema name and the new name.
      *
      * @return the inline schema name mappings
@@ -450,6 +460,7 @@ public final class GeneratorSettings implements Serializable {
         typeMappings = Collections.unmodifiableMap(builder.typeMappings);
         importMappings = Collections.unmodifiableMap(builder.importMappings);
         schemaMappings = Collections.unmodifiableMap(builder.schemaMappings);
+        forcedGenerateSchemas = Collections.unmodifiableSet(builder.forcedGenerateSchemas);
         inlineSchemaNameMappings = Collections.unmodifiableMap(builder.inlineSchemaNameMappings);
         inlineSchemaOptions = Collections.unmodifiableMap(builder.inlineSchemaOptions);
         nameMappings = Collections.unmodifiableMap(builder.nameMappings);
@@ -530,6 +541,7 @@ public final class GeneratorSettings implements Serializable {
         additionalProperties = Collections.unmodifiableMap(new HashMap<>(0));
         importMappings = Collections.unmodifiableMap(new HashMap<>(0));
         schemaMappings = Collections.unmodifiableMap(new HashMap<>(0));
+        forcedGenerateSchemas = Collections.unmodifiableSet(new HashSet<>(0));
         inlineSchemaNameMappings = Collections.unmodifiableMap(new HashMap<>(0));
         inlineSchemaOptions = Collections.unmodifiableMap(new HashMap<>(0));
         nameMappings = Collections.unmodifiableMap(new HashMap<>(0));
@@ -592,6 +604,9 @@ public final class GeneratorSettings implements Serializable {
         }
         if (copy.getSchemaMappings() != null) {
             builder.schemaMappings.putAll(copy.getSchemaMappings());
+        }
+        if (copy.getForcedGenerateSchemas() != null) {
+            builder.forcedGenerateSchemas.addAll(copy.getForcedGenerateSchemas());
         }
         if (copy.getInlineSchemaNameMappings() != null) {
             builder.inlineSchemaNameMappings.putAll(copy.getInlineSchemaNameMappings());
@@ -660,6 +675,7 @@ public final class GeneratorSettings implements Serializable {
         private Map<String, Object> additionalProperties;
         private Map<String, String> importMappings;
         private Map<String, String> schemaMappings;
+        private Set<String> forcedGenerateSchemas;
         private Map<String, String> inlineSchemaNameMappings;
         private Map<String, String> inlineSchemaOptions;
         private Map<String, String> nameMappings;
@@ -687,6 +703,7 @@ public final class GeneratorSettings implements Serializable {
             additionalProperties = new HashMap<>();
             importMappings = new HashMap<>();
             schemaMappings = new HashMap<>();
+            forcedGenerateSchemas = new HashSet<>();
             inlineSchemaNameMappings = new HashMap<>();
             inlineSchemaOptions = new HashMap<>();
             nameMappings = new HashMap<>();
@@ -935,6 +952,33 @@ public final class GeneratorSettings implements Serializable {
                 this.schemaMappings = new HashMap<>();
             }
             this.schemaMappings.put(key, value);
+            return this;
+        }
+
+        /**
+         * Sets the {@code forcedGenerateSchemas} (schemas to generate even when listed in schemaMappings or importMappings)
+         * and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param schemas the {@code forcedGenerateSchemas} to set
+         * @return a reference to this Builder
+         */
+        public Builder withForcedGenerateSchemas(Set<String> schemas) {
+            this.forcedGenerateSchemas = schemas;
+            return this;
+        }
+
+        /**
+         * Adds a single schema name to {@code forcedGenerateSchemas} (schemas to generate even when listed in schemaMappings or importMappings)
+         * and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param schema the schema name to add
+         * @return a reference to this Builder
+         */
+        public Builder withForcedGenerateSchema(String schema) {
+            if (this.forcedGenerateSchemas == null) {
+                this.forcedGenerateSchemas = new HashSet<>();
+            }
+            this.forcedGenerateSchemas.add(schema);
             return this;
         }
 
@@ -1350,6 +1394,7 @@ public final class GeneratorSettings implements Serializable {
                 ", typeMappings=" + typeMappings +
                 ", additionalProperties=" + additionalProperties +
                 ", importMappings=" + importMappings +
+                ", forcedGenerateSchemas=" + forcedGenerateSchemas +
                 ", languageSpecificPrimitives=" + languageSpecificPrimitives +
                 ", openapiGeneratorIgnoreList=" + openapiGeneratorIgnoreList +
                 ", reservedWordsMappings=" + reservedWordsMappings +
@@ -1383,6 +1428,7 @@ public final class GeneratorSettings implements Serializable {
                 Objects.equals(getAdditionalProperties(), that.getAdditionalProperties()) &&
                 Objects.equals(getImportMappings(), that.getImportMappings()) &&
                 Objects.equals(getSchemaMappings(), that.getSchemaMappings()) &&
+                Objects.equals(getForcedGenerateSchemas(), that.getForcedGenerateSchemas()) &&
                 Objects.equals(getInlineSchemaNameMappings(), that.getInlineSchemaNameMappings()) &&
                 Objects.equals(getInlineSchemaOptions(), that.getInlineSchemaOptions()) &&
                 Objects.equals(getNameMappings(), that.getNameMappings()) &&
@@ -1421,6 +1467,7 @@ public final class GeneratorSettings implements Serializable {
                 getAdditionalProperties(),
                 getImportMappings(),
                 getSchemaMappings(),
+                getForcedGenerateSchemas(),
                 getInlineSchemaNameMappings(),
                 getInlineSchemaOptions(),
                 getNameMappings(),

--- a/modules/openapi-generator-gradle-plugin/README.adoc
+++ b/modules/openapi-generator-gradle-plugin/README.adoc
@@ -245,6 +245,11 @@ apply plugin: 'org.openapi.generator'
 |None
 |specifies mappings between the schema and the new name in the format of schema_a=Cat,schema_b=Bird. https://openapi-generator.tech/docs/customization/#schema-mapping
 
+|forcedGenerateSchemas
+|List / Provider<List>
+|None
+|Forces generation of the named schemas even when they are listed in `schemaMappings` or `importMappings` (which would normally suppress their generation). The primary use case is producing a *reference copy* of a hand-written class — for example, a custom enum that replaces a generated one — so you can assert in a test that the hand-written version has not diverged from what the generator would produce. List of schema names, e.g. `["MyEnum", "OtherSchema"]`.
+
 |nameMappings
 |Map / Provider<Map>
 |None

--- a/modules/openapi-generator-gradle-plugin/README.adoc
+++ b/modules/openapi-generator-gradle-plugin/README.adoc
@@ -248,7 +248,7 @@ apply plugin: 'org.openapi.generator'
 |forcedGenerateSchemas
 |List / Provider<List>
 |None
-|Forces generation of the named schemas even when they are listed in `schemaMappings` or `importMappings` (which would normally suppress their generation). The primary use case is producing a *reference copy* of a hand-written class — for example, a custom enum that replaces a generated one — so you can assert in a test that the hand-written version has not diverged from what the generator would produce. List of schema names, e.g. `["MyEnum", "OtherSchema"]`.
+|Forces generation of the named schemas even when they are listed in `schemaMappings` or `importMappings` (which would normally suppress their generation). The primary use case is producing a *reference copy* of a hand-written class — for example, a custom enum that replaces a generated one — so you can assert in a test that the hand-written version has not diverged from what the generator would produce. List of schema names, e.g. `["MyEnum", "OtherSchema"]`. Use `["*"]` as a wildcard to force-generate *all* schemas that would otherwise be suppressed by a mapping.
 
 |nameMappings
 |Map / Provider<Map>

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
@@ -122,6 +122,7 @@ class OpenApiGeneratorPlugin : Plugin<Project> {
                     openapiGeneratorIgnoreList.set(generate.openapiGeneratorIgnoreList)
                     importMappings.set(generate.importMappings)
                     schemaMappings.set(generate.schemaMappings)
+                    forcedGenerateSchemas.set(generate.forcedGenerateSchemas)
                     inlineSchemaNameMappings.set(generate.inlineSchemaNameMappings)
                     inlineSchemaOptions.set(generate.inlineSchemaOptions)
                     nameMappings.set(generate.nameMappings)

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
@@ -184,6 +184,11 @@ open class OpenApiGeneratorGenerateExtension(private val project: Project) {
     val schemaMappings = project.objects.mapProperty<String, String>()
 
     /**
+     * Specifies schema names that must be generated even when listed in schemaMappings or importMappings
+     */
+    val forcedGenerateSchemas = project.objects.listProperty<String>()
+
+    /**
      * Specifies mappings between an inline schema name and the new name
      */
     val inlineSchemaNameMappings = project.objects.mapProperty<String, String>()

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
@@ -86,6 +86,7 @@ interface OpenApiWorkParameters : WorkParameters {
     val instantiationTypes: MapProperty<String, String>
     val importMappings: MapProperty<String, String>
     val schemaMappings: MapProperty<String, String>
+    val forcedGenerateSchemas: ListProperty<String>
     val inlineSchemaNameMappings: MapProperty<String, String>
     val inlineSchemaOptions: MapProperty<String, String>
     val nameMappings: MapProperty<String, String>
@@ -204,6 +205,7 @@ abstract class OpenApiWorkAction : WorkAction<OpenApiWorkParameters> {
             params.instantiationTypes.orNull?.forEach { (k, v) -> configurator.addInstantiationType(k, v) }
             params.importMappings.orNull?.forEach { (k, v) -> configurator.addImportMapping(k, v) }
             params.schemaMappings.orNull?.forEach { (k, v) -> configurator.addSchemaMapping(k, v) }
+            params.forcedGenerateSchemas.orNull?.forEach { configurator.addForcedGenerateSchema(it) }
             params.inlineSchemaNameMappings.orNull?.forEach { (k, v) -> configurator.addInlineSchemaNameMapping(k, v) }
             params.inlineSchemaOptions.orNull?.forEach { (k, v) -> configurator.addInlineSchemaOption(k, v) }
             params.nameMappings.orNull?.forEach { (k, v) -> configurator.addNameMapping(k, v) }
@@ -548,6 +550,13 @@ abstract class GenerateTask : DefaultTask() {
     @get:Optional
     @get:Input
     abstract val schemaMappings: MapProperty<String, String>
+
+    /**
+     * Specifies schema names that must be generated even when listed in schemaMappings or importMappings.
+     */
+    @get:Optional
+    @get:Input
+    abstract val forcedGenerateSchemas: ListProperty<String>
 
     /**
      * Specifies mappings between the inline scheme name and the new name
@@ -964,6 +973,7 @@ abstract class GenerateTask : DefaultTask() {
                 parameters.instantiationTypes.set(instantiationTypes)
                 parameters.importMappings.set(importMappings)
                 parameters.schemaMappings.set(schemaMappings)
+                parameters.forcedGenerateSchemas.set(forcedGenerateSchemas)
                 parameters.inlineSchemaNameMappings.set(inlineSchemaNameMappings)
                 parameters.inlineSchemaOptions.set(inlineSchemaOptions)
                 parameters.nameMappings.set(nameMappings)

--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -352,6 +352,12 @@ public class CodeGenMojo extends AbstractMojo {
     private List<String> schemaMappings;
 
     /**
+     * A list of schema names that must be generated even when listed in schemaMappings or importMappings
+     */
+    @Parameter(name = "forcedGenerateSchemas", property = "openapi.generator.maven.plugin.forcedGenerateSchemas")
+    private List<String> forcedGenerateSchemas;
+
+    /**
      * A map of inline scheme names and the new names
      */
     @Parameter(name = "inlineSchemaNameMappings", property = "openapi.generator.maven.plugin.inlineSchemaNameMappings")
@@ -889,6 +895,11 @@ public class CodeGenMojo extends AbstractMojo {
             // Apply Schema Mappings
             if (schemaMappings != null && (configOptions == null || !configOptions.containsKey("schema-mappings"))) {
                 applySchemaMappingsKvpList(schemaMappings, configurator);
+            }
+
+            // Apply Forced Generate Schemas
+            if (forcedGenerateSchemas != null && (configOptions == null || !configOptions.containsKey("forced-generate-schemas"))) {
+                applyForcedGenerateSchemasKvpList(forcedGenerateSchemas, configurator);
             }
 
             // Apply Inline Schema Name Mappings

--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -831,6 +831,13 @@ public class CodeGenMojo extends AbstractMojo {
                             configurator);
                 }
 
+                // Retained for backwards-compatibility with configOptions -> forced-generate-schemas
+                if (forcedGenerateSchemas == null && configOptions.containsKey("forced-generate-schemas")) {
+                    applyForcedGenerateSchemasKvpList(
+                            Arrays.asList(configOptions.get("forced-generate-schemas").toString().split(",")),
+                            configurator);
+                }
+
                 // Retained for backwards-compatibility with configOptions -> inline-schema-name-mappings
                 if (inlineSchemaNameMappings == null && configOptions.containsKey("inline-schema-name-mappings")) {
                     applyInlineSchemaNameMappingsKvp(configOptions.get("inline-schema-name-mappings").toString(),

--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -352,7 +352,8 @@ public class CodeGenMojo extends AbstractMojo {
     private List<String> schemaMappings;
 
     /**
-     * A list of schema names that must be generated even when listed in schemaMappings or importMappings
+     * A list of schema names that must be generated even when listed in schemaMappings or importMappings.
+     * Use {@code <param>*</param>} as a wildcard to force-generate all mapped schemas at once.
      */
     @Parameter(name = "forcedGenerateSchemas", property = "openapi.generator.maven.plugin.forcedGenerateSchemas")
     private List<String> forcedGenerateSchemas;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
@@ -146,6 +146,8 @@ public interface CodegenConfig {
 
     Map<String, String> schemaMapping();
 
+    Set<String> forcedGenerateSchemas();
+
     Map<String, String> inlineSchemaNameMapping();
 
     Map<String, String> inlineSchemaOption();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
@@ -146,6 +146,13 @@ public interface CodegenConfig {
 
     Map<String, String> schemaMapping();
 
+    /**
+     * Returns the set of schema names that must be generated even when they appear in
+     * schemaMappings or importMappings (which would normally suppress their generation).
+     * <p>
+     * Use {@link CodegenConstants#FORCE_GENERATE_ALL_SCHEMAS} ({@code "*"}) as a wildcard
+     * to force-generate <em>all</em> mapped schemas at once.
+     */
     Set<String> forcedGenerateSchemas();
 
     Map<String, String> inlineSchemaNameMapping();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -36,6 +36,12 @@ public class CodegenConstants {
     public static final String SKIP_FORM_MODEL = "skipFormModel";
     /* /end System Properties */
 
+    /**
+     * Wildcard token for {@code forcedGenerateSchemas}: when this value is present in the set,
+     * all schemas are generated even if they appear in schemaMappings or importMappings.
+     */
+    public static final String FORCE_GENERATE_ALL_SCHEMAS = "*";
+
     public static final String API_NAME = "apiName";
 
     public static final String API_PACKAGE = "apiPackage";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -179,7 +179,8 @@ public class DefaultCodegen implements CodegenConfig {
     protected Map<String, String> importMapping = new HashMap<>();
     // a map to store the mapping between a schema and the new one
     protected Map<String, String> schemaMapping = new HashMap<>();
-    // a set of schema names that must be generated even when listed in schemaMappings or importMappings
+    // a set of schema names that must be generated even when listed in schemaMappings or importMappings.
+    // Use CodegenConstants.FORCE_GENERATE_ALL_SCHEMAS ("*") to force-generate all mapped schemas.
     protected Set<String> forcedGenerateSchemas = new HashSet<>();
     // a map to store the mapping between inline schema and the name provided by the user
     protected Map<String, String> inlineSchemaNameMapping = new HashMap<>();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -179,6 +179,8 @@ public class DefaultCodegen implements CodegenConfig {
     protected Map<String, String> importMapping = new HashMap<>();
     // a map to store the mapping between a schema and the new one
     protected Map<String, String> schemaMapping = new HashMap<>();
+    // a set of schema names that must be generated even when listed in schemaMappings or importMappings
+    protected Set<String> forcedGenerateSchemas = new HashSet<>();
     // a map to store the mapping between inline schema and the name provided by the user
     protected Map<String, String> inlineSchemaNameMapping = new HashMap<>();
     // a map to store the inline schema naming conventions
@@ -1300,6 +1302,11 @@ public class DefaultCodegen implements CodegenConfig {
     @Override
     public Map<String, String> schemaMapping() {
         return schemaMapping;
+    }
+
+    @Override
+    public Set<String> forcedGenerateSchemas() {
+        return forcedGenerateSchemas;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -404,6 +404,17 @@ public class DefaultGenerator implements Generator {
         }
     }
 
+    /**
+     * Returns {@code true} if the named schema should be generated even when it appears in
+     * schemaMappings or importMappings. This is the case when the schema name is explicitly
+     * listed in {@code forcedGenerateSchemas} or when the wildcard
+     * {@link CodegenConstants#FORCE_GENERATE_ALL_SCHEMAS} ({@code "*"}) is present.
+     */
+    private boolean isForcedGenerate(String schemaName) {
+        return config.forcedGenerateSchemas().contains(CodegenConstants.FORCE_GENERATE_ALL_SCHEMAS)
+                || config.forcedGenerateSchemas().contains(schemaName);
+    }
+
     private void generateModelDocumentation(List<File> files, Map<String, Object> models, String modelName) throws IOException {
         for (String templateName : config.modelDocTemplateFiles().keySet()) {
             String docExtension = config.getDocExtension();
@@ -468,7 +479,7 @@ public class DefaultGenerator implements Generator {
             processedModels.add(name);
             try {
                 //don't generate models that have an import mapping or are in the list of schemas to always generate
-                if (config.schemaMapping().containsKey(name) && !config.forcedGenerateSchemas().contains(name)) {
+                if (config.schemaMapping().containsKey(name) && !isForcedGenerate(name)) {
                     LOGGER.info("Model {} not generated due to schema mapping", name);
                     continue;
                 }
@@ -550,7 +561,7 @@ public class DefaultGenerator implements Generator {
             models.put("modelPackage", config.modelPackage());
             try {
                 //don't generate models that have a schema mapping or are in the list of schemas to always generate
-                if (config.schemaMapping().containsKey(modelName) && !config.forcedGenerateSchemas().contains(modelName)) {
+                if (config.schemaMapping().containsKey(modelName) && !isForcedGenerate(modelName)) {
                     continue;
                 }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -410,9 +410,9 @@ public class DefaultGenerator implements Generator {
      * listed in {@code forcedGenerateSchemas} or when the wildcard
      * {@link CodegenConstants#FORCE_GENERATE_ALL_SCHEMAS} ({@code "*"}) is present.
      */
-    private boolean isForcedGenerate(String schemaName) {
-        return config.forcedGenerateSchemas().contains(CodegenConstants.FORCE_GENERATE_ALL_SCHEMAS)
-                || config.forcedGenerateSchemas().contains(schemaName);
+    private boolean isNotForcedGenerate(String schemaName) {
+        return !config.forcedGenerateSchemas().contains(CodegenConstants.FORCE_GENERATE_ALL_SCHEMAS)
+                && !config.forcedGenerateSchemas().contains(schemaName);
     }
 
     private void generateModelDocumentation(List<File> files, Map<String, Object> models, String modelName) throws IOException {
@@ -479,7 +479,7 @@ public class DefaultGenerator implements Generator {
             processedModels.add(name);
             try {
                 //don't generate models that have an import mapping or are in the list of schemas to always generate
-                if (config.schemaMapping().containsKey(name) && !isForcedGenerate(name)) {
+                if (config.schemaMapping().containsKey(name) && isNotForcedGenerate(name)) {
                     LOGGER.info("Model {} not generated due to schema mapping", name);
                     continue;
                 }
@@ -561,7 +561,7 @@ public class DefaultGenerator implements Generator {
             models.put("modelPackage", config.modelPackage());
             try {
                 //don't generate models that have a schema mapping or are in the list of schemas to always generate
-                if (config.schemaMapping().containsKey(modelName) && !isForcedGenerate(modelName)) {
+                if (config.schemaMapping().containsKey(modelName) && isNotForcedGenerate(modelName)) {
                     continue;
                 }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -467,8 +467,8 @@ public class DefaultGenerator implements Generator {
         for (String name : modelKeys) {
             processedModels.add(name);
             try {
-                //don't generate models that have an import mapping
-                if (config.schemaMapping().containsKey(name)) {
+                //don't generate models that have an import mapping or are in the list of schemas to always generate
+                if (config.schemaMapping().containsKey(name) && !config.forcedGenerateSchemas().contains(name)) {
                     LOGGER.info("Model {} not generated due to schema mapping", name);
                     continue;
                 }
@@ -549,8 +549,8 @@ public class DefaultGenerator implements Generator {
             ModelsMap models = allProcessedModels.get(modelName);
             models.put("modelPackage", config.modelPackage());
             try {
-                //don't generate models that have a schema mapping
-                if (config.schemaMapping().containsKey(modelName)) {
+                //don't generate models that have a schema mapping or are in the list of schemas to always generate
+                if (config.schemaMapping().containsKey(modelName) && !config.forcedGenerateSchemas().contains(modelName)) {
                     continue;
                 }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -230,12 +230,23 @@ public class CodegenConfigurator {
         return this;
     }
 
+    /**
+     * Adds a single schema name to {@code forcedGenerateSchemas}.
+     * Schemas in this set are generated even when they appear in schemaMappings or importMappings.
+     * Use {@code "*"} ({@link CodegenConstants#FORCE_GENERATE_ALL_SCHEMAS}) to force-generate
+     * all mapped schemas at once.
+     */
     public CodegenConfigurator addForcedGenerateSchema(String schema) {
         this.forcedGenerateSchemas.add(schema);
         generatorSettingsBuilder.withForcedGenerateSchema(schema);
         return this;
     }
 
+    /**
+     * Replaces the entire {@code forcedGenerateSchemas} set.
+     * Use {@code "*"} ({@link CodegenConstants#FORCE_GENERATE_ALL_SCHEMAS}) as a wildcard
+     * to force-generate all mapped schemas at once.
+     */
     public CodegenConfigurator setForcedGenerateSchemas(Set<String> schemas) {
         this.forcedGenerateSchemas = schemas;
         generatorSettingsBuilder.withForcedGenerateSchemas(schemas);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -69,6 +69,7 @@ public class CodegenConfigurator {
     private Map<String, Object> additionalProperties = new HashMap<>();
     private Map<String, String> importMappings = new HashMap<>();
     private Map<String, String> schemaMappings = new HashMap<>();
+    private Set<String> forcedGenerateSchemas = new HashSet<>();
     private Map<String, String> inlineSchemaNameMappings = new HashMap<>();
     private Map<String, String> inlineSchemaOptions = new HashMap<>();
     private Map<String, String> nameMappings = new HashMap<>();
@@ -123,6 +124,9 @@ public class CodegenConfigurator {
             }
             if (generatorSettings.getSchemaMappings() != null) {
                 configurator.schemaMappings.putAll(generatorSettings.getSchemaMappings());
+            }
+            if (generatorSettings.getForcedGenerateSchemas() != null) {
+                configurator.forcedGenerateSchemas.addAll(generatorSettings.getForcedGenerateSchemas());
             }
             if (generatorSettings.getInlineSchemaNameMappings() != null) {
                 configurator.inlineSchemaNameMappings.putAll(generatorSettings.getInlineSchemaNameMappings());
@@ -223,6 +227,18 @@ public class CodegenConfigurator {
     public CodegenConfigurator addSchemaMapping(String key, String value) {
         this.schemaMappings.put(key, value);
         generatorSettingsBuilder.withSchemaMapping(key, value);
+        return this;
+    }
+
+    public CodegenConfigurator addForcedGenerateSchema(String schema) {
+        this.forcedGenerateSchemas.add(schema);
+        generatorSettingsBuilder.withForcedGenerateSchema(schema);
+        return this;
+    }
+
+    public CodegenConfigurator setForcedGenerateSchemas(Set<String> schemas) {
+        this.forcedGenerateSchemas = schemas;
+        generatorSettingsBuilder.withForcedGenerateSchemas(schemas);
         return this;
     }
 
@@ -773,6 +789,7 @@ public class CodegenConfigurator {
         config.typeMapping().putAll(generatorSettings.getTypeMappings());
         config.importMapping().putAll(generatorSettings.getImportMappings());
         config.schemaMapping().putAll(generatorSettings.getSchemaMappings());
+        config.forcedGenerateSchemas().addAll(generatorSettings.getForcedGenerateSchemas());
         config.inlineSchemaNameMapping().putAll(generatorSettings.getInlineSchemaNameMappings());
         config.inlineSchemaOption().putAll(generatorSettings.getInlineSchemaOptions());
         config.nameMapping().putAll(generatorSettings.getNameMappings());

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfiguratorUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfiguratorUtils.java
@@ -94,6 +94,12 @@ public final class CodegenConfiguratorUtils {
         }
     }
 
+    public static void applyForcedGenerateSchemasKvpList(List<String> schemas, CodegenConfigurator configurator) {
+        for (String schema : schemas) {
+            configurator.addForcedGenerateSchema(schema.trim());
+        }
+    }
+
     public static void applyInlineSchemaNameMappingsKvpList(List<String> inlineSchemaNameMappings, CodegenConfigurator configurator) {
         for (String propString : inlineSchemaNameMappings) {
             applyInlineSchemaNameMappingsKvp(propString, configurator);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
@@ -424,6 +424,48 @@ public class DefaultGeneratorTest {
         } finally {
             target2.toFile().deleteOnExit();
         }
+
+        // --- Part 3: wildcard "*" must force-generate ALL schemas suppressed by schemaMappings ---
+        // Two schemas are mapped (Category->ExternalCategory, Tag->ExternalTag).
+        // Adding only "*" (FORCE_GENERATE_ALL_SCHEMAS) to forcedGenerateSchemas must cause both to be generated.
+        Path target3 = Files.createTempDirectory("test-forced-gen-wildcard");
+        try {
+            final CodegenConfigurator configurator = new CodegenConfigurator()
+                    .setGeneratorName("java")
+                    .setInputSpec("src/test/resources/3_0/petstore.yaml")
+                    .setOutputDir(target3.toAbsolutePath().toString())
+                    .addSchemaMapping("Category", "ExternalCategory")
+                    .addSchemaMapping("Tag", "ExternalTag")
+                    .addForcedGenerateSchema(CodegenConstants.FORCE_GENERATE_ALL_SCHEMAS);
+
+            final ClientOptInput clientOptInput = configurator.toClientOptInput();
+            DefaultGenerator generator = new DefaultGenerator(false);
+            generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+            generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+            generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+            generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "false");
+            generator.setGeneratorPropertyDefault(CodegenConstants.SUPPORTING_FILES, "false");
+
+            List<File> files = generator.opts(clientOptInput).generate();
+
+            final String externalCategoryRelPath = "src/main/java/org/openapitools/client/model/ExternalCategory.java";
+            final String externalTagRelPath = "src/main/java/org/openapitools/client/model/ExternalTag.java";
+
+            Assert.assertTrue(
+                    files.stream().anyMatch(f -> f.getPath().replace('\\', '/').endsWith(externalCategoryRelPath)),
+                    "ExternalCategory.java MUST be generated when wildcard \"*\" is in forcedGenerateSchemas");
+            Assert.assertTrue(
+                    files.stream().anyMatch(f -> f.getPath().replace('\\', '/').endsWith(externalTagRelPath)),
+                    "ExternalTag.java MUST be generated when wildcard \"*\" is in forcedGenerateSchemas");
+            Assert.assertTrue(
+                    new File(target3.toFile(), externalCategoryRelPath).exists(),
+                    "ExternalCategory.java MUST exist on disk when wildcard \"*\" is used");
+            Assert.assertTrue(
+                    new File(target3.toFile(), externalTagRelPath).exists(),
+                    "ExternalTag.java MUST exist on disk when wildcard \"*\" is used");
+        } finally {
+            target3.toFile().deleteOnExit();
+        }
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
@@ -344,6 +344,88 @@ public class DefaultGeneratorTest {
         }
     }
 
+    /**
+     * Verifies that a schema listed in schemaMappings is skipped by default, but is generated
+     * when it also appears in forcedGenerateSchemas.
+     *
+     * When a schema is in schemaMappings, the generator renames the model using the mapped value.
+     * For example, mapping "Category" -> "ExternalCategory" means the generated file is
+     * ExternalCategory.java. Part 2 verifies that this file IS written when forcedGenerateSchemas
+     * contains "Category", whereas Part 1 verifies that NO such file exists without it.
+     */
+    @Test
+    public void forcedGenerateSchemaOverridesSchemaMappingSkip() throws IOException {
+        // Using a simple (non-FQN) mapped name so the generated filename is predictable.
+        final String mappedModelRelPath = "src/main/java/org/openapitools/client/model/ExternalCategory.java";
+        final String originalModelRelPath = "src/main/java/org/openapitools/client/model/Category.java";
+
+        // --- Part 1: schemaMapping alone must suppress generation of Category entirely ---
+        Path target1 = Files.createTempDirectory("test-forced-gen-skip");
+        try {
+            final CodegenConfigurator configurator = new CodegenConfigurator()
+                    .setGeneratorName("java")
+                    .setInputSpec("src/test/resources/3_0/petstore.yaml")
+                    .setOutputDir(target1.toAbsolutePath().toString())
+                    .addSchemaMapping("Category", "ExternalCategory");
+
+            final ClientOptInput clientOptInput = configurator.toClientOptInput();
+            DefaultGenerator generator = new DefaultGenerator(false);
+            generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+            generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+            generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+            generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "false");
+            generator.setGeneratorPropertyDefault(CodegenConstants.SUPPORTING_FILES, "false");
+
+            List<File> files = generator.opts(clientOptInput).generate();
+
+            Assert.assertFalse(
+                    files.stream().anyMatch(f -> f.getPath().replace('\\', '/').endsWith(originalModelRelPath)),
+                    "Category.java must NOT be generated when it is in schemaMappings");
+            Assert.assertFalse(
+                    files.stream().anyMatch(f -> f.getPath().replace('\\', '/').endsWith(mappedModelRelPath)),
+                    "ExternalCategory.java must NOT be generated when Category is in schemaMappings");
+        } finally {
+            target1.toFile().deleteOnExit();
+        }
+
+        // --- Part 2: forcedGenerateSchemas must force generation despite schemaMapping ---
+        // The Java generator resolves the model name through schemaMapping (Category -> ExternalCategory),
+        // so the output file is ExternalCategory.java, not Category.java.
+        Path target2 = Files.createTempDirectory("test-forced-gen-force");
+        try {
+            final CodegenConfigurator configurator = new CodegenConfigurator()
+                    .setGeneratorName("java")
+                    .setInputSpec("src/test/resources/3_0/petstore.yaml")
+                    .setOutputDir(target2.toAbsolutePath().toString())
+                    .addSchemaMapping("Category", "ExternalCategory")
+                    .addForcedGenerateSchema("Category");
+
+            final ClientOptInput clientOptInput = configurator.toClientOptInput();
+
+            Assert.assertTrue(
+                    clientOptInput.getConfig().forcedGenerateSchemas().contains("Category"),
+                    "forcedGenerateSchemas must be wired to the config by toClientOptInput()");
+
+            DefaultGenerator generator = new DefaultGenerator(false);
+            generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+            generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+            generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+            generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "false");
+            generator.setGeneratorPropertyDefault(CodegenConstants.SUPPORTING_FILES, "false");
+
+            List<File> files = generator.opts(clientOptInput).generate();
+
+            Assert.assertTrue(
+                    files.stream().anyMatch(f -> f.getPath().replace('\\', '/').endsWith(mappedModelRelPath)),
+                    "ExternalCategory.java MUST be generated when Category is in both schemaMappings and forcedGenerateSchemas");
+            Assert.assertTrue(
+                    new File(target2.toFile(), mappedModelRelPath).exists(),
+                    "ExternalCategory.java MUST exist on disk when forcedGenerateSchemas overrides schemaMappings");
+        } finally {
+            target2.toFile().deleteOnExit();
+        }
+    }
+
     @Test
     public void testNonStrictProcessPaths() throws Exception {
         OpenAPI openAPI = TestUtils.createOpenAPI();


### PR DESCRIPTION
When a schema is listed in `schemaMappings`, OpenAPI Generator skips it entirely during model generation (no file is written). This is correct for normal use, but makes it impossible to generate a "reference copy" of the schema - e.g. for a test that asserts a hand-written enum class has not diverged from what the generator would produce.

This feature adds a `forcedGenerateSchemas` option: a set of schema names that must be generated even when they also appear in `schemaMappings` or `importMappings`. It is also possible to just pass an asterisk `*` in the list to force generation of all schemas.



<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
