### PR TITLE
[php-nextgen] Test with phpstan

### DIFF
--- a/.github/workflows/samples-php-nextgen-phpstan.yaml
+++ b/.github/workflows/samples-php-nextgen-phpstan.yaml
@@ -1,20 +1,18 @@
-name: Samples PHP Syntax Checker
+name: Samples php-nextgen (phpstan)
 
 on:
   push:
     paths:
-      - samples/client/petstore/php/OpenAPIClient-php/**
       - samples/client/petstore/php-nextgen/OpenAPIClient-php/**
   pull_request:
     paths:
-      - samples/client/petstore/php/OpenAPIClient-php/**
       - samples/client/petstore/php-nextgen/OpenAPIClient-php/**
 jobs:
   build:
-    name: Build PHP projects
+    name: Build 
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         php:
           - "8.1"
@@ -23,7 +21,6 @@ jobs:
           - "8.4"
         sample:
           # clients
-          - samples/client/petstore/php/OpenAPIClient-php/
           - samples/client/petstore/php-nextgen/OpenAPIClient-php/
     steps:
       - uses: actions/checkout@v7
@@ -31,6 +28,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php }}"
-      - name: php -l
+      - name: phpstan
         working-directory: ${{ matrix.sample }}
-        run: find . -name "*.php" -exec php -l {} +
+        run: |
+          composer require --dev phpstan/phpstan
+          vendor/bin/phpstan analyse src

--- a/.github/workflows/samples-php-syntax-check.yaml
+++ b/.github/workflows/samples-php-syntax-check.yaml
@@ -34,3 +34,8 @@ jobs:
       - name: php -l
         working-directory: ${{ matrix.sample }}
         run: find . -name "*.php" -exec php -l {} +
+      - name: phpstan
+        working-directory: ${{ matrix.sample }}
+        run: |
+          composer require --dev phpstan/phpstan
+          vendor/bin/phpstan analyse src

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/.openapi-generator-ignore
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/.openapi-generator-ignore
@@ -23,3 +23,5 @@
 #!docs/README.md
 #
 #
+#
+#


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `phpstan/phpstan` static analysis to CI for the `php-nextgen` PHP sample to catch type issues early. Also tidy `.openapi-generator-ignore` comments.

- **Dependencies**
  - Adds a GitHub Actions workflow scoped to `samples/client/petstore/php-nextgen/OpenAPIClient-php`, runs on PHP 8.1–8.4, installs `phpstan/phpstan` via Composer, and runs `vendor/bin/phpstan analyse src`.

<sup>Written for commit 096bdf9c0679c225640aca43e8429155d93a402c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

