### PR TITLE
[python] fix regex validator for date-time fields with a pattern

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_generic.mustache
@@ -53,10 +53,8 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
         {{/isNullable}}
         {{/required}}
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"{{{.}}}", value{{#vendorExtensions.x-modifiers}} ,re.{{{.}}}{{/vendorExtensions.x-modifiers}}):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"{{{.}}}", s{{#vendorExtensions.x-modifiers}} ,re.{{{.}}}{{/vendorExtensions.x-modifiers}}):
             raise ValueError(r"must validate the regular expression {{{vendorExtensions.x-pattern}}}")
         return value
     {{/vendorExtensions.x-regex}}

--- a/modules/openapi-generator/src/main/resources/python/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_generic.mustache
@@ -53,6 +53,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
         {{/isNullable}}
         {{/required}}
+        # match against the ISO string of parsed values (e.g. datetime) without mutating value
         s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
         if not re.match(r"{{{.}}}", s{{#vendorExtensions.x-modifiers}} ,re.{{{.}}}{{/vendorExtensions.x-modifiers}}):
             raise ValueError(r"must validate the regular expression {{{vendorExtensions.x-pattern}}}")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
@@ -670,6 +670,17 @@ public class PythonClientCodegenTest {
         assertFileContains(p, "from pydantic import BaseModel, ConfigDict, field_validator");
     }
 
+    @Test(description = "date-time property with pattern should coerce via isoformat() before regex match")
+    public void testDatetimeWithPatternUsesIsoformat() throws IOException {
+        final DefaultCodegen codegen = new PythonClientCodegen();
+        final String outputPath = generateFiles(codegen, "src/test/resources/bugs/issue_datetime_with_pattern.yaml");
+        final Path p = Paths.get(outputPath + "openapi_client/models/datetime_with_pattern.py");
+
+        assertFileExists(p);
+        assertFileContains(p, "s = value if isinstance(value, str) else value.isoformat() if hasattr(value, \"isoformat\") else str(value)");
+        TestUtils.assertFileNotContains(p, "return s");
+    }
+
     @Test(description = "Verify default buildSystem uses setuptools")
     public void testDefaultBuildSystemSetuptools() throws IOException {
         File output = Files.createTempDirectory("test").toFile().getCanonicalFile();

--- a/modules/openapi-generator/src/test/resources/bugs/issue_datetime_with_pattern.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/issue_datetime_with_pattern.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.0
+info:
+  title: Test date-time with pattern
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    DatetimeWithPattern:
+      type: object
+      properties:
+        created_at:
+          type: string
+          format: date-time
+          pattern: "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})$"

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/format_test.py
@@ -56,10 +56,8 @@ class FormatTest(BaseModel):
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"[a-z]", value ,re.IGNORECASE):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"[a-z]", s ,re.IGNORECASE):
             raise ValueError(r"must validate the regular expression /[a-z]/i")
         return value
 
@@ -69,10 +67,8 @@ class FormatTest(BaseModel):
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"this is \"something\"", value):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"this is \"something\"", s):
             raise ValueError(r"must validate the regular expression /this is \"something\"/")
         return value
 
@@ -82,10 +78,8 @@ class FormatTest(BaseModel):
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^\d{10}$", value):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"^\d{10}$", s):
             raise ValueError(r"must validate the regular expression /^\d{10}$/")
         return value
 
@@ -95,10 +89,8 @@ class FormatTest(BaseModel):
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^image_\d{1,3}$", value ,re.IGNORECASE):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"^image_\d{1,3}$", s ,re.IGNORECASE):
             raise ValueError(r"must validate the regular expression /^image_\d{1,3}$/i")
         return value
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_property.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_property.py
@@ -38,10 +38,8 @@ class NullableProperty(BaseModel):
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^[A-Z].*", value):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"^[A-Z].*", s):
             raise ValueError(r"must validate the regular expression /^[A-Z].*/")
         return value
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/uuid_with_pattern.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/uuid_with_pattern.py
@@ -37,10 +37,8 @@ class UuidWithPattern(BaseModel):
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$", value):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$", s):
             raise ValueError(r"must validate the regular expression /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/")
         return value
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/format_test.py
@@ -56,10 +56,8 @@ class FormatTest(BaseModel):
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"[a-z]", value ,re.IGNORECASE):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"[a-z]", s ,re.IGNORECASE):
             raise ValueError(r"must validate the regular expression /[a-z]/i")
         return value
 
@@ -69,10 +67,8 @@ class FormatTest(BaseModel):
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"this is \"something\"", value):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"this is \"something\"", s):
             raise ValueError(r"must validate the regular expression /this is \"something\"/")
         return value
 
@@ -82,10 +78,8 @@ class FormatTest(BaseModel):
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^\d{10}$", value):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"^\d{10}$", s):
             raise ValueError(r"must validate the regular expression /^\d{10}$/")
         return value
 
@@ -95,10 +89,8 @@ class FormatTest(BaseModel):
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^image_\d{1,3}$", value ,re.IGNORECASE):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"^image_\d{1,3}$", s ,re.IGNORECASE):
             raise ValueError(r"must validate the regular expression /^image_\d{1,3}$/i")
         return value
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/nullable_property.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/nullable_property.py
@@ -38,10 +38,8 @@ class NullableProperty(BaseModel):
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^[A-Z].*", value):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"^[A-Z].*", s):
             raise ValueError(r"must validate the regular expression /^[A-Z].*/")
         return value
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/uuid_with_pattern.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/uuid_with_pattern.py
@@ -37,10 +37,8 @@ class UuidWithPattern(BaseModel):
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$", value):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$", s):
             raise ValueError(r"must validate the regular expression /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/")
         return value
 

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/format_test.py
@@ -57,10 +57,8 @@ class FormatTest(BaseModel):
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"[a-z]", value ,re.IGNORECASE):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"[a-z]", s ,re.IGNORECASE):
             raise ValueError(r"must validate the regular expression /[a-z]/i")
         return value
 
@@ -70,10 +68,8 @@ class FormatTest(BaseModel):
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"this is \"something\"", value):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"this is \"something\"", s):
             raise ValueError(r"must validate the regular expression /this is \"something\"/")
         return value
 
@@ -83,10 +79,8 @@ class FormatTest(BaseModel):
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^\d{10}$", value):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"^\d{10}$", s):
             raise ValueError(r"must validate the regular expression /^\d{10}$/")
         return value
 
@@ -96,10 +90,8 @@ class FormatTest(BaseModel):
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^image_\d{1,3}$", value ,re.IGNORECASE):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"^image_\d{1,3}$", s ,re.IGNORECASE):
             raise ValueError(r"must validate the regular expression /^image_\d{1,3}$/i")
         return value
 

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/nullable_property.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/nullable_property.py
@@ -39,10 +39,8 @@ class NullableProperty(BaseModel):
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^[A-Z].*", value):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"^[A-Z].*", s):
             raise ValueError(r"must validate the regular expression /^[A-Z].*/")
         return value
 

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/uuid_with_pattern.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/uuid_with_pattern.py
@@ -38,10 +38,8 @@ class UuidWithPattern(BaseModel):
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$", value):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$", s):
             raise ValueError(r"must validate the regular expression /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/")
         return value
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/format_test.py
@@ -57,10 +57,8 @@ class FormatTest(BaseModel):
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"[a-z]", value ,re.IGNORECASE):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"[a-z]", s ,re.IGNORECASE):
             raise ValueError(r"must validate the regular expression /[a-z]/i")
         return value
 
@@ -70,10 +68,8 @@ class FormatTest(BaseModel):
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"this is \"something\"", value):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"this is \"something\"", s):
             raise ValueError(r"must validate the regular expression /this is \"something\"/")
         return value
 
@@ -83,10 +79,8 @@ class FormatTest(BaseModel):
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^\d{10}$", value):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"^\d{10}$", s):
             raise ValueError(r"must validate the regular expression /^\d{10}$/")
         return value
 
@@ -96,10 +90,8 @@ class FormatTest(BaseModel):
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^image_\d{1,3}$", value ,re.IGNORECASE):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"^image_\d{1,3}$", s ,re.IGNORECASE):
             raise ValueError(r"must validate the regular expression /^image_\d{1,3}$/i")
         return value
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/nullable_property.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/nullable_property.py
@@ -39,10 +39,8 @@ class NullableProperty(BaseModel):
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^[A-Z].*", value):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"^[A-Z].*", s):
             raise ValueError(r"must validate the regular expression /^[A-Z].*/")
         return value
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/uuid_with_pattern.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/uuid_with_pattern.py
@@ -38,10 +38,8 @@ class UuidWithPattern(BaseModel):
         if value is None:
             return value
 
-        if not isinstance(value, str):
-            value = str(value)
-
-        if not re.match(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$", value):
+        s = value if isinstance(value, str) else value.isoformat() if hasattr(value, "isoformat") else str(value)
+        if not re.match(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$", s):
             raise ValueError(r"must validate the regular expression /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/")
         return value
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Description

Fixes the regex `@field_validator` generated for a property that has both `format: date-time` (or `date`/`time`) **and** a `pattern`, in the `python` (pydantic v2) generator.

Because the field is typed `datetime`, pydantic parses the JSON string into a `datetime` **before** the after-mode validator runs. The previous template did:

```python
if not isinstance(value, str):
  value = str(value)          # -> "2026-06-23 10:21:47.710000+00:00" (space, not "T")
if not re.match(r"^...T...$", value):
  raise ValueError(...)
return value                    # -> field value clobbered to a str
```

Two defects:

1. Wrong stringification: `str(datetime)` is space-separated and fails any ISO-8601 pattern, so every valid patterned date-time field raised ValidationError on deserialization.
2. Type clobbering: value was reassigned to its stringified form and then returned, replacing the strongly-typed value with a str (e.g. a UUID/datetime field ends up holding a str, surfacing as PydanticSerializationUnexpectedValue).

The validator now matches against a derived string and returns the original value:

- datetime/date/time → .isoformat() → T-separated, offset-aware → matches.
- UUID/Decimal/int/enum → no isoformat → unchanged str() for matching only.
- return value preserves the declared field type. No new imports required.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
cc @cbornet (2017/09) @tomplus (2018/10) @krjakbrjak (2023/02) @fa0311 (2023/10) @multani (2023/10)
