### PR TITLE
[python] separate property and parameter mappings

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -248,6 +248,10 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
             return nameMapping.get(name);
         }
 
+        return toVarNameWithoutNameMapping(name);
+    }
+
+    private String toVarNameWithoutNameMapping(String name) {
         // sanitize name
         name = sanitizeName(name); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
 
@@ -291,8 +295,8 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
             return "param_callback";
         }
 
-        // should be the same as variable name
-        return toVarName(name);
+        // use variable-name normalization without model property mappings
+        return toVarNameWithoutNameMapping(name);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonPydanticV1Codegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonPydanticV1Codegen.java
@@ -215,6 +215,10 @@ public abstract class AbstractPythonPydanticV1Codegen extends DefaultCodegen imp
             return nameMapping.get(name);
         }
 
+        return toVarNameWithoutNameMapping(name);
+    }
+
+    private String toVarNameWithoutNameMapping(String name) {
         // sanitize name
         name = sanitizeName(name); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
 
@@ -258,8 +262,8 @@ public abstract class AbstractPythonPydanticV1Codegen extends DefaultCodegen imp
             return "param_callback";
         }
 
-        // should be the same as variable name
-        return toVarName(name);
+        // use variable-name normalization without model property mappings
+        return toVarNameWithoutNameMapping(name);
     }
 
     @Override

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
@@ -759,4 +759,16 @@ public class PythonClientCodegenTest {
         TestUtils.assertFileContains(filePath, "double: Optional[Union[Annotated[float, Field(le=123.4, strict=True, ge=67.8)], Annotated[int, Field(le=123, strict=True, ge=68)]]]");
         TestUtils.assertFileContains(filePath, "decimal: Optional[Annotated[Decimal, Field(multiple_of=0.1, lt=123.4, strict=True, gt=67.8)]]");
     }
+
+    @Test
+    public void testModelNameMappingDoesNotRenameParameters() {
+        final PythonClientCodegen codegen = new PythonClientCodegen();
+        codegen.nameMapping().put("some-value", "model_value");
+
+        Assert.assertEquals(codegen.toVarName("some-value"), "model_value");
+        Assert.assertEquals(codegen.toParamName("some-value"), "some_value");
+
+        codegen.parameterNameMapping().put("some-value", "parameter_value");
+        Assert.assertEquals(codegen.toParamName("some-value"), "parameter_value");
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonPydanticV1ClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonPydanticV1ClientCodegenTest.java
@@ -534,4 +534,16 @@ public class PythonPydanticV1ClientCodegenTest {
         assertFileContains(initFilePath, "from openapi_client.models.tag import Tag as Tag");
         assertFileContains(initFilePath, "from openapi_client.models.user import User as User");
     }
+
+    @Test
+    public void testModelNameMappingDoesNotRenameParameters() {
+        final PythonPydanticV1ClientCodegen codegen = new PythonPydanticV1ClientCodegen();
+        codegen.nameMapping().put("some-value", "model_value");
+
+        Assert.assertEquals(codegen.toVarName("some-value"), "model_value");
+        Assert.assertEquals(codegen.toParamName("some-value"), "some_value");
+
+        codegen.parameterNameMapping().put("some-value", "parameter_value");
+        Assert.assertEquals(codegen.toParamName("some-value"), "parameter_value");
+    }
 }


### PR DESCRIPTION
Unmapped Python operation parameters currently fall back from
`toParamName()` to `toVarName()`, which also applies model property
`nameMappings`. A mapping intended for a model property can therefore
rename an unrelated operation parameter with the same source name.

Apply explicit mappings to operation parameters only through
`parameterNameMappings` in the `python` and `python-pydantic-v1`
generators. Continue to normalize unmapped parameter names as Python
identifiers. This gives `nameMappings` and `parameterNameMappings` their
documented property and parameter scopes.

Configurations that intentionally used `nameMappings` to rename
parameters must add the same entries to `parameterNameMappings`. Retain
the `nameMappings` entries when they are also needed for model
properties.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops model property `nameMappings` from renaming unrelated operation parameters in the `python` and `python-pydantic-v1` generators. Unmapped parameters are now normalized as Python identifiers without applying `nameMappings`; only `parameterNameMappings` affects parameters.

- **Bug Fixes**
  - `toParamName()` no longer applies model property mappings by falling back to `toVarName()`.
  - Added a normalization path that skips `nameMappings` for parameter names.
  - Tests added to confirm parameters aren’t renamed by `nameMappings` and respect `parameterNameMappings`.

- **Migration**
  - If you used `nameMappings` to rename parameters, add those entries to `parameterNameMappings` and keep `nameMappings` for model properties.
  - No action needed if you already used `parameterNameMappings` or relied on default normalization.

<sup>Written for commit aa21493c1566091e723c4520270fc08b20106f5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

