### PR TITLE
[julia-server] Use req.headers for HTTP.jl 2.x compatibility

### DIFF
--- a/modules/openapi-generator/src/main/resources/julia-server/api.mustache
+++ b/modules/openapi-generator/src/main/resources/julia-server/api.mustache
@@ -9,7 +9,7 @@ function {{operationId}}_read(handler)
         openapi_params["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"] = OpenAPI.Servers.to_param({{dataType}}, path_params, "{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}", {{#required}}required=true, {{/required}}{{#isListContainer}}collection_format="{{collectionFormat}}", {{/isListContainer}}){{/pathParams}}{{/hasPathParams}}{{#hasQueryParams}}
         query_params = HTTP.queryparams(URIs.URI(req.target)){{#queryParams}}
         openapi_params["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"] = OpenAPI.Servers.to_param({{dataType}}, query_params, "{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}", {{#required}}required=true, {{/required}}style="{{style}}", is_explode={{isExplode}}{{#isListContainer}},collection_format="{{collectionFormat}}"{{/isListContainer}}){{/queryParams}}{{/hasQueryParams}}{{#hasHeaderParams}}
-        headers = Dict{String,String}(HTTP.headers(req)){{#headerParams}}
+        headers = Dict{String,String}(req.headers){{#headerParams}}
         openapi_params["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"] = OpenAPI.Servers.to_param({{dataType}}, headers, "{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}", {{#required}}required=true, {{/required}}{{#isListContainer}}collection_format="{{collectionFormat}}", {{/isListContainer}}){{/headerParams}}{{/hasHeaderParams}}{{#hasBodyParam}}{{#bodyParams}}
         openapi_params["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"] = OpenAPI.Servers.to_param_type({{dataType}}, String(req.body)){{/bodyParams}}{{/hasBodyParam}}{{#hasFormParams}}
         ismultipart = {{#isMultipart}}true{{/isMultipart}}{{^isMultipart}}false{{/isMultipart}}

--- a/samples/server/petstore/julia/src/apis/api_FakeApi.jl
+++ b/samples/server/petstore/julia/src/apis/api_FakeApi.jl
@@ -5,7 +5,7 @@
 function uuid_default_value_read(handler)
     function uuid_default_value_read_handler(req::HTTP.Request)
         openapi_params = Dict{String,Any}()
-        headers = Dict{String,String}(HTTP.headers(req))
+        headers = Dict{String,String}(req.headers)
         openapi_params["uuid_parameter"] = OpenAPI.Servers.to_param(String, headers, "uuid_parameter", required=true, )
         req.context[:openapi_params] = openapi_params
 

--- a/samples/server/petstore/julia/src/apis/api_PetApi.jl
+++ b/samples/server/petstore/julia/src/apis/api_PetApi.jl
@@ -47,7 +47,7 @@ function delete_pet_read(handler)
         openapi_params = Dict{String,Any}()
         path_params = HTTP.getparams(req)
         openapi_params["petId"] = OpenAPI.Servers.to_param(Int64, path_params, "petId", required=true, )
-        headers = Dict{String,String}(HTTP.headers(req))
+        headers = Dict{String,String}(req.headers)
         openapi_params["api_key"] = OpenAPI.Servers.to_param(String, headers, "api_key", )
         req.context[:openapi_params] = openapi_params
 


### PR DESCRIPTION
HTTP.jl 2.x removed the single-arg HTTP.headers(req) accessor, so generated server read-handlers with header params throw a MethodError (500) under HTTP 2. Use req.headers instead, which works on both HTTP.jl 1.x and 2.x.

Regenerated the julia-server petstore sample to match.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch generated Julia server header parsing to req.headers to restore compatibility with `HTTP.jl` 2.x and prevent 500 MethodErrors when handlers read header params. Remains compatible with `HTTP.jl` 1.x; regenerated julia-server petstore samples to match.

<sup>Written for commit 5abb02627584b71f66556ccdfee0016ff220c603. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

