### PR TITLE
[python] centralize the Python constraint rules

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -1839,10 +1839,6 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
 
     class PydanticType {
 
-        private static final String LESS_THAN = "lt";
-        private static final String GREATER_THAN = "gt";
-        private static final String GREATER_OR_EQUAL_TO = "ge";
-        private static final String LESS_OR_EQUAL_TO = "le";
         private static final String TYPING = "typing";
 
         private static final String DECIMAL = "Decimal";
@@ -1872,12 +1868,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
 
         private PythonType arrayType(IJsonSchemaValidationProperties cp) {
             PythonType pt = new PythonType();
-            if (cp.getMaxItems() != null) {
-                pt.constrain("max_length", cp.getMaxItems());
-            }
-            if (cp.getMinItems() != null) {
-                pt.constrain("min_length", cp.getMinItems());
-            }
+            ConstraintApplier.applyConstraints(cp, pt, ConstraintType.ARRAY);
             if (cp.getUniqueItems()) {
                 // A unique "array" is a set
                 // TODO: pydantic v2: Pydantic suggest to convert this to a set, but this has some implications:
@@ -1915,12 +1906,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
 
                 // e.g. constr(regex=r'/[a-z]/i', strict=True)
                 pt.constrain("strict", true);
-                if (cp.getMaxLength() != null) {
-                    pt.constrain("max_length", cp.getMaxLength());
-                }
-                if (cp.getMinLength() != null) {
-                    pt.constrain("min_length", cp.getMinLength());
-                }
+                ConstraintApplier.applyConstraints(cp, pt, ConstraintType.STRING);
 
                 if (cp.getPattern() != null) {
                     moduleImports.add(PYDANTIC, "field_validator");
@@ -1952,28 +1938,8 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                 PythonType floatt = new PythonType("float");
                 PythonType intt = new PythonType("int");
 
-                // e.g. confloat(ge=10, le=100, strict=True)
-                if (cp.getMaximum() != null) {
-                    if (cp.getExclusiveMaximum()) {
-                        floatt.constrain(LESS_THAN, cp.getMaximum(), false);
-                        intt.constrain(LESS_THAN, (int) Math.ceil(Double.valueOf(cp.getMaximum()))); // e.g. < 7.59 => < 8
-                    } else {
-                        floatt.constrain(LESS_OR_EQUAL_TO, cp.getMaximum(), false);
-                        intt.constrain(LESS_OR_EQUAL_TO, (int) Math.floor(Double.valueOf(cp.getMaximum()))); // e.g. <= 7.59 => <= 7
-                    }
-                }
-                if (cp.getMinimum() != null) {
-                    if (cp.getExclusiveMinimum()) {
-                        floatt.constrain(GREATER_THAN, cp.getMinimum(), false);
-                        intt.constrain(GREATER_THAN, (int) Math.floor(Double.valueOf(cp.getMinimum()))); // e.g. > 7.59 => > 7
-                    } else {
-                        floatt.constrain(GREATER_OR_EQUAL_TO, cp.getMinimum(), false);
-                        intt.constrain(GREATER_OR_EQUAL_TO, (int) Math.ceil(Double.valueOf(cp.getMinimum()))); // e.g. >= 7.59 => >= 8
-                    }
-                }
-                if (cp.getMultipleOf() != null) {
-                    floatt.constrain("multiple_of", cp.getMultipleOf());
-                }
+                ConstraintApplier.applyConstraints(cp, floatt, ConstraintType.NUMBER);
+                ConstraintApplier.applyConstraints(cp, intt, ConstraintType.ROUNDED_NUMBER);
 
                 if ("Union[StrictFloat, StrictInt]".equals(mapNumberTo)) {
                     floatt.constrain("strict", true);
@@ -2013,7 +1979,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                 PythonType pt = new PythonType("int");
                 // e.g. conint(ge=10, le=100, strict=True)
                 pt.constrain("strict", true);
-                applyConstraints(pt, cp);
+                ConstraintApplier.applyConstraints(cp, pt, ConstraintType.NUMBER);
                 return pt;
             } else {
                 moduleImports.add(PYDANTIC, "StrictInt");
@@ -2029,14 +1995,8 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                 // e.g. conbytes(min_length=2, max_length=10)
                 bytest.constrain("strict", true);
                 strt.constrain("strict", true);
-                if (cp.getMaxLength() != null) {
-                    bytest.constrain("max_length", cp.getMaxLength());
-                    strt.constrain("max_length", cp.getMaxLength());
-                }
-                if (cp.getMinLength() != null) {
-                    bytest.constrain("min_length", cp.getMinLength());
-                    strt.constrain("min_length", cp.getMinLength());
-                }
+                ConstraintApplier.applyConstraints(cp, bytest, ConstraintType.BINARY);
+                ConstraintApplier.applyConstraints(cp, strt, ConstraintType.BINARY);
                 if (cp.getPattern() != null) {
                     moduleImports.add(PYDANTIC, "field_validator");
                     // use validator instead as regex doesn't support flags, e.g. IGNORECASE
@@ -2097,7 +2057,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
             if (cp.getHasValidation()) {
                 // e.g. condecimal(ge=10, le=100, strict=True)
                 pt.constrain("strict", true);
-                applyConstraints(pt, cp);
+                ConstraintApplier.applyConstraints(cp, pt, ConstraintType.NUMBER);
             }
 
             return pt;
@@ -2315,26 +2275,6 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
             return result;
         }
 
-        private void applyConstraints(PythonType pythonType, IJsonSchemaValidationProperties cp) {
-            if (cp.getMaximum() != null) {
-                if (cp.getExclusiveMaximum()) {
-                    pythonType.constrain(LESS_THAN, cp.getMaximum(), false);
-                } else {
-                    pythonType.constrain(LESS_OR_EQUAL_TO, cp.getMaximum(), false);
-                }
-            }
-            if (cp.getMinimum() != null) {
-                if (cp.getExclusiveMinimum()) {
-                    pythonType.constrain(GREATER_THAN, cp.getMinimum(), false);
-                } else {
-                    pythonType.constrain(GREATER_OR_EQUAL_TO, cp.getMinimum(), false);
-                }
-            }
-            if (cp.getMultipleOf() != null) {
-                pythonType.constrain("multiple_of", cp.getMultipleOf());
-            }
-        }
-
         private String finalizeType(CodegenParameter cp, PythonType pt) {
             if (!cp.required || cp.isNullable) {
                 moduleImports.add("typing", "Optional");
@@ -2349,6 +2289,96 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
 
             //return pt.asTypeConstraint(moduleImports);
             return pt.asTypeConstraintWithAnnotations(moduleImports);
+        }
+    }
+
+    private enum ConstraintType {
+        ARRAY, BINARY, STRING, NUMBER, ROUNDED_NUMBER
+    }
+
+    private static class ConstraintApplier {
+
+        private static final String MAX_LENGTH = "max_length";
+        private static final String MIN_LENGTH = "min_length";
+        private static final String LESS_THAN = "lt";
+        private static final String GREATER_THAN = "gt";
+        private static final String GREATER_OR_EQUAL_TO = "ge";
+        private static final String LESS_OR_EQUAL_TO = "le";
+        private static final String MULTIPLE_OF = "multiple_of";
+
+        static void applyConstraints(IJsonSchemaValidationProperties cp, PythonType pythonType, ConstraintType type) {
+            if (cp == null || pythonType == null) {
+                return;
+            }
+
+            switch (type) {
+                case ARRAY:
+                    if (cp.getMaxItems() != null) {
+                        pythonType.constrain(MAX_LENGTH, cp.getMaxItems());
+                    }
+                    if (cp.getMinItems() != null) {
+                        pythonType.constrain(MIN_LENGTH, cp.getMinItems());
+                    }
+                case BINARY:
+                case STRING:
+                    if (cp.getMaxLength() != null) {
+                        pythonType.constrain(MAX_LENGTH, cp.getMaxLength());
+                    }
+                    if (cp.getMinLength() != null) {
+                        pythonType.constrain(MIN_LENGTH, cp.getMinLength());
+                    }
+                    break;
+                case NUMBER:
+                case ROUNDED_NUMBER:
+                    applyNumericConstraints(cp, pythonType, type == ConstraintType.ROUNDED_NUMBER);
+                    break;
+            }
+        }
+
+        private static void applyNumericConstraints(IJsonSchemaValidationProperties cp, PythonType pythonType, boolean rounded) {
+            if (cp.getMaximum() != null) {
+                if (rounded) {
+                    if (cp.getExclusiveMaximum()) {
+                        pythonType.constrain(LESS_THAN, ceilValue(cp.getMaximum())); // e.g. < 7.59 => < 8
+                    } else {
+                        pythonType.constrain(LESS_OR_EQUAL_TO, floorValue(cp.getMaximum())); // e.g. <= 7.59 => <= 7
+                    }
+                } else {
+                    if (cp.getExclusiveMaximum()) {
+                        pythonType.constrain(LESS_THAN, cp.getMaximum(), false);
+                    } else {
+                        pythonType.constrain(LESS_OR_EQUAL_TO, cp.getMaximum(), false);
+                    }
+                }
+            }
+
+            if (cp.getMinimum() != null) {
+                if (rounded) {
+                    if (cp.getExclusiveMinimum()) {
+                        pythonType.constrain(GREATER_THAN, floorValue(cp.getMinimum())); // e.g. > 7.59 => > 7
+                    } else {
+                        pythonType.constrain(GREATER_OR_EQUAL_TO, ceilValue(cp.getMinimum()));  // e.g. >= 7.59 => >= 8
+                    }
+                } else {
+                    if (cp.getExclusiveMinimum()) {
+                        pythonType.constrain(GREATER_THAN, cp.getMinimum(), false);
+                    } else {
+                        pythonType.constrain(GREATER_OR_EQUAL_TO, cp.getMinimum(), false);
+                    }
+                }
+            }
+
+            if (!rounded && cp.getMultipleOf() != null) {
+                pythonType.constrain(MULTIPLE_OF, cp.getMultipleOf());
+            }
+        }
+
+        private static int ceilValue(String value) {
+            return (int) Math.ceil(Double.parseDouble(value));
+        }
+
+        private static int floorValue(String value) {
+            return (int) Math.floor(Double.parseDouble(value));
         }
     }
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Centralize the handling of applying constraints to different OAS types to remove duplicates (e.g., the current `String` and `Binary` logic is the exact same). This also makes it easier to reuse them, for example when creating types that are purely tied to the constraints coming from OAS and not those that may be relevant for different internal Python validators (e.g., Pydantic).

This could also be helpful for the case where you might want to represent constraints differently for different contexts, for example this [PR](https://github.com/OpenAPITools/openapi-generator/pull/24098/changes/47eb4c2f53f757ed68995eed00a6c4aab2c4762b..4decf3c8dfd96e8eee57115e216bac04d5291562) where queries has to be handled differently with how constraints are constructed.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Python technical committee — @cbornet @tomplus @krjakbrjak @fa0311 @multani (@krjakbrjak as the python-fastapi generator author).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized how OAS constraints are applied in the Python generator to remove duplicated logic and keep behavior consistent across types. This simplifies future changes and enables context-specific constraint handling.

- **Refactors**
  - Added `ConstraintApplier` and `ConstraintType` (incl. `ROUNDED_NUMBER`) to standardize length and numeric rules.
  - Replaced inline constraint code for arrays, strings, binaries, numbers, ints, and decimals in `AbstractPythonCodegen`; removed `PydanticType.applyConstraints` and centralized comparison constants.
  - Kept semantics unchanged: inclusive/exclusive bounds, ceil/floor for integer limits, and `multiple_of` only for non-rounded numeric types.

<sup>Written for commit dd8d9e7792b54a154e960a0beb0292d8db68f200. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

