### PR TITLE
Update python pydantic v1 workflow to test with supported python versions

### DIFF
--- a/.github/workflows/samples-python-pydantic-v1-client-echo-api.yaml
+++ b/.github/workflows/samples-python-pydantic-v1-client-echo-api.yaml
@@ -17,11 +17,11 @@ jobs:
           # clients
           - samples/client/echo_api/python-pydantic-v1/
         python-version:
-          - "3.8"
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
+          - "3.14"
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6

--- a/.github/workflows/samples-python-pydantic-v1-client-echo-api.yaml
+++ b/.github/workflows/samples-python-pydantic-v1-client-echo-api.yaml
@@ -21,7 +21,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
-          - "3.14"
+          #- "3.14"
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6

--- a/.github/workflows/samples-python-pydantic-v1-petstore.yaml
+++ b/.github/workflows/samples-python-pydantic-v1-petstore.yaml
@@ -15,10 +15,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
+          - "3.14"
         sample:
           - samples/openapi3/client/petstore/python-pydantic-v1-aiohttp
           - samples/openapi3/client/petstore/python-pydantic-v1


### PR DESCRIPTION
update python pydantic v1 workflow to test with supported python versions

for https://github.com/OpenAPITools/openapi-generator/pull/24061

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CI workflows for `python-pydantic-v1` samples to run on supported Python versions. Drop 3.8/3.9; add 3.13 in both; enable 3.14 in `samples-python-pydantic-v1-petstore.yaml` and keep it commented in `samples-python-pydantic-v1-client-echo-api.yaml`.

<sup>Written for commit 682ccd699cca44e42219306cb3ddbec83b710fa1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



