### PR TITLE
fix(avro): order "null" first in union when default is null

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AvroSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AvroSchemaCodegen.java
@@ -16,6 +16,7 @@
 
 package org.openapitools.codegen.languages;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.swagger.v3.oas.models.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
@@ -167,6 +168,17 @@ public class AvroSchemaCodegen extends DefaultCodegen implements CodegenConfig {
     @Override
     public String toDefaultValue(Schema p) {
         if (p.getDefault() == null) {
+            return null;
+        }
+
+        // The Swagger Parser represents an explicit `default: null` (common with
+        // `nullable: true`, e.g. via allOf composition) as a Jackson NullNode rather than a
+        // Java null. Treating it as a concrete default produces an invalid Avro union such as
+        // `["Foo", "null"]` with `"default": null`, because Avro requires a union's default
+        // value to match its FIRST branch. Treat an explicit null default as "no default" so
+        // the field falls through to the nullable-union form `["null", "Foo"]` with
+        // `"default": null`, which is valid.
+        if (p.getDefault() instanceof JsonNode && ((JsonNode) p.getDefault()).isNull()) {
             return null;
         }
 

--- a/modules/openapi-generator/src/test/resources/3_0/issue6268.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue6268.yaml
@@ -19,12 +19,26 @@ paths:
           description: successful operation
 components:
   schemas:
+    AvroDefaultNullReference:
+      type: object
+      properties:
+        id:
+          type: string
     SampleModelToTestAvroDefaultValues:
       type: object
       required:
         - tagsRequired
         - tagsRequiredWithDefault
       properties:
+        nullableScalarWithNullDefault:
+          type: string
+          nullable: true
+          default: null
+        nullableModelWithNullDefault:
+          nullable: true
+          default: null
+          allOf:
+            - $ref: '#/components/schemas/AvroDefaultNullReference'
         name:
           type: string
           default: 'defaultName'

--- a/samples/openapi3/schema/petstore/avro-schema-issue6268/.openapi-generator/FILES
+++ b/samples/openapi3/schema/petstore/avro-schema-issue6268/.openapi-generator/FILES
@@ -1,1 +1,2 @@
+AvroDefaultNullReference.avsc
 SampleModelToTestAvroDefaultValues.avsc

--- a/samples/openapi3/schema/petstore/avro-schema-issue6268/AvroDefaultNullReference.avsc
+++ b/samples/openapi3/schema/petstore/avro-schema-issue6268/AvroDefaultNullReference.avsc
@@ -1,0 +1,15 @@
+{
+  "namespace": "model",
+  "type": "record",
+  "doc": "",
+  "name": "AvroDefaultNullReference",
+  "fields": [
+    {
+      "name": "id",
+      "type": ["null", "string"],
+      "doc": "",
+      "default": null
+    }
+  ]
+
+}

--- a/samples/openapi3/schema/petstore/avro-schema-issue6268/SampleModelToTestAvroDefaultValues.avsc
+++ b/samples/openapi3/schema/petstore/avro-schema-issue6268/SampleModelToTestAvroDefaultValues.avsc
@@ -5,6 +5,18 @@
   "name": "SampleModelToTestAvroDefaultValues",
   "fields": [
     {
+      "name": "nullableScalarWithNullDefault",
+      "type": ["null", "string"],
+      "doc": "",
+      "default": null
+    },
+    {
+      "name": "nullableModelWithNullDefault",
+      "type": ["null", "model.AvroDefaultNullReference"],
+      "doc": "",
+      "default": null
+    },
+    {
       "name": "name",
       "type": ["string", "null"],
       "doc": "",


### PR DESCRIPTION
The avro-schema generator emitted an invalid union when a property combined a non-null type with an explicit `default: null` (commonly produced by `nullable: true` + `allOf` composition), e.g. `["model.Foo", "null"]` with `"default": null`. Per the Avro specification, a union's default value must match the FIRST branch of the union, so the default `null` is only valid when `"null"` is the first branch. The invalid ordering is accepted by most schema parsers but fails at read time when the default is applied during schema evolution, crashing consumers.

The Swagger Parser represents an explicit `default: null` as a Jackson `NullNode` (a non-null Java object) rather than a Java `null`, so `toDefaultValue` returned the string "null" and the field was rendered through the concrete-default branch (`[<type>, "null"]`). Treat an explicit null default as "no default" so the field falls through to the existing nullable-union form (`["null", <type>]` with `"default": null`), which is valid. Real (non-null) defaults are unaffected.

Extends the issue6268 test spec with a nullable scalar and an allOf-composed model reference, both using `default: null`, and regenerates the sample.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Closes: https://github.com/OpenAPITools/openapi-generator/issues/24134
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Avro union ordering when a field has `default: null` by placing "null" first, preventing invalid schemas and runtime crashes during schema evolution.

- **Bug Fixes**
  - In `org.openapitools.codegen.languages.AvroSchemaCodegen`, treat explicit `default: null` (Jackson `NullNode`) as no concrete default in `toDefaultValue`, so we emit `["null", <type>]` with `"default": null` per Avro spec.
  - Extended `issue6268.yaml` with a nullable scalar and an `allOf`-composed model using `default: null`; regenerated samples (`AvroDefaultNullReference.avsc`, updated `SampleModelToTestAvroDefaultValues.avsc`).
  - Real (non-null) defaults are unchanged.

<sup>Written for commit a210b47ef7779eb2a356159af549b2218d0eb20b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

