### PR TITLE
[python] fix uniqueItems validation tests

### DIFF
--- a/samples/openapi3/client/petstore/python-lazyImports/tests/test_api_validation.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/tests/test_api_validation.py
@@ -40,12 +40,6 @@ class ApiExceptionTests(unittest.TestCase):
         self.pet.category = self.category
         self.pet.tags = [self.tag]
 
-    def test_set_param_validation(self):
-        try:
-            self.pet_api.find_pets_by_tags(["a", "a"])
-        except ValidationError as e:
-            self.assertTrue("the list has duplicated items" in str(e))
-
     def test_required_param_validation(self):
         try:
             self.pet_api.get_pet_by_id()  # type: ignore

--- a/samples/openapi3/client/petstore/python-pydantic-v1/tests/test_api_validation.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/tests/test_api_validation.py
@@ -47,10 +47,10 @@ class ApiExceptionTests(unittest.TestCase):
         self.pet.tags = [self.tag]
 
     def test_set_param_validation(self):
-        try:
+        with self.assertRaisesRegex(
+            ValidationError, "the list has duplicated items"
+        ):
             self.pet_api.find_pets_by_tags(["a", "a"])
-        except ValidationError as e:
-            self.assertTrue("the list has duplicated items" in str(e))
 
     def test_required_param_validation(self):
         try:

--- a/samples/openapi3/client/petstore/python/tests/test_api_validation.py
+++ b/samples/openapi3/client/petstore/python/tests/test_api_validation.py
@@ -40,12 +40,6 @@ class ApiExceptionTests(unittest.TestCase):
         self.pet.category = self.category
         self.pet.tags = [self.tag]
 
-    def test_set_param_validation(self):
-        try:
-            self.pet_api.find_pets_by_tags(["a", "a"])
-        except ValidationError as e:
-            self.assertTrue("the list has duplicated items" in str(e))
-
     def test_required_param_validation(self):
         try:
             self.pet_api.get_pet_by_id()  # type: ignore


### PR DESCRIPTION
Pydantic 2 removed `conlist(unique_items=True)`. The migration in
04fa53b6 kept OpenAPI arrays as lists because sets would lose ordering
and complicate JSON serialization, but left these tests behind.

The tests do not require an exception, so they normally pass after
making a Petstore request. They fail when that request produces an
unrelated response validation error. Remove them from the two Pydantic 2
samples; the Pydantic 1 sample still exercises the supported validation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove duplicate-item validation tests from Petstore samples on `python` and `python-lazyImports` (Pydantic v2) to align with removal of `conlist(unique_items=True)` and eliminate flaky failures. In `python-pydantic-v1`, require the expected ValidationError with `assertRaisesRegex("the list has duplicated items")` to prevent silent regressions.

<sup>Written for commit cb5bb552f7dd650c0cceb89c7a24db4476c5c7ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

