### PR TITLE
[python] Set API key cookie as key-value pair

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -680,7 +680,11 @@ class ApiClient:
         :param auth_setting: auth settings for the endpoint
         """
         if auth_setting['in'] == 'cookie':
-            headers['Cookie'] = f"{auth_setting['key']}={auth_setting['value']}"
+            if not 'Cookie' in headers:
+                headers['Cookie'] = ""
+            else:
+                headers['Cookie'] += "; "
+            headers['Cookie'] += f"{auth_setting['key']}={auth_setting['value']}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -680,7 +680,7 @@ class ApiClient:
         :param auth_setting: auth settings for the endpoint
         """
         if auth_setting['in'] == 'cookie':
-            headers['Cookie'] = auth_setting['value']
+            headers['Cookie'] = f"{auth_setting['key']}={auth_setting['value']}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -684,8 +684,8 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Encode spaces and semicolons in cookie value, leaving other characters as-is
-            cookie_value = str(auth_setting['value']).replace(" ", "%20").replace(";", "%3B")
+            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
+            cookie_value = quote(str(auth_setting['value']), safe='+/=')
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -684,7 +684,9 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            headers['Cookie'] += f"{auth_setting['key']}={auth_setting['value']}"
+            # Account for cookie value containing spaces or being non-string value
+            cookie_value = quote(str(auth_setting['value']), safe='')
+            headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -684,8 +684,11 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe='+/=')
+            # Account for cookie value containing spaces and special characters
+            cookie_value = str(auth_setting['value'])
+            if not re.match("^\".*\"$", cookie_value):
+                cookie_value = cookie_value.replace("\"", "\\\"")
+                cookie_value = f"\"{cookie_value}\""
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -684,8 +684,8 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces or being non-string value
-            cookie_value = quote(str(auth_setting['value']), safe='')
+            # Encode spaces and semicolons in cookie value, leaving other characters as-is
+            cookie_value = str(auth_setting['value']).replace(" ", "%20").replace(";", "%3B")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
@@ -677,8 +677,11 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe='+/=')
+            # Account for cookie value containing spaces and special characters
+            cookie_value = str(auth_setting['value'])
+            if not re.match("^\".*\"$", cookie_value):
+                cookie_value = cookie_value.replace("\"", "\\\"")
+                cookie_value = f"\"{cookie_value}\""
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
@@ -677,7 +677,9 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            headers['Cookie'] += f"{auth_setting['key']}={auth_setting['value']}"
+            # Account for cookie value containing spaces or being non-string value
+            cookie_value = quote(str(auth_setting['value']), safe='')
+            headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
@@ -677,8 +677,8 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces or being non-string value
-            cookie_value = quote(str(auth_setting['value']), safe='')
+            # Encode spaces and semicolons in cookie value, leaving other characters as-is
+            cookie_value = str(auth_setting['value']).replace(" ", "%20").replace(";", "%3B")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
@@ -673,7 +673,7 @@ class ApiClient:
         :param auth_setting: auth settings for the endpoint
         """
         if auth_setting['in'] == 'cookie':
-            headers['Cookie'] = auth_setting['value']
+            headers['Cookie'] = f"{auth_setting['key']}={auth_setting['value']}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
@@ -677,8 +677,8 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Encode spaces and semicolons in cookie value, leaving other characters as-is
-            cookie_value = str(auth_setting['value']).replace(" ", "%20").replace(";", "%3B")
+            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
+            cookie_value = quote(str(auth_setting['value']), safe='+/=')
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
@@ -673,7 +673,11 @@ class ApiClient:
         :param auth_setting: auth settings for the endpoint
         """
         if auth_setting['in'] == 'cookie':
-            headers['Cookie'] = f"{auth_setting['key']}={auth_setting['value']}"
+            if not 'Cookie' in headers:
+                headers['Cookie'] = ""
+            else:
+                headers['Cookie'] += "; "
+            headers['Cookie'] += f"{auth_setting['key']}={auth_setting['value']}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -677,8 +677,11 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe='+/=')
+            # Account for cookie value containing spaces and special characters
+            cookie_value = str(auth_setting['value'])
+            if not re.match("^\".*\"$", cookie_value):
+                cookie_value = cookie_value.replace("\"", "\\\"")
+                cookie_value = f"\"{cookie_value}\""
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -677,7 +677,9 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            headers['Cookie'] += f"{auth_setting['key']}={quote(auth_setting['value'], safe='')}"
+            # Account for cookie value containing spaces or being non-string value
+            cookie_value = quote(str(auth_setting['value']), safe='')
+            headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -677,7 +677,7 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            headers['Cookie'] += f"{auth_setting['key']}={auth_setting['value']}"
+            headers['Cookie'] += f"{auth_setting['key']}={quote(auth_setting['value'], safe='')}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -677,8 +677,8 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces or being non-string value
-            cookie_value = quote(str(auth_setting['value']), safe='')
+            # Encode spaces and semicolons in cookie value, leaving other characters as-is
+            cookie_value = str(auth_setting['value']).replace(" ", "%20").replace(";", "%3B")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -673,7 +673,7 @@ class ApiClient:
         :param auth_setting: auth settings for the endpoint
         """
         if auth_setting['in'] == 'cookie':
-            headers['Cookie'] = auth_setting['value']
+            headers['Cookie'] = f"{auth_setting['key']}={auth_setting['value']}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -677,8 +677,8 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Encode spaces and semicolons in cookie value, leaving other characters as-is
-            cookie_value = str(auth_setting['value']).replace(" ", "%20").replace(";", "%3B")
+            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
+            cookie_value = quote(str(auth_setting['value']), safe='+/=')
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -673,7 +673,11 @@ class ApiClient:
         :param auth_setting: auth settings for the endpoint
         """
         if auth_setting['in'] == 'cookie':
-            headers['Cookie'] = f"{auth_setting['key']}={auth_setting['value']}"
+            if not 'Cookie' in headers:
+                headers['Cookie'] = ""
+            else:
+                headers['Cookie'] += "; "
+            headers['Cookie'] += f"{auth_setting['key']}={auth_setting['value']}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -679,8 +679,11 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe='+/=')
+            # Account for cookie value containing spaces and special characters
+            cookie_value = str(auth_setting['value'])
+            if not re.match("^\".*\"$", cookie_value):
+                cookie_value = cookie_value.replace("\"", "\\\"")
+                cookie_value = f"\"{cookie_value}\""
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -679,7 +679,9 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            headers['Cookie'] += f"{auth_setting['key']}={auth_setting['value']}"
+            # Account for cookie value containing spaces or being non-string value
+            cookie_value = quote(str(auth_setting['value']), safe='')
+            headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -679,8 +679,8 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces or being non-string value
-            cookie_value = quote(str(auth_setting['value']), safe='')
+            # Encode spaces and semicolons in cookie value, leaving other characters as-is
+            cookie_value = str(auth_setting['value']).replace(" ", "%20").replace(";", "%3B")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -675,7 +675,11 @@ class ApiClient:
         :param auth_setting: auth settings for the endpoint
         """
         if auth_setting['in'] == 'cookie':
-            headers['Cookie'] = f"{auth_setting['key']}={auth_setting['value']}"
+            if not 'Cookie' in headers:
+                headers['Cookie'] = ""
+            else:
+                headers['Cookie'] += "; "
+            headers['Cookie'] += f"{auth_setting['key']}={auth_setting['value']}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -675,7 +675,7 @@ class ApiClient:
         :param auth_setting: auth settings for the endpoint
         """
         if auth_setting['in'] == 'cookie':
-            headers['Cookie'] = auth_setting['value']
+            headers['Cookie'] = f"{auth_setting['key']}={auth_setting['value']}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -679,8 +679,8 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Encode spaces and semicolons in cookie value, leaving other characters as-is
-            cookie_value = str(auth_setting['value']).replace(" ", "%20").replace(";", "%3B")
+            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
+            cookie_value = quote(str(auth_setting['value']), safe='+/=')
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/api_client.py
@@ -679,8 +679,11 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe='+/=')
+            # Account for cookie value containing spaces and special characters
+            cookie_value = str(auth_setting['value'])
+            if not re.match("^\".*\"$", cookie_value):
+                cookie_value = cookie_value.replace("\"", "\\\"")
+                cookie_value = f"\"{cookie_value}\""
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/api_client.py
@@ -679,7 +679,9 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            headers['Cookie'] += f"{auth_setting['key']}={auth_setting['value']}"
+            # Account for cookie value containing spaces or being non-string value
+            cookie_value = quote(str(auth_setting['value']), safe='')
+            headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/api_client.py
@@ -679,8 +679,8 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces or being non-string value
-            cookie_value = quote(str(auth_setting['value']), safe='')
+            # Encode spaces and semicolons in cookie value, leaving other characters as-is
+            cookie_value = str(auth_setting['value']).replace(" ", "%20").replace(";", "%3B")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/api_client.py
@@ -675,7 +675,11 @@ class ApiClient:
         :param auth_setting: auth settings for the endpoint
         """
         if auth_setting['in'] == 'cookie':
-            headers['Cookie'] = f"{auth_setting['key']}={auth_setting['value']}"
+            if not 'Cookie' in headers:
+                headers['Cookie'] = ""
+            else:
+                headers['Cookie'] += "; "
+            headers['Cookie'] += f"{auth_setting['key']}={auth_setting['value']}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/api_client.py
@@ -675,7 +675,7 @@ class ApiClient:
         :param auth_setting: auth settings for the endpoint
         """
         if auth_setting['in'] == 'cookie':
-            headers['Cookie'] = auth_setting['value']
+            headers['Cookie'] = f"{auth_setting['key']}={auth_setting['value']}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/api_client.py
@@ -679,8 +679,8 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Encode spaces and semicolons in cookie value, leaving other characters as-is
-            cookie_value = str(auth_setting['value']).replace(" ", "%20").replace(";", "%3B")
+            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
+            cookie_value = quote(str(auth_setting['value']), safe='+/=')
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/api_client.py
@@ -679,8 +679,11 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe='+/=')
+            # Account for cookie value containing spaces and special characters
+            cookie_value = str(auth_setting['value'])
+            if not re.match("^\".*\"$", cookie_value):
+                cookie_value = cookie_value.replace("\"", "\\\"")
+                cookie_value = f"\"{cookie_value}\""
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/api_client.py
@@ -679,7 +679,9 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            headers['Cookie'] += f"{auth_setting['key']}={auth_setting['value']}"
+            # Account for cookie value containing spaces or being non-string value
+            cookie_value = quote(str(auth_setting['value']), safe='')
+            headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/api_client.py
@@ -679,8 +679,8 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces or being non-string value
-            cookie_value = quote(str(auth_setting['value']), safe='')
+            # Encode spaces and semicolons in cookie value, leaving other characters as-is
+            cookie_value = str(auth_setting['value']).replace(" ", "%20").replace(";", "%3B")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/api_client.py
@@ -675,7 +675,11 @@ class ApiClient:
         :param auth_setting: auth settings for the endpoint
         """
         if auth_setting['in'] == 'cookie':
-            headers['Cookie'] = f"{auth_setting['key']}={auth_setting['value']}"
+            if not 'Cookie' in headers:
+                headers['Cookie'] = ""
+            else:
+                headers['Cookie'] += "; "
+            headers['Cookie'] += f"{auth_setting['key']}={auth_setting['value']}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/api_client.py
@@ -675,7 +675,7 @@ class ApiClient:
         :param auth_setting: auth settings for the endpoint
         """
         if auth_setting['in'] == 'cookie':
-            headers['Cookie'] = auth_setting['value']
+            headers['Cookie'] = f"{auth_setting['key']}={auth_setting['value']}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/api_client.py
@@ -679,8 +679,8 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Encode spaces and semicolons in cookie value, leaving other characters as-is
-            cookie_value = str(auth_setting['value']).replace(" ", "%20").replace(";", "%3B")
+            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
+            cookie_value = quote(str(auth_setting['value']), safe='+/=')
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api_client.py
@@ -672,7 +672,7 @@ class ApiClient:
         :param auth_setting: auth settings for the endpoint
         """
         if auth_setting['in'] == 'cookie':
-            headers['Cookie'] = auth_setting['value']
+            headers['Cookie'] = f"{auth_setting['key']}={auth_setting['value']}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api_client.py
@@ -676,8 +676,8 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces or being non-string value
-            cookie_value = quote(str(auth_setting['value']), safe='')
+            # Encode spaces and semicolons in cookie value, leaving other characters as-is
+            cookie_value = str(auth_setting['value']).replace(" ", "%20").replace(";", "%3B")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api_client.py
@@ -672,7 +672,11 @@ class ApiClient:
         :param auth_setting: auth settings for the endpoint
         """
         if auth_setting['in'] == 'cookie':
-            headers['Cookie'] = f"{auth_setting['key']}={auth_setting['value']}"
+            if not 'Cookie' in headers:
+                headers['Cookie'] = ""
+            else:
+                headers['Cookie'] += "; "
+            headers['Cookie'] += f"{auth_setting['key']}={auth_setting['value']}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api_client.py
@@ -676,8 +676,8 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Encode spaces and semicolons in cookie value, leaving other characters as-is
-            cookie_value = str(auth_setting['value']).replace(" ", "%20").replace(";", "%3B")
+            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
+            cookie_value = quote(str(auth_setting['value']), safe='+/=')
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api_client.py
@@ -676,8 +676,11 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe='+/=')
+            # Account for cookie value containing spaces and special characters
+            cookie_value = str(auth_setting['value'])
+            if not re.match("^\".*\"$", cookie_value):
+                cookie_value = cookie_value.replace("\"", "\\\"")
+                cookie_value = f"\"{cookie_value}\""
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api_client.py
@@ -676,7 +676,9 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            headers['Cookie'] += f"{auth_setting['key']}={auth_setting['value']}"
+            # Account for cookie value containing spaces or being non-string value
+            cookie_value = quote(str(auth_setting['value']), safe='')
+            headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -672,7 +672,7 @@ class ApiClient:
         :param auth_setting: auth settings for the endpoint
         """
         if auth_setting['in'] == 'cookie':
-            headers['Cookie'] = auth_setting['value']
+            headers['Cookie'] = f"{auth_setting['key']}={auth_setting['value']}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -676,8 +676,8 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces or being non-string value
-            cookie_value = quote(str(auth_setting['value']), safe='')
+            # Encode spaces and semicolons in cookie value, leaving other characters as-is
+            cookie_value = str(auth_setting['value']).replace(" ", "%20").replace(";", "%3B")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -672,7 +672,11 @@ class ApiClient:
         :param auth_setting: auth settings for the endpoint
         """
         if auth_setting['in'] == 'cookie':
-            headers['Cookie'] = f"{auth_setting['key']}={auth_setting['value']}"
+            if not 'Cookie' in headers:
+                headers['Cookie'] = ""
+            else:
+                headers['Cookie'] += "; "
+            headers['Cookie'] += f"{auth_setting['key']}={auth_setting['value']}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -676,8 +676,8 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Encode spaces and semicolons in cookie value, leaving other characters as-is
-            cookie_value = str(auth_setting['value']).replace(" ", "%20").replace(";", "%3B")
+            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
+            cookie_value = quote(str(auth_setting['value']), safe='+/=')
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -676,8 +676,11 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe='+/=')
+            # Account for cookie value containing spaces and special characters
+            cookie_value = str(auth_setting['value'])
+            if not re.match("^\".*\"$", cookie_value):
+                cookie_value = cookie_value.replace("\"", "\\\"")
+                cookie_value = f"\"{cookie_value}\""
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -676,7 +676,9 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            headers['Cookie'] += f"{auth_setting['key']}={auth_setting['value']}"
+            # Account for cookie value containing spaces or being non-string value
+            cookie_value = quote(str(auth_setting['value']), safe='')
+            headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':
                 headers[auth_setting['key']] = auth_setting['value']


### PR DESCRIPTION
Instead of the expected format for API key cookies such as `Cookie: apikey=1234`, these cookies are included in an incorrect `Cookie: 1234` format. This change correctly formats the API key as a key-value pair.

Fixes #23301 

@cbornet @tomplus @krjakbrjak @fa0311

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes API key cookie auth in generated Python clients by sending `Cookie: key="value"` and supporting multiple cookies; values are stringified and wrapped in double quotes with internal quotes escaped, preserving `+` `/` `=` and avoiding parsing errors (fixes #23301).

<sup>Written for commit 64003e5f096c0cdcc082c49b634b1738e8206ab6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

