### PR TITLE
[JAVA] [SPRING] #24087 add option to pass authorization token in a method parameter for Java Spring Cloud

### DIFF
--- a/docs/generators/java-camel.md
+++ b/docs/generators/java-camel.md
@@ -121,6 +121,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |useJspecify|Use Jspecify for null checks| |false|
 |useOneOfInterfaces|whether to use a java interface to describe a set of oneOf options, where each option is a class that implements the interface| |true|
 |useOptional|Use Optional container for optional parameters| |false|
+|useParamForAuthorization|Use method parameter instead of interceptor to pass authorization token to request. Requires library=spring-cloud.| |false|
 |useResponseEntity|Use the `ResponseEntity` type to wrap return values of generated API methods. If disabled, method are annotated using a `@ResponseStatus` annotation, which has the status of the first response declared in the Api definition| |true|
 |useSealed|Whether to generate sealed model interfaces and classes| |false|
 |useSpringBoot3|Generate code and provide dependencies for use with Spring Boot &ge; 3 (use jakarta instead of javax in imports). Enabling this option will also enable `useJakartaEe`.| |true|

--- a/docs/generators/spring.md
+++ b/docs/generators/spring.md
@@ -113,6 +113,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |useJakartaEe|whether to use Jakarta EE namespace instead of javax| |false|
 |useJspecify|Use Jspecify for null checks| |false|
 |useOneOfInterfaces|whether to use a java interface to describe a set of oneOf options, where each option is a class that implements the interface| |true|
+|useParamForAuthorization| Pass authorization token in a method param. Available only with Spring Cloud.| |false|
 |useOptional|Use Optional container for optional parameters| |false|
 |useResponseEntity|Use the `ResponseEntity` type to wrap return values of generated API methods. If disabled, method are annotated using a `@ResponseStatus` annotation, which has the status of the first response declared in the Api definition| |true|
 |useSealed|Whether to generate sealed model interfaces and classes| |false|

--- a/docs/generators/spring.md
+++ b/docs/generators/spring.md
@@ -113,8 +113,8 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |useJakartaEe|whether to use Jakarta EE namespace instead of javax| |false|
 |useJspecify|Use Jspecify for null checks| |false|
 |useOneOfInterfaces|whether to use a java interface to describe a set of oneOf options, where each option is a class that implements the interface| |true|
-|useParamForAuthorization| Pass authorization token in a method param. Available only with Spring Cloud.| |false|
 |useOptional|Use Optional container for optional parameters| |false|
+|useParamForAuthorization|Use method parameter instead of interceptor to pass authorization token to request. Requires library=spring-cloud.| |false|
 |useResponseEntity|Use the `ResponseEntity` type to wrap return values of generated API methods. If disabled, method are annotated using a `@ResponseStatus` annotation, which has the status of the first response declared in the Api definition| |true|
 |useSealed|Whether to generate sealed model interfaces and classes| |false|
 |useSpringBoot3|Generate code and provide dependencies for use with Spring Boot &ge; 3 (use jakarta instead of javax in imports). Enabling this option will also enable `useJakartaEe`.| |true|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -350,7 +350,7 @@ public class SpringCodegen extends AbstractJavaCodegen
         );
         cliOptions.add(CliOption.newBoolean(USE_JSPECIFY, "Use Jspecify for null checks", useJspecify));
         cliOptions.add(CliOption.newString(CLIENT_REGISTRATION_ID, "Client registration ID for OAuth2 in Spring HTTP Interface (@ClientRegistrationId annotation). Requires library=spring-http-interface and useSpringBoot4=true (Spring Security 7)."));
-        cliOptions.add(CliOption.newString(USE_PARAM_FOR_AUTHORIZATION, "Create parameter to pass authorisation header to request"));
+        cliOptions.add(CliOption.newBoolean(USE_PARAM_FOR_AUTHORIZATION, "Use method parameter instead of interceptor to pass authorization token to request. Requires library=spring-cloud.", false));
         supportedLibraries.put(SPRING_BOOT, "Spring-boot Server application.");
         supportedLibraries.put(SPRING_CLOUD_LIBRARY,
                 "Spring-Cloud-Feign client with Spring-Boot auto-configured settings.");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -30,6 +30,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.http.HttpHeaders;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.languages.features.*;
 import org.openapitools.codegen.meta.features.*;
@@ -123,6 +124,7 @@ public class SpringCodegen extends AbstractJavaCodegen
     public static final String GENERATE_PAGEABLE_CONSTRAINT_VALIDATION = "generatePageableConstraintValidation";
     public static final String SUBSTITUTE_GENERIC_PAGED_MODEL = "substituteGenericPagedModel";
     public static final String CLIENT_REGISTRATION_ID = "clientRegistrationId";
+    public static final String USE_PARAM_FOR_AUTHORIZATION = "useParamForAuthorization";
 
     @Getter
     public enum RequestMappingMode {
@@ -200,6 +202,7 @@ public class SpringCodegen extends AbstractJavaCodegen
     @Getter @Setter
     protected String clientRegistrationId = null;
     @Setter protected boolean useEnumValueInterface = false;
+    @Setter protected boolean useAuthParam = false;
     private String valuedEnumClassName = "ValuedEnum";
 
     // Map from schema name to detected paged-model info (populated when substituteGenericPagedModel=true)
@@ -347,6 +350,7 @@ public class SpringCodegen extends AbstractJavaCodegen
         );
         cliOptions.add(CliOption.newBoolean(USE_JSPECIFY, "Use Jspecify for null checks", useJspecify));
         cliOptions.add(CliOption.newString(CLIENT_REGISTRATION_ID, "Client registration ID for OAuth2 in Spring HTTP Interface (@ClientRegistrationId annotation). Requires library=spring-http-interface and useSpringBoot4=true (Spring Security 7)."));
+        cliOptions.add(CliOption.newString(USE_PARAM_FOR_AUTHORIZATION, "Create parameter to pass authorisation header to request"));
         supportedLibraries.put(SPRING_BOOT, "Spring-boot Server application.");
         supportedLibraries.put(SPRING_CLOUD_LIBRARY,
                 "Spring-Cloud-Feign client with Spring-Boot auto-configured settings.");
@@ -617,6 +621,12 @@ public class SpringCodegen extends AbstractJavaCodegen
         convertPropertyToBooleanAndWriteBack(SUBSTITUTE_GENERIC_PAGED_MODEL, this::setSubstituteGenericPagedModel);
         convertPropertyToBooleanAndWriteBack(CodegenConstants.USE_ENUM_VALUE_INTERFACE, this::setUseEnumValueInterface);
 
+        convertPropertyToBooleanAndWriteBack(USE_PARAM_FOR_AUTHORIZATION, this::setUseAuthParam);
+
+        if(useAuthParam && !SPRING_CLOUD_LIBRARY.equals(library)){
+            throw new IllegalArgumentException(USE_PARAM_FOR_AUTHORIZATION + " is only available with Spring Cloud");
+        }
+
         if (SPRING_BOOT.equals(library)) {
             convertPropertyToBooleanAndWriteBack(AUTO_X_SPRING_PAGINATED, this::setAutoXSpringPaginated);
             convertPropertyToBooleanAndWriteBack(GENERATE_SORT_VALIDATION, this::setGenerateSortValidation);
@@ -672,9 +682,14 @@ public class SpringCodegen extends AbstractJavaCodegen
             }
             if (SPRING_CLOUD_LIBRARY.equals(library)) {
 
-                supportingFiles.add(new SupportingFile("apiKeyRequestInterceptor.mustache",
-                        (sourceFolder + File.separator + configPackage).replace(".", java.io.File.separator),
-                        "ApiKeyRequestInterceptor.java"));
+                if (!useAuthParam) {
+                    supportingFiles.add(new SupportingFile("apiKeyRequestInterceptor.mustache",
+                            (sourceFolder + File.separator + configPackage).replace(".", java.io.File.separator),
+                            "ApiKeyRequestInterceptor.java"));
+                    supportingFiles.add(new SupportingFile("clientConfiguration.mustache",
+                            (sourceFolder + File.separator + configPackage).replace(".", java.io.File.separator),
+                            "ClientConfiguration.java"));
+                }
 
                 if (ProcessUtils.hasOAuthMethods(openAPI)) {
                     supportingFiles.add(new SupportingFile("clientPropertiesConfiguration.mustache",
@@ -682,9 +697,6 @@ public class SpringCodegen extends AbstractJavaCodegen
                             "ClientPropertiesConfiguration.java"));
                 }
 
-                supportingFiles.add(new SupportingFile("clientConfiguration.mustache",
-                        (sourceFolder + File.separator + configPackage).replace(".", java.io.File.separator),
-                        "ClientConfiguration.java"));
 
                 apiTemplateFiles.put("apiClient.mustache", "Client.java");
                 if (!additionalProperties.containsKey(SINGLE_CONTENT_TYPES)) {
@@ -981,6 +993,19 @@ public class SpringCodegen extends AbstractJavaCodegen
         if (operations != null) {
             final List<CodegenOperation> ops = operations.getOperation();
             for (final CodegenOperation operation : ops) {
+                if (useAuthParam && operation.authMethods != null && operation.authMethods.stream()
+                        .anyMatch(cs -> cs.isBasic)) {
+                    CodegenParameter parameter = new CodegenParameter();
+                    parameter.isString = true;
+                    parameter.isHeaderParam = true;
+                    parameter.required = true;
+                    parameter.dataType = "String";
+                    parameter.paramName = "auth";
+                    parameter.baseName = HttpHeaders.AUTHORIZATION;
+                    parameter.description = "authorization";
+                    operation.headerParams.add(parameter);
+                    operation.allParams.add(parameter);
+                }
                 final List<CodegenResponse> responses = operation.responses;
                 if (responses != null) {
                     for (final CodegenResponse resp : responses) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -8132,4 +8132,27 @@ public class SpringCodegenTest {
         JavaFileAssert.assertThat(files.get("MyObject.java"))
                 .assertProperty("optionalRef").withType("JsonNullable<com.example.ExternalModel>");
     }
+
+    @Test
+    void shouldUseHeaderAuthParam() throws IOException {
+        Map<String, File> files = generateFromContract(
+                "src/test/resources/2_0/minimalBasicAuth.yaml",
+                SPRING_CLOUD_LIBRARY,
+                Map.of(USE_PARAM_FOR_AUTHORIZATION, "true"));
+
+        JavaFileAssert.assertThat(files.get("SomethingApi.java"))
+                .assertMethod("somethingGet", "String")
+                .assertParameter("auth")
+                .assertParameterAnnotations()
+                .containsWithName("RequestHeader");
+    }
+
+    @Test(expectedExceptions = {IllegalArgumentException.class},
+            expectedExceptionsMessageRegExp = "useParamForAuthorization is only available with Spring Cloud")
+    void useHeaderAuthParamShouldRequireSpringCloud() throws IOException {
+        generateFromContract(
+                "src/test/resources/2_0/minimalBasicAuth.yaml",
+                SPRING_BOOT,
+                Map.of(USE_PARAM_FOR_AUTHORIZATION, "true"));
+    }
 }

--- a/modules/openapi-generator/src/test/resources/2_0/minimalBasicAuth.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/minimalBasicAuth.yaml
@@ -1,0 +1,26 @@
+swagger: '2.0'
+info:
+  version: ''
+  title: minimalBasicAuth
+  contact: {}
+host: www.example.com
+basePath: /
+schemes:
+  - https
+consumes:
+  - application/json
+produces:
+  - application/json
+securityDefinitions:
+  basicAuth:
+    type: basic
+
+paths:
+  /something:
+    get:
+      # To apply Basic auth to an individual operation:
+      security:
+        - basicAuth: []
+      responses:
+        200:
+          description: OK (successfully authenticated)


### PR DESCRIPTION
this fixes #24087 

This change adds an option `useParamForAuthorization` to the spring-cloud generator. When said option is enabled generator won't create Interceptor nor ClientConfiguration files. Instead, for every method that requires any kind of basic authorization it adds an extra parameter to provide an authorization token. E.g.

```
    ResponseEntity<String> somethingGet(
        @NotNull
        @Parameter(name = "Authorization", description = "authorization", required = true, in = ParameterIn.HEADER)
        @RequestHeader(value = "Authorization", required = true) 
        String auth
    );
```

### 

Dear technical committee, please kindly review my PR
@cachescrubber @welshm @MelleD  @atextor  @manedev79  @javisst @borsch  @banlevente @Zomzog @martin-mfg

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `useParamForAuthorization` to the Spring Cloud generator to pass auth tokens via method parameters instead of an interceptor. Fixes #24087.

- **New Features**
  - New option: `useParamForAuthorization` (requires `spring-cloud`).
  - When enabled, methods that use Basic auth get a required `String auth` parameter annotated with `@RequestHeader("Authorization")`.
  - Skips generating `ApiKeyRequestInterceptor` and `ClientConfiguration`; OAuth client properties stay as-is.
  - Updated docs (`spring.md`, `java-camel.md`) and added tests for header param and library restriction.

<sup>Written for commit c3d0b00869efa9417dad83afb524924abfeaa3a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

