### PR TITLE
fix(asciidoc): escape table cell pipes in generated docs

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AsciidocDocumentationCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AsciidocDocumentationCodegen.java
@@ -150,6 +150,27 @@ public class AsciidocDocumentationCodegen extends DefaultCodegen implements Code
         }
     }
 
+    /**
+     * Lambda escaping AsciiDoc table cell separators ("|") in rendered content, so
+     * that free-form values (descriptions, defaults, patterns, enum values, ...)
+     * cannot break the layout of the table they are placed in. Use:
+     *
+     * <pre>
+     * {{#tablecellcontent}}{{description}}{{/tablecellcontent}}
+     * </pre>
+     */
+    public static class TableCellContentLambda implements Mustache.Lambda {
+        // Only escape a "|" that isn't already escaped, so values that legitimately
+        // contain a backslash-escaped pipe (e.g. a regex pattern using "\|" to match
+        // a literal pipe character) aren't mangled with a redundant backslash.
+        private static final java.util.regex.Pattern UNESCAPED_PIPE = java.util.regex.Pattern.compile("(?<!\\\\)\\|");
+
+        @Override
+        public void execute(final Template.Fragment frag, final Writer out) throws IOException {
+            out.write(UNESCAPED_PIPE.matcher(frag.execute()).replaceAll("\\\\|"));
+        }
+    }
+
     protected String invokerPackage = "org.openapitools.client";
     protected String groupId = "org.openapitools";
     protected String artifactId = "openapi-client";
@@ -275,6 +296,7 @@ public class AsciidocDocumentationCodegen extends DefaultCodegen implements Code
         languageSpecificPrimitives = new HashSet<>();
         importMapping = new HashMap<>();
 
+        additionalProperties.put("tablecellcontent", new TableCellContentLambda());
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/asciidoc-documentation/model.mustache
+++ b/modules/openapi-generator/src/main/resources/asciidoc-documentation/model.mustache
@@ -17,12 +17,12 @@
 | Field Name| Required| Nullable | Type| Description | Format
 
 {{#vars}}
-| {{baseName}}
+| {{#tablecellcontent}}{{baseName}}{{/tablecellcontent}}
 | {{#required}}X{{/required}}
 | {{#isNullable}}X{{/isNullable}}
 | {{#isModel}}<<{{ dataType }}>>{{/isModel}} {{^container}}{{^allowableValues}} {{^isModel}}{{ dataType }}{{/isModel}}{{/allowableValues}}{{#allowableValues}}{{^allowableValues.empty}}<<{{ dataType }}>>{{/allowableValues.empty}}{{/allowableValues}} {{/container}} {{#isContainer}} of <<{{complexType}}>>{{/isContainer}}
-| {{description}}
-| {{{dataFormat}}} {{#isEnum}}_Enum:_ {{#_enum}}{{this}}, {{/_enum}}{{/isEnum}} {{^isEnum}}{{^container}}{{^allowableValues.empty}} {{#allowableValues.values}}{{this}}, {{/allowableValues.values}} {{/allowableValues.empty}}{{/container}}{{/isEnum}}
+| {{#tablecellcontent}}{{description}}{{/tablecellcontent}}
+| {{#tablecellcontent}}{{{dataFormat}}} {{#isEnum}}_Enum:_ {{#_enum}}{{this}}, {{/_enum}}{{/isEnum}} {{^isEnum}}{{^container}}{{^allowableValues.empty}} {{#allowableValues.values}}{{this}}, {{/allowableValues.values}} {{/allowableValues.empty}}{{/container}}{{/isEnum}}{{/tablecellcontent}}
 
 {{/vars}}
 |===
@@ -36,7 +36,7 @@
 | Enum Values
 
 {{#allowableValues.values}}
-| {{this}}
+| {{#tablecellcontent}}{{this}}{{/tablecellcontent}}
 {{/allowableValues.values}}
 
 |===

--- a/modules/openapi-generator/src/main/resources/asciidoc-documentation/param.mustache
+++ b/modules/openapi-generator/src/main/resources/asciidoc-documentation/param.mustache
@@ -1,5 +1,5 @@
-| {{baseName}}
-| {{description}} {{#baseType}}<<{{.}}>>{{/baseType}}
+| {{#tablecellcontent}}{{baseName}}{{/tablecellcontent}}
+| {{#tablecellcontent}}{{description}}{{/tablecellcontent}} {{#baseType}}<<{{.}}>>{{/baseType}}
 | {{^required}}-{{/required}}{{#required}}X{{/required}}
-| {{defaultValue}}
-| {{{pattern}}}
+| {{#tablecellcontent}}{{defaultValue}}{{/tablecellcontent}}
+| {{#tablecellcontent}}{{{pattern}}}{{/tablecellcontent}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/asciidoc/AsciidocGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/asciidoc/AsciidocGeneratorTest.java
@@ -28,6 +28,40 @@ public class AsciidocGeneratorTest {
     private final Logger LOGGER = LoggerFactory.getLogger(AsciidocGeneratorTest.class);
 
     @Test
+    public void testPipeInPatternIsEscapedInGeneratedTables() throws Exception {
+        File output = Files.createTempDirectory("test").toFile();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator().setGeneratorName("asciidoc")
+                .setInputSpec("src/test/resources/3_0/issue24119-asciidoc-table-cell-pipe.yaml")
+                .setOutputDir(output.getAbsolutePath());
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.setGenerateMetadata(false);
+        List<File> generatedFiles = generator.opts(configurator.toClientOptInput()).generate();
+        TestUtils.ensureContainsFile(generatedFiles, output, "index.adoc");
+
+        String markupContent = FileUtils.readFileToString(
+                new File(output, "index.adoc"), StandardCharsets.UTF_8);
+
+        Assert.assertFalse(markupContent.contains("/^([0-9A-Z]{3})|([0-9A-Z]{5})$/"),
+                "unescaped pipe should not appear in generated table cell: " + markupContent);
+        Assert.assertTrue(markupContent.contains("/^([0-9A-Z]{3})\\|([0-9A-Z]{5})$/"),
+                "expected escaped pipe in pattern column: " + markupContent);
+
+        Assert.assertFalse(markupContent.contains("Accepts AAA|BBBBB"),
+                "unescaped pipe should not appear in generated description cell: " + markupContent);
+        Assert.assertTrue(markupContent.contains("Accepts AAA\\|BBBBB"),
+                "expected escaped pipe in description column: " + markupContent);
+
+        // a pipe that is already backslash-escaped in the source pattern must not be
+        // escaped a second time.
+        Assert.assertTrue(markupContent.contains("/^A\\|B$/"),
+                "expected already-escaped pipe to remain single-escaped: " + markupContent);
+        Assert.assertFalse(markupContent.contains("/^A\\\\|B$/"),
+                "already-escaped pipe should not be double-escaped: " + markupContent);
+    }
+
+    @Test
     public void testPingSpecTitle() throws Exception {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/ping.yaml");
 

--- a/modules/openapi-generator/src/test/resources/3_0/issue24119-asciidoc-table-cell-pipe.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue24119-asciidoc-table-cell-pipe.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.3
+info:
+  title: asciidoc pipe escaping test
+  version: '1.0'
+paths:
+  /things:
+    get:
+      operationId: getThing
+      parameters:
+        - name: code
+          in: query
+          required: false
+          description: "Accepts AAA|BBBBB"
+          schema:
+            type: string
+            pattern: "^([0-9A-Z]{3})|([0-9A-Z]{5})$"
+        - name: preEscapedCode
+          in: query
+          required: false
+          schema:
+            type: string
+            pattern: "^A\\|B$"
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        code:
+          type: string
+          description: "Accepts AAA|BBBBB"
+          pattern: "^([0-9A-Z]{3})|([0-9A-Z]{5})$"


### PR DESCRIPTION
Regex alternation patterns like `^([0-9A-Z]{3})|([0-9A-Z]{5})$` currently render an unescaped `|` inside generated AsciiDoc `|===` model/parameter tables. AsciiDoc treats `|` as a table cell separator, so the row can be split into extra cells and the table layout breaks.

This issue is not limited to `pattern`. Any free-form OpenAPI value rendered inside a table cell can contain `|`, including descriptions, default values, enum values, allowable values, and field names.

This PR adds a reusable Mustache lambda, `tablecellcontent`, for escaping AsciiDoc table-cell content. It escapes unescaped `|` characters as `\|` when rendering table-cell values in `model.mustache` and `param.mustache`.

The escaping is idempotent: values that already contain a backslash-escaped pipe, such as `\|`, are preserved and not double-escaped.

Added regression coverage for:

* regex patterns containing raw `|`
* description fields containing raw `|`
* already escaped `\|` values to ensure they are not double-escaped

Fixes #24119


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escape pipes in AsciiDoc table cells to prevent broken `|===` tables by adding a reusable `tablecellcontent` Mustache lambda and using it in `model.mustache` and `param.mustache` (fixes #24119).
It handles patterns, descriptions, defaults, and enums, and preserves existing `\|` escapes.

- **Bug Fixes**
  - Added `tablecellcontent` in `AsciidocDocumentationCodegen` to escape unescaped `|` via `(?<!\\)\|` and avoid double-escaping.
  - Applied the lambda to all relevant table-cell fields in `model.mustache` and `param.mustache`.
  - Added tests and a sample spec to verify escaping for raw `|` and preservation of pre-escaped `\|`.

<sup>Written for commit d33e4647649d3d3550b6d3de60f805c930c51049. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

