### PR TITLE
fix(dart-dio): use enum type for discriminator when property is enum

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/class.mustache
@@ -13,7 +13,6 @@ part '{{classFilename}}.g.dart';
 }
 {{#discriminator}}{{#hasDiscriminatorWithNonEmptyMapping}}
 {{>serialization/built_value/class_discriminator}}
-
 {{/hasDiscriminatorWithNonEmptyMapping}}{{/discriminator}}
 {{>serialization/built_value/class_serializer}}{{#vendorExtensions.x-is-parent}}
 

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/class_discriminator.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/class_discriminator.mustache
@@ -1,3 +1,4 @@
+{{^discriminator.isEnum}}
 extension {{classname}}DiscriminatorExt on {{classname}} {
     String? get discriminatorValue {
         {{#mappedModels}}
@@ -18,3 +19,26 @@ extension {{classname}}BuilderDiscriminatorExt on {{classname}}Builder {
         return null;
     }
 }
+{{/discriminator.isEnum}}
+{{#discriminator.isEnum}}
+extension {{classname}}DiscriminatorExt on {{classname}} {
+    {{discriminator.propertyType}} get discriminatorValue {
+        {{#mappedModels}}
+        if (this is {{modelName}}) {
+            return {{discriminator.propertyType}}.valueOf(r'{{mappingName}}');
+        }
+        {{/mappedModels}}
+        throw UnsupportedError('Invalid discriminator value for {{classname}}');
+    }
+}
+extension {{classname}}BuilderDiscriminatorExt on {{classname}}Builder {
+    {{discriminator.propertyType}} get discriminatorValue {
+        {{#mappedModels}}
+        if (this is {{modelName}}Builder) {
+            return {{discriminator.propertyType}}.valueOf(r'{{mappingName}}');
+        }
+        {{/mappedModels}}
+        throw UnsupportedError('Invalid discriminator value for {{classname}}Builder');
+    }
+}
+{{/discriminator.isEnum}}

--- a/modules/openapi-generator/src/test/resources/3_0/dart-dio/enum-discriminator.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/dart-dio/enum-discriminator.yaml
@@ -1,0 +1,51 @@
+openapi: 3.0.3
+info:
+  title: Dart Dio Enum Discriminator
+  version: 1.0.0
+paths:
+  /merchant:
+    get:
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MerchantDetailsDto'
+components:
+  schemas:
+    MerchantDetailsDto:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        merchantType:
+          $ref: '#/components/schemas/MerchantTypeEnum'
+      required:
+        - uuid
+        - merchantType
+      discriminator:
+        propertyName: merchantType
+        mapping:
+          TYPE_A: '#/components/schemas/MerchantDetailsTypeADto'
+          TYPE_B: '#/components/schemas/MerchantDetailsTypeBDto'
+    MerchantDetailsTypeADto:
+      allOf:
+        - $ref: '#/components/schemas/MerchantDetailsDto'
+        - type: object
+          properties:
+            aField:
+              type: string
+    MerchantDetailsTypeBDto:
+      allOf:
+        - $ref: '#/components/schemas/MerchantDetailsDto'
+        - type: object
+          properties:
+            bField:
+              type: string
+    MerchantTypeEnum:
+      type: string
+      enum:
+        - TYPE_A
+        - TYPE_B

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/fruit.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/fruit.dart
@@ -46,25 +46,25 @@ abstract class Fruit implements Built<Fruit, FruitBuilder> {
 }
 
 extension FruitDiscriminatorExt on Fruit {
-    String? get discriminatorValue {
+    FruitType get discriminatorValue {
         if (this is Apple) {
-            return r'APPLE';
+            return FruitType.valueOf(r'APPLE');
         }
         if (this is Banana) {
-            return r'BANANA';
+            return FruitType.valueOf(r'BANANA');
         }
-        return null;
+        throw UnsupportedError('Invalid discriminator value for Fruit');
     }
 }
 extension FruitBuilderDiscriminatorExt on FruitBuilder {
-    String? get discriminatorValue {
+    FruitType get discriminatorValue {
         if (this is AppleBuilder) {
-            return r'APPLE';
+            return FruitType.valueOf(r'APPLE');
         }
         if (this is BananaBuilder) {
-            return r'BANANA';
+            return FruitType.valueOf(r'BANANA');
         }
-        return null;
+        throw UnsupportedError('Invalid discriminator value for FruitBuilder');
     }
 }
 


### PR DESCRIPTION
based on https://github.com/OpenAPITools/openapi-generator/pull/22612 with resolved merge conflicts

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `dart-dio` built_value discriminator generation when the discriminator is an enum. The generated `discriminatorValue` now uses the enum type instead of `String` for type safety and correct enum handling.

- **Bug Fixes**
  - Generate enum-typed `discriminatorValue` getters in `class_discriminator.mustache` when the discriminator is an enum; non-enum behavior is unchanged.
  - Use `<Enum>.valueOf('...')` for mappings and throw `UnsupportedError` instead of returning `null`.
  - Added a test (`verifyEnumDiscriminatorUsesEnumType`) with a new enum-discriminator spec (`enum-discriminator.yaml`) to enforce the behavior.
  - Regenerated the sample (`fruit.dart`) and applied a minor template cleanup.

<sup>Written for commit 67087e51afd79ec95578bc00740d4771b3031d7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

