### PR TITLE
[C#][generichost] Fix enum generation

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/JsonConverter.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/JsonConverter.mustache
@@ -537,9 +537,7 @@
             {{/isNullable}}
             {{/isInnerEnum}}
             {{^isInnerEnum}}
-            {{#lambda.copyText}}
-            {{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}
-            {{/lambda.copyText}}
+            {{#lambda.copyText}}{{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}{{/lambda.copyText}}
             {{#required}}
             {{#isNullable}}
             if ({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}} == null)


### PR DESCRIPTION
Using the template genericHost to generate c# client api,
Previous version cause the enum variable wrote with a jump in the JsonConverter.mustach, So the project won't compile

ex : 
myEnum
RawValue

The solution write it well
myEnumRawValue



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix enum name generation in the C# `generichost` template by removing an unintended line break in `JsonConverter.mustache`. Names like myEnumRawValue are now emitted on one line instead of being split (myEnum + newline + RawValue), so generated projects compile.

<sup>Written for commit adc181bc87bd2c6f33f530ddd1e4cfe55ada7ba3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

