### PR TITLE
[python] serialize structured YAML bodies

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/rest.mustache
@@ -167,12 +167,20 @@ class RESTClientObject:
             # For `POST`, `PUT`, `PATCH`, `OPTIONS`, `DELETE`
             if method in ['POST', 'PUT', 'PATCH', 'OPTIONS', 'DELETE']:
 
-                # no content type provided or payload is json
                 content_type = headers.get('Content-Type')
-                if (
+                is_json = (
                     not content_type
                     or re.search('json', content_type, re.IGNORECASE)
-                ):
+                )
+                # JSON is valid YAML 1.2, so structured YAML bodies can use
+                # the existing JSON serializer:
+                # https://yaml.org/spec/1.2.2/#13-relation-to-json
+                is_structured_yaml = (
+                    content_type
+                    and re.search('yaml', content_type, re.IGNORECASE)
+                    and not isinstance(body, (str, bytes))
+                )
+                if is_json or is_structured_yaml:
                     request_body = None
                     if body is not None:
                         request_body = json.dumps(body{{#setEnsureAsciiToFalse}}, ensure_ascii=False{{/setEnsureAsciiToFalse}})

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/rest.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/rest.py
@@ -177,12 +177,20 @@ class RESTClientObject:
             # For `POST`, `PUT`, `PATCH`, `OPTIONS`, `DELETE`
             if method in ['POST', 'PUT', 'PATCH', 'OPTIONS', 'DELETE']:
 
-                # no content type provided or payload is json
                 content_type = headers.get('Content-Type')
-                if (
+                is_json = (
                     not content_type
                     or re.search('json', content_type, re.IGNORECASE)
-                ):
+                )
+                # JSON is valid YAML 1.2, so structured YAML bodies can use
+                # the existing JSON serializer:
+                # https://yaml.org/spec/1.2.2/#13-relation-to-json
+                is_structured_yaml = (
+                    content_type
+                    and re.search('yaml', content_type, re.IGNORECASE)
+                    and not isinstance(body, (str, bytes))
+                )
+                if is_json or is_structured_yaml:
                     request_body = None
                     if body is not None:
                         request_body = json.dumps(body, ensure_ascii=False)

--- a/samples/client/echo_api/python/openapi_client/rest.py
+++ b/samples/client/echo_api/python/openapi_client/rest.py
@@ -177,12 +177,20 @@ class RESTClientObject:
             # For `POST`, `PUT`, `PATCH`, `OPTIONS`, `DELETE`
             if method in ['POST', 'PUT', 'PATCH', 'OPTIONS', 'DELETE']:
 
-                # no content type provided or payload is json
                 content_type = headers.get('Content-Type')
-                if (
+                is_json = (
                     not content_type
                     or re.search('json', content_type, re.IGNORECASE)
-                ):
+                )
+                # JSON is valid YAML 1.2, so structured YAML bodies can use
+                # the existing JSON serializer:
+                # https://yaml.org/spec/1.2.2/#13-relation-to-json
+                is_structured_yaml = (
+                    content_type
+                    and re.search('yaml', content_type, re.IGNORECASE)
+                    and not isinstance(body, (str, bytes))
+                )
+                if is_json or is_structured_yaml:
                     request_body = None
                     if body is not None:
                         request_body = json.dumps(body)

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/rest.py
@@ -176,12 +176,20 @@ class RESTClientObject:
             # For `POST`, `PUT`, `PATCH`, `OPTIONS`, `DELETE`
             if method in ['POST', 'PUT', 'PATCH', 'OPTIONS', 'DELETE']:
 
-                # no content type provided or payload is json
                 content_type = headers.get('Content-Type')
-                if (
+                is_json = (
                     not content_type
                     or re.search('json', content_type, re.IGNORECASE)
-                ):
+                )
+                # JSON is valid YAML 1.2, so structured YAML bodies can use
+                # the existing JSON serializer:
+                # https://yaml.org/spec/1.2.2/#13-relation-to-json
+                is_structured_yaml = (
+                    content_type
+                    and re.search('yaml', content_type, re.IGNORECASE)
+                    and not isinstance(body, (str, bytes))
+                )
+                if is_json or is_structured_yaml:
                     request_body = None
                     if body is not None:
                         request_body = json.dumps(body)

--- a/samples/openapi3/client/petstore/python/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/rest.py
@@ -176,12 +176,20 @@ class RESTClientObject:
             # For `POST`, `PUT`, `PATCH`, `OPTIONS`, `DELETE`
             if method in ['POST', 'PUT', 'PATCH', 'OPTIONS', 'DELETE']:
 
-                # no content type provided or payload is json
                 content_type = headers.get('Content-Type')
-                if (
+                is_json = (
                     not content_type
                     or re.search('json', content_type, re.IGNORECASE)
-                ):
+                )
+                # JSON is valid YAML 1.2, so structured YAML bodies can use
+                # the existing JSON serializer:
+                # https://yaml.org/spec/1.2.2/#13-relation-to-json
+                is_structured_yaml = (
+                    content_type
+                    and re.search('yaml', content_type, re.IGNORECASE)
+                    and not isinstance(body, (str, bytes))
+                )
+                if is_json or is_structured_yaml:
                     request_body = None
                     if body is not None:
                         request_body = json.dumps(body)

--- a/samples/openapi3/client/petstore/python/tests/test_rest.py
+++ b/samples/openapi3/client/petstore/python/tests/test_rest.py
@@ -1,8 +1,53 @@
+import json
 import os
 import unittest
 from unittest.mock import Mock, patch
 
 import petstore_api
+from petstore_api.rest import RESTClientObject
+
+
+class TestYamlRequestBodies(unittest.TestCase):
+    def setUp(self):
+        self.rest_client = RESTClientObject(
+            petstore_api.Configuration(proxy="")
+        )
+        self.request_mock = Mock(
+            return_value=Mock(status=200, reason="OK")
+        )
+        self.rest_client.pool_manager = Mock(request=self.request_mock)
+
+    def test_structured_yaml_body_is_json_encoded(self):
+        body = {"apiVersion": "example.com/v1", "kind": "Example"}
+        for content_type in (
+            "application/yaml",
+            "application/apply-patch+yaml; charset=utf-8",
+        ):
+            with self.subTest(content_type=content_type):
+                self.request_mock.reset_mock()
+                self.rest_client.request(
+                    "PATCH",
+                    "https://api.example",
+                    headers={"Content-Type": content_type},
+                    body=body,
+                )
+
+                self.request_mock.assert_called_once()
+                request_body = self.request_mock.call_args.kwargs["body"]
+                self.assertEqual(json.loads(request_body), body)
+
+    def test_serialized_yaml_body_is_passed_through(self):
+        body = "apiVersion: example.com/v1\nkind: Example\n"
+        self.rest_client.request(
+            "PATCH",
+            "https://api.example",
+            headers={"Content-Type": "application/yaml"},
+            body=body,
+        )
+
+        self.request_mock.assert_called_once()
+        request_body = self.request_mock.call_args.kwargs["body"]
+        self.assertEqual(request_body, body)
 
 
 class TestMultipleResponseTypes(unittest.TestCase):


### PR DESCRIPTION
The synchronous Python client only serializes structured request bodies
when `Content-Type` contains `json`. Kubernetes server-side apply sends
dictionary bodies as `application/apply-patch+yaml`, so those requests
reach the unsupported-content fallback. The downstream client has
carried a special case since
[kubernetes-client/python 5529dedc][downstream].

[JSON is valid YAML 1.2][yaml]. Use the existing JSON serializer for
structured YAML bodies while preserving pass-through for serialized
`str` and `bytes` values. This covers both standard YAML media types and
`+yaml` structured suffixes.

Fixes #24083.

[downstream]: https://github.com/kubernetes-client/python/commit/5529dedcb35fd076301b8c6c894647aca593916c
[yaml]: https://yaml.org/spec/1.2.2/#13-relation-to-json

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize structured YAML request bodies in the Python REST client using the existing JSON encoder to avoid unsupported-content fallbacks. Supports `application/yaml` and `+yaml` types while preserving pass-through for `str`/`bytes`.

- **Bug Fixes**
  - JSON-encode non-string bodies when `Content-Type` includes `yaml` (e.g., `application/yaml`, `application/apply-patch+yaml; charset=utf-8`), while keeping pass-through for pre-serialized YAML.
  - Updated `rest.mustache` and Python samples; added unit tests in the petstore client to verify JSON encoding for dicts and pass-through for string bodies.

<sup>Written for commit a5209c1d9bcd2709bab0206df389c26aeb8c5cb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

