### PR TITLE
[core] Restore sibling example for allOf with a single $ref (#23335)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4307,6 +4307,13 @@ public class DefaultCodegen implements CodegenConfig {
             if (original.getTitle() != null) {
                 property.setTitle(original.getTitle());
             }
+            // the example was computed above against the inner (allOf/$ref) schema, which does
+            // not carry the example declared as a sibling of the allOf/$ref. Restore it here so
+            // that e.g. `allOf: [ $ref ]` with a sibling `example` keeps the declared example
+            // instead of falling back to the literal "null".
+            if (original.getExample() != null) {
+                property.example = toExampleValue(original);
+            }
         }
 
         // override defaultValue if it's not set and defaultToEmptyContainer is set

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -2106,6 +2106,22 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void testAllOfSingleRefSiblingExample() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/property-title.yaml");
+        new InlineModelResolver().flatten(openAPI);
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        final Map testProperties = Collections.unmodifiableMap(openAPI.getComponents().getSchemas().get("ModelWithTitledProperties").getProperties());
+
+        // a plain property keeps its example
+        assertEquals("Simple-Property-Example", codegen.fromProperty("simpleProperty", (Schema) testProperties.get("simpleProperty")).example);
+        // an `allOf: [ $ref ]` property must keep the example declared as a sibling of the allOf,
+        // instead of falling back to the literal "null" computed against the inner $ref schema
+        assertEquals("Ref-Property-Example", codegen.fromProperty("refProperty", (Schema) testProperties.get("refProperty")).example);
+    }
+
+    @Test
     public void testDeprecatedRef() {
         final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/model-deprecated.yaml");
         new InlineModelResolver().flatten(openAPI);

--- a/modules/openapi-generator/src/test/resources/3_0/property-title.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/property-title.yaml
@@ -19,9 +19,11 @@ components:
         simpleProperty:
           type: string
           title: Simple-Property-Title
+          example: Simple-Property-Example
         refProperty:
           type: string
           title: Ref-Property-Title
+          example: Ref-Property-Example
           allOf:
             - $ref: '#/components/schemas/RefObject'
       type: object


### PR DESCRIPTION
Fixes #23335

### Problem

When a model property is declared as `allOf` with a **single** `$ref` and has a sibling `example`, the generated `@Schema` annotation emits the literal string `example = "null"` instead of the declared example. This worked correctly in 6.x.

Example spec:

```yaml
status:
  allOf:
    - $ref: '#/components/schemas/StatusEnum'
  example: ACTIVE
  description: Current status of the item.
```

Generated (kotlin-spring), before:

```kotlin
@Schema(example = "null", description = "Current status of the item.")
@get:JsonProperty("status") val status: StatusEnum? = null
```

### Root cause

In `DefaultCodegen.fromProperty(...)`, when a property is `allOf` with a single sub-schema, the working schema `p` is reassigned to the inner (`$ref`) schema and the outer schema is kept as `original`. `property.example` is then computed via `toExampleValue(p)` against the **inner** schema, which has no example, so `toExampleValue` returns the literal `"null"`.

The later *"restore original schema"* block re-applies the outer schema's `nullable`, `description`, `min/max`, `title`, etc., but it never restores the `example`. (The `default` value is unaffected because it is recomputed *after* that block against `original`.)

### Fix

Restore the example from the `original` (outer) schema in the same restore block, mirroring the existing handling of the other sibling attributes:

```java
if (original.getExample() != null) {
    property.example = toExampleValue(original);
}
```

The change is in `DefaultCodegen`, so all generators that rely on `property.example` (java, kotlin, spring, …) benefit.

### Tests

- Added `DefaultCodegenTest#testAllOfSingleRefSiblingExample`, reusing `3_0/property-title.yaml` (extended with sibling `example` values). It asserts the `allOf: [ $ref ]` property keeps `Ref-Property-Example`. Verified it **fails without the fix** (`expected: <Ref-Property-Example> but was: <null>`) and passes with it.
- `DefaultCodegenTest` (160), `JavaClientCodegenTest` (238) and `KotlinSpringServerCodegenTest` (229) all pass.
- No committed samples change: the only sample-input specs matching the `allOf:[single $ref] + sibling example` pattern are unit-test resources (`property-title.yaml`, `allof_primitive.yaml`), neither of which drives a `bin/configs` sample.

Verification done: reproduced the `example = "null"` symptom on master, confirmed root cause in `DefaultCodegen.fromProperty` restore block, added a failing-then-passing regression test, ran the affected codegen test classes, and checked there is no in-flight PR for this issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression where `allOf: [ $ref ]` properties ignored their sibling `example`, generating `example = "null"`. Restores the declared example in generated schemas across Java/Kotlin/Spring (Fixes #23335).

- **Bug Fixes**
  - Reapply the outer schema’s `example` in `DefaultCodegen#fromProperty` when handling `allOf: [ $ref ]`.
  - Added regression test `testAllOfSingleRefSiblingExample` and extended `3_0/property-title.yaml` with examples.

<sup>Written for commit 31b695f86092eb5510654d9467d2ee09c82ee01a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

