### PR TITLE
Convert maintained JAX-RS samples to JUnit 5

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
@@ -417,7 +417,7 @@
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
         {{/useJakartaEe}}
-        <junit-version>5.10.0</junit-version>
+        <junit-version>5.14.4</junit-version>
         {{#hasHttpSignatureMethods}}
         <http-signature-version>1.8</http-signature-version>
         {{/hasHttpSignatureMethods}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/api_test.mustache
@@ -4,9 +4,16 @@ package {{package}};
 
 {{#imports}}import {{import}};
 {{/imports}}
+{{#generateSpringBootApplication}}
 import org.junit.Test;
 import org.junit.Before;
 import static org.junit.Assert.*;
+{{/generateSpringBootApplication}}
+{{^generateSpringBootApplication}}
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
+{{/generateSpringBootApplication}}
 
 {{#useBeanValidation}}
 import {{javaxPackage}}.validation.Valid;
@@ -78,7 +85,7 @@ public class {{classname}}Test {
 
     private {{classname}} api;
 
-    @Before
+    {{#generateSpringBootApplication}}@Before{{/generateSpringBootApplication}}{{^generateSpringBootApplication}}@BeforeEach{{/generateSpringBootApplication}}
     public void setup() {
         JacksonJsonProvider provider = new JacksonJsonProvider();
         List providers = new ArrayList();

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/pom.mustache
@@ -21,8 +21,12 @@
     <sourceDirectory>src/main/java</sourceDirectory>
     <plugins>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -147,8 +151,8 @@ for this project used jakarta.validation-api -->
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -253,7 +257,7 @@ for this project used jakarta.validation-api -->
     <swagger-annotations-version>2.2.7</swagger-annotations-version>
 {{/swagger2AnnotationLibrary}}
     <jetty-version>9.2.9.v20150224</jetty-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <logback-version>1.5.33</logback-version>
 {{#useBeanValidation}}
     <beanvalidation-version>2.0.2</beanvalidation-version>

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
@@ -21,8 +21,12 @@
     <sourceDirectory>src/main/java</sourceDirectory>
     <plugins>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -156,8 +160,8 @@ for this project used jakarta.validation-api -->
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -310,7 +314,7 @@ for this project used jakarta.validation-api -->
     <swagger-annotations-version>2.2.7</swagger-annotations-version>
 {{/swagger2AnnotationLibrary}}
     <jetty-version>9.2.9.v20150224</jetty-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <logback-version>1.5.33</logback-version>
 {{#useBeanValidation}}
     <beanvalidation-version>2.0.2</beanvalidation-version>

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/libraries/jersey3/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/libraries/jersey3/pom.mustache
@@ -30,8 +30,12 @@
         <version>3.1.0</version>
       </plugin>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -138,8 +142,8 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -221,7 +225,7 @@
     <jetty-version>11.0.15</jetty-version>
     <jersey3-version>3.1.3</jersey3-version>
     <jackson-version>2.17.1</jackson-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <logback-version>1.5.33</logback-version>
     <servlet-api-version>5.0.0</servlet-api-version>    
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/pom.mustache
@@ -31,8 +31,12 @@
         <version>3.1.0</version>
       </plugin>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -138,8 +142,8 @@ for this project used jakarta.validation-api -->
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -221,7 +225,7 @@ for this project used jakarta.validation-api -->
     <jetty-version>9.2.9.v20150224</jetty-version>
     <jersey2-version>2.35</jersey2-version>
     <jackson-version>2.17.1</jackson-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <logback-version>1.5.33</logback-version>
     <servlet-api-version>4.0.4</servlet-api-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/libraries/thorntail/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/libraries/thorntail/pom.mustache
@@ -18,7 +18,7 @@
 
   <properties>
     <version.thorntail>2.5.0.Final</version.thorntail>
-    <version.junit>4.8.1</version.junit>
+    <version.junit>5.14.4</version.junit>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <failOnMissingWebXml>false</failOnMissingWebXml>
@@ -45,8 +45,8 @@
       <artifactId>microprofile-openapi</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pom.mustache
@@ -53,8 +53,12 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -135,8 +139,8 @@
         <version>3.0.2</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -185,7 +189,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jackson-version>2.19.2</jackson-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <joda-version>2.10.13</joda-version>
 {{#useJakartaEe}}
     <javax.annotation-api-version>2.1.1</javax.annotation-api-version>

--- a/samples/client/others/java/jersey2-oneOf-Mixed/pom.xml
+++ b/samples/client/others/java/jersey2-oneOf-Mixed/pom.xml
@@ -336,7 +336,7 @@
         <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
-        <junit-version>5.10.0</junit-version>
+        <junit-version>5.14.4</junit-version>
         <spotless.version>2.21.0</spotless.version>
     </properties>
 </project>

--- a/samples/client/others/java/jersey2-oneOf-duplicates/pom.xml
+++ b/samples/client/others/java/jersey2-oneOf-duplicates/pom.xml
@@ -336,7 +336,7 @@
         <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
-        <junit-version>5.10.0</junit-version>
+        <junit-version>5.14.4</junit-version>
         <spotless.version>2.21.0</spotless.version>
     </properties>
 </project>

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/pom.xml
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/pom.xml
@@ -341,7 +341,7 @@
         <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
-        <junit-version>5.10.0</junit-version>
+        <junit-version>5.14.4</junit-version>
         <scribejava-apis-version>8.3.3</scribejava-apis-version>
         <spotless.version>2.21.0</spotless.version>
     </properties>

--- a/samples/client/petstore/java/jersey2-java8/pom.xml
+++ b/samples/client/petstore/java/jersey2-java8/pom.xml
@@ -341,7 +341,7 @@
         <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
-        <junit-version>5.10.0</junit-version>
+        <junit-version>5.14.4</junit-version>
         <scribejava-apis-version>8.3.3</scribejava-apis-version>
         <spotless.version>2.21.0</spotless.version>
     </properties>

--- a/samples/client/petstore/jaxrs-cxf-client-jackson/pom.xml
+++ b/samples/client/petstore/jaxrs-cxf-client-jackson/pom.xml
@@ -12,8 +12,12 @@
     <sourceDirectory>src/main/java</sourceDirectory>
     <plugins>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -120,8 +124,8 @@ for this project used jakarta.validation-api -->
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -188,7 +192,7 @@ for this project used jakarta.validation-api -->
   <properties>
     <swagger-core-version>1.6.6</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <logback-version>1.5.33</logback-version>
     <cxf-version>4.2.0</cxf-version>
     <jackson-jaxrs-version>3.1.2</jackson-jaxrs-version>

--- a/samples/client/petstore/jaxrs-cxf-client-jackson/src/test/java/org/openapitools/api/PetApiTest.java
+++ b/samples/client/petstore/jaxrs-cxf-client-jackson/src/test/java/org/openapitools/api/PetApiTest.java
@@ -16,9 +16,9 @@ package org.openapitools.api;
 import java.io.File;
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
-import org.junit.Test;
-import org.junit.Before;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
 
 import jakarta.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
@@ -48,7 +48,7 @@ public class PetApiTest {
 
     private PetApi api;
 
-    @Before
+    @BeforeEach
     public void setup() {
         JacksonJsonProvider provider = new JacksonJsonProvider();
         List providers = new ArrayList();

--- a/samples/client/petstore/jaxrs-cxf-client-jackson/src/test/java/org/openapitools/api/StoreApiTest.java
+++ b/samples/client/petstore/jaxrs-cxf-client-jackson/src/test/java/org/openapitools/api/StoreApiTest.java
@@ -14,9 +14,9 @@
 package org.openapitools.api;
 
 import org.openapitools.model.Order;
-import org.junit.Test;
-import org.junit.Before;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
 
 import jakarta.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
@@ -46,7 +46,7 @@ public class StoreApiTest {
 
     private StoreApi api;
 
-    @Before
+    @BeforeEach
     public void setup() {
         JacksonJsonProvider provider = new JacksonJsonProvider();
         List providers = new ArrayList();

--- a/samples/client/petstore/jaxrs-cxf-client-jackson/src/test/java/org/openapitools/api/UserApiTest.java
+++ b/samples/client/petstore/jaxrs-cxf-client-jackson/src/test/java/org/openapitools/api/UserApiTest.java
@@ -15,9 +15,9 @@ package org.openapitools.api;
 
 import java.util.Date;
 import org.openapitools.model.User;
-import org.junit.Test;
-import org.junit.Before;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
 
 import jakarta.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
@@ -47,7 +47,7 @@ public class UserApiTest {
 
     private UserApi api;
 
-    @Before
+    @BeforeEach
     public void setup() {
         JacksonJsonProvider provider = new JacksonJsonProvider();
         List providers = new ArrayList();

--- a/samples/client/petstore/jaxrs-cxf-client-swagger2/pom.xml
+++ b/samples/client/petstore/jaxrs-cxf-client-swagger2/pom.xml
@@ -12,8 +12,12 @@
     <sourceDirectory>src/main/java</sourceDirectory>
     <plugins>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -111,8 +115,8 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -184,7 +188,7 @@
   <properties>
     <swagger-annotations-version>2.2.7</swagger-annotations-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <logback-version>1.5.33</logback-version>
     <cxf-version>3.5.9</cxf-version>
     <jackson-jaxrs-version>2.17.1</jackson-jaxrs-version>

--- a/samples/client/petstore/jaxrs-cxf-client-swagger2/src/test/java/org/openapitools/api/PetApiTest.java
+++ b/samples/client/petstore/jaxrs-cxf-client-swagger2/src/test/java/org/openapitools/api/PetApiTest.java
@@ -16,9 +16,9 @@ package org.openapitools.api;
 import java.io.File;
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
-import org.junit.Test;
-import org.junit.Before;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
@@ -48,7 +48,7 @@ public class PetApiTest {
 
     private PetApi api;
 
-    @Before
+    @BeforeEach
     public void setup() {
         JacksonJsonProvider provider = new JacksonJsonProvider();
         List providers = new ArrayList();

--- a/samples/client/petstore/jaxrs-cxf-client-swagger2/src/test/java/org/openapitools/api/StoreApiTest.java
+++ b/samples/client/petstore/jaxrs-cxf-client-swagger2/src/test/java/org/openapitools/api/StoreApiTest.java
@@ -14,9 +14,9 @@
 package org.openapitools.api;
 
 import org.openapitools.model.Order;
-import org.junit.Test;
-import org.junit.Before;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
@@ -46,7 +46,7 @@ public class StoreApiTest {
 
     private StoreApi api;
 
-    @Before
+    @BeforeEach
     public void setup() {
         JacksonJsonProvider provider = new JacksonJsonProvider();
         List providers = new ArrayList();

--- a/samples/client/petstore/jaxrs-cxf-client-swagger2/src/test/java/org/openapitools/api/UserApiTest.java
+++ b/samples/client/petstore/jaxrs-cxf-client-swagger2/src/test/java/org/openapitools/api/UserApiTest.java
@@ -15,9 +15,9 @@ package org.openapitools.api;
 
 import java.util.Date;
 import org.openapitools.model.User;
-import org.junit.Test;
-import org.junit.Before;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
@@ -47,7 +47,7 @@ public class UserApiTest {
 
     private UserApi api;
 
-    @Before
+    @BeforeEach
     public void setup() {
         JacksonJsonProvider provider = new JacksonJsonProvider();
         List providers = new ArrayList();

--- a/samples/client/petstore/jaxrs-cxf-client/pom.xml
+++ b/samples/client/petstore/jaxrs-cxf-client/pom.xml
@@ -12,8 +12,12 @@
     <sourceDirectory>src/main/java</sourceDirectory>
     <plugins>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -120,8 +124,8 @@ for this project used jakarta.validation-api -->
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -193,7 +197,7 @@ for this project used jakarta.validation-api -->
   <properties>
     <swagger-core-version>1.6.6</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <logback-version>1.5.33</logback-version>
     <cxf-version>3.5.9</cxf-version>
     <jackson-jaxrs-version>2.17.1</jackson-jaxrs-version>

--- a/samples/client/petstore/jaxrs-cxf-client/src/test/java/org/openapitools/api/PetApiTest.java
+++ b/samples/client/petstore/jaxrs-cxf-client/src/test/java/org/openapitools/api/PetApiTest.java
@@ -16,9 +16,9 @@ package org.openapitools.api;
 import java.io.File;
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
-import org.junit.Test;
-import org.junit.Before;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
@@ -48,7 +48,7 @@ public class PetApiTest {
 
     private PetApi api;
 
-    @Before
+    @BeforeEach
     public void setup() {
         JacksonJsonProvider provider = new JacksonJsonProvider();
         List providers = new ArrayList();

--- a/samples/client/petstore/jaxrs-cxf-client/src/test/java/org/openapitools/api/StoreApiTest.java
+++ b/samples/client/petstore/jaxrs-cxf-client/src/test/java/org/openapitools/api/StoreApiTest.java
@@ -14,9 +14,9 @@
 package org.openapitools.api;
 
 import org.openapitools.model.Order;
-import org.junit.Test;
-import org.junit.Before;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
@@ -46,7 +46,7 @@ public class StoreApiTest {
 
     private StoreApi api;
 
-    @Before
+    @BeforeEach
     public void setup() {
         JacksonJsonProvider provider = new JacksonJsonProvider();
         List providers = new ArrayList();

--- a/samples/client/petstore/jaxrs-cxf-client/src/test/java/org/openapitools/api/UserApiTest.java
+++ b/samples/client/petstore/jaxrs-cxf-client/src/test/java/org/openapitools/api/UserApiTest.java
@@ -15,9 +15,9 @@ package org.openapitools.api;
 
 import java.util.Date;
 import org.openapitools.model.User;
-import org.junit.Test;
-import org.junit.Before;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
@@ -47,7 +47,7 @@ public class UserApiTest {
 
     private UserApi api;
 
-    @Before
+    @BeforeEach
     public void setup() {
         JacksonJsonProvider provider = new JacksonJsonProvider();
         List providers = new ArrayList();

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/pom.xml
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/pom.xml
@@ -336,7 +336,7 @@
         <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
-        <junit-version>5.10.0</junit-version>
+        <junit-version>5.14.4</junit-version>
         <spotless.version>2.21.0</spotless.version>
     </properties>
 </project>

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/pom.xml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/pom.xml
@@ -336,7 +336,7 @@
         <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
-        <junit-version>5.10.0</junit-version>
+        <junit-version>5.14.4</junit-version>
         <spotless.version>2.21.0</spotless.version>
     </properties>
 </project>

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/pom.xml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/pom.xml
@@ -347,7 +347,7 @@
         <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
-        <junit-version>5.10.0</junit-version>
+        <junit-version>5.14.4</junit-version>
         <scribejava-apis-version>8.3.3</scribejava-apis-version>
         <spotless.version>2.21.0</spotless.version>
     </properties>

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/pom.xml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/pom.xml
@@ -347,7 +347,7 @@
         <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
-        <junit-version>5.10.0</junit-version>
+        <junit-version>5.14.4</junit-version>
         <scribejava-apis-version>8.3.3</scribejava-apis-version>
         <spotless.version>2.21.0</spotless.version>
     </properties>

--- a/samples/openapi3/client/petstore/java/jersey2-java8/pom.xml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/pom.xml
@@ -352,7 +352,7 @@
         <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
-        <junit-version>5.10.0</junit-version>
+        <junit-version>5.14.4</junit-version>
         <http-signature-version>1.8</http-signature-version>
         <scribejava-apis-version>8.3.3</scribejava-apis-version>
         <commons-lang3-version>3.17.0</commons-lang3-version>

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/test/java/org/openapitools/client/ApiClientTest.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/test/java/org/openapitools/client/ApiClientTest.java
@@ -9,7 +9,6 @@ import java.lang.Exception;
 import java.security.spec.AlgorithmParameterSpec;
 import java.util.*;
 import java.net.URI;
-import org.junit.*;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
 

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/pom.xml
@@ -12,8 +12,12 @@
     <sourceDirectory>src/main/java</sourceDirectory>
     <plugins>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -136,8 +140,8 @@ for this project used jakarta.validation-api -->
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -225,7 +229,7 @@ for this project used jakarta.validation-api -->
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <swagger-core-version>1.6.6</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <logback-version>1.5.33</logback-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>
     <cxf-version>3.5.9</cxf-version>

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/test/java/org/openapitools/api/PetApiTest.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/test/java/org/openapitools/api/PetApiTest.java
@@ -16,9 +16,9 @@ package org.openapitools.api;
 import java.io.File;
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
-import org.junit.Test;
-import org.junit.Before;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.validation.Valid;
 import javax.ws.rs.core.Response;
@@ -49,7 +49,7 @@ public class PetApiTest {
 
     private PetApi api;
 
-    @Before
+    @BeforeEach
     public void setup() {
         JacksonJsonProvider provider = new JacksonJsonProvider();
         List providers = new ArrayList();

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/test/java/org/openapitools/api/StoreApiTest.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/test/java/org/openapitools/api/StoreApiTest.java
@@ -15,9 +15,9 @@ package org.openapitools.api;
 
 import java.util.Map;
 import org.openapitools.model.Order;
-import org.junit.Test;
-import org.junit.Before;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.validation.Valid;
 import javax.ws.rs.core.Response;
@@ -48,7 +48,7 @@ public class StoreApiTest {
 
     private StoreApi api;
 
-    @Before
+    @BeforeEach
     public void setup() {
         JacksonJsonProvider provider = new JacksonJsonProvider();
         List providers = new ArrayList();

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/test/java/org/openapitools/api/UserApiTest.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/test/java/org/openapitools/api/UserApiTest.java
@@ -15,9 +15,9 @@ package org.openapitools.api;
 
 import java.util.Date;
 import org.openapitools.model.User;
-import org.junit.Test;
-import org.junit.Before;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.validation.Valid;
 import javax.ws.rs.core.Response;
@@ -48,7 +48,7 @@ public class UserApiTest {
 
     private UserApi api;
 
-    @Before
+    @BeforeEach
     public void setup() {
         JacksonJsonProvider provider = new JacksonJsonProvider();
         List providers = new ArrayList();

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/pom.xml
@@ -12,8 +12,12 @@
     <sourceDirectory>src/main/java</sourceDirectory>
     <plugins>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -136,8 +140,8 @@ for this project used jakarta.validation-api -->
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -225,7 +229,7 @@ for this project used jakarta.validation-api -->
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <swagger-core-version>1.6.6</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <logback-version>1.5.33</logback-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>
     <cxf-version>3.5.9</cxf-version>

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/test/java/org/openapitools/api/PetApiTest.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/test/java/org/openapitools/api/PetApiTest.java
@@ -16,9 +16,9 @@ package org.openapitools.api;
 import java.io.File;
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
-import org.junit.Test;
-import org.junit.Before;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.validation.Valid;
 import javax.ws.rs.core.Response;
@@ -49,7 +49,7 @@ public class PetApiTest {
 
     private PetApi api;
 
-    @Before
+    @BeforeEach
     public void setup() {
         JacksonJsonProvider provider = new JacksonJsonProvider();
         List providers = new ArrayList();

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/test/java/org/openapitools/api/StoreApiTest.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/test/java/org/openapitools/api/StoreApiTest.java
@@ -15,9 +15,9 @@ package org.openapitools.api;
 
 import java.util.Map;
 import org.openapitools.model.Order;
-import org.junit.Test;
-import org.junit.Before;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.validation.Valid;
 import javax.ws.rs.core.Response;
@@ -48,7 +48,7 @@ public class StoreApiTest {
 
     private StoreApi api;
 
-    @Before
+    @BeforeEach
     public void setup() {
         JacksonJsonProvider provider = new JacksonJsonProvider();
         List providers = new ArrayList();

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/test/java/org/openapitools/api/UserApiTest.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/test/java/org/openapitools/api/UserApiTest.java
@@ -15,9 +15,9 @@ package org.openapitools.api;
 
 import java.util.Date;
 import org.openapitools.model.User;
-import org.junit.Test;
-import org.junit.Before;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.validation.Valid;
 import javax.ws.rs.core.Response;
@@ -48,7 +48,7 @@ public class UserApiTest {
 
     private UserApi api;
 
-    @Before
+    @BeforeEach
     public void setup() {
         JacksonJsonProvider provider = new JacksonJsonProvider();
         List providers = new ArrayList();

--- a/samples/server/petstore/jaxrs-cxf/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf/pom.xml
@@ -12,8 +12,12 @@
     <sourceDirectory>src/main/java</sourceDirectory>
     <plugins>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -136,8 +140,8 @@ for this project used jakarta.validation-api -->
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -225,7 +229,7 @@ for this project used jakarta.validation-api -->
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <swagger-core-version>1.6.6</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <logback-version>1.5.33</logback-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>
     <cxf-version>3.5.9</cxf-version>

--- a/samples/server/petstore/jaxrs-cxf/src/test/java/org/openapitools/api/AnotherFakeApiTest.java
+++ b/samples/server/petstore/jaxrs-cxf/src/test/java/org/openapitools/api/AnotherFakeApiTest.java
@@ -15,9 +15,9 @@ package org.openapitools.api;
 
 import org.openapitools.model.Client;
 import java.util.UUID;
-import org.junit.Test;
-import org.junit.Before;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.validation.Valid;
 import javax.ws.rs.core.Response;
@@ -48,7 +48,7 @@ public class AnotherFakeApiTest {
 
     private AnotherFakeApi api;
 
-    @Before
+    @BeforeEach
     public void setup() {
         JacksonJsonProvider provider = new JacksonJsonProvider();
         List providers = new ArrayList();

--- a/samples/server/petstore/jaxrs-cxf/src/test/java/org/openapitools/api/FakeApiTest.java
+++ b/samples/server/petstore/jaxrs-cxf/src/test/java/org/openapitools/api/FakeApiTest.java
@@ -23,9 +23,9 @@ import java.util.Map;
 import org.openapitools.model.OuterComposite;
 import org.openapitools.model.User;
 import org.openapitools.model.XmlItem;
-import org.junit.Test;
-import org.junit.Before;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.validation.Valid;
 import javax.ws.rs.core.Response;
@@ -56,7 +56,7 @@ public class FakeApiTest {
 
     private FakeApi api;
 
-    @Before
+    @BeforeEach
     public void setup() {
         JacksonJsonProvider provider = new JacksonJsonProvider();
         List providers = new ArrayList();

--- a/samples/server/petstore/jaxrs-cxf/src/test/java/org/openapitools/api/FakeClassnameTags123ApiTest.java
+++ b/samples/server/petstore/jaxrs-cxf/src/test/java/org/openapitools/api/FakeClassnameTags123ApiTest.java
@@ -14,9 +14,9 @@
 package org.openapitools.api;
 
 import org.openapitools.model.Client;
-import org.junit.Test;
-import org.junit.Before;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.validation.Valid;
 import javax.ws.rs.core.Response;
@@ -47,7 +47,7 @@ public class FakeClassnameTags123ApiTest {
 
     private FakeClassnameTags123Api api;
 
-    @Before
+    @BeforeEach
     public void setup() {
         JacksonJsonProvider provider = new JacksonJsonProvider();
         List providers = new ArrayList();

--- a/samples/server/petstore/jaxrs-cxf/src/test/java/org/openapitools/api/PetApiTest.java
+++ b/samples/server/petstore/jaxrs-cxf/src/test/java/org/openapitools/api/PetApiTest.java
@@ -17,9 +17,9 @@ import java.io.File;
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
 import java.util.Set;
-import org.junit.Test;
-import org.junit.Before;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.validation.Valid;
 import javax.ws.rs.core.Response;
@@ -50,7 +50,7 @@ public class PetApiTest {
 
     private PetApi api;
 
-    @Before
+    @BeforeEach
     public void setup() {
         JacksonJsonProvider provider = new JacksonJsonProvider();
         List providers = new ArrayList();

--- a/samples/server/petstore/jaxrs-cxf/src/test/java/org/openapitools/api/StoreApiTest.java
+++ b/samples/server/petstore/jaxrs-cxf/src/test/java/org/openapitools/api/StoreApiTest.java
@@ -15,9 +15,9 @@ package org.openapitools.api;
 
 import java.util.Map;
 import org.openapitools.model.Order;
-import org.junit.Test;
-import org.junit.Before;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.validation.Valid;
 import javax.ws.rs.core.Response;
@@ -48,7 +48,7 @@ public class StoreApiTest {
 
     private StoreApi api;
 
-    @Before
+    @BeforeEach
     public void setup() {
         JacksonJsonProvider provider = new JacksonJsonProvider();
         List providers = new ArrayList();

--- a/samples/server/petstore/jaxrs-cxf/src/test/java/org/openapitools/api/UserApiTest.java
+++ b/samples/server/petstore/jaxrs-cxf/src/test/java/org/openapitools/api/UserApiTest.java
@@ -15,9 +15,9 @@ package org.openapitools.api;
 
 import java.util.Date;
 import org.openapitools.model.User;
-import org.junit.Test;
-import org.junit.Before;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.validation.Valid;
 import javax.ws.rs.core.Response;
@@ -48,7 +48,7 @@ public class UserApiTest {
 
     private UserApi api;
 
-    @Before
+    @BeforeEach
     public void setup() {
         JacksonJsonProvider provider = new JacksonJsonProvider();
         List providers = new ArrayList();

--- a/samples/server/petstore/jaxrs-datelib-j8/pom.xml
+++ b/samples/server/petstore/jaxrs-datelib-j8/pom.xml
@@ -24,8 +24,12 @@
         <version>3.1.0</version>
       </plugin>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -129,8 +133,8 @@ for this project used jakarta.validation-api -->
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -208,7 +212,7 @@ for this project used jakarta.validation-api -->
     <jetty-version>9.2.9.v20150224</jetty-version>
     <jersey2-version>2.35</jersey2-version>
     <jackson-version>2.17.1</jackson-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <logback-version>1.5.33</logback-version>
     <servlet-api-version>4.0.4</servlet-api-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/samples/server/petstore/jaxrs-jersey/pom.xml
+++ b/samples/server/petstore/jaxrs-jersey/pom.xml
@@ -24,8 +24,12 @@
         <version>3.1.0</version>
       </plugin>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -129,8 +133,8 @@ for this project used jakarta.validation-api -->
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -208,7 +212,7 @@ for this project used jakarta.validation-api -->
     <jetty-version>9.2.9.v20150224</jetty-version>
     <jersey2-version>2.35</jersey2-version>
     <jackson-version>2.17.1</jackson-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <logback-version>1.5.33</logback-version>
     <servlet-api-version>4.0.4</servlet-api-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/samples/server/petstore/jaxrs-spec-interface-response/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-interface-response/pom.xml
@@ -76,8 +76,8 @@
         <version>3.0.2</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -100,7 +100,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jackson-version>2.19.2</jackson-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <joda-version>2.10.13</joda-version>
     <javax.annotation-api-version>1.3.2</javax.annotation-api-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>

--- a/samples/server/petstore/jaxrs-spec-interface/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-interface/pom.xml
@@ -76,8 +76,8 @@
         <version>3.0.2</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -100,7 +100,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jackson-version>2.19.2</jackson-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <joda-version>2.10.13</joda-version>
     <javax.annotation-api-version>1.3.2</javax.annotation-api-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>

--- a/samples/server/petstore/jaxrs-spec-jakarta/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-jakarta/pom.xml
@@ -38,8 +38,12 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -91,8 +95,8 @@
         <version>3.0.2</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -135,7 +139,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jackson-version>2.19.2</jackson-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <joda-version>2.10.13</joda-version>
     <javax.annotation-api-version>2.1.1</javax.annotation-api-version>
     <beanvalidation-version>3.0.2</beanvalidation-version>

--- a/samples/server/petstore/jaxrs-spec-required-and-readonly-property/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-required-and-readonly-property/pom.xml
@@ -38,8 +38,12 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -91,8 +95,8 @@
         <version>3.0.2</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -135,7 +139,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jackson-version>2.19.2</jackson-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <joda-version>2.10.13</joda-version>
     <javax.annotation-api-version>1.3.2</javax.annotation-api-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>

--- a/samples/server/petstore/jaxrs-spec-swagger-annotations/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-swagger-annotations/pom.xml
@@ -38,8 +38,12 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -91,8 +95,8 @@
         <version>3.0.2</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -135,7 +139,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jackson-version>2.19.2</jackson-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <joda-version>2.10.13</joda-version>
     <javax.annotation-api-version>1.3.2</javax.annotation-api-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>

--- a/samples/server/petstore/jaxrs-spec-swagger-v3-annotations-jakarta/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-swagger-v3-annotations-jakarta/pom.xml
@@ -38,8 +38,12 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -91,8 +95,8 @@
         <version>3.0.2</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -135,7 +139,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jackson-version>2.19.2</jackson-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <joda-version>2.10.13</joda-version>
     <javax.annotation-api-version>2.1.1</javax.annotation-api-version>
     <beanvalidation-version>3.0.2</beanvalidation-version>

--- a/samples/server/petstore/jaxrs-spec-swagger-v3-annotations/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-swagger-v3-annotations/pom.xml
@@ -38,8 +38,12 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -91,8 +95,8 @@
         <version>3.0.2</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -135,7 +139,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jackson-version>2.19.2</jackson-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <joda-version>2.10.13</joda-version>
     <javax.annotation-api-version>1.3.2</javax.annotation-api-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>

--- a/samples/server/petstore/jaxrs-spec-withxml/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-withxml/pom.xml
@@ -38,8 +38,12 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -91,8 +95,8 @@
         <version>3.0.2</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -135,7 +139,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jackson-version>2.19.2</jackson-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <joda-version>2.10.13</joda-version>
     <javax.annotation-api-version>1.3.2</javax.annotation-api-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>

--- a/samples/server/petstore/jaxrs-spec/pom.xml
+++ b/samples/server/petstore/jaxrs-spec/pom.xml
@@ -38,8 +38,12 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -91,8 +95,8 @@
         <version>3.0.2</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -135,7 +139,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jackson-version>2.19.2</jackson-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <joda-version>2.10.13</joda-version>
     <javax.annotation-api-version>1.3.2</javax.annotation-api-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>

--- a/samples/server/petstore/jaxrs/jersey2-useTags/pom.xml
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/pom.xml
@@ -24,8 +24,12 @@
         <version>3.1.0</version>
       </plugin>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -129,8 +133,8 @@ for this project used jakarta.validation-api -->
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -208,7 +212,7 @@ for this project used jakarta.validation-api -->
     <jetty-version>9.2.9.v20150224</jetty-version>
     <jersey2-version>2.35</jersey2-version>
     <jackson-version>2.17.1</jackson-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <logback-version>1.5.33</logback-version>
     <servlet-api-version>4.0.4</servlet-api-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/samples/server/petstore/jaxrs/jersey2/pom.xml
+++ b/samples/server/petstore/jaxrs/jersey2/pom.xml
@@ -24,8 +24,12 @@
         <version>3.1.0</version>
       </plugin>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -129,8 +133,8 @@ for this project used jakarta.validation-api -->
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -208,7 +212,7 @@ for this project used jakarta.validation-api -->
     <jetty-version>9.2.9.v20150224</jetty-version>
     <jersey2-version>2.35</jersey2-version>
     <jackson-version>2.17.1</jackson-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <logback-version>1.5.33</logback-version>
     <servlet-api-version>4.0.4</servlet-api-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/samples/server/petstore/jaxrs/jersey3/pom.xml
+++ b/samples/server/petstore/jaxrs/jersey3/pom.xml
@@ -23,8 +23,12 @@
         <version>3.1.0</version>
       </plugin>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -129,8 +133,8 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -208,7 +212,7 @@
     <jetty-version>11.0.15</jetty-version>
     <jersey3-version>3.1.3</jersey3-version>
     <jackson-version>2.17.1</jackson-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <logback-version>1.5.33</logback-version>
     <servlet-api-version>5.0.0</servlet-api-version>    
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Use JUnit Jupiter Engine 5.14.4 for the generated tests and update generated Surefire/Failsafe plugin declarations to 3.5.6 so Maven runs the JUnit Platform tests instead of silently ignoring them.

Set the generated CXF client POMs to compile as Java 8. JUnit 5 requires Java 8, and generated Java code in the 2020s should not fall back to Maven's old source/target 5 defaults.

Leave the unmaintained generator outputs and templates out of this conversion, including java-pkmst and cxf-ext.

### Testing

Ran generated sample verification without command-line compiler source/target overrides:

```bash
for pom in \
  samples/client/petstore/jaxrs-cxf-client-jackson/pom.xml \
  samples/client/petstore/jaxrs-cxf-client-swagger2/pom.xml \
  samples/client/petstore/jaxrs-cxf-client/pom.xml \
  samples/server/petstore/jaxrs-cxf-annotated-base-path/pom.xml \
  samples/server/petstore/jaxrs-cxf-non-spring-app/pom.xml \
  samples/server/petstore/jaxrs-cxf/pom.xml
do
  ./mvnw -q -f "$pom" verify || exit 1
done
```

Results:

```text
jaxrs-cxf-client-jackson:       tests=20 failures=0 errors=0 skipped=0
jaxrs-cxf-client-swagger2:      tests=20 failures=0 errors=0 skipped=0
jaxrs-cxf-client:               tests=20 failures=0 errors=0 skipped=0
jaxrs-cxf-annotated-base-path:  tests=20 failures=0 errors=0 skipped=0
jaxrs-cxf-non-spring-app:       tests=20 failures=0 errors=0 skipped=0
jaxrs-cxf:                      tests=37 failures=0 errors=0 skipped=0
```

Also ran the changed Jersey2 Java 8 generated test directly:

```bash
./mvnw -q -f samples/openapi3/client/petstore/java/jersey2-java8/pom.xml \
  -Dtest=org.openapitools.client.ApiClientTest test
```

Result:

```text
ApiClientTest: tests=3 failures=0 errors=0 skipped=0
```

`git diff --check` passes.

<!-- Please check the completed items below -->

### PR checklist

* [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
* [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:

  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ```

  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files.
  This is important, as CI jobs will verify *all* generator outputs of your HEAD commit as it would merge with master.
  These must match the expectations made by your contribution.
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`.
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
* [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@hiveship


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Convert maintained JAX-RS generators and samples (CXF, Jersey 2/3, spec) to JUnit 5 and run tests on the JUnit Platform. The Spring Boot CXF server path stays on JUnit 4 for compatibility.

- **Dependencies**
  - Replace `junit:junit` with `org.junit.jupiter:junit-jupiter-engine` 5.14.4.
  - Upgrade `maven-surefire-plugin` and `maven-failsafe-plugin` to 3.5.6.

- **Migration**
  - Generate non-Spring tests with JUnit 5 (`@BeforeEach`, `Assertions`); when `generateSpringBootApplication` is true, use JUnit 4.
  - Do not force Java version in CXF client POMs; configure if needed.
  - Exclude unmaintained generators (e.g., `java-pkmst`, `cxf-ext`) and align samples to JUnit 5.

<sup>Written for commit 0730a8a6ee236ed7725d269535eb4d2575cfdaea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


