### PR TITLE
[dart-dio][built_value] Register BuilderFactory for nested additionalProperties shapes

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
@@ -660,7 +660,118 @@ public class DartDioClientCodegen extends AbstractDartCodegen {
                             items.getAdditionalProperties().dataType
                     ));
                 }
+
+                // Recursively register builder factories for every nested
+                // container reachable from this property. Without this step,
+                // shapes like Map<String, List<X>> (e.g. an OpenAPI object
+                // with `additionalProperties: { type: array, items: ...}`)
+                // never get a `BuiltList<X>` factory registered, and
+                // built_value throws "No builder factory for BuiltList<X>"
+                // at deserialization time.
+                registerNestedBuilderFactories(property);
             }
+        }
+    }
+
+    /**
+     * Walk the CodegenProperty tree and register a built_value
+     * BuilderFactory for every container node, including the top one.
+     * Handles arbitrary nesting like {@code Map<String, List<X>>},
+     * {@code List<Map<String, X>>}, {@code List<List<X>>}, etc.
+     */
+    private void registerNestedBuilderFactories(CodegenProperty prop) {
+        if (prop == null || !prop.isContainer || prop.items == null) {
+            return;
+        }
+        // Recurse first so deeper containers are registered too. Order
+        // doesn't matter for correctness (built_value resolves factories
+        // by FullType lookup), but it keeps the emitted list intuitive.
+        registerNestedBuilderFactories(prop.items);
+
+        BuilderFactoryExpr expr = renderBuilderFactory(prop);
+        if (expr != null) {
+            addBuiltValueSerializer(BuiltValueSerializer.composite(
+                    expr.fullTypeArgs,
+                    expr.builderInstantiation));
+        }
+    }
+
+    /**
+     * Render the FullType argument list and the matching Builder
+     * instantiation for a container CodegenProperty.
+     *
+     * @return null if {@code prop} is not a container we can render.
+     */
+    private BuilderFactoryExpr renderBuilderFactory(CodegenProperty prop) {
+        if (prop == null || !prop.isContainer || prop.items == null) {
+            return null;
+        }
+        String innerFullType = renderInnerFullType(prop.items);
+        String innerDart = renderDartType(prop.items);
+
+        if (prop.isArray) {
+            String collection = prop.getUniqueItems() ? "BuiltSet" : "BuiltList";
+            String builder = prop.getUniqueItems() ? "SetBuilder" : "ListBuilder";
+            return new BuilderFactoryExpr(
+                    collection + ", [FullType(" + innerFullType + ")]",
+                    builder + "<" + innerDart + ">");
+        }
+        if (prop.isMap) {
+            return new BuilderFactoryExpr(
+                    "BuiltMap, [FullType(String), FullType(" + innerFullType + ")]",
+                    "MapBuilder<String, " + innerDart + ">");
+        }
+        return null;
+    }
+
+    /**
+     * What goes inside {@code FullType(...)} for this property:
+     * a leaf type name like {@code "Foo"}, or a nested expression like
+     * {@code "BuiltList, [FullType(Foo)]"}.
+     */
+    private String renderInnerFullType(CodegenProperty prop) {
+        if (prop == null) return "dynamic";
+        if (!prop.isContainer || prop.items == null) {
+            return prop.dataType;
+        }
+        String inner = renderInnerFullType(prop.items);
+        if (prop.isArray) {
+            String collection = prop.getUniqueItems() ? "BuiltSet" : "BuiltList";
+            return collection + ", [FullType(" + inner + ")]";
+        }
+        if (prop.isMap) {
+            return "BuiltMap, [FullType(String), FullType(" + inner + ")]";
+        }
+        return prop.dataType;
+    }
+
+    /**
+     * Render the Dart type literal (e.g. {@code BuiltMap<String, BuiltList<Foo>>})
+     * used inside the {@code () => XBuilder<...>()} lambda.
+     */
+    private String renderDartType(CodegenProperty prop) {
+        if (prop == null) return "dynamic";
+        if (!prop.isContainer || prop.items == null) {
+            return prop.dataType;
+        }
+        String inner = renderDartType(prop.items);
+        if (prop.isArray) {
+            String collection = prop.getUniqueItems() ? "BuiltSet" : "BuiltList";
+            return collection + "<" + inner + ">";
+        }
+        if (prop.isMap) {
+            return "BuiltMap<String, " + inner + ">";
+        }
+        return prop.dataType;
+    }
+
+    private static final class BuilderFactoryExpr {
+        final String fullTypeArgs;
+        final String builderInstantiation;
+
+        BuilderFactoryExpr(String fullTypeArgs, String builderInstantiation) {
+            this.fullTypeArgs = fullTypeArgs;
+            this.builderInstantiation = builderInstantiation;
         }
     }
 
@@ -817,12 +928,45 @@ public class DartDioClientCodegen extends AbstractDartCodegen {
 
         @Getter final String dataType;
 
+        // When non-null, the serializer is rendered verbatim from these
+        // pre-computed strings instead of being dispatched through the
+        // isArray/isMap branches in serializers.mustache. Used for
+        // arbitrarily nested container types where dataType alone can't
+        // express the FullType expression (e.g. Map<String, List<X>>).
+        @Getter final String fullTypeArgs;
+
+        @Getter final String builderInstantiation;
+
         private BuiltValueSerializer(boolean isArray, boolean uniqueItems, boolean isMap, boolean isNullable, String dataType) {
             this.isArray = isArray;
             this.uniqueItems = uniqueItems;
             this.isMap = isMap;
             this.isNullable = isNullable;
             this.dataType = dataType;
+            this.fullTypeArgs = null;
+            this.builderInstantiation = null;
+        }
+
+        private BuiltValueSerializer(String fullTypeArgs, String builderInstantiation) {
+            this.isArray = false;
+            this.uniqueItems = false;
+            this.isMap = false;
+            this.isNullable = false;
+            this.dataType = "";
+            this.fullTypeArgs = fullTypeArgs;
+            this.builderInstantiation = builderInstantiation;
+        }
+
+        /**
+         * Build a serializer for a nested-container BuilderFactory whose
+         * type signature can't be expressed by the simple
+         * (isArray, isMap, dataType) form. {@code fullTypeArgs} is the
+         * argument list for {@code FullType(...)} (without the wrapping
+         * call) and {@code builderInstantiation} is the inside of
+         * {@code () => ...()}.
+         */
+        public static BuiltValueSerializer composite(String fullTypeArgs, String builderInstantiation) {
+            return new BuiltValueSerializer(fullTypeArgs, builderInstantiation);
         }
 
         public boolean isArray() {
@@ -842,11 +986,18 @@ public class DartDioClientCodegen extends AbstractDartCodegen {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             BuiltValueSerializer that = (BuiltValueSerializer) o;
+            if (fullTypeArgs != null || that.fullTypeArgs != null) {
+                return Objects.equals(fullTypeArgs, that.fullTypeArgs)
+                        && Objects.equals(builderInstantiation, that.builderInstantiation);
+            }
             return isArray == that.isArray && uniqueItems == that.uniqueItems && isMap == that.isMap && isNullable == that.isNullable && dataType.equals(that.dataType);
         }
 
         @Override
         public int hashCode() {
+            if (fullTypeArgs != null) {
+                return Objects.hash(fullTypeArgs, builderInstantiation);
+            }
             return Objects.hash(isArray, uniqueItems, isMap, isNullable, dataType);
         }
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
@@ -683,16 +683,29 @@ public class DartDioClientCodegen extends AbstractDartCodegen {
         if (prop == null || !prop.isContainer || prop.items == null) {
             return;
         }
-        // Recurse first so deeper containers are registered too. Order
-        // doesn't matter for correctness (built_value resolves factories
-        // by FullType lookup), but it keeps the emitted list intuitive.
+        // Recurse first so deeper containers are registered too.
         registerNestedBuilderFactories(prop.items);
 
-        BuilderFactoryExpr expr = renderBuilderFactory(prop);
-        if (expr != null) {
-            addBuiltValueSerializer(BuiltValueSerializer.composite(
-                    expr.fullTypeArgs,
-                    expr.builderInstantiation));
+        if (prop.items.isContainer) {
+            // Truly nested container (e.g. Map<String, List<X>>):
+            // must use composite form because the simple constructor
+            // cannot express the nested FullType.
+            BuilderFactoryExpr expr = renderBuilderFactory(prop);
+            if (expr != null) {
+                addBuiltValueSerializer(BuiltValueSerializer.composite(
+                        expr.fullTypeArgs,
+                        expr.builderInstantiation));
+            }
+        } else {
+            // Leaf container (e.g. List<X>, Map<String, X>): use the
+            // same simple constructor the rest of the codegen uses so
+            // the Set deduplicates correctly.
+            addBuiltValueSerializer(new BuiltValueSerializer(
+                    prop.isArray,
+                    prop.getUniqueItems(),
+                    prop.isMap,
+                    prop.items.isNullable,
+                    prop.items.dataType));
         }
     }
 

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/serializers.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/serializers.mustache
@@ -23,6 +23,11 @@ part 'serializers.g.dart';
 ])
 Serializers serializers = (_$serializers.toBuilder(){{#builtValueSerializers}}
       ..addBuilderFactory(
+{{#fullTypeArgs}}
+        const FullType({{{fullTypeArgs}}}),
+        () => {{{builderInstantiation}}}(),
+{{/fullTypeArgs}}
+{{^fullTypeArgs}}
 {{#isArray}}
         const FullType(Built{{#uniqueItems}}Set{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}, [FullType{{#isNullable}}.nullable{{/isNullable}}({{dataType}})]),
         () => {{#uniqueItems}}Set{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}Builder<{{dataType}}>(),
@@ -31,6 +36,7 @@ Serializers serializers = (_$serializers.toBuilder(){{#builtValueSerializers}}
         const FullType(BuiltMap, [FullType(String), FullType{{#isNullable}}.nullable{{/isNullable}}({{dataType}})]),
         () => MapBuilder<String, {{dataType}}{{#isNullable}}?{{/isNullable}}>(),
 {{/isMap}}
+{{/fullTypeArgs}}
       ){{/builtValueSerializers}}
       {{#models}}{{#model}}{{#vendorExtensions.x-is-parent}}..add({{classname}}.serializer)
       {{/vendorExtensions.x-is-parent}}{{/model}}{{/models}}..add(const OneOfSerializer())

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/dio/DartDioClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/dio/DartDioClientCodegenTest.java
@@ -142,6 +142,50 @@ public class DartDioClientCodegenTest {
                 "package:my_api/src/model/custom_address.dart");
     }
 
+    /**
+     * Regression test for missing BuilderFactory entries on container
+     * types reachable only via {@code additionalProperties}.
+     *
+     * Before the fix, a property like
+     * {@code Map<String, List<Widget>>} (an object schema with
+     * {@code additionalProperties: { type: array, items: ... }}) ended
+     * up in the generated Dart class but no
+     * {@code addBuilderFactory(BuiltList<Widget>, ...)} call was
+     * emitted in {@code serializers.dart}. built_value then failed at
+     * runtime with
+     * {@code Bad state: No builder factory for BuiltList<Widget>}.
+     *
+     * The fix walks every model property's container tree and registers
+     * a factory for each nested layer.
+     */
+    @Test
+    public void testNestedAdditionalPropertiesGetBuilderFactories() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("dart-dio")
+                .setInputSpec("src/test/resources/3_0/dart-dio/built_value_additional_properties_factory.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        ClientOptInput opts = configurator.toClientOptInput();
+        Generator generator = new DefaultGenerator().opts(opts);
+        List<File> files = generator.generate();
+        files.forEach(File::deleteOnExit);
+
+        Path serializers = output.toPath().resolve("lib/src/serializers.dart");
+
+        // Inner container: List<Widget>.
+        TestUtils.assertFileContains(serializers,
+                "const FullType(BuiltList, [FullType(Widget)]),",
+                "() => ListBuilder<Widget>(),");
+
+        // Outer container: Map<String, List<Widget>>.
+        TestUtils.assertFileContains(serializers,
+                "const FullType(BuiltMap, [FullType(String), FullType(BuiltList, [FullType(Widget)])]),",
+                "() => MapBuilder<String, BuiltList<Widget>>(),");
+    }
+
     @Test
     public void verifyDartDioGeneratorRuns() throws IOException {
         File output = Files.createTempDirectory("test").toFile();

--- a/modules/openapi-generator/src/test/resources/3_0/dart-dio/built_value_additional_properties_factory.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/dart-dio/built_value_additional_properties_factory.yaml
@@ -1,0 +1,51 @@
+openapi: "3.0.0"
+info:
+  title: Built-value additionalProperties BuilderFactory test
+  version: "1.0.0"
+paths:
+  /catalog/{id}:
+    get:
+      operationId: getCatalog
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: integer }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Catalog"
+components:
+  schemas:
+    Widget:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+    # `additionalProperties: { type: array, items: ... }` is the canonical
+    # "map of array of $ref" shape. Without the BuilderFactory walk,
+    # deserialization throws
+    #   Bad state: No builder factory for BuiltList<Widget>
+    WidgetsByCategory:
+      type: object
+      additionalProperties:
+        type: array
+        items:
+          $ref: "#/components/schemas/Widget"
+    Catalog:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+        widgetsByCategory:
+          $ref: "#/components/schemas/WidgetsByCategory"

--- a/samples/openapi3/client/petstore/dart-dio/petstore-timemachine/lib/src/serializers.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore-timemachine/lib/src/serializers.dart
@@ -47,6 +47,10 @@ Serializers serializers = (_$serializers.toBuilder()
         const FullType(BuiltList, [FullType(String)]),
         () => ListBuilder<String>(),
       )
+      ..addBuilderFactory(
+        const FullType(BuiltList, [FullType(Tag)]),
+        () => ListBuilder<Tag>(),
+      )
       ..add(const OneOfSerializer())
       ..add(const AnyOfSerializer())      
       ..add(const OffsetDateSerializer())

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/serializers.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/serializers.dart
@@ -137,12 +137,52 @@ Serializers serializers = (_$serializers.toBuilder()
         () => MapBuilder<String, String>(),
       )
       ..addBuilderFactory(
+        const FullType(BuiltList, [FullType(BuiltList, [FullType(int)])]),
+        () => ListBuilder<BuiltList<int>>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltMap, [FullType(String), FullType(num)]),
+        () => MapBuilder<String, num>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltMap, [FullType(String), FullType(Animal)]),
+        () => MapBuilder<String, Animal>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltList, [FullType(ReadOnlyFirst)]),
+        () => ListBuilder<ReadOnlyFirst>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltList, [FullType(BuiltList, [FullType(ReadOnlyFirst)])]),
+        () => ListBuilder<BuiltList<ReadOnlyFirst>>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltMap, [FullType(String), FullType(BuiltMap, [FullType(String), FullType(String)])]),
+        () => MapBuilder<String, BuiltMap<String, String>>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltMap, [FullType(String), FullType(int)]),
+        () => MapBuilder<String, int>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltList, [FullType(BuiltList, [FullType(num)])]),
+        () => ListBuilder<BuiltList<num>>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltList, [FullType(num)]),
+        () => ListBuilder<num>(),
+      )
+      ..addBuilderFactory(
         const FullType(BuiltList, [FullType(User)]),
         () => ListBuilder<User>(),
       )
       ..addBuilderFactory(
         const FullType(BuiltSet, [FullType(String)]),
         () => SetBuilder<String>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltMap, [FullType(String), FullType(BuiltList, [FullType(int)])]),
+        () => MapBuilder<String, BuiltList<int>>(),
       )
       ..addBuilderFactory(
         const FullType(BuiltSet, [FullType(Pet)]),
@@ -153,20 +193,44 @@ Serializers serializers = (_$serializers.toBuilder()
         () => ListBuilder<Pet>(),
       )
       ..addBuilderFactory(
-        const FullType(BuiltMap, [FullType(String), FullType.nullable(JsonObject)]),
-        () => MapBuilder<String, JsonObject?>(),
-      )
-      ..addBuilderFactory(
-        const FullType(BuiltMap, [FullType(String), FullType(int)]),
-        () => MapBuilder<String, int>(),
+        const FullType(BuiltList, [FullType(JsonObject)]),
+        () => ListBuilder<JsonObject>(),
       )
       ..addBuilderFactory(
         const FullType(BuiltList, [FullType(ModelEnumClass)]),
         () => ListBuilder<ModelEnumClass>(),
       )
       ..addBuilderFactory(
+        const FullType(BuiltList, [FullType.nullable(JsonObject)]),
+        () => ListBuilder<JsonObject>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltList, [FullType(Tag)]),
+        () => ListBuilder<Tag>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltList, [FullType(ModelFile)]),
+        () => ListBuilder<ModelFile>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltList, [FullType(int)]),
+        () => ListBuilder<int>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltMap, [FullType(String), FullType.nullable(JsonObject)]),
+        () => MapBuilder<String, JsonObject?>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltMap, [FullType(String), FullType(bool)]),
+        () => MapBuilder<String, bool>(),
+      )
+      ..addBuilderFactory(
         const FullType(BuiltList, [FullType(String)]),
         () => ListBuilder<String>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltMap, [FullType(String), FullType(JsonObject)]),
+        () => MapBuilder<String, JsonObject>(),
       )
       ..add(Animal.serializer)
       ..add(ParentWithNullable.serializer)


### PR DESCRIPTION
based on https://github.com/OpenAPITools/openapi-generator/pull/23662 with resolved merge conflicts

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing builder factories for nested `additionalProperties` in Dart `dart-dio` `built_value` serializers. Prevents runtime errors like "Bad state: No builder factory for BuiltList<X>" for shapes such as Map<String, List<Model>>.

- **Bug Fixes**
  - Walk container trees and register builder factories for each nested layer (e.g., Map<String, List<X>>, List<Map<String, X>>).
  - Add composite serializer support in `serializers.mustache` to emit nested `FullType(...)` and matching builders.
  - Extend `BuiltValueSerializer` with a composite mode and proper dedup via `equals`/`hashCode`.
  - Add regression test and fixture covering Map<String, List<$ref>>; update generated petstore samples.

<sup>Written for commit a7187d1ebd2ff67ece1a52060c20d4bcb3e4d36a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

