### PR TITLE
[python] test HTTPX sync wire names

### DIFF
--- a/samples/openapi3/client/petstore/python-httpx-sync/tests/test_model.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/tests/test_model.py
@@ -75,14 +75,18 @@ class ModelTests(unittest.TestCase):
         self.assertFalse(self.pet1 == self.pet2)
 
     def test_oneOf(self):
+        mapping_value = """basque'"\\pig\nkind"""
+        wire_name = """class'"\\Name"""
+        wire_value = {wire_name: mapping_value, "color": "red"}
+        wire_json = json.dumps(wire_value)
+
         # test new Pig
         new_pig = petstore_api.Pig()
         self.assertEqual("null", new_pig.to_json())
         self.assertEqual(None, new_pig.actual_instance)
 
         # test from_json
-        json_str = '{"className": "BasquePig", "color": "red"}'
-        p = petstore_api.Pig.from_json(json_str)
+        p = petstore_api.Pig.from_json(wire_json)
         self.assertIsInstance(p.actual_instance, petstore_api.BasquePig)
 
         # test init
@@ -113,11 +117,19 @@ class ModelTests(unittest.TestCase):
             self.assertIn("Input should be a valid dictionary or instance of DanishPig", str(e))
 
         # test to_json
-        self.assertEqual(p.to_json(), '{"className": "BasquePig", "color": "red"}')
+        self.assertEqual(p.to_json(), wire_json)
 
         # test nested property
-        nested = petstore_api.WithNestedOneOf(size = 1, nested_pig = p)
-        self.assertEqual(nested.to_json(), '{"size": 1, "nested_pig": {"className": "BasquePig", "color": "red"}}')
+        nested_wire_name = "nested_\npig"
+        nested = petstore_api.WithNestedOneOf.from_dict({
+            "size": 1,
+            nested_wire_name: wire_value,
+        })
+        assert nested is not None
+        self.assertEqual(
+            nested.to_json(),
+            json.dumps({"size": 1, nested_wire_name: wire_value}),
+        )
 
         nested_json = nested.to_json()
         nested2 = petstore_api.WithNestedOneOf.from_json(nested_json)
@@ -125,14 +137,18 @@ class ModelTests(unittest.TestCase):
         self.assertEqual(nested2.to_json(), nested_json)
 
     def test_anyOf(self):
+        mapping_value = """basque'"\\pig\nkind"""
+        wire_name = """class'"\\Name"""
+        wire_value = {wire_name: mapping_value, "color": "red"}
+        wire_json = json.dumps(wire_value)
+
         # test new AnyOfPig
         new_anypig = petstore_api.AnyOfPig()
         self.assertEqual("null", new_anypig.to_json())
         self.assertEqual(None, new_anypig.actual_instance)
 
         # test from_json
-        json_str = '{"className": "BasquePig", "color": "red"}'
-        p = petstore_api.AnyOfPig.from_json(json_str)
+        p = petstore_api.AnyOfPig.from_json(wire_json)
         self.assertIsInstance(p.actual_instance, petstore_api.BasquePig)
 
         # test init
@@ -168,7 +184,7 @@ class ModelTests(unittest.TestCase):
             self.assertIn("Input should be a valid dictionary or instance of DanishPig", str(e))
 
         # test to_json
-        self.assertEqual(p.to_json(), '{"className": "BasquePig", "color": "red"}')
+        self.assertEqual(p.to_json(), wire_json)
 
     def test_inheritance(self):
         dog = petstore_api.Dog(breed="bulldog", className="dog", color="white")


### PR DESCRIPTION
Commit [2b6b544f] brings the HTTPX sync generated models in line with
[3a307ab7]. The handwritten `oneOf` and `anyOf` tests still construct
payloads with sanitized Python names, so the sample jobs now fail while
deserializing `BasquePig`.

Update those tests to send and assert the exact wire names. This keeps
the regression coverage aligned with the generated fields and catches
future sample drift.

[2b6b544f]: https://github.com/OpenAPITools/openapi-generator/commit/2b6b544f769
[3a307ab7]: https://github.com/OpenAPITools/openapi-generator/commit/3a307ab7752
