### PR TITLE
[core] Resolve oneOf discriminator property type from child schemas

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3684,13 +3684,13 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     /**
-     * Get the property type for the discriminator
+     * Get the property type for the discriminator from the schema, or its child schemas (from oneOf/anyOf refs) or returns String as a fallback
      *
      * @param schema                    The input OAS schema.
      * @param discriminatorPropertyName The name of the discriminator property.
      */
     protected String getDiscriminatorPropertyType(Schema schema, String discriminatorPropertyName) {
-        return DiscriminatorUtils.getDiscriminatorPropertyType(schema, discriminatorPropertyName)
+        return DiscriminatorUtils.getDiscriminatorPropertyType(openAPI, schema, discriminatorPropertyName)
                 .map(this::toModelName)
                 .orElseGet(() -> typeMapping.get("string"));
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/DiscriminatorUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/DiscriminatorUtils.java
@@ -17,6 +17,8 @@ public class DiscriminatorUtils {
     private static final String CONFLICTING_DISCRIMINATOR_NAMES =
             "The alternative schemas have conflicting discriminator property names. The schemas must have the same property name, but found {}";
 
+    private DiscriminatorUtils(){}
+
     /**
      * Gets the simple ref name of the discriminator property type from the schema.
      *
@@ -24,10 +26,11 @@ public class DiscriminatorUtils {
      * @param discriminatorPropertyName The name of the discriminator property.
      * @return referenced type name, or an empty optional if unavailable
      */
-    public static Optional<String> getDiscriminatorPropertyType(Schema schema, String discriminatorPropertyName) {
+    public static Optional<String> getDiscriminatorPropertyType(OpenAPI openAPI, Schema schema, String discriminatorPropertyName) {
         return Optional.ofNullable(getDiscriminatorSchema(schema, discriminatorPropertyName))
                 .map(Schema::get$ref)
-                .map(ModelUtils::getSimpleRef);
+                .map(ModelUtils::getSimpleRef)
+                .or(()-> getDiscriminatorPropertyTypeFromChildren(openAPI, schema, discriminatorPropertyName));
     }
 
     /**
@@ -47,6 +50,74 @@ public class DiscriminatorUtils {
             discSchema = (Schema) discSchema.getAllOf().get(0);
         }
         return discSchema;
+    }
+
+    /**
+     * Resolve the discriminator property type by inspecting the oneOf/anyOf child schemas. Returns the simple
+     * ref name of the first child that declares the discriminator property as a $ref (e.g. an enum), or an
+     * empty optional if no child resolves to a typed property.
+     *
+     * @param openAPI                   the OpenAPI specification, used to resolve referenced child schemas.
+     * @param schema                    The oneOf/anyOf interface schema.
+     * @param discriminatorPropertyName The name of the discriminator property.
+     */
+    static Optional<String> getDiscriminatorPropertyTypeFromChildren(OpenAPI openAPI, Schema schema, String discriminatorPropertyName) {
+        List<Schema> children = new ArrayList<>();
+        if (schema.getOneOf() != null) {
+            children.addAll(schema.getOneOf());
+        }
+        if (schema.getAnyOf() != null) {
+            children.addAll(schema.getAnyOf());
+        }
+        for (Schema child : children) {
+            Schema resolved = ModelUtils.getReferencedSchema(openAPI, child);
+            if (resolved == null) {
+                continue;
+            }
+            Schema discSchema = getDiscriminatorSchemaDeep(openAPI, resolved, discriminatorPropertyName, new ArrayList<>());
+            if (discSchema != null && discSchema.get$ref() != null) {
+                return Optional.ofNullable(ModelUtils.getSimpleRef(discSchema.get$ref()));
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Like {@link #getDiscriminatorSchema(Schema, String)}, but also chases the discriminator property through
+     * a schema's allOf members. A oneOf child commonly carries the discriminator property indirectly, via an
+     * allOf reference to a shared base schema rather than as a direct property.
+     *
+     * @param openAPI           the OpenAPI specification, used to resolve referenced allOf members.
+     * @param schema            The schema to inspect.
+     * @param discriminatorName The name of the discriminator property.
+     * @param visited           A list of schemas already visited in the recursion, to avoid infinite loops.
+     * @return The discriminator property schema, or null if not found.
+     */
+    static Schema getDiscriminatorSchemaDeep(OpenAPI openAPI, Schema schema, String discriminatorName, List<Schema> visited) {
+        for (Schema s : visited) {
+            if (s == schema) {
+                return null;
+            }
+        }
+        visited.add(schema);
+
+        Schema direct = getDiscriminatorSchema(schema, discriminatorName);
+        if (direct != null) {
+            return direct;
+        }
+        if (ModelUtils.isAllOf(schema)) {
+            for (Object member : schema.getAllOf()) {
+                Schema resolvedMember = ModelUtils.getReferencedSchema(openAPI, (Schema) member);
+                if (resolvedMember == null) {
+                    continue;
+                }
+                Schema found = getDiscriminatorSchemaDeep(openAPI, resolvedMember, discriminatorName, visited);
+                if (found != null) {
+                    return found;
+                }
+            }
+        }
+        return null;
     }
 
     /**

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -1211,6 +1211,51 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void testOneOfDiscriminatorTypeResolvedFromSharedBase() {
+        // The oneOf interface (PetRequest) declares no properties of its own; the discriminator
+        // property `petType` is declared only on the shared base (PetBase), which the children
+        // inherit via allOf. The discriminator property type must still resolve to the enum model
+        // (PetType) by inspecting the mapped child schemas, rather than falling back to "string".
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/oneof_discriminator_enum_shared_base.yaml");
+        DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setUseOneOfInterfaces(true);
+        codegen.setOpenAPI(openAPI);
+
+        Schema petRequest = openAPI.getComponents().getSchemas().get("PetRequest");
+        CodegenModel petRequestModel = codegen.fromModel("PetRequest", petRequest);
+
+        assertTrue(petRequestModel.getHasDiscriminatorWithNonEmptyMapping());
+        assertEquals("PetType", petRequestModel.discriminator.getPropertyType());
+
+        // The concrete subtypes resolve the same property type, so the generated getter signatures
+        // are consistent with the interface (no String-vs-enum return type clash).
+        Schema catRequest = openAPI.getComponents().getSchemas().get("CatRequest");
+        CodegenModel catRequestModel = codegen.fromModel("CatRequest", catRequest);
+        CodegenProperty petTypeVar = catRequestModel.getVars().stream()
+                .filter(v -> "petType".equals(v.baseName))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("petType property not found on CatRequest"));
+        assertEquals("PetType", petTypeVar.dataType);
+    }
+
+    @Test
+    public void testOneOfDiscriminatorTypeFallsBackToStringWhenNotTyped() {
+        // The discriminator property (petType) is declared only as a plain inline string on the children,
+        // with no $ref to a typed schema. There is nothing to resolve from the schema or its children, so
+        // the discriminator property type must fall back to "string".
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/oneof_discriminator_string_fallback.yaml");
+        DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setUseOneOfInterfaces(true);
+        codegen.setOpenAPI(openAPI);
+
+        Schema petRequest = openAPI.getComponents().getSchemas().get("PetRequest");
+        CodegenModel petRequestModel = codegen.fromModel("PetRequest", petRequest);
+
+        assertTrue(petRequestModel.getHasDiscriminatorWithNonEmptyMapping());
+        assertEquals("String", petRequestModel.discriminator.getPropertyType());
+    }
+
+    @Test
     public void testParentName() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/allOf.yaml");
         DefaultCodegen codegen = new DefaultCodegen();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/DiscriminatorUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/DiscriminatorUtilsTest.java
@@ -1,0 +1,96 @@
+package org.openapitools.codegen.utils;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
+import org.openapitools.codegen.TestUtils;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+public class DiscriminatorUtilsTest {
+
+    /**
+     * A pure oneOf interface schema declares no properties of its own, so resolving the discriminator
+     * property type from the schema alone yields nothing. The type must instead be resolved from the
+     * mapped child schemas, which inherit the discriminator property from a shared base via allOf.
+     */
+    @Test
+    public void resolvesDiscriminatorPropertyTypeFromChildrenWhenNotOnSchema() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/oneof_discriminator_enum_shared_base.yaml");
+        Schema petRequest = openAPI.getComponents().getSchemas().get("PetRequest");
+
+        // The oneOf interface declares no discriminator property of its own, so the type is resolved from
+        // the mapped children, finding the enum ref (PetType) declared on the shared base.
+        Optional<String> resolved = DiscriminatorUtils.getDiscriminatorPropertyType(openAPI, petRequest, "petType");
+        assertEquals(resolved.orElse(null), "PetType");
+    }
+
+    /**
+     * When the discriminator property is declared directly on the schema, the own-properties resolution is
+     * used and the children are not consulted.
+     */
+    @Test
+    public void resolvesDiscriminatorPropertyTypeFromOwnPropertiesWhenPresent() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/oneof_discriminator_enum_shared_base.yaml");
+        Schema petBase = openAPI.getComponents().getSchemas().get("PetBase");
+
+        Optional<String> resolved = DiscriminatorUtils.getDiscriminatorPropertyType(openAPI, petBase, "petType");
+        assertEquals(resolved.orElse(null), "PetType");
+    }
+
+    /**
+     * The children fallback also resolves the discriminator property type when the interface uses anyOf
+     * rather than oneOf.
+     */
+    @Test
+    public void resolvesDiscriminatorPropertyTypeFromAnyOfChildren() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/anyof_discriminator_enum_shared_base.yaml");
+        Schema petRequest = openAPI.getComponents().getSchemas().get("PetRequest");
+
+        Optional<String> resolved = DiscriminatorUtils.getDiscriminatorPropertyType(openAPI, petRequest, "petType");
+        assertEquals(resolved.orElse(null), "PetType");
+    }
+
+    /**
+     * The discriminator property is reached only by recursing through more than one level of allOf (the
+     * children allOf an intermediate base that itself allOf the grandparent declaring the property).
+     */
+    @Test
+    public void resolvesDiscriminatorPropertyTypeThroughMultiLevelAllOf() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/oneof_discriminator_enum_nested_base.yaml");
+        Schema petRequest = openAPI.getComponents().getSchemas().get("PetRequest");
+
+        Optional<String> resolved = DiscriminatorUtils.getDiscriminatorPropertyType(openAPI, petRequest, "petType");
+        assertEquals(resolved.orElse(null), "PetType");
+    }
+
+    /**
+     * When neither the schema nor its children declare the discriminator property as a typed ($ref) schema
+     * - the children carry it only as a plain inline string - there is nothing to resolve, so the lookup
+     * returns empty (the caller then falls back to "string").
+     */
+    @Test
+    public void returnsEmptyWhenDiscriminatorPropertyHasNoTypedSchema() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/oneof_discriminator_string_fallback.yaml");
+        Schema petRequest = openAPI.getComponents().getSchemas().get("PetRequest");
+
+        assertFalse(DiscriminatorUtils.getDiscriminatorPropertyType(openAPI, petRequest, "petType").isPresent());
+    }
+
+    /**
+     * A cyclic allOf composition (two bases that allOf each other) must not cause the allOf descent to
+     * recurse infinitely. Resolution terminates; since no schema in the cycle declares the discriminator
+     * property as a typed $ref, the lookup returns empty.
+     */
+    @Test
+    public void terminatesOnCyclicAllOfComposition() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/oneof_discriminator_cyclic_allof.yaml");
+        Schema petRequest = openAPI.getComponents().getSchemas().get("PetRequest");
+
+        // Must return (not StackOverflowError) - the visited-set guard breaks the allOf cycle.
+        assertFalse(DiscriminatorUtils.getDiscriminatorPropertyType(openAPI, petRequest, "petType").isPresent());
+    }
+}

--- a/modules/openapi-generator/src/test/resources/3_0/anyof_discriminator_enum_shared_base.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/anyof_discriminator_enum_shared_base.yaml
@@ -1,0 +1,70 @@
+openapi: 3.0.3
+info:
+  title: anyOf discriminator with shared base
+  description: >
+    Same shape as the oneOf shared-base case, but the interface schema uses anyOf
+    instead of oneOf. The discriminator property type must still be resolved from
+    the mapped child schemas (through their allOf base), exercising the anyOf
+    branch of the children fallback.
+  version: 1.0.0
+paths:
+  /pets:
+    post:
+      operationId: createPet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PetRequest'
+      responses:
+        '201':
+          description: created
+components:
+  schemas:
+    PetType:
+      type: string
+      enum:
+        - CAT
+        - DOG
+      description: Discriminator value identifying the type of pet
+
+    PetRequest:
+      type: object
+      anyOf:
+        - $ref: '#/components/schemas/CatRequest'
+        - $ref: '#/components/schemas/DogRequest'
+      discriminator:
+        propertyName: petType
+        mapping:
+          CAT: '#/components/schemas/CatRequest'
+          DOG: '#/components/schemas/DogRequest'
+
+    PetBase:
+      type: object
+      required:
+        - petType
+        - name
+      properties:
+        petType:
+          $ref: '#/components/schemas/PetType'
+        name:
+          type: string
+
+    CatRequest:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/PetBase'
+        - type: object
+          properties:
+            indoor:
+              type: boolean
+
+    DogRequest:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/PetBase'
+        - type: object
+          properties:
+            trained:
+              type: boolean

--- a/modules/openapi-generator/src/test/resources/3_0/oneof_discriminator_cyclic_allof.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/oneof_discriminator_cyclic_allof.yaml
@@ -1,0 +1,63 @@
+openapi: 3.0.3
+info:
+  title: oneOf discriminator with a cyclic allOf composition
+  description: >
+    The children allOf two bases (PetBaseA, PetBaseB) that allOf each other, forming
+    a cycle. Resolving the discriminator property type must terminate instead of
+    recursing infinitely; since no schema in the cycle declares the discriminator
+    property as a typed $ref, the type falls back to "string".
+  version: 1.0.0
+paths:
+  /pets:
+    post:
+      operationId: createPet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PetRequest'
+      responses:
+        '201':
+          description: created
+components:
+  schemas:
+    PetRequest:
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/CatRequest'
+        - $ref: '#/components/schemas/DogRequest'
+      discriminator:
+        propertyName: petType
+        mapping:
+          CAT: '#/components/schemas/CatRequest'
+          DOG: '#/components/schemas/DogRequest'
+
+    # Two bases that allOf each other -> cyclic allOf composition.
+    PetBaseA:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/PetBaseB'
+
+    PetBaseB:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/PetBaseA'
+
+    CatRequest:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/PetBaseA'
+        - type: object
+          properties:
+            indoor:
+              type: boolean
+
+    DogRequest:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/PetBaseB'
+        - type: object
+          properties:
+            trained:
+              type: boolean

--- a/modules/openapi-generator/src/test/resources/3_0/oneof_discriminator_enum_nested_base.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/oneof_discriminator_enum_nested_base.yaml
@@ -1,0 +1,81 @@
+openapi: 3.0.3
+info:
+  title: oneOf discriminator with multi-level allOf base
+  description: >
+    The discriminator property is declared on a grandparent schema (PetRoot). The
+    children allOf an intermediate base (PetBase) that itself allOf the grandparent,
+    so the discriminator property is reached only by recursing through more than one
+    level of allOf. Exercises the recursive descent of getDiscriminatorSchemaDeep.
+  version: 1.0.0
+paths:
+  /pets:
+    post:
+      operationId: createPet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PetRequest'
+      responses:
+        '201':
+          description: created
+components:
+  schemas:
+    PetType:
+      type: string
+      enum:
+        - CAT
+        - DOG
+      description: Discriminator value identifying the type of pet
+
+    PetRequest:
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/CatRequest'
+        - $ref: '#/components/schemas/DogRequest'
+      discriminator:
+        propertyName: petType
+        mapping:
+          CAT: '#/components/schemas/CatRequest'
+          DOG: '#/components/schemas/DogRequest'
+
+    # Grandparent: declares the discriminator property.
+    PetRoot:
+      type: object
+      required:
+        - petType
+      properties:
+        petType:
+          $ref: '#/components/schemas/PetType'
+
+    # Intermediate base: inherits the discriminator property from the grandparent
+    # via allOf and adds a property of its own.
+    PetBase:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/PetRoot'
+        - type: object
+          required:
+            - name
+          properties:
+            name:
+              type: string
+
+    CatRequest:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/PetBase'
+        - type: object
+          properties:
+            indoor:
+              type: boolean
+
+    DogRequest:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/PetBase'
+        - type: object
+          properties:
+            trained:
+              type: boolean

--- a/modules/openapi-generator/src/test/resources/3_0/oneof_discriminator_enum_shared_base.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/oneof_discriminator_enum_shared_base.yaml
@@ -1,0 +1,79 @@
+openapi: 3.0.3
+info:
+  title: oneOf discriminator with shared base
+  description: >
+    A oneOf interface schema whose discriminator property is declared only on a
+    shared base schema that the concrete subtypes inherit via allOf. The oneOf
+    interface itself declares no properties, so the discriminator property type
+    must be resolved from the mapped child schemas (and through their allOf base)
+    rather than defaulting to string.
+  version: 1.0.0
+paths:
+  /pets:
+    post:
+      operationId: createPet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PetRequest'
+      responses:
+        '201':
+          description: created
+components:
+  schemas:
+    PetType:
+      type: string
+      enum:
+        - CAT
+        - DOG
+      description: Discriminator value identifying the type of pet
+
+    # oneOf interface schema. It declares no properties of its own: the
+    # discriminator property lives on PetBase, which the children allOf-inherit.
+    PetRequest:
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/CatRequest'
+        - $ref: '#/components/schemas/DogRequest'
+      discriminator:
+        propertyName: petType
+        mapping:
+          CAT: '#/components/schemas/CatRequest'
+          DOG: '#/components/schemas/DogRequest'
+
+    # Shared base WITHOUT a discriminator, so children flatten it via allOf
+    # instead of extending it (which would create a cyclical reference).
+    PetBase:
+      type: object
+      required:
+        - petType
+        - name
+      properties:
+        petType:
+          $ref: '#/components/schemas/PetType'
+        name:
+          type: string
+
+    CatRequest:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/PetBase'
+        - type: object
+          required:
+            - indoor
+          properties:
+            indoor:
+              type: boolean
+
+    DogRequest:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/PetBase'
+        - type: object
+          required:
+            - trained
+          properties:
+            trained:
+              type: boolean

--- a/modules/openapi-generator/src/test/resources/3_0/oneof_discriminator_string_fallback.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/oneof_discriminator_string_fallback.yaml
@@ -1,0 +1,60 @@
+openapi: 3.0.3
+info:
+  title: oneOf discriminator with no resolvable typed property
+  description: >
+    A oneOf interface whose discriminator property is a plain inline string on the
+    children (no $ref, no enum). There is no typed schema to resolve, so the
+    discriminator property type must fall back to "string".
+  version: 1.0.0
+paths:
+  /pets:
+    post:
+      operationId: createPet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PetRequest'
+      responses:
+        '201':
+          description: created
+components:
+  schemas:
+    PetRequest:
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/CatRequest'
+        - $ref: '#/components/schemas/DogRequest'
+      discriminator:
+        propertyName: petType
+        mapping:
+          CAT: '#/components/schemas/CatRequest'
+          DOG: '#/components/schemas/DogRequest'
+
+    # Shared base whose discriminator property is a plain string (no $ref/enum).
+    PetBase:
+      type: object
+      required:
+        - petType
+      properties:
+        petType:
+          type: string
+
+    CatRequest:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/PetBase'
+        - type: object
+          properties:
+            indoor:
+              type: boolean
+
+    DogRequest:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/PetBase'
+        - type: object
+          properties:
+            trained:
+              type: boolean


### PR DESCRIPTION
### What

`getDiscriminatorPropertyType` resolved the discriminator property's type only from the `oneOf`/`anyOf` schema's own properties, defaulting to `"string"` otherwise. For a pure `oneOf`/`anyOf` interface whose discriminator property lives on a shared base the children inherit via `allOf`, this produced a `String` getter that clashed with the enum the subtypes actually expose.

This adds a fallback (in `DiscriminatorUtils`) that resolves the type from the mapped child schemas, chasing the property through each child's `allOf` members. It only fires when the previous code would have returned `"string"`, so existing specs are unaffected — regenerating the full sample suite produces no diffs.

### Scenarios covered

| Discriminator property declared… | Resolves to | Test |
|---|---|---|
| As a `$ref` on the schema's own properties (unchanged path) | the referenced type (e.g. `PetType`) | `DiscriminatorUtilsTest`, `DefaultCodegenTest` |
| Only on a shared base the `oneOf` children inherit via `allOf` | `PetType` (from children) | `DiscriminatorUtilsTest`, `DefaultCodegenTest` |
| Only on a shared base the `anyOf` children inherit via `allOf` | `PetType` (from children) | `DiscriminatorUtilsTest` |
| On a grandparent reached through multi-level `allOf` | `PetType` (recursive descent) | `DiscriminatorUtilsTest` |
| As a plain inline `string` (no `$ref`, no enum) | `"string"` (fallback, unchanged) | `DiscriminatorUtilsTest`, `DefaultCodegenTest` |

Simples example where the `discriminator` is in the `base` object that is separate from the schema that contains `oneOf`
```YAML
PetRequest:
      type: object
      oneOf:
        - $ref: '#/components/schemas/CatRequest'
        - $ref: '#/components/schemas/DogRequest'
      discriminator:
        propertyName: petType
        mapping:
          CAT: '#/components/schemas/CatRequest'
          DOG: '#/components/schemas/DogRequest'

    # Shared base WITHOUT a discriminator, so children flatten it via allOf
    # instead of extending it (which would create a cyclical reference).
    PetBase:
      type: object
      required:
        - petType
        - name
      properties:
        petType:
          $ref: '#/components/schemas/PetType'  # ---> This would be duplicated into PetRequest without this PR refactor
        name:
          type: string

    CatRequest:
      type: object
      allOf:
        - $ref: '#/components/schemas/PetBase'
        - type: object
          required:
            - indoor
          properties:
            indoor:
              type: boolean

    DogRequest:
      type: object
      allOf:
        - $ref: '#/components/schemas/PetBase'
        - type: object
          required:
            - trained
          properties:
            trained:
              type: boolean
```

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes discriminator type resolution for oneOf/anyOf interfaces by deriving the property type from child schemas (via allOf) with cycle-safe recursion. Getter types now use the correct enum (e.g., PetType) instead of "string", avoiding interface vs subtype mismatches.

- **Bug Fixes**
  - Updated `DiscriminatorUtils.getDiscriminatorPropertyType(OpenAPI, ...)` to first check the schema’s own `$ref`, then fall back to oneOf/anyOf children via `getDiscriminatorPropertyTypeFromChildren` and recursive `getDiscriminatorSchemaDeep` (supports multi-level allOf with a visited guard for cycles).
  - Updated `DefaultCodegen.getDiscriminatorPropertyType` to pass `openAPI`, map to model names, and keep the "string" fallback.
  - Added `DiscriminatorUtilsTest`, expanded `DefaultCodegenTest`, and new YAMLs (oneOf/anyOf, nested base, cyclic, string fallback). Regenerating samples shows no diffs.

<sup>Written for commit a0934fe43dc961050363d604df951bdacc569f64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



