### PR TITLE
[core] Fix UnsupportedOperationException for oneOf members declaring x-implements (#23577)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/OneOfImplementorAdditionalData.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/OneOfImplementorAdditionalData.java
@@ -103,11 +103,20 @@ public class OneOfImplementorAdditionalData {
      */
     @SuppressWarnings("unchecked")
     public void addToImplementor(CodegenConfig cc, CodegenModel implcm, List<Map<String, String>> implImports, boolean addInterfaceImports) {
-        implcm.getVendorExtensions().putIfAbsent(X_IMPLEMENTS, new ArrayList<String>());
+        // The model may already declare x-implements in the spec, in which case the parsed value can be
+        // a scalar string or an immutable list. Normalize it to a fresh mutable list (preserving any
+        // existing entries) so the oneOf interfaces below can be appended without failing.
+        Object existing = implcm.getVendorExtensions().get(X_IMPLEMENTS);
+        List<String> impl = new ArrayList<>();
+        if (existing instanceof Collection) {
+            impl.addAll((Collection<String>) existing);
+        } else if (existing instanceof String && !((String) existing).isEmpty()) {
+            impl.add((String) existing);
+        }
+        implcm.getVendorExtensions().put(X_IMPLEMENTS, impl);
 
         // Add implemented interfaces
         for (String intf : additionalInterfaces) {
-            List<String> impl = (List<String>) implcm.getVendorExtensions().get(X_IMPLEMENTS);
             impl.add(intf);
             if (addInterfaceImports) {
                 // Add imports for interfaces

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -7996,6 +7996,19 @@ public class SpringCodegenTest {
     }
 
     @Test
+    void oneOf_issue_23577_userDefinedXImplements() throws IOException {
+        // Default oneOf-interface generation (without REPLACE_ONE_OF_BY_DISCRIMINATOR_MAPPING):
+        // a member schema that already declares its own x-implements must still be able to
+        // receive the oneOf interface, i.e. the user-supplied x-implements value must remain mutable.
+        Map<String, File> files = generateFromContract("src/test/resources/3_0/oneOf_issue_23577.yaml", SPRING_BOOT,
+                Map.of(GENERATE_MODEL_DOCS, false, GENERATE_APIS, false, INTERFACE_ONLY, true));
+        JavaFileAssert.assertThat(files.get("CreatedEvent.java"))
+                .implementsInterfaces("com.example.Notification", "Event");
+        JavaFileAssert.assertThat(files.get("UpdatedEvent.java"))
+                .implementsInterfaces("Event");
+    }
+
+    @Test
     void oneof_polymorphism_and_inheritance() throws IOException {
         Map<String, File> files = generateFromContract("src/test/resources/3_0/oneof_polymorphism_and_inheritance.yaml", SPRING_BOOT,
                 Map.of(MODEL_NAME_SUFFIX, "Dto",


### PR DESCRIPTION
Fixes #23577

### Problem

When a schema is a member of a `oneOf` and **also** declares its own `x-implements` in the spec, generation crashes with `java.lang.UnsupportedOperationException` during model post-processing:

```
java.lang.UnsupportedOperationException
    at java.util.AbstractList.add(AbstractList.java:155)
    at org.openapitools.codegen.utils.OneOfImplementorAdditionalData.addToImplementor(OneOfImplementorAdditionalData.java:111)
    at org.openapitools.codegen.DefaultCodegen.postProcessAllModels(DefaultCodegen.java:577)
    ...
```

`addToImplementor` did `putIfAbsent(X_IMPLEMENTS, new ArrayList<>())` and then `List.add(...)` on the stored value. When the model already carries `x-implements` from the spec, that value is the parser-supplied object (a scalar string or an immutable list), so `putIfAbsent` is a no-op and the subsequent `add` fails.

This is the default `oneOf`-interface code path. The existing `oneOf_issue_23577` test only covers the `REPLACE_ONE_OF_BY_DISCRIMINATOR_MAPPING` normalizer path, which converts `oneOf` to inheritance and never reaches this code — so the default path remained broken.

### Fix

Normalize the existing `x-implements` value into a fresh **mutable** list (preserving any user-supplied interfaces, whether stored as a scalar string or a list) before appending the `oneOf` interface. Models without a pre-existing `x-implements` are unaffected — the result is identical to the previous `putIfAbsent(new ArrayList<>())` behavior.

### Test evidence

Added `SpringCodegenTest#oneOf_issue_23577_userDefinedXImplements`, which generates the reporter's spec on the **default** `oneOf`-interface path (no normalizer) and asserts the member implements both its declared interface and the `oneOf` parent:

- `CreatedEvent` implements `com.example.Notification` **and** `Event`
- `UpdatedEvent` implements `Event`

Confirmed the new test fails with `UnsupportedOperationException` before the change and passes after. The pre-existing `oneOf_issue_23577` and `OneOfImplementorAdditionalDataTest` still pass.

```
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

No generated samples change (the previously-crashing combination produced no committed samples; the no-`x-implements` path is byte-for-byte unchanged), so no sample regeneration is included.

Verification done: (1) no in-flight PR (searched open PRs for `x-implements`/`OneOfImplementor`/`#23577`); (2) no claim comments on the issue; (3) code fix in `.java` only; (4) reproduced the crash on `upstream/master` via a failing test, then confirmed the fix; (5) no parent epic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when a oneOf member also declares its own `x-implements`. We now normalize existing `x-implements` to a mutable list before adding the oneOf interface.

- **Bug Fixes**
  - Convert pre-existing `x-implements` (string or immutable list) into a new mutable list before appending oneOf interfaces; models without `x-implements` are unchanged.
  - Add test `oneOf_issue_23577_userDefinedXImplements` to verify members implement both the user-defined interface(s) and the oneOf parent.

<sup>Written for commit bac76e76d2a0539016ef75dcb6d9e9a8ca7bc590. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

