### PR TITLE
update ujson to newer version (python-fastapi)

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-fastapi/requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python-fastapi/requirements.mustache
@@ -28,7 +28,7 @@ requests==2.33.0
 Rx==1.6.1
 starlette==0.49.1
 typing-extensions==4.13.2
-ujson==5.12.1
+ujson==5.13.0
 urllib3==2.7.0
 uvicorn==0.13.4
 uvloop==0.21.0

--- a/samples/server/petstore/python-fastapi/requirements.txt
+++ b/samples/server/petstore/python-fastapi/requirements.txt
@@ -28,7 +28,7 @@ requests==2.33.0
 Rx==1.6.1
 starlette==0.49.1
 typing-extensions==4.13.2
-ujson==5.12.1
+ujson==5.13.0
 urllib3==2.7.0
 uvicorn==0.13.4
 uvloop==0.21.0


### PR DESCRIPTION
to close https://github.com/OpenAPITools/openapi-generator/pull/24085

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `ujson` to 5.13.0 in the `python-fastapi` generator and sample to pick up bug fixes and improved compatibility. Bumps the version in the requirements template and sample `requirements.txt`.

<sup>Written for commit 17461245d4c106ac07e0cd169c7b0d0f47789315. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

