### PR TITLE
[php-nextgen] Fix undefined variable $queryParams

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
@@ -689,9 +689,7 @@ use {{invokerPackage}}\ObjectSerializer;
         {{#hasBodyOrFormParams}}
         $formParams = [];
         {{/hasBodyOrFormParams}}
-        {{#hasQueryParams}}
         $queryParams = [];
-        {{/hasQueryParams}}
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/AuthApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/AuthApi.php
@@ -317,6 +317,7 @@ class AuthApi
     {
 
         $resourcePath = '/auth/http/basic';
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -548,6 +549,7 @@ class AuthApi
     {
 
         $resourcePath = '/auth/http/bearer';
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/BodyApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/BodyApi.php
@@ -341,6 +341,7 @@ class BodyApi
     {
 
         $resourcePath = '/binary/gif';
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -578,6 +579,7 @@ class BodyApi
 
         $resourcePath = '/body/application/octetstream/binary';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -852,6 +854,7 @@ class BodyApi
 
         $resourcePath = '/body/application/octetstream/array_of_binary';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1122,6 +1125,7 @@ class BodyApi
 
         $resourcePath = '/body/application/octetstream/single_binary';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1392,6 +1396,7 @@ class BodyApi
 
         $resourcePath = '/echo/body/allOf/Pet';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1660,6 +1665,7 @@ class BodyApi
 
         $resourcePath = '/echo/body/FreeFormObject/response_string';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1928,6 +1934,7 @@ class BodyApi
 
         $resourcePath = '/echo/body/Pet';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2196,6 +2203,7 @@ class BodyApi
 
         $resourcePath = '/echo/body/Pet/response_string';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2464,6 +2472,7 @@ class BodyApi
 
         $resourcePath = '/echo/body/string_enum';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2732,6 +2741,7 @@ class BodyApi
 
         $resourcePath = '/echo/body/Tag/response_string';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/FormApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/FormApi.php
@@ -351,6 +351,7 @@ class FormApi
 
         $resourcePath = '/form/integer/boolean/string';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -629,6 +630,7 @@ class FormApi
 
         $resourcePath = '/form/object/multipart';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -949,6 +951,7 @@ class FormApi
 
         $resourcePath = '/form/oneof';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/HeaderApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/HeaderApi.php
@@ -364,6 +364,7 @@ class HeaderApi
     {
 
         $resourcePath = '/header/integer/boolean/string/enums';
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/PathApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/PathApi.php
@@ -378,6 +378,7 @@ class PathApi
         }
 
         $resourcePath = '/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}';
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/echo_api/php-nextgen/src/Api/AuthApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/AuthApi.php
@@ -317,6 +317,7 @@ class AuthApi
     {
 
         $resourcePath = '/auth/http/basic';
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -548,6 +549,7 @@ class AuthApi
     {
 
         $resourcePath = '/auth/http/bearer';
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
@@ -341,6 +341,7 @@ class BodyApi
     {
 
         $resourcePath = '/binary/gif';
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -578,6 +579,7 @@ class BodyApi
 
         $resourcePath = '/body/application/octetstream/binary';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -852,6 +854,7 @@ class BodyApi
 
         $resourcePath = '/body/application/octetstream/array_of_binary';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1122,6 +1125,7 @@ class BodyApi
 
         $resourcePath = '/body/application/octetstream/single_binary';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1392,6 +1396,7 @@ class BodyApi
 
         $resourcePath = '/echo/body/allOf/Pet';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1660,6 +1665,7 @@ class BodyApi
 
         $resourcePath = '/echo/body/FreeFormObject/response_string';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1928,6 +1934,7 @@ class BodyApi
 
         $resourcePath = '/echo/body/Pet';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2196,6 +2203,7 @@ class BodyApi
 
         $resourcePath = '/echo/body/Pet/response_string';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2464,6 +2472,7 @@ class BodyApi
 
         $resourcePath = '/echo/body/string_enum';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2732,6 +2741,7 @@ class BodyApi
 
         $resourcePath = '/echo/body/Tag/response_string';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/echo_api/php-nextgen/src/Api/FormApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/FormApi.php
@@ -351,6 +351,7 @@ class FormApi
 
         $resourcePath = '/form/integer/boolean/string';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -629,6 +630,7 @@ class FormApi
 
         $resourcePath = '/form/object/multipart';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -949,6 +951,7 @@ class FormApi
 
         $resourcePath = '/form/oneof';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
@@ -364,6 +364,7 @@ class HeaderApi
     {
 
         $resourcePath = '/header/integer/boolean/string/enums';
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
@@ -378,6 +378,7 @@ class PathApi
         }
 
         $resourcePath = '/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}';
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
@@ -330,6 +330,7 @@ class AnotherFakeApi
 
         $resourcePath = '/another-fake/dummy';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
@@ -302,6 +302,7 @@ class DefaultApi
     {
 
         $resourcePath = '/error';
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -520,6 +521,7 @@ class DefaultApi
     {
 
         $resourcePath = '/foo';
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
@@ -398,6 +398,7 @@ class FakeApi
     {
 
         $resourcePath = '/fake/BigDecimalMap';
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -618,6 +619,7 @@ class FakeApi
         }
 
         $resourcePath = '/fake/pet/{pet_id}';
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1154,6 +1156,7 @@ class FakeApi
     {
 
         $resourcePath = '/fake/health';
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1644,6 +1647,7 @@ class FakeApi
 
         $resourcePath = '/fake/outer/boolean';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1904,6 +1908,7 @@ class FakeApi
 
         $resourcePath = '/fake/outer/composite';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2164,6 +2169,7 @@ class FakeApi
 
         $resourcePath = '/fake/outer/number';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2424,6 +2430,7 @@ class FakeApi
 
         $resourcePath = '/fake/outer/string';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2690,6 +2697,7 @@ class FakeApi
 
         $resourcePath = '/fake/property/enum-int';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2996,6 +3004,7 @@ class FakeApi
 
         $resourcePath = '/fake/with_400_and_4xx_range_response/endpoint';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -3270,6 +3279,7 @@ class FakeApi
 
         $resourcePath = '/fake/with_400_and_4xx_range_response_no_4xx_datatype/endpoint';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -3558,6 +3568,7 @@ class FakeApi
 
         $resourcePath = '/fake/with_400_response/endpoint';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -3850,6 +3861,7 @@ class FakeApi
 
         $resourcePath = '/fake/with_4xx_range_response/endpoint';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -4124,6 +4136,7 @@ class FakeApi
 
         $resourcePath = '/fake/with_4xx_range_response_no_4xx_datatype/endpoint';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -4351,6 +4364,7 @@ class FakeApi
 
         $resourcePath = '/fake/additionalProperties-reference';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -4570,6 +4584,7 @@ class FakeApi
 
         $resourcePath = '/fake/body-with-binary';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -4789,6 +4804,7 @@ class FakeApi
 
         $resourcePath = '/fake/body-with-file-schema';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -5308,6 +5324,7 @@ class FakeApi
 
         $resourcePath = '/fake';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -5722,6 +5739,7 @@ class FakeApi
 
         $resourcePath = '/fake';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -6625,6 +6643,7 @@ class FakeApi
 
         $resourcePath = '/fake/inline-additionalProperties';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -6852,6 +6871,7 @@ class FakeApi
 
         $resourcePath = '/fake/inline-freeform-additionalProperties';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -7095,6 +7115,7 @@ class FakeApi
 
         $resourcePath = '/fake/jsonFormData';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -7325,6 +7346,7 @@ class FakeApi
 
         $resourcePath = '/fake/nullable';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -7599,6 +7621,7 @@ class FakeApi
 
         $resourcePath = '/fake/oneof';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -8167,6 +8190,7 @@ class FakeApi
 
         $resourcePath = '/fake/stringMap-reference';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
@@ -330,6 +330,7 @@ class FakeClassnameTags123Api
 
         $resourcePath = '/fake_classname_test';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
@@ -414,6 +414,7 @@ class PetApi
 
         $resourcePath = '/pet';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -711,6 +712,7 @@ class PetApi
         }
 
         $resourcePath = '/pet/{petId}';
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1489,6 +1491,7 @@ class PetApi
         }
 
         $resourcePath = '/pet/{petId}';
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1804,6 +1807,7 @@ class PetApi
 
         $resourcePath = '/pet';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2112,6 +2116,7 @@ class PetApi
 
         $resourcePath = '/pet/{petId}';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2422,6 +2427,7 @@ class PetApi
 
         $resourcePath = '/pet/{petId}/uploadImage';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -2738,6 +2744,7 @@ class PetApi
 
         $resourcePath = '/fake/{petId}/uploadImageWithRequiredFile';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
@@ -291,6 +291,7 @@ class StoreApi
         }
 
         $resourcePath = '/store/order/{order_id}';
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -525,6 +526,7 @@ class StoreApi
     {
 
         $resourcePath = '/store/inventory';
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -779,6 +781,7 @@ class StoreApi
         }
 
         $resourcePath = '/store/order/{order_id}';
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1030,6 +1033,7 @@ class StoreApi
 
         $resourcePath = '/store/order';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
@@ -304,6 +304,7 @@ class UserApi
 
         $resourcePath = '/user';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -531,6 +532,7 @@ class UserApi
 
         $resourcePath = '/user/createWithArray';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -758,6 +760,7 @@ class UserApi
 
         $resourcePath = '/user/createWithList';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -984,6 +987,7 @@ class UserApi
         }
 
         $resourcePath = '/user/{username}';
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1234,6 +1238,7 @@ class UserApi
         }
 
         $resourcePath = '/user/{username}';
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1698,6 +1703,7 @@ class UserApi
     {
 
         $resourcePath = '/user/logout';
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -1910,6 +1916,7 @@ class UserApi
 
         $resourcePath = '/user/{username}';
         $formParams = [];
+        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;


### PR DESCRIPTION
`$queryParams` is used in the generated code below so this variable must exist in order to avoid undefined variable error.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always initialize `$queryParams` in `php-nextgen` generated API methods to eliminate “undefined variable $queryParams” when endpoints have no query params. The template now sets it by default and samples are regenerated to match.

- **Bug Fixes**
  - Remove the `{{#hasQueryParams}}` guard and unconditionally set `$queryParams = [];` in `php-nextgen/api.mustache`.
  - Regenerate samples for `php-nextgen` and `php-nextgen-streaming` (echo_api) and petstore `php-nextgen` so all endpoints include the `$queryParams` initialization.

<sup>Written for commit f1811a3ecbfbee582e6692af5847a8341b786acc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

