### PR TITLE
[python] Run regex pattern validators in mode="before" so they see the wire value (#24065)

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_generic.mustache
@@ -38,7 +38,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 {{#vars}}
     {{#vendorExtensions.x-regex}}
 
-    @field_validator('{{{name}}}')
+    @field_validator('{{{name}}}', mode="before")
     def {{{name}}}_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         {{^required}}
@@ -53,10 +53,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
         {{/isNullable}}
         {{/required}}
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"{{{.}}}", value{{#vendorExtensions.x-modifiers}} ,re.{{{.}}}{{/vendorExtensions.x-modifiers}}):
+        if isinstance(value, str) and not re.match(r"{{{.}}}", value{{#vendorExtensions.x-modifiers}} ,re.{{{.}}}{{/vendorExtensions.x-modifiers}}):
             raise ValueError(r"must validate the regular expression {{{vendorExtensions.x-pattern}}}")
         return value
     {{/vendorExtensions.x-regex}}

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/format_test.py
@@ -50,55 +50,43 @@ class FormatTest(BaseModel):
     pattern_with_digits_and_delimiter: Optional[Annotated[str, Field(strict=True)]] = Field(default=None, description="A string starting with 'image_' (case insensitive) and one to three digits following i.e. Image_01.")
     __properties: ClassVar[List[str]] = ["integer", "int32", "int64", "number", "float", "double", "decimal", "string", "string_with_double_quote_pattern", "byte", "binary", "date", "dateTime", "uuid", "password", "pattern_with_digits", "pattern_with_digits_and_delimiter"]
 
-    @field_validator('string')
+    @field_validator('string', mode="before")
     def string_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"[a-z]", value ,re.IGNORECASE):
+        if isinstance(value, str) and not re.match(r"[a-z]", value ,re.IGNORECASE):
             raise ValueError(r"must validate the regular expression /[a-z]/i")
         return value
 
-    @field_validator('string_with_double_quote_pattern')
+    @field_validator('string_with_double_quote_pattern', mode="before")
     def string_with_double_quote_pattern_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"this is \"something\"", value):
+        if isinstance(value, str) and not re.match(r"this is \"something\"", value):
             raise ValueError(r"must validate the regular expression /this is \"something\"/")
         return value
 
-    @field_validator('pattern_with_digits')
+    @field_validator('pattern_with_digits', mode="before")
     def pattern_with_digits_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^\d{10}$", value):
+        if isinstance(value, str) and not re.match(r"^\d{10}$", value):
             raise ValueError(r"must validate the regular expression /^\d{10}$/")
         return value
 
-    @field_validator('pattern_with_digits_and_delimiter')
+    @field_validator('pattern_with_digits_and_delimiter', mode="before")
     def pattern_with_digits_and_delimiter_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^image_\d{1,3}$", value ,re.IGNORECASE):
+        if isinstance(value, str) and not re.match(r"^image_\d{1,3}$", value ,re.IGNORECASE):
             raise ValueError(r"must validate the regular expression /^image_\d{1,3}$/i")
         return value
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_property.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_property.py
@@ -32,16 +32,13 @@ class NullableProperty(BaseModel):
     name: Optional[Annotated[str, Field(strict=True)]]
     __properties: ClassVar[List[str]] = ["id", "name"]
 
-    @field_validator('name')
+    @field_validator('name', mode="before")
     def name_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^[A-Z].*", value):
+        if isinstance(value, str) and not re.match(r"^[A-Z].*", value):
             raise ValueError(r"must validate the regular expression /^[A-Z].*/")
         return value
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/uuid_with_pattern.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/uuid_with_pattern.py
@@ -31,16 +31,13 @@ class UuidWithPattern(BaseModel):
     id: Optional[UUID] = None
     __properties: ClassVar[List[str]] = ["id"]
 
-    @field_validator('id')
+    @field_validator('id', mode="before")
     def id_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$", value):
+        if isinstance(value, str) and not re.match(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$", value):
             raise ValueError(r"must validate the regular expression /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/")
         return value
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/format_test.py
@@ -50,55 +50,43 @@ class FormatTest(BaseModel):
     pattern_with_digits_and_delimiter: Optional[Annotated[str, Field(strict=True)]] = Field(default=None, description="A string starting with 'image_' (case insensitive) and one to three digits following i.e. Image_01.")
     __properties: ClassVar[List[str]] = ["integer", "int32", "int64", "number", "float", "double", "decimal", "string", "string_with_double_quote_pattern", "byte", "binary", "date", "dateTime", "uuid", "password", "pattern_with_digits", "pattern_with_digits_and_delimiter"]
 
-    @field_validator('string')
+    @field_validator('string', mode="before")
     def string_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"[a-z]", value ,re.IGNORECASE):
+        if isinstance(value, str) and not re.match(r"[a-z]", value ,re.IGNORECASE):
             raise ValueError(r"must validate the regular expression /[a-z]/i")
         return value
 
-    @field_validator('string_with_double_quote_pattern')
+    @field_validator('string_with_double_quote_pattern', mode="before")
     def string_with_double_quote_pattern_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"this is \"something\"", value):
+        if isinstance(value, str) and not re.match(r"this is \"something\"", value):
             raise ValueError(r"must validate the regular expression /this is \"something\"/")
         return value
 
-    @field_validator('pattern_with_digits')
+    @field_validator('pattern_with_digits', mode="before")
     def pattern_with_digits_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^\d{10}$", value):
+        if isinstance(value, str) and not re.match(r"^\d{10}$", value):
             raise ValueError(r"must validate the regular expression /^\d{10}$/")
         return value
 
-    @field_validator('pattern_with_digits_and_delimiter')
+    @field_validator('pattern_with_digits_and_delimiter', mode="before")
     def pattern_with_digits_and_delimiter_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^image_\d{1,3}$", value ,re.IGNORECASE):
+        if isinstance(value, str) and not re.match(r"^image_\d{1,3}$", value ,re.IGNORECASE):
             raise ValueError(r"must validate the regular expression /^image_\d{1,3}$/i")
         return value
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/nullable_property.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/nullable_property.py
@@ -32,16 +32,13 @@ class NullableProperty(BaseModel):
     name: Optional[Annotated[str, Field(strict=True)]]
     __properties: ClassVar[List[str]] = ["id", "name"]
 
-    @field_validator('name')
+    @field_validator('name', mode="before")
     def name_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^[A-Z].*", value):
+        if isinstance(value, str) and not re.match(r"^[A-Z].*", value):
             raise ValueError(r"must validate the regular expression /^[A-Z].*/")
         return value
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/uuid_with_pattern.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/uuid_with_pattern.py
@@ -31,16 +31,13 @@ class UuidWithPattern(BaseModel):
     id: Optional[UUID] = None
     __properties: ClassVar[List[str]] = ["id"]
 
-    @field_validator('id')
+    @field_validator('id', mode="before")
     def id_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$", value):
+        if isinstance(value, str) and not re.match(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$", value):
             raise ValueError(r"must validate the regular expression /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/")
         return value
 

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/format_test.py
@@ -51,55 +51,43 @@ class FormatTest(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["integer", "int32", "int64", "number", "float", "double", "decimal", "string", "string_with_double_quote_pattern", "byte", "binary", "date", "dateTime", "uuid", "password", "pattern_with_digits", "pattern_with_digits_and_delimiter"]
 
-    @field_validator('string')
+    @field_validator('string', mode="before")
     def string_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"[a-z]", value ,re.IGNORECASE):
+        if isinstance(value, str) and not re.match(r"[a-z]", value ,re.IGNORECASE):
             raise ValueError(r"must validate the regular expression /[a-z]/i")
         return value
 
-    @field_validator('string_with_double_quote_pattern')
+    @field_validator('string_with_double_quote_pattern', mode="before")
     def string_with_double_quote_pattern_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"this is \"something\"", value):
+        if isinstance(value, str) and not re.match(r"this is \"something\"", value):
             raise ValueError(r"must validate the regular expression /this is \"something\"/")
         return value
 
-    @field_validator('pattern_with_digits')
+    @field_validator('pattern_with_digits', mode="before")
     def pattern_with_digits_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^\d{10}$", value):
+        if isinstance(value, str) and not re.match(r"^\d{10}$", value):
             raise ValueError(r"must validate the regular expression /^\d{10}$/")
         return value
 
-    @field_validator('pattern_with_digits_and_delimiter')
+    @field_validator('pattern_with_digits_and_delimiter', mode="before")
     def pattern_with_digits_and_delimiter_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^image_\d{1,3}$", value ,re.IGNORECASE):
+        if isinstance(value, str) and not re.match(r"^image_\d{1,3}$", value ,re.IGNORECASE):
             raise ValueError(r"must validate the regular expression /^image_\d{1,3}$/i")
         return value
 

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/nullable_property.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/nullable_property.py
@@ -33,16 +33,13 @@ class NullableProperty(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["id", "name"]
 
-    @field_validator('name')
+    @field_validator('name', mode="before")
     def name_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^[A-Z].*", value):
+        if isinstance(value, str) and not re.match(r"^[A-Z].*", value):
             raise ValueError(r"must validate the regular expression /^[A-Z].*/")
         return value
 

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/uuid_with_pattern.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/uuid_with_pattern.py
@@ -32,16 +32,13 @@ class UuidWithPattern(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["id"]
 
-    @field_validator('id')
+    @field_validator('id', mode="before")
     def id_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$", value):
+        if isinstance(value, str) and not re.match(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$", value):
             raise ValueError(r"must validate the regular expression /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/")
         return value
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/format_test.py
@@ -51,55 +51,43 @@ class FormatTest(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["integer", "int32", "int64", "number", "float", "double", "decimal", "string", "string_with_double_quote_pattern", "byte", "binary", "date", "dateTime", "uuid", "password", "pattern_with_digits", "pattern_with_digits_and_delimiter"]
 
-    @field_validator('string')
+    @field_validator('string', mode="before")
     def string_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"[a-z]", value ,re.IGNORECASE):
+        if isinstance(value, str) and not re.match(r"[a-z]", value ,re.IGNORECASE):
             raise ValueError(r"must validate the regular expression /[a-z]/i")
         return value
 
-    @field_validator('string_with_double_quote_pattern')
+    @field_validator('string_with_double_quote_pattern', mode="before")
     def string_with_double_quote_pattern_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"this is \"something\"", value):
+        if isinstance(value, str) and not re.match(r"this is \"something\"", value):
             raise ValueError(r"must validate the regular expression /this is \"something\"/")
         return value
 
-    @field_validator('pattern_with_digits')
+    @field_validator('pattern_with_digits', mode="before")
     def pattern_with_digits_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^\d{10}$", value):
+        if isinstance(value, str) and not re.match(r"^\d{10}$", value):
             raise ValueError(r"must validate the regular expression /^\d{10}$/")
         return value
 
-    @field_validator('pattern_with_digits_and_delimiter')
+    @field_validator('pattern_with_digits_and_delimiter', mode="before")
     def pattern_with_digits_and_delimiter_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^image_\d{1,3}$", value ,re.IGNORECASE):
+        if isinstance(value, str) and not re.match(r"^image_\d{1,3}$", value ,re.IGNORECASE):
             raise ValueError(r"must validate the regular expression /^image_\d{1,3}$/i")
         return value
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/nullable_property.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/nullable_property.py
@@ -33,16 +33,13 @@ class NullableProperty(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["id", "name"]
 
-    @field_validator('name')
+    @field_validator('name', mode="before")
     def name_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^[A-Z].*", value):
+        if isinstance(value, str) and not re.match(r"^[A-Z].*", value):
             raise ValueError(r"must validate the regular expression /^[A-Z].*/")
         return value
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/uuid_with_pattern.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/uuid_with_pattern.py
@@ -32,16 +32,13 @@ class UuidWithPattern(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["id"]
 
-    @field_validator('id')
+    @field_validator('id', mode="before")
     def id_validate_regular_expression(cls, value):
         """Validates the regular expression"""
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$", value):
+        if isinstance(value, str) and not re.match(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$", value):
             raise ValueError(r"must validate the regular expression /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/")
         return value
 


### PR DESCRIPTION
Fixes #24065

### Problem

The Python (pydantic v2) generator emitted regex `@field_validator`s without a `mode`, so they defaulted to `mode="after"` and ran **after** pydantic had already coerced the incoming value to its declared Python type:

```python
@field_validator('created_at')
def created_at_validate_regular_expression(cls, value):
    if not isinstance(value, str):
        value = str(value)        # <- typed value stringified here
    if not re.match(PATTERN, value):
        raise ValueError(...)
    return value
```

Because the validator received the *already-converted* value, two things broke:

- A `string` with `format: date-time` arrived as a `datetime`. `str(datetime)` produces e.g. `2026-05-29 06:25:09.281000+00:00`, which no longer matches a `pattern` written for the RFC 3339 wire form (`...T...Z`) — so a **valid response was rejected**.
- A `string` with `format: uuid` was coerced to `UUID`, then the validator returned `str(value)`, leaving the field value a **`str` despite the `UUID` annotation**.

### Fix

Run the pattern check in `mode="before"` against the raw wire value, and only when it is a `str`; then let pydantic perform its normal conversion. Already-typed Python values pass through untouched.

```python
@field_validator('created_at', mode="before")
def created_at_validate_regular_expression(cls, value):
    if isinstance(value, str) and not re.match(PATTERN, value):
        raise ValueError(...)
    return value
```

Single template change: `modules/openapi-generator/src/main/resources/python/model_generic.mustache`. Affected python samples were regenerated (`python`, `python-aiohttp`, `python-httpx`, `python-lazyImports`); pydantic-v1 and fastapi use separate templates and are unaffected.

### Test evidence

Built the generator (JDK 21) and regenerated the samples — the only generated diff is the validator signature/body, as intended.

Against the regenerated `python` sample's `UuidWithPattern` (`id: Optional[UUID]`, with a UUID-v4 `pattern`), verified with pydantic 2.13:

- Valid UUID-v4 string on the wire → field is a proper `UUID` (previously a `str` — bug reproduced on `master` then confirmed fixed).
- Optional `None` accepted.
- Malformed string still rejected by the pattern.
- An already-typed `UUID` passed to the constructor is preserved (not coerced to `str`).

Existing sample unit tests `test_uuid_with_pattern.py` and `test_format_test.py` pass.

### Verification done
(1) No in-flight PR — searched open PRs for python regex/pattern-validator work and cross-checked my own open PRs; none overlap. (2) Issue is unclaimed (no comments). (3) Code-focused — `.mustache` template + regenerated `.py` samples. (4) Confirmed the old (uncorrected) template still ships in `master`. (6) N/A (not a spring-projects repo).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run pattern validators in the Python `pydantic` v2 generator in `mode="before"` so patterns check the raw wire string. This prevents false rejections for RFC 3339 `date-time` and preserves `UUID` types.

- Bug Fixes
  - Generate regex `@field_validator(..., mode="before")` and run the check only for `str` inputs; let `pydantic` handle conversion afterward.
  - Prevent false negatives for `date-time` and stop converting `UUID` values to `str`.
  - Regenerated `python`, `python-aiohttp`, `python-httpx`, and `python-lazyImports`; `pydantic` v1 and `fastapi` templates are unchanged.

<sup>Written for commit addfe64adfafc974ea8b66ae286a74a36dbfa6a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

