### PR TITLE
[python] run Petstore CI for lazy imports

### DIFF
--- a/.github/workflows/samples-python-petstore.yaml
+++ b/.github/workflows/samples-python-petstore.yaml
@@ -6,6 +6,7 @@ on:
       - samples/openapi3/client/petstore/python-aiohttp/**
       - samples/openapi3/client/petstore/python-httpx/**
       - samples/openapi3/client/petstore/python/**
+      - samples/openapi3/client/petstore/python-lazyImports/**
       - .github/workflows/samples-python-petstore.yaml
 
 jobs:


### PR DESCRIPTION
The Python Petstore workflow tests `python-lazyImports` in its matrix,
but its pull-request path filter does not include that directory. A
change confined to the lazy-import sample therefore receives no Python
Petstore coverage.

Add the missing path so the workflow runs whenever that sample changes.