### PR TITLE
fix(ruby): JSON-encode query params with content:application/json

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
@@ -176,12 +176,22 @@ module {{moduleName}}
       query_params = opts[:query_params] || {}
       {{#queryParams}}
       {{#required}}
+      {{#queryIsJsonMimeType}}
+      query_params[:'{{{baseName}}}'] = {{{paramName}}}.to_json
+      {{/queryIsJsonMimeType}}
+      {{^queryIsJsonMimeType}}
       query_params[:'{{{baseName}}}'] = {{#collectionFormat}}@api_client.build_collection_param({{{paramName}}}, :{{{collectionFormat}}}){{/collectionFormat}}{{^collectionFormat}}{{{paramName}}}{{/collectionFormat}}
+      {{/queryIsJsonMimeType}}
       {{/required}}
       {{/queryParams}}
       {{#queryParams}}
       {{^required}}
+      {{#queryIsJsonMimeType}}
+      query_params[:'{{{baseName}}}'] = opts[:'{{{paramName}}}'].to_json if !opts[:'{{{paramName}}}'].nil?
+      {{/queryIsJsonMimeType}}
+      {{^queryIsJsonMimeType}}
       query_params[:'{{{baseName}}}'] = {{#collectionFormat}}@api_client.build_collection_param(opts[:'{{{paramName}}}'], :{{{collectionFormat}}}){{/collectionFormat}}{{^collectionFormat}}opts[:'{{{paramName}}}']{{/collectionFormat}} if !opts[:'{{{paramName}}}'].nil?
+      {{/queryIsJsonMimeType}}
       {{/required}}
       {{/queryParams}}
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
@@ -749,4 +749,17 @@ public class RubyClientCodegenTest {
         // patten_starts_ends_with_slash '/root/'
         Assert.assertEquals(op.allParams.get(8).pattern, "/root/");
     }
+
+    @Test
+    public void testQueryParamJsonSerializationSetsQueryIsJsonMimeType() {
+        RubyClientCodegen codegen = new RubyClientCodegen();
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/echo_api.yaml");
+        codegen.setOpenAPI(openAPI);
+        String path = "/query/style_jsonSerialization/object";
+        CodegenOperation op = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+
+        Assert.assertEquals(op.queryParams.size(), 2);
+        assertTrue(op.queryParams.stream().allMatch(p -> p.queryIsJsonMimeType),
+                "All content:application/json query params should have queryIsJsonMimeType=true");
+    }
 }

--- a/samples/client/echo_api/ruby-faraday/lib/openapi_client/api/query_api.rb
+++ b/samples/client/echo_api/ruby-faraday/lib/openapi_client/api/query_api.rb
@@ -664,8 +664,8 @@ module OpenapiClient
 
       # query parameters
       query_params = opts[:query_params] || {}
-      query_params[:'json_serialized_object_ref_string_query'] = opts[:'json_serialized_object_ref_string_query'] if !opts[:'json_serialized_object_ref_string_query'].nil?
-      query_params[:'json_serialized_object_array_ref_string_query'] = @api_client.build_collection_param(opts[:'json_serialized_object_array_ref_string_query'], :csv) if !opts[:'json_serialized_object_array_ref_string_query'].nil?
+      query_params[:'json_serialized_object_ref_string_query'] = opts[:'json_serialized_object_ref_string_query'].to_json if !opts[:'json_serialized_object_ref_string_query'].nil?
+      query_params[:'json_serialized_object_array_ref_string_query'] = opts[:'json_serialized_object_array_ref_string_query'].to_json if !opts[:'json_serialized_object_array_ref_string_query'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/query_api.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/query_api.rb
@@ -664,7 +664,7 @@ module OpenapiClient
 
       # query parameters
       query_params = opts[:query_params] || {}
-      query_params[:'json_serialized_object_ref_string_query'] = opts[:'json_serialized_object_ref_string_query'].to_json if !opts[:'json_serialized_object_ref_string_query'].nil?
+      query_params[:'json_serialized_object_ref_string_query'] = @api_client.object_to_hash(opts[:'json_serialized_object_ref_string_query']).to_json if !opts[:'json_serialized_object_ref_string_query'].nil?
       query_params[:'json_serialized_object_array_ref_string_query'] = opts[:'json_serialized_object_array_ref_string_query'].to_json if !opts[:'json_serialized_object_array_ref_string_query'].nil?
 
       # header parameters

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/query_api.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/query_api.rb
@@ -664,7 +664,7 @@ module OpenapiClient
 
       # query parameters
       query_params = opts[:query_params] || {}
-      query_params[:'json_serialized_object_ref_string_query'] = @api_client.object_to_hash(opts[:'json_serialized_object_ref_string_query']).to_json if !opts[:'json_serialized_object_ref_string_query'].nil?
+      query_params[:'json_serialized_object_ref_string_query'] = opts[:'json_serialized_object_ref_string_query'].to_json if !opts[:'json_serialized_object_ref_string_query'].nil?
       query_params[:'json_serialized_object_array_ref_string_query'] = opts[:'json_serialized_object_array_ref_string_query'].to_json if !opts[:'json_serialized_object_array_ref_string_query'].nil?
 
       # header parameters

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/query_api.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/query_api.rb
@@ -664,8 +664,8 @@ module OpenapiClient
 
       # query parameters
       query_params = opts[:query_params] || {}
-      query_params[:'json_serialized_object_ref_string_query'] = opts[:'json_serialized_object_ref_string_query'] if !opts[:'json_serialized_object_ref_string_query'].nil?
-      query_params[:'json_serialized_object_array_ref_string_query'] = @api_client.build_collection_param(opts[:'json_serialized_object_array_ref_string_query'], :csv) if !opts[:'json_serialized_object_array_ref_string_query'].nil?
+      query_params[:'json_serialized_object_ref_string_query'] = opts[:'json_serialized_object_ref_string_query'].to_json if !opts[:'json_serialized_object_ref_string_query'].nil?
+      query_params[:'json_serialized_object_array_ref_string_query'] = opts[:'json_serialized_object_array_ref_string_query'].to_json if !opts[:'json_serialized_object_array_ref_string_query'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}

--- a/samples/client/echo_api/ruby-typhoeus/lib/openapi_client/api/query_api.rb
+++ b/samples/client/echo_api/ruby-typhoeus/lib/openapi_client/api/query_api.rb
@@ -664,8 +664,8 @@ module OpenapiClient
 
       # query parameters
       query_params = opts[:query_params] || {}
-      query_params[:'json_serialized_object_ref_string_query'] = opts[:'json_serialized_object_ref_string_query'] if !opts[:'json_serialized_object_ref_string_query'].nil?
-      query_params[:'json_serialized_object_array_ref_string_query'] = @api_client.build_collection_param(opts[:'json_serialized_object_array_ref_string_query'], :csv) if !opts[:'json_serialized_object_array_ref_string_query'].nil?
+      query_params[:'json_serialized_object_ref_string_query'] = opts[:'json_serialized_object_ref_string_query'].to_json if !opts[:'json_serialized_object_ref_string_query'].nil?
+      query_params[:'json_serialized_object_array_ref_string_query'] = opts[:'json_serialized_object_array_ref_string_query'].to_json if !opts[:'json_serialized_object_array_ref_string_query'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}


### PR DESCRIPTION
Fixes #24122.

Query parameters declared with `content: { "application/json": ... }` must be
serialized as JSON strings per the [OpenAPI 3 spec](https://swagger.io/docs/specification/describing-parameters/#schema-vs-content). The Ruby client generator was ignoring this and emitting raw Ruby object representations instead.

The core model already handles this correctly: `DefaultCodegen.fromParameter()` sets `queryIsJsonMimeType = true` on any parameter whose `content` map has an `application/json` entry, and a test for this exists in `DefaultCodegenTest#testQueryIsJsonMimeType`. The Ruby `api.mustache` template was simply not using the flag.

(I used Claude Code to generate this PR, but I've hand-reviewed the code as well.  Happy to remove the Claude attribution from the commit if desired!)

Mentioning the Ruby technical committee members: @cliffano @zlx @autopp

### Changes

- `api.mustache` (ruby-client): branch on `{{#queryIsJsonMimeType}}` for both required and optional query params, calling `.to_json` instead of passing the value (or calling `build_collection_param`) directly
- Updated three echo_api Ruby samples (faraday, httpx, typhoeus) to reflect the corrected output
- Added `RubyClientCodegenTest#testQueryParamJsonSerializationSetsQueryIsJsonMimeType` to assert the flag propagates correctly through the Ruby codegen path

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
JSON-encode Ruby client query parameters defined with content: application/json so they are sent as JSON strings, not Ruby object literals. Aligns with OpenAPI 3 and fixes #24122.

- **Bug Fixes**
  - In `ruby-client/api.mustache`, use `queryIsJsonMimeType` for required and optional query params and call `.to_json`; fallback keeps existing behavior.
  - Regenerated echo_api samples for ruby-faraday, ruby-httpx, and ruby-typhoeus; in ruby-httpx, object refs use `@api_client.object_to_hash(...).to_json`.
  - Added `RubyClientCodegenTest#testQueryParamJsonSerializationSetsQueryIsJsonMimeType` to assert flag propagation for `content: application/json` params.

<sup>Written for commit 69196ff64654aeecb39d5121b9fd831b7b4d2657. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

