### PR TITLE
[csharp][generichost] Revert to DropWrite

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/RateLimitProvider`1.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/RateLimitProvider`1.mustache
@@ -34,7 +34,7 @@ namespace {{packageName}}.{{clientPackage}}
             {{#lambda.copy}}
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
@@ -48,7 +48,7 @@ namespace {{packageName}}.{{clientPackage}}
                 {
                     global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
                     AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/latest/ComposedEnum/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/latest/ComposedEnum/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/latest/HelloWorld/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/latest/HelloWorld/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/latest/Tags/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/latest/Tags/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Client
                 {
                     global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
                     AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Client
             {
                 global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
                 {
-                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
                 AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -44,7 +44,7 @@ namespace Org.OpenAPITools.Client
                 {
                     global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
                     AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Client
             {
                 global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
                 {
-                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
                 AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Client
                 {
                     global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
                     AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
@@ -52,7 +52,7 @@ namespace Org.OpenAPITools.Client
             {
                 global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
                 {
-                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
                 AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -44,7 +44,7 @@ namespace Org.OpenAPITools.Client
                 {
                     global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
                     AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Client
             {
                 global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
                 {
-                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
                 AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Client
                 {
                     global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
                     AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
@@ -52,7 +52,7 @@ namespace Org.OpenAPITools.Client
             {
                 global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
                 {
-                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
                 AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -44,7 +44,7 @@ namespace Org.OpenAPITools.Client
                 {
                     global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
                     AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Client
             {
                 global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
                 {
-                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
                 AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net10/UseDateTimeForDate/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/UseDateTimeForDate/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Client
                 {
                     global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
                     AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
@@ -52,7 +52,7 @@ namespace Org.OpenAPITools.Client
             {
                 global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
                 {
-                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
                 AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Client
                 {
                     global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
                     AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
@@ -52,7 +52,7 @@ namespace Org.OpenAPITools.Client
             {
                 global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
                 {
-                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
                 AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Client
                 {
                     global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
                     AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
@@ -52,7 +52,7 @@ namespace Org.OpenAPITools.Client
             {
                 global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
                 {
-                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
                 AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Client
                 {
                     global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
                     AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
@@ -52,7 +52,7 @@ namespace Org.OpenAPITools.Client
             {
                 global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
                 {
-                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
                 AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Client
                 {
                     global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
                     AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
@@ -52,7 +52,7 @@ namespace Org.OpenAPITools.Client
             {
                 global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
                 {
-                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
                 AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -44,7 +44,7 @@ namespace Org.OpenAPITools.Client
                 {
                     global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
                     AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Client
             {
                 global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
                 {
-                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
                 AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Client
                 {
                     global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
                     AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
@@ -52,7 +52,7 @@ namespace Org.OpenAPITools.Client
             {
                 global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
                 {
-                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
                 AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -44,7 +44,7 @@ namespace Org.OpenAPITools.Client
                 {
                     global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
                     AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Client
             {
                 global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
                 {
-                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
                 AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Client
                 {
                     global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
                     AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
@@ -52,7 +52,7 @@ namespace Org.OpenAPITools.Client
             {
                 global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
                 {
-                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
                 AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -44,7 +44,7 @@ namespace Org.OpenAPITools.Client
                 {
                     global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
                     AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Client
             {
                 global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
                 {
-                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
                 AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Client
                 {
                     global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
                     AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
@@ -52,7 +52,7 @@ namespace Org.OpenAPITools.Client
             {
                 global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
                 {
-                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
                 AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -44,7 +44,7 @@ namespace Org.OpenAPITools.Client
                 {
                     global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
                     AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Client
             {
                 global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
                 {
-                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
                 AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Client
 
             global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
             {
-                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
             };
 
             AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Client
                 {
                     global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(apiKeyTokenContainer.Tokens.Count(t => ClientUtils.ApiKeyHeaderToString(t.Header).Equals(header)))
                     {
-                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                        FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                     };
 
                     AvailableTokens.Add(header, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));
@@ -52,7 +52,7 @@ namespace Org.OpenAPITools.Client
             {
                 global::System.Threading.Channels.BoundedChannelOptions options = new global::System.Threading.Channels.BoundedChannelOptions(container.Tokens.Count)
                 {
-                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropOldest
+                    FullMode = global::System.Threading.Channels.BoundedChannelFullMode.DropWrite
                 };
 
                 AvailableTokens.Add(string.Empty, global::System.Threading.Channels.Channel.CreateBounded<TTokenBase>(options));


### PR DESCRIPTION
Partial revert from https://github.com/OpenAPITools/openapi-generator/pull/22233 In most simple cases we are only going to be concerned about rate limiting. For other concerns, we can give new default limiters for each token type. Users can also provide their own rate limiter. We can consider other changes as well to address some of what EraYaN said feels off about the approach currently used. The following is copilot's view on it.


# C# GenericHost: revert `BoundedChannelFullMode` in `RateLimitProvider` from `DropOldest` to `DropWrite`

PR #22233 changed `BoundedChannelFullMode` in `RateLimitProvider` from `DropWrite` to `DropOldest`. This reverts that change.

## Why `DropWrite` is correct

The bounded channel in `RateLimitProvider` has a capacity equal to `container.Tokens.Count`. Each token writes itself to the channel when its rate-limit timer fires. A full channel simply means every token is already queued and available — any additional write for that token is a no-op duplicate. `DropWrite` handles this correctly by silently discarding the redundant write.

`DropOldest` evicts the longest-waiting token from the front of the queue to make room for the incoming write. This is actively harmful for rate limiting:

1. **FIFO ordering is intentional.** The token that cooled down longest ago should be served first to maximize throughput while respecting per-token rate limits.
2. **A full channel is not an error condition here.** The capacity is bounded by design — there is no scenario where a genuinely new, distinct token needs to displace an existing one.
3. **`DropOldest` can cause tokens to "disappear."** If the evicted token's `TokenBecameAvailable` event doesn't fire again immediately, the channel will have one fewer token than expected until the next timer tick.

## Note on JIT / OAuth tokens

The concern raised in #22233 about token freshness and expired claims is valid but belongs in a different `TokenProvider` subclass designed for JIT/OAuth flows, not in `RateLimitProvider` which is designed solely for fixed-key rate limiting.

## Changes

- `RateLimitProvider\`1.mustache`: `BoundedChannelFullMode.DropOldest` → `BoundedChannelFullMode.DropWrite`
- Regenerated all affected C# GenericHost samples


<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
