### PR TITLE
fix: Remove extra commas when generating with cookies with Retrofit2

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -955,6 +955,13 @@ public class JavaClientCodegen extends AbstractJavaCodegen
                                 return 0;
                             }
                         });
+
+                        // Retrofit2 has no annotation for cookie parameters, so they cannot be
+                        // expressed in the interface method signature. Drop them so the generated
+                        // interface (and its Javadoc) only references parameters that are actually
+                        // rendered; otherwise the parameter separator logic would emit a dangling
+                        // comma for the omitted parameter.
+                        operation.allParams.removeIf(param -> param.isCookieParam);
                     }
                 }
             }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -338,6 +338,44 @@ public class JavaClientCodegenTest {
     }
 
     @Test
+    public void testRetrofit2CookieParamsOmittedFromSignature() {
+        final Path output = newTempFolder();
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(JAVA_GENERATOR)
+                .setLibrary(JavaClientCodegen.RETROFIT_2)
+                .setInputSpec("src/test/resources/3_0/java/retrofit2-cookie-params.yaml")
+                .setOutputDir(output.toString().replace("\\", "/"));
+
+        List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+
+        // Retrofit2 has no annotation for cookie parameters, so they are omitted from the
+        // interface method signature. Previously the cookie param was dropped while its
+        // separator comma was kept, producing an uncompilable signature such as
+        // "cookieLast(@Header(...) String xApiVersion, );". validateJavaSourceFiles parses
+        // every generated file, so a stray leading/trailing comma fails the parse here.
+        validateJavaSourceFiles(files);
+
+        Map<String, File> fileMap = files.stream()
+                .collect(Collectors.toMap(File::getName, Function.identity()));
+
+        JavaFileAssert.assertThat(fileMap.get("DefaultApi.java"))
+                // cookie param is last -> no trailing comma, cookie param omitted
+                .assertMethod("cookieLast", "String")
+                .assertParameter("xApiVersion")
+                .toMethod()
+                .toFileAssert()
+                // cookie param is first -> no leading comma, remaining params kept
+                .assertMethod("cookieFirst", "String", "String")
+                .assertParameter("xApiVersion")
+                .toMethod()
+                .assertParameter("filter")
+                .toMethod()
+                .toFileAssert()
+                // only a cookie param -> empty parameter list
+                .assertMethod("cookieOnly");
+    }
+
+    @Test
     public void testSupportedSecuritySchemesJersey() {
         final JavaClientCodegen codegen = new JavaClientCodegen();
         codegen.additionalProperties().put(CodegenConstants.LIBRARY, JavaClientCodegen.JERSEY3);

--- a/modules/openapi-generator/src/test/resources/3_0/java/retrofit2-cookie-params.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/java/retrofit2-cookie-params.yaml
@@ -1,0 +1,61 @@
+openapi: 3.0.0
+info:
+  title: Retrofit2 cookie params
+  description: >
+    Retrofit2 has no annotation for cookie parameters, so they are omitted from
+    the generated interface method signature. This spec exercises cookie params
+    in various positions to ensure the parameter separator logic never produces
+    an uncompilable signature (e.g. a trailing or leading comma).
+  version: 1.0.0
+paths:
+  /cookie-last:
+    get:
+      operationId: cookieLast
+      parameters:
+        - name: x-api-version
+          in: header
+          required: true
+          schema:
+            type: string
+        - name: JSESSIONID
+          in: cookie
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+  /cookie-first:
+    get:
+      operationId: cookieFirst
+      parameters:
+        - name: JSESSIONID
+          in: cookie
+          required: true
+          schema:
+            type: string
+        - name: x-api-version
+          in: header
+          required: true
+          schema:
+            type: string
+        - name: filter
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+  /cookie-only:
+    get:
+      operationId: cookieOnly
+      parameters:
+        - name: JSESSIONID
+          in: cookie
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK


### PR DESCRIPTION
Fixes https://github.com/OpenAPITools/openapi-generator/issues/2689 using the strategy described [here](https://github.com/OpenAPITools/openapi-generator/issues/2689#issuecomment-4855115763).

Added a unit test to verify the logic.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Pinging the Java committee members as per the PR checklist: @sreeshas @lukoyanov @jeff9finger @Zomzog @martin-mfg (half, since the group is so big).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents dangling commas in generated `retrofit2` interfaces when operations include cookie parameters by omitting cookie params from method signatures. Fixes #2689 and adds tests to ensure generated code compiles.

- **Bug Fixes**
  - In `JavaClientCodegen` (for `retrofit2`), remove cookie parameters from `operation.allParams` before rendering to avoid trailing/leading commas and invalid Javadoc.
  - Added `testRetrofit2CookieParamsOmittedFromSignature` and `retrofit2-cookie-params.yaml` to cover cookie-first/last/only cases and validate Java parsing.

<sup>Written for commit e66494fbffb66ab91d62334ece24e08f7cd6f5a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

