### PR TITLE
[core] Add introspection support for discovering the discriminator type in a oneOf allOf polymorphic structure

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -93,6 +93,7 @@ import java.util.stream.Stream;
 
 import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
+import static org.openapitools.codegen.utils.DiscriminatorUtils.*;
 import static org.openapitools.codegen.utils.OnceLogger.once;
 import static org.openapitools.codegen.utils.StringUtils.*;
 
@@ -1720,7 +1721,11 @@ public class DefaultCodegen implements CodegenConfig {
      */
     @SuppressWarnings("static-method")
     public String toEnumName(CodegenProperty property) {
-        return StringUtils.capitalize(property.name) + "Enum";
+        return toEnumName(property.name);
+    }
+
+    public String toEnumName(String propertyName) {
+        return StringUtils.capitalize(propertyName) + "Enum";
     }
 
     /**
@@ -3349,7 +3354,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param sc             The Schema that may contain the discriminator
      * @param visitedSchemas An array list of visited schemas
      */
-    private Discriminator recursiveGetDiscriminator(Schema sc, ArrayList<Schema> visitedSchemas) {
+    private DiscriminatorData recursiveGetDiscriminator(Schema sc, ArrayList<Schema> visitedSchemas) {
         return DiscriminatorUtils.recursiveGetDiscriminator(openAPI, this.getLegacyDiscriminatorBehavior(), sc, visitedSchemas);
     }
 
@@ -3486,7 +3491,7 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     protected CodegenDiscriminator createDiscriminator(String schemaName, Schema schema) {
-        Discriminator sourceDiscriminator = recursiveGetDiscriminator(schema, new ArrayList<Schema>());
+        DiscriminatorData sourceDiscriminator = recursiveGetDiscriminator(schema, new ArrayList<Schema>());
         if (sourceDiscriminator == null) {
             return null;
         }
@@ -3503,7 +3508,25 @@ public class DefaultCodegen implements CodegenConfig {
         // FIXME: there are other ways to define the type of the discriminator property (inline
         //  for example). Handling those scenarios is too complicated for me, I'm leaving it for
         //  the future..
-        discriminator.setPropertyType(getDiscriminatorPropertyType(schema, discriminatorPropertyName));
+        String discriminatorType;
+        Schema discSchema = sourceDiscriminator.getDiscriminatorSchema();
+        if (discSchema != null) {
+            if (ModelUtils.hasRef(discSchema)) {
+                discriminatorType = toModelName(ModelUtils.getSimpleRef(discSchema.get$ref()));
+            } else {
+                // Inline schema (inline enum, uri, ...): resolve via the same pipeline the
+                // concrete model classes use so the oneOf interface getter type matches.
+                // Keep String for typeless const to avoid resolving to Object.
+                if (ModelUtils.getType(discSchema) == null || discSchema.getEnum() == null) {
+                    discriminatorType = getTypeDeclaration(discSchema);
+                } else {
+                    discriminatorType = toEnumName(discriminatorPropertyName);
+                }
+            }
+        } else {
+            discriminatorType = getDiscriminatorPropertyType(schema, discriminatorPropertyName);
+        }
+        discriminator.setPropertyType(discriminatorType);
 
         // check to see if the discriminator property is an enum string
         boolean isEnum = Optional

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/DiscriminatorUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/DiscriminatorUtils.java
@@ -3,6 +3,7 @@ package org.openapitools.codegen.utils;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.Discriminator;
 import io.swagger.v3.oas.models.media.Schema;
+import org.jspecify.annotations.Nullable;
 import org.openapitools.codegen.CodegenProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,6 +18,8 @@ public class DiscriminatorUtils {
 
     private static final String CONFLICTING_DISCRIMINATOR_NAMES =
             "The alternative schemas have conflicting discriminator property names. The schemas must have the same property name, but found {}";
+    private static final String CONFLICTING_DISCRIMINATOR_TYPES =
+            "The alternative schemas have conflicting discriminator property types ({})";
     private static final String DEFINES_DISCRIMINATOR_BUT_REFERENCE_ALTERNATIVE_IS_MISSING =
             "'{}' defines discriminator '{}', but the referenced schema '{}' is missing {}";
     private static final String DEFINES_DISCRIMINATOR_BUT_ALTERNATIVE_HAS_OTHER_DEFINITION =
@@ -124,15 +127,19 @@ public class DiscriminatorUtils {
      * @param sc                          The Schema that may contain the discriminator
      * @param visitedSchemas              an array list of visited schemas
      */
-    public static Discriminator recursiveGetDiscriminator(
+    public static DiscriminatorData recursiveGetDiscriminator(
             OpenAPI openAPI,
             boolean legacyDiscriminatorBehavior,
             Schema sc,
             ArrayList<Schema> visitedSchemas) {
         Schema refSchema = ModelUtils.getReferencedSchema(openAPI, sc);
-        Discriminator foundDisc = refSchema.getDiscriminator();
-        if (foundDisc != null) {
-            return foundDisc;
+        DiscriminatorData foundDisc = new DiscriminatorData(refSchema.getDiscriminator(), null);
+        if (foundDisc.getDiscriminator() != null) {
+            String discriminatorPropertyName = foundDisc.getDiscriminator().getPropertyName();
+            return new DiscriminatorData(
+                    foundDisc.getDiscriminator(),
+                    DiscriminatorUtils.getDiscriminatorSchema(refSchema, discriminatorPropertyName)
+            );
         }
 
         if (legacyDiscriminatorBehavior) {
@@ -156,7 +163,7 @@ public class DiscriminatorUtils {
                     if (foundDisc != null) {
                         disc.setPropertyName(foundDisc.getPropertyName());
                         disc.setMapping(foundDisc.getMapping());
-                        return disc;
+                        return new DiscriminatorData(disc, foundDisc.getDiscriminatorSchema());
                     }
                 }
             }
@@ -178,7 +185,7 @@ public class DiscriminatorUtils {
      * An example of a sibling is an enum-ref that has its own description. This will lead to the enum being
      * referenced as an allOf that in turn has a ref, rather than a regular ref directly to the enum.
      *
-     * @param schema            The input OAS schema.
+     * @param schema            The input OAS schema that has the discriminator as a property.
      * @param discriminatorName The name of the discriminator property.
      */
     private static Schema getDiscriminatorSchema(Schema schema, String discriminatorName) {
@@ -201,16 +208,17 @@ public class DiscriminatorUtils {
      * @param visitedSchemas              an array list of visited schemas
      * @return the discriminator if the alternatives correctly shares one, otherwise null
      */
-    private static Discriminator getDiscriminatorFromAlternatives(
+    private static DiscriminatorData getDiscriminatorFromAlternatives(
             OpenAPI openAPI,
             boolean legacyDiscriminatorBehavior,
             List<Schema> alternativeSchemas,
             ArrayList<Schema> visitedSchemas) {
         Discriminator discriminator = new Discriminator();
-        Discriminator foundDisc = null;
+        DiscriminatorData foundDisc = null;
         Integer hasDiscriminatorCnt = 0;
         Integer hasNullTypeCnt = 0;
         Set<String> discriminatorsPropNames = new HashSet<>();
+        Set<Schema> discriminatorTypes = new HashSet<>();
         for (Object alternative : alternativeSchemas) {
             if (ModelUtils.isNullType((Schema) alternative)) {
                 // The null type does not have a discriminator. Skip.
@@ -221,16 +229,23 @@ public class DiscriminatorUtils {
             if (foundDisc != null) {
                 discriminatorsPropNames.add(foundDisc.getPropertyName());
                 hasDiscriminatorCnt++;
+                if (foundDisc.getDiscriminatorSchema() != null) {
+                    discriminatorTypes.add(foundDisc.getDiscriminatorSchema());
+                }
             }
         }
         if (discriminatorsPropNames.size() > 1) {
             once(LOGGER).warn(CONFLICTING_DISCRIMINATOR_NAMES, String.join(", ", discriminatorsPropNames));
         }
+        if (discriminatorTypes.size() > 1) {
+            once(LOGGER).warn(CONFLICTING_DISCRIMINATOR_TYPES, String.join(", ", discriminatorTypes.toString()));
+        }
         boolean allAlternativesHaveADiscriminator = hasDiscriminatorCnt + hasNullTypeCnt == alternativeSchemas.size();
         if (foundDisc != null && allAlternativesHaveADiscriminator && discriminatorsPropNames.size() == 1) {
             discriminator.setPropertyName(foundDisc.getPropertyName());
             discriminator.setMapping(foundDisc.getMapping());
-            return discriminator;
+            Schema uniqueDiscriminatorType = discriminatorTypes.size() == 1 ? discriminatorTypes.iterator().next() : null;
+            return new DiscriminatorData(discriminator, uniqueDiscriminatorType);
         }
         // If the scenario when composite schema has two children and one of them is the 'null' type,
         // there is no need for a discriminator.
@@ -269,6 +284,38 @@ public class DiscriminatorUtils {
                     composedSchemaName, discPropName, modelName, discPropName, discPropName);
         }
         return null;
+    }
+
+    public static class DiscriminatorData {
+        private final Discriminator discriminator;
+
+        @Nullable
+        private final Schema discriminatorSchema;
+
+        public DiscriminatorData(Discriminator discriminator, @Nullable Schema discriminatorSchema) {
+            this.discriminator = discriminator;
+            this.discriminatorSchema = discriminatorSchema;
+        }
+
+        public Discriminator getDiscriminator() {
+            return discriminator;
+        }
+
+        public @Nullable Schema getDiscriminatorSchema() {
+            return discriminatorSchema;
+        }
+
+        public String getPropertyName() {
+            return discriminator.getPropertyName();
+        }
+
+        public Map<String, String> getMapping() {
+            return discriminator.getMapping();
+        }
+
+        public Map<String, Object> getExtensions() {
+            return discriminator.getExtensions();
+        }
     }
 
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -2393,6 +2393,16 @@ public class ModelUtils {
     }
 
     /**
+     * Returns true if the schema contains a $ref
+     *
+     * @param schema the schema
+     * @return true if $ref is set
+     */
+    public static boolean hasRef(Schema schema) {
+        return schema != null && schema.get$ref() != null;
+    }
+
+    /**
      * Returns schema type.
      * For 3.1 spec, return the first one.
      *

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/OneOfImplementorAdditionalData.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/OneOfImplementorAdditionalData.java
@@ -15,21 +15,21 @@ import static org.openapitools.codegen.CodegenConstants.X_IMPLEMENTS;
  * This class holds data to add to `oneOf` members. Let's consider this example:
  * <p>
  * Foo:
- * properties:
- * x:
- * oneOf:
- * - $ref: "#/components/schemas/One
- * - $ref: "#/components/schemas/Two
- * y:
- * type: string
+ *   properties:
+ *     x:
+ *       oneOf:
+ *         - $ref: "#/components/schemas/One"
+ *         - $ref: "#/components/schemas/Two"
+ *     y:
+ *       type: string
  * One:
- * properties:
- * z:
- * type: string
+ *   properties:
+ *     z:
+ *       type: string
  * Two:
- * properties:
- * a:
- * type: string
+ *   properties:
+ *     a:
+ *       type: string
  * <p>
  * In codegens that use this mechanism, `Foo` will become an interface and `One` will
  * become its implementing class. This class carries all data necessary to properly modify
@@ -99,7 +99,7 @@ public class OneOfImplementorAdditionalData {
      * @param cc                  CodegenConfig running this operation
      * @param implcm              the implementing model
      * @param implImports         imports of the implementing model
-     * @param addInterfaceImports whether or not to add the interface model as import (will vary by language)
+     * @param addInterfaceImports whether to add the interface model as import (will vary by language)
      */
     @SuppressWarnings("unchecked")
     public void addToImplementor(CodegenConfig cc, CodegenModel implcm, List<Map<String, String>> implImports, boolean addInterfaceImports) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -1211,6 +1211,87 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void testOneOfAllOfEnumRefDiscriminatorInheritance() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/oneOfDiscriminator.yaml");
+        new OpenAPINormalizer(openAPI, Map.of()).normalize();
+        DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setUseOneOfInterfaces(true);
+        codegen.setLegacyDiscriminatorBehavior(false);
+
+        Schema inner = openAPI.getComponents().getSchemas().get("VehicleResponse");
+        codegen.setOpenAPI(openAPI);
+        CodegenModel innerModel = codegen.fromModel("VehicleResponse", inner);
+        assertTrue(innerModel.getHasDiscriminatorWithNonEmptyMapping());
+        assertTrue(innerModel.discriminator.getIsEnum());
+        assertEquals("VehicleType", innerModel.discriminator.getPropertyType());
+        assertTrue(innerModel.getVars().get(0).isEnumRef);
+        
+        Schema car = openAPI.getComponents().getSchemas().get("Car");
+        CodegenModel carModel = codegen.fromModel("Car", car);
+        assertTrue(carModel.discriminator.getIsEnum());
+        assertEquals("VehicleType", carModel.discriminator.getPropertyType());
+        assertTrue(carModel.getVars().get(0).isEnumRef);
+
+        Schema bike = openAPI.getComponents().getSchemas().get("Bike");
+        CodegenModel bikeModel = codegen.fromModel("Bike", bike);
+        assertTrue(bikeModel.discriminator.getIsEnum());
+        assertEquals("VehicleType", bikeModel.discriminator.getPropertyType());
+        assertTrue(bikeModel.getVars().get(0).isEnumRef);
+    }
+
+    @Test
+    public void testOneOfAllOfInlineEnumDiscriminatorInheritance() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/oneOfDiscriminator.yaml");
+        new OpenAPINormalizer(openAPI, Map.of()).normalize();
+        DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setUseOneOfInterfaces(true);
+        codegen.setLegacyDiscriminatorBehavior(false);
+
+        Schema inner = openAPI.getComponents().getSchemas().get("PetResponseEnumDisc");
+        codegen.setOpenAPI(openAPI);
+        CodegenModel innerModel = codegen.fromModel("PetResponseEnumDisc", inner);
+        assertTrue(innerModel.getHasDiscriminatorWithNonEmptyMapping());
+        assertTrue(innerModel.discriminator.getIsEnum());
+        assertEquals("PetTypeEnum", innerModel.discriminator.getPropertyType());
+        assertFalse(innerModel.getVars().get(0).isEnumRef);
+
+        Schema dog = openAPI.getComponents().getSchemas().get("DogEnumDisc");
+        CodegenModel dogModel = codegen.fromModel("DogEnumDisc", dog);
+        assertTrue(dogModel.discriminator.getIsEnum());
+        assertEquals("PetTypeEnum", dogModel.discriminator.getPropertyType());
+        assertFalse(dogModel.getVars().get(0).isEnumRef);
+
+        Schema cat = openAPI.getComponents().getSchemas().get("CatEnumDisc");
+        CodegenModel catModel = codegen.fromModel("CatEnumDisc", cat);
+        assertTrue(catModel.discriminator.getIsEnum());
+        assertEquals("PetTypeEnum", catModel.discriminator.getPropertyType());
+        assertFalse(catModel.getVars().get(0).isEnumRef);
+    }
+
+    @Test
+    public void testOneOfAllOfInlineStringWithFormatDiscriminatorInheritance() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/oneOfDiscriminator.yaml");
+        new OpenAPINormalizer(openAPI, Map.of()).normalize();
+        DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setUseOneOfInterfaces(true);
+        codegen.setLegacyDiscriminatorBehavior(false);
+
+        Schema inner = openAPI.getComponents().getSchemas().get("PetResponseUriDisc");
+        codegen.setOpenAPI(openAPI);
+        CodegenModel innerModel = codegen.fromModel("PetResponseUriDisc", inner);
+        assertTrue(innerModel.getHasDiscriminatorWithNonEmptyMapping());
+        assertEquals("URI", innerModel.discriminator.getPropertyType());
+
+        Schema dog = openAPI.getComponents().getSchemas().get("DogUriDisc");
+        CodegenModel dogModel = codegen.fromModel("DogUriDisc", dog);
+        assertEquals("URI", dogModel.discriminator.getPropertyType());
+
+        Schema cat = openAPI.getComponents().getSchemas().get("CatUriDisc");
+        CodegenModel catModel = codegen.fromModel("CatUriDisc", cat);
+        assertEquals("URI", catModel.discriminator.getPropertyType());
+    }
+
+    @Test
     public void testParentName() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/allOf.yaml");
         DefaultCodegen codegen = new DefaultCodegen();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -2039,6 +2039,37 @@ public class JavaClientCodegenTest {
     }
 
     @Test
+    public void testOneOfInterfaceInheritedEnumDiscriminator() {
+        final Path output = newTempFolder();
+        final OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/oneOfDiscriminator.yaml", null, new ParseOptions())
+                .getOpenAPI();
+
+        // resttemplate (unlike the default okhttp-gson) renders oneOf as interfaces, so it uses the
+        // base Java/oneof_interface template that emits the discriminator getter type.
+        final JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.setLibrary("resttemplate");
+        codegen.setOutputDir(output.toString());
+        codegen.setUseOneOfInterfaces(true);
+        codegen.setLegacyDiscriminatorBehavior(false);
+
+        final ClientOptInput input = new ClientOptInput().openAPI(openAPI).config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.SUPPORTING_FILES, "false");
+        generator.opts(input).generate();
+
+        // Issue #22541: the inline-enum discriminator inherited from a base schema via allOf must
+        // resolve to the enum type in the oneOf interface getter, not String.
+        assertThat(output.resolve("src/main/java/org/openapitools/client/model/PetResponseEnumDisc.java"))
+                .content().contains("public PetTypeEnum getPetType();");
+    }
+
+    @Test
     public void testDiscriminatorWithoutMappingIssue14731() {
         final Path output = newTempFolder();
         final OpenAPI openAPI = new OpenAPIParser()

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/helidon/JavaHelidonCommonCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/helidon/JavaHelidonCommonCodegenTest.java
@@ -21,6 +21,7 @@ import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.DefaultGenerator;
 import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.config.CodegenConfigurator;
+import org.openapitools.codegen.languages.AbstractJavaCodegen;
 import org.openapitools.codegen.languages.JavaHelidonCommonCodegen;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -68,6 +69,35 @@ public class JavaHelidonCommonCodegenTest {
 
         mpServerGenerator = new DefaultGenerator();
         mpClientGenerator = new DefaultGenerator();
+    }
+
+    @Test
+    public void testOneOfInterfaceInheritedEnumDiscriminator() throws IOException {
+        File output = Files.createTempDirectory("testHelidonEnumDisc").toFile();
+        output.deleteOnExit();
+        String outputDir = output.getAbsolutePath().replace('\\', '/');
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("java-helidon-client")
+                .setLibrary("mp")
+                .setInputSpec("src/test/resources/3_0/oneOfDiscriminator.yaml")
+                .addAdditionalProperty(AbstractJavaCodegen.USE_ONE_OF_INTERFACES, true)
+                .addAdditionalProperty(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, false)
+                .setOutputDir(outputDir);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.SUPPORTING_FILES, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+        generator.opts(configurator.toClientOptInput()).generate();
+
+        // Issue #22541: the inline-enum discriminator inherited from a base schema via allOf must
+        // resolve to the enum type in the oneOf interface getter, not String.
+        TestUtils.assertFileContains(
+                Paths.get(outputDir + "/src/main/java/org/openapitools/client/model/PetResponseEnumDisc.java"),
+                "PetTypeEnum getPetType()");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/micronaut/JavaMicronautClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/micronaut/JavaMicronautClientCodegenTest.java
@@ -48,6 +48,21 @@ public class JavaMicronautClientCodegenTest extends AbstractMicronautCodegenTest
     }
 
     @Test
+    public void testOneOfInterfaceInheritedEnumDiscriminator() {
+        JavaMicronautClientCodegen codegen = new JavaMicronautClientCodegen();
+        codegen.setUseOneOfInterfaces(true);
+        codegen.setLegacyDiscriminatorBehavior(false);
+        String outputPath = generateFiles(codegen, "src/test/resources/3_0/oneOfDiscriminator.yaml",
+                CodegenConstants.MODELS);
+
+        // Issue #22541: the inline-enum discriminator is inherited from a base schema via allOf, so
+        // the oneOf interface getter must resolve to the enum type, not String
+        // (DefaultCodegen.getDiscriminatorPropertyType).
+        assertFileContains(outputPath + "src/main/java/org/openapitools/model/PetResponseEnumDisc.java",
+                "public PetTypeEnum getPetType();");
+    }
+
+    @Test
     public void testApiAndModelFilesPresent() {
         JavaMicronautClientCodegen codegen = new JavaMicronautClientCodegen();
         codegen.additionalProperties().put(CodegenConstants.INVOKER_PACKAGE, "org.test.test");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -2140,6 +2140,92 @@ public class SpringCodegenTest {
     }
 
     @Test
+    void testOneOfWithInheritedEnumDiscriminator() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/oneOfDiscriminator.yaml", null, new ParseOptions()).getOpenAPI();
+
+        SpringCodegen codegen = new SpringCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(CXFServerFeatures.LOAD_TEST_DATA_FROM_FILE, "true");
+        codegen.setUseOneOfInterfaces(true);
+
+        ClientOptInput input = new ClientOptInput();
+        input.openAPI(openAPI);
+        input.config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        codegen.setHateoas(true);
+        generator.setGenerateMetadata(false);
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "false");
+
+        codegen.setUseOneOfInterfaces(true);
+        codegen.setLegacyDiscriminatorBehavior(false);
+
+        generator.opts(input).generate();
+
+        // The discriminator (inline enum) is inherited from the base PetEnumDisc via allOf. The
+        // oneOf interface getter must use the same enum type as the concrete base class, not
+        // String, otherwise the generated code does not compile (issue #22541).
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/model/PetResponseEnumDisc.java"),
+                "public PetTypeEnum getPetType();"
+        );
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/model/PetEnumDisc.java"),
+                "public PetTypeEnum getPetType()"
+        );
+    }
+
+    @Test
+    void testOneOfWithInheritedUriDiscriminator() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/oneOfDiscriminator.yaml", null, new ParseOptions()).getOpenAPI();
+
+        SpringCodegen codegen = new SpringCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(CXFServerFeatures.LOAD_TEST_DATA_FROM_FILE, "true");
+        codegen.setUseOneOfInterfaces(true);
+
+        ClientOptInput input = new ClientOptInput();
+        input.openAPI(openAPI);
+        input.config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        codegen.setHateoas(true);
+        generator.setGenerateMetadata(false);
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "false");
+
+        codegen.setUseOneOfInterfaces(true);
+        codegen.setLegacyDiscriminatorBehavior(false);
+
+        generator.opts(input).generate();
+
+        // The discriminator (string, format: uri) is inherited from the base PetUriDisc via allOf.
+        // The oneOf interface getter must use URI, matching the concrete base class, not String,
+        // otherwise the generated code does not compile (issue #18693).
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/model/PetResponseUriDisc.java"),
+                "public URI getPetType();"
+        );
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/model/PetUriDisc.java"),
+                "public URI getPetType()"
+        );
+    }
+
+    @Test
     void testOneOfWithEnumDiscriminator() throws IOException {
         File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
         output.deleteOnExit();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
@@ -122,6 +122,39 @@ public class KotlinSpringServerCodegenTest {
     }
 
     @Test
+    public void testOneOfInterfaceInheritedEnumDiscriminator() throws IOException {
+        // Cross-generator check for the DefaultCodegen discriminator-type fix: the kotlin-spring
+        // oneof_interface template emits the discriminator getter type too. Issue #22541: the
+        // inline-enum discriminator is inherited from a base schema via allOf, so the sealed
+        // interface must use the enum type rather than String.
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        final KotlinSpringServerCodegen codegen = new KotlinSpringServerCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.setUseOneOfInterfaces(true);
+        codegen.setLegacyDiscriminatorBehavior(false);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.setGenerateMetadata(false);
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "false");
+
+        generator.opts(new ClientOptInput()
+                        .openAPI(TestUtils.parseSpec("src/test/resources/3_0/oneOfDiscriminator.yaml"))
+                        .config(codegen))
+                .generate();
+
+        assertFileContains(
+                Paths.get(output + "/src/main/kotlin/org/openapitools/model/PetResponseEnumDisc.kt"),
+                "val petType: PetType"
+        );
+    }
+
+    @Test
     public void testNoRequestMappingAnnotationNone() throws IOException {
         File output = generatePetstoreWithRequestMappingMode(KotlinSpringServerCodegen.RequestMappingMode.none);
 

--- a/modules/openapi-generator/src/test/resources/3_0/oneOfDiscriminator.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/oneOfDiscriminator.yaml
@@ -298,3 +298,90 @@ components:
         - $ref: '#/components/schemas/FruitType'
       discriminator:
         propertyName: fruitType
+     # oneOf interface whose discriminator property is an inline enum inherited from a shared base
+     # schema (PetEnumDisc) via allOf. The interface getter must use the same enum type the
+     # concrete classes generate, not String. Ref: issue #22541.
+    PetResponseEnumDisc:
+      oneOf:
+        - $ref: '#/components/schemas/DogEnumDisc'
+        - $ref: '#/components/schemas/CatEnumDisc'
+    PetEnumDisc:
+      type: object
+      required:
+        - petType
+      properties:
+        petType:
+          type: string
+          enum:
+            - dog
+            - cat
+      discriminator:
+        propertyName: petType
+        mapping:
+          dog: DogEnumDisc
+          cat: CatEnumDisc
+    DogEnumDisc:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/PetEnumDisc'
+    CatEnumDisc:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/PetEnumDisc'
+     # oneOf interface whose discriminator property is an inline string with a non-string format
+     # (uri) inherited from a shared base schema (PetUriDisc) via allOf. The interface getter must
+     # use URI, matching the concrete classes, not String. Ref: issue #18693.
+    PetResponseUriDisc:
+      oneOf:
+        - $ref: '#/components/schemas/DogUriDisc'
+        - $ref: '#/components/schemas/CatUriDisc'
+    PetUriDisc:
+      type: object
+      required:
+        - petType
+      properties:
+        petType:
+          type: string
+          format: uri
+      discriminator:
+        propertyName: petType
+        mapping:
+          dog: DogUriDisc
+          cat: CatUriDisc
+    DogUriDisc:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/PetUriDisc'
+    CatUriDisc:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/PetUriDisc'
+      # oneOf interface whose discriminator property is an enum inherited from through a shared base
+      # schema (Vehicle) via allOf -> property ref. The interface getter must use the same enum type the
+      # concrete classes generate, not String. Ref: issue #22541.
+    VehicleResponse:
+      oneOf:
+        - $ref: '#/components/schemas/Car'
+        - $ref: '#/components/schemas/Bike'
+    VehicleType:
+      type: string
+      enum:
+        - Car
+        - Bike
+    Vehicle:
+      type: object
+      discriminator:
+        propertyName: vehicleType
+      properties:
+        vehicleType:
+          $ref: '#/components/schemas/VehicleType'
+      required:
+        - vehicleType
+    Car:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Vehicle'
+    Bike:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Vehicle'


### PR DESCRIPTION
This PR adds so that the `useOneOfInterfaces` setting properly supports when the discriminator is an enum for the case where the discriminator is inherited in a oneOf -> allOf scenario. 

Fixes https://github.com/OpenAPITools/openapi-generator/issues/22541, https://github.com/OpenAPITools/openapi-generator/issues/18693, https://github.com/OpenAPITools/openapi-generator/issues/19194, https://github.com/OpenAPITools/openapi-generator/issues/9048

### Summary
This PR introduces so that the discriminator discovering (done in method `recursiveGetDiscriminator`) not only finds the property carrying the discriminator, but also the property's type. This gives the interface creator the opportunity to ensure that its discriminator type field aligns with that of the implementing children.

### Example scenario

For example given the specification:

```yaml
openapi: 3.1.0
info:
  title: Polymorphism example with oneOf, allOf and enum-discriminator
  version: "1.0"
paths:
  /pets:
    get:
      operationId: getAllPets
      responses:
        "200":
          content:
            application/json:
              schema:
                type: array
                items:
                  oneOf:
                    - $ref: "#/components/schemas/Cat"
                    - $ref: "#/components/schemas/Dog"
          description: Success
components:
  schemas:
    PetType:
      type: string
      enum:
        - Cat
        - Dog
    Pet:
      type: object
      discriminator:
        propertyName: petType
      properties:
        petType:
          $ref: '#/components/schemas/PetType'
      required:
        - petType
    Cat:
      description: A representation of a cat
      allOf:
        - $ref: '#/components/schemas/Pet'
        - type: object
          properties:
            huntingSkill:
              type: string
              description: The measured skill for hunting
              enum:
                - clueless
                - lazy
                - adventurous
                - aggressive
          required:
            - huntingSkill
    Dog:
      description: A representation of a dog
      allOf:
        - $ref: '#/components/schemas/Pet'
        - type: object
          properties:
            packSize:
              type: integer
              format: int32
              description: the size of the pack the dog is from
              default: 0
              minimum: 0
          required:
            - packSize
```
where a oneOf containing both children exists. The children in turn references a parent (`Pet`) that in turn defines the discriminator value as an enum (`PetType`).

With the current generator, the property type of the parent is not considered, so the generated `interface` has type `String`, while the children have the enum `PetType`. This means that the code does not compile.

This type of structure is what you natively get with [swagger-core](https://github.com/swagger-api/swagger-core) and [springdoc](https://github.com/springdoc/springdoc-openapi) when using `@JsonSubTypes` for polymorphism in an array-context. So out-of-the-box support would be very useful.
 
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds introspection to discover discriminator property types inherited through oneOf/allOf (enum refs, inline enums, and formatted strings like URI) so generated oneOf interfaces and models use the correct type instead of String. Fixes compile errors with `useOneOfInterfaces` when the discriminator is defined on a parent and referenced by children.

- **New Features**
  - `recursiveGetDiscriminator` now returns `DiscriminatorData` (discriminator + resolved schema). `DefaultCodegen` uses it to set `CodegenDiscriminator.propertyType` from `$ref`, inline enums (via `toEnumName`), or formatted strings (e.g., URI via `getTypeDeclaration`).
  - Validates oneOf alternatives share the same discriminator name and type; logs warnings on conflicts.
  - Adds cross-generator tests (Java resttemplate, Helidon MP, Micronaut, Spring, Kotlin Spring) and expands the 3.0 sample spec to cover enum-ref, inline enum, and string format: uri inheritance cases.

<sup>Written for commit 9c52c87ce0cbdac2d89afa6d9578f9aaa1d63d20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





