### PR TITLE
chore: update typescript samples

### DIFF
--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/enum-test.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/enum-test.ts
@@ -142,7 +142,7 @@ export type EnumTestEnumNumberEnum = typeof EnumTestEnumNumberEnum[keyof typeof 
  * Check if a given object implements the EnumTest interface.
  */
 export function instanceOfEnumTest(value: object): value is EnumTest {
-    if ((!('enumStringRequired' in value) && !('enum_string_required' in value)) || (value['enumStringRequired'] === undefined && value['enum_string_required'] === undefined)) return false;
+    if ((!('enumStringRequired' in (value as Record<string, any>)) && !('enum_string_required' in (value as Record<string, any>))) || ((value as Record<string, any>)['enumStringRequired'] === undefined && (value as Record<string, any>)['enum_string_required'] === undefined)) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/format-test.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/format-test.ts
@@ -122,7 +122,7 @@ export interface FormatTest {
  */
 export function instanceOfFormatTest(value: object): value is FormatTest {
     if (!('number' in value) || value['number'] === undefined) return false;
-    if ((!('_byte' in value) && !('byte' in value)) || (value['_byte'] === undefined && value['byte'] === undefined)) return false;
+    if ((!('_byte' in (value as Record<string, any>)) && !('byte' in (value as Record<string, any>))) || ((value as Record<string, any>)['_byte'] === undefined && (value as Record<string, any>)['byte'] === undefined)) return false;
     if (!('date' in value) || value['date'] === undefined) return false;
     if (!('password' in value) || value['password'] === undefined) return false;
     return true;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Update typescript samples that were most likely missed in https://github.com/OpenAPITools/openapi-generator/pull/23982.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update TypeScript `typescript-fetch` kebab-case samples to cast `value` to `Record<string, any>` in `instanceOfFormatTest` and `instanceOfEnumTest`. This fixes strict TypeScript errors when checking `_byte`/`byte` and `enumStringRequired` fields and keeps the samples compiling.

<sup>Written for commit d25e2c26438fa56d583a32365866a4ff0750c8fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

