### PR TITLE
[Kotlin][Spring] fix option useSpringBuiltInValidation not implemented

### DIFF
--- a/docs/generators/kotlin-spring.md
+++ b/docs/generators/kotlin-spring.md
@@ -71,6 +71,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |useSealedResponseInterfaces|Generate sealed interfaces for endpoint responses that all possible response types implement. Allows controllers to return any valid response type in a type-safe manner (e.g., sealed interface CreateUserResponse implemented by User, ConflictResponse, ErrorResponse)| |false|
 |useSpringBoot3|Generate code and provide dependencies for use with Spring Boot &ge; 3 (use jakarta instead of javax in imports). Enabling this option will also enable `useJakartaEe`.| |false|
 |useSpringBoot4|Generate code and provide dependencies for use with Spring Boot 4.x. Enabling this option will also enable `useJakartaEe`.| |false|
+|useSpringBuiltInValidation|Disable `@Validated` at the class level when using built-in validation.| |false|
 |useSwaggerUI|Open the OpenApi specification in swagger-ui. Will also import and configure needed dependencies| |true|
 |useTags|Whether to use tags for creating interface and controller class names| |false|
 |xKotlinImplementsFieldsSkip|A list of fields per schema name that should NOT be created with `override` keyword despite their presence in vendor extension `x-kotlin-implements-fields` for the schema. Example: yaml `xKotlinImplementsFieldsSkip: Pet: [photoUrls]` skips `override` for `photoUrls` in schema `Pet`| |empty map|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
@@ -532,6 +532,7 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
         }
         if (additionalProperties.containsKey(USE_SPRING_BUILT_IN_VALIDATION)) {
             this.setUseSpringBuiltInValidation(convertPropertyToBoolean(USE_SPRING_BUILT_IN_VALIDATION));
+            writePropertyBack(USE_SPRING_BUILT_IN_VALIDATION, useSpringBuiltInValidation);
         }
         if (additionalProperties.containsKey(INCLUDE_HTTP_REQUEST_CONTEXT)) {
             this.setIncludeHttpRequestContext(convertPropertyToBoolean(INCLUDE_HTTP_REQUEST_CONTEXT));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
@@ -98,6 +98,7 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
 
     public static final String USE_SPRING_BOOT3 = "useSpringBoot3";
     public static final String USE_SPRING_BOOT4 = "useSpringBoot4";
+    public static final String USE_SPRING_BUILT_IN_VALIDATION = "useSpringBuiltInValidation";
     public static final String INCLUDE_HTTP_REQUEST_CONTEXT = "includeHttpRequestContext";
     public static final String USE_FLOW_FOR_ARRAY_RETURN_TYPE = "useFlowForArrayReturnType";
     public static final String REQUEST_MAPPING_OPTION = "requestMappingMode";
@@ -190,6 +191,8 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
     protected boolean useSpringBoot3 = false;
     @Getter @Setter
     protected boolean useSpringBoot4 = false;
+    @Getter @Setter
+    protected boolean useSpringBuiltInValidation = false;
     protected RequestMappingMode requestMappingMode = RequestMappingMode.controller;
     private DocumentationProvider documentationProvider;
     private AnnotationLibrary annotationLibrary;
@@ -286,6 +289,7 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
                 " (contexts) added to single project.", beanQualifiers);
         addSwitch(USE_SPRING_BOOT3, "Generate code and provide dependencies for use with Spring Boot ≥ 3 (use jakarta instead of javax in imports). Enabling this option will also enable `useJakartaEe`.", useSpringBoot3);
         addSwitch(USE_SPRING_BOOT4, "Generate code and provide dependencies for use with Spring Boot 4.x. Enabling this option will also enable `useJakartaEe`.", useSpringBoot4);
+        addSwitch(USE_SPRING_BUILT_IN_VALIDATION, "Disable `@Validated` at the class level when using built-in validation.", useSpringBuiltInValidation);
         addSwitch(USE_JACKSON_3, "Use Jackson 3 dependencies (tools.jackson package). Only available with `useSpringBoot4`. Defaults to true when `useSpringBoot4` is enabled.", useJackson3);
         addSwitch(USE_FLOW_FOR_ARRAY_RETURN_TYPE, "Whether to use Flow for array/collection return types when reactive is enabled. If false, will use List instead.", useFlowForArrayReturnType);
         addSwitch(INCLUDE_HTTP_REQUEST_CONTEXT, "Whether to include HttpServletRequest (blocking) or ServerWebExchange (reactive) as additional parameter in generated methods.", includeHttpRequestContext);
@@ -520,6 +524,9 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
         }
         if (additionalProperties.containsKey(USE_SPRING_BOOT4)) {
             this.setUseSpringBoot4(convertPropertyToBoolean(USE_SPRING_BOOT4));
+        }
+        if (additionalProperties.containsKey(USE_SPRING_BUILT_IN_VALIDATION)) {
+            this.setUseSpringBuiltInValidation(convertPropertyToBoolean(USE_SPRING_BUILT_IN_VALIDATION));
         }
         if (additionalProperties.containsKey(INCLUDE_HTTP_REQUEST_CONTEXT)) {
             this.setIncludeHttpRequestContext(convertPropertyToBoolean(INCLUDE_HTTP_REQUEST_CONTEXT));

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/api.mustache
@@ -29,9 +29,7 @@ import org.springframework.http.ResponseEntity
 {{/useResponseEntity}}
 
 import org.springframework.web.bind.annotation.*
-{{#useBeanValidation}}
-import org.springframework.validation.annotation.Validated
-{{/useBeanValidation}}
+{{#useBeanValidation}}{{^useSpringBuiltInValidation}}import org.springframework.validation.annotation.Validated{{/useSpringBuiltInValidation}}{{/useBeanValidation}}
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -54,9 +52,7 @@ import kotlin.collections.List
 import kotlin.collections.Map
 
 @RestController{{#beanQualifiers}}("{{package}}.{{classname}}Controller"){{/beanQualifiers}}
-{{#useBeanValidation}}
-@Validated
-{{/useBeanValidation}}
+{{#useBeanValidation}}{{^useSpringBuiltInValidation}}@Validated{{/useSpringBuiltInValidation}}{{/useBeanValidation}}
 {{#swagger1AnnotationLibrary}}
 @Api(value = "{{{baseName}}}", description = "The {{{baseName}}} API")
 {{/swagger1AnnotationLibrary}}

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/api.mustache
@@ -29,7 +29,11 @@ import org.springframework.http.ResponseEntity
 {{/useResponseEntity}}
 
 import org.springframework.web.bind.annotation.*
-{{#useBeanValidation}}{{^useSpringBuiltInValidation}}import org.springframework.validation.annotation.Validated{{/useSpringBuiltInValidation}}{{/useBeanValidation}}
+{{#useBeanValidation}}
+{{^useSpringBuiltInValidation}}
+import org.springframework.validation.annotation.Validated
+{{/useSpringBuiltInValidation}}
+{{/useBeanValidation}}
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -52,7 +56,11 @@ import kotlin.collections.List
 import kotlin.collections.Map
 
 @RestController{{#beanQualifiers}}("{{package}}.{{classname}}Controller"){{/beanQualifiers}}
-{{#useBeanValidation}}{{^useSpringBuiltInValidation}}@Validated{{/useSpringBuiltInValidation}}{{/useBeanValidation}}
+{{#useBeanValidation}}
+{{^useSpringBuiltInValidation}}
+@Validated
+{{/useSpringBuiltInValidation}}
+{{/useBeanValidation}}
 {{#swagger1AnnotationLibrary}}
 @Api(value = "{{{baseName}}}", description = "The {{{baseName}}} API")
 {{/swagger1AnnotationLibrary}}

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/apiInterface.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/apiInterface.mustache
@@ -34,9 +34,7 @@ import org.springframework.http.ResponseEntity
 {{/useResponseEntity}}
 
 import org.springframework.web.bind.annotation.*
-{{#useBeanValidation}}
-import org.springframework.validation.annotation.Validated
-{{/useBeanValidation}}
+{{#useBeanValidation}}{{^useSpringBuiltInValidation}}import org.springframework.validation.annotation.Validated{{/useSpringBuiltInValidation}}{{/useBeanValidation}}
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -61,9 +59,7 @@ import kotlin.collections.Map
 {{^useFeignClient}}
 @RestController
 {{/useFeignClient}}
-{{#useBeanValidation}}
-@Validated
-{{/useBeanValidation}}
+{{#useBeanValidation}}{{^useSpringBuiltInValidation}}@Validated{{/useSpringBuiltInValidation}}{{/useBeanValidation}}
 {{#swagger1AnnotationLibrary}}
 @Api(value = "{{{baseName}}}", description = "The {{{baseName}}} API")
 {{/swagger1AnnotationLibrary}}

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/apiInterface.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/apiInterface.mustache
@@ -34,7 +34,11 @@ import org.springframework.http.ResponseEntity
 {{/useResponseEntity}}
 
 import org.springframework.web.bind.annotation.*
-{{#useBeanValidation}}{{^useSpringBuiltInValidation}}import org.springframework.validation.annotation.Validated{{/useSpringBuiltInValidation}}{{/useBeanValidation}}
+{{#useBeanValidation}}
+{{^useSpringBuiltInValidation}}
+import org.springframework.validation.annotation.Validated
+{{/useSpringBuiltInValidation}}
+{{/useBeanValidation}}
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -59,7 +63,11 @@ import kotlin.collections.Map
 {{^useFeignClient}}
 @RestController
 {{/useFeignClient}}
-{{#useBeanValidation}}{{^useSpringBuiltInValidation}}@Validated{{/useSpringBuiltInValidation}}{{/useBeanValidation}}
+{{#useBeanValidation}}
+{{^useSpringBuiltInValidation}}
+@Validated
+{{/useSpringBuiltInValidation}}
+{{/useBeanValidation}}
 {{#swagger1AnnotationLibrary}}
 @Api(value = "{{{baseName}}}", description = "The {{{baseName}}} API")
 {{/swagger1AnnotationLibrary}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinSpringServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinSpringServerCodegenTest.java
@@ -105,4 +105,101 @@ public class KotlinSpringServerCodegenTest {
         // derived doesn't contain disciminator
         TestUtils.assertFileNotContains(birdKt, "val discriminator");
     }
+
+    @Test(description = "should not generate @Validated annotation on interface when built-in validation option is set to true")
+    public void shouldEnableBuiltInValidationOptionWhenSetToTrueInterface() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        KotlinSpringServerCodegen codegen = new KotlinSpringServerCodegen() ;
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        codegen.setUseSpringBoot3(true);
+        codegen.additionalProperties().put(KotlinSpringServerCodegen.USE_BEANVALIDATION, true);
+        codegen.additionalProperties().put(KotlinSpringServerCodegen.USE_SPRING_BUILT_IN_VALIDATION, true);
+        codegen.additionalProperties().put(KotlinSpringServerCodegen.INTERFACE_ONLY, true);
+
+        new DefaultGenerator().opts(
+                new ClientOptInput()
+                        .openAPI(TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml"))
+                        .config(codegen)
+        ).generate();
+
+        final Path userApiKt = Paths.get(output + "/src/main/kotlin/org/openapitools/api/UserApi.kt");
+        TestUtils.assertFileNotContains(userApiKt, "import org.springframework.validation.annotation.Validated");
+        TestUtils.assertFileNotContains(userApiKt, "@org.springframework.validation.annotation.Validated");
+        TestUtils.assertFileNotContains(userApiKt, "@Validated");
+    }
+
+    @Test(description = "should not generate @Validated annotation on controller when built-in validation option is set to true")
+    public void shouldEnableBuiltInValidationOptionWhenSetToTrueController() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        KotlinSpringServerCodegen codegen = new KotlinSpringServerCodegen() ;
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        codegen.setUseSpringBoot3(true);
+        codegen.additionalProperties().put(KotlinSpringServerCodegen.USE_BEANVALIDATION, true);
+        codegen.additionalProperties().put(KotlinSpringServerCodegen.USE_SPRING_BUILT_IN_VALIDATION, true);
+
+        new DefaultGenerator().opts(
+                new ClientOptInput()
+                        .openAPI(TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml"))
+                        .config(codegen)
+        ).generate();
+
+        final Path userApiKt = Paths.get(output + "/src/main/kotlin/org/openapitools/api/UserApiController.kt");
+        TestUtils.assertFileNotContains(userApiKt, "import org.springframework.validation.annotation.Validated");
+        TestUtils.assertFileNotContains(userApiKt, "@org.springframework.validation.annotation.Validated");
+        TestUtils.assertFileNotContains(userApiKt, "@Validated");
+    }
+
+    @Test(description = "should generate @Validated annotation when built-in validation option is set to false")
+    public void shouldDisableBuiltInValidationOptionWhenSetToFalse() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        KotlinSpringServerCodegen codegen = new KotlinSpringServerCodegen() ;
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        codegen.setUseSpringBoot3(true);
+        codegen.additionalProperties().put(KotlinSpringServerCodegen.USE_BEANVALIDATION, true);
+        codegen.additionalProperties().put(KotlinSpringServerCodegen.USE_SPRING_BUILT_IN_VALIDATION, false);
+        codegen.additionalProperties().put(KotlinSpringServerCodegen.INTERFACE_ONLY, true);
+
+        new DefaultGenerator().opts(
+                new ClientOptInput()
+                        .openAPI(TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml"))
+                        .config(codegen)
+        ).generate();
+
+        final Path userApiKt = Paths.get(output + "/src/main/kotlin/org/openapitools/api/UserApi.kt");
+        TestUtils.assertFileContains(userApiKt, "import org.springframework.validation.annotation.Validated");
+        TestUtils.assertFileContains(userApiKt, "@Validated");
+    }
+
+    @Test(description = "should generate @Validated annotation when built-in validation option has default value")
+    public void shouldDisableBuiltInValidationOptionByDefault() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        KotlinSpringServerCodegen codegen = new KotlinSpringServerCodegen() ;
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        codegen.additionalProperties().put(KotlinSpringServerCodegen.INTERFACE_ONLY, true);
+
+        codegen.setUseSpringBoot3(true);
+
+        new DefaultGenerator().opts(
+                new ClientOptInput()
+                        .openAPI(TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml"))
+                        .config(codegen)
+        ).generate();
+
+        final Path userApiKt = Paths.get(output + "/src/main/kotlin/org/openapitools/api/UserApi.kt");
+        TestUtils.assertFileContains(userApiKt, "import org.springframework.validation.annotation.Validated");
+        TestUtils.assertFileContains(userApiKt, "@Validated");
+    }
+
 }


### PR DESCRIPTION
based on https://github.com/OpenAPITools/openapi-generator/pull/23951 with updated doc, bug fix.

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `kotlin-spring` generator so `useSpringBuiltInValidation` disables class-level `@Validated` on generated controllers and interfaces when `useBeanValidation` is on. Default behavior is unchanged.

- **Bug Fixes**
  - Wired the option in `KotlinSpringServerCodegen` (flag, CLI switch, `processOpts`/`writePropertyBack`).
  - Updated `api.mustache` and `apiInterface.mustache` to skip the import and annotation when enabled.
  - Added tests for interface/controller and default/true/false cases.
  - Documented the option in `docs/generators/kotlin-spring.md`.

<sup>Written for commit bb4112b41d8b488cfbb77129039a1aef42640ff9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



