### PR TITLE
Add Carmatec entry to users.yml

### DIFF
--- a/website/src/dynamic/users.yml
+++ b/website/src/dynamic/users.yml
@@ -129,6 +129,11 @@
   infoLink: "https://www.carlsberggroup.com/"
   pinned: false
 -
+  caption: Carmatec
+  image: "img/companies/carmatec.png"
+  infoLink: "https://www.carmatec.com/"
+  pinned: false
+ -  
   caption: Cisco 
   image: "img/companies/cisco.png"
   infoLink: "https://www.cisco.com"

--- a/website/src/dynamic/users.yml
+++ b/website/src/dynamic/users.yml
@@ -133,7 +133,7 @@
   image: "img/companies/carmatec.png"
   infoLink: "https://www.carmatec.com/"
   pinned: false
- -  
+-
   caption: Cisco 
   image: "img/companies/cisco.png"
   infoLink: "https://www.cisco.com"

--- a/website/src/dynamic/users.yml
+++ b/website/src/dynamic/users.yml
@@ -688,3 +688,8 @@
   image: "img/companies/outscale.png"
   infoLink: "https://www.outscale.com/"
   pinned: false
+-
+  caption: Carmatec
+  image: "img/companies/carmatec logo.png"
+  infoLink: "https://www.carmatec.com/"
+  pinned: false


### PR DESCRIPTION
Added Carmatec

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Carmatec to the website users list with logo and link. Only `website/src/dynamic/users.yml` changed; two Carmatec entries were added.

<sup>Written for commit cfe72ecbee79c5982b4c234531341bb72fc9a8f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

