### PR TITLE
[KOTLIN-SPRING;JAVA-SPRING] bugfix: update JsonInclude annotations for optional+nullable fields to handle serialization correctly when openApiNullable = true

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -1216,6 +1216,11 @@ public class SpringCodegen extends AbstractJavaCodegen
                 model.imports.add("Nulls");
             }
         }
+        // Optional + nullable with openApiNullable: emit @JsonInclude(NON_ABSENT) so that
+        // JsonNullable.undefined() is excluded from serialized output.
+        if (openApiNullable && !property.required && property.isNullable) {
+            model.imports.add("JsonInclude");
+        }
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
@@ -67,6 +67,9 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
   @JsonInclude(JsonInclude.Include.NON_NULL)
   {{/isNullable}}
   {{/required}}
+  {{#vendorExtensions.x-is-jackson-optional-nullable}}
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
+  {{/vendorExtensions.x-is-jackson-optional-nullable}}
   {{/jackson}}
   {{#deprecated}}
   @Deprecated

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/dataClassOptVar.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/dataClassOptVar.mustache
@@ -3,7 +3,8 @@
     @ApiModelProperty({{#example}}example = "{{#lambdaRemoveLineBreak}}{{#lambdaEscapeInNormalString}}{{{.}}}{{/lambdaEscapeInNormalString}}{{/lambdaRemoveLineBreak}}", {{/example}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}value = "{{{description}}}"){{/swagger1AnnotationLibrary}}{{#deprecated}}
     @Deprecated(message = ""){{/deprecated}}{{#vendorExtensions.x-field-extra-annotation}}
     {{{.}}}{{/vendorExtensions.x-field-extra-annotation}}{{^isNullable}}
-    @field:JsonInclude(JsonInclude.Include.NON_NULL){{/isNullable}}{{#vendorExtensions.x-has-json-setter-nulls-skip}}
+    @field:JsonInclude(JsonInclude.Include.NON_NULL){{/isNullable}}{{#vendorExtensions.x-is-jackson-optional-nullable}}
+    @field:JsonInclude(JsonInclude.Include.NON_ABSENT){{/vendorExtensions.x-is-jackson-optional-nullable}}{{#vendorExtensions.x-has-json-setter-nulls-skip}}
     @field:JsonSetter(nulls = Nulls.SKIP){{/vendorExtensions.x-has-json-setter-nulls-skip}}{{#vendorExtensions.x-has-json-setter-nulls-fail}}
     @field:JsonSetter(nulls = Nulls.FAIL){{/vendorExtensions.x-has-json-setter-nulls-fail}}
     @param:JsonProperty("{{{baseName}}}")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -8162,4 +8162,58 @@ public class SpringCodegenTest {
         JavaFileAssert.assertThat(files.get("UserBrLockDTO.java")).implementsInterfaces("BrLockDTO")
                 .fileDoesNotContain("@JsonTypeName");
     }
+
+    /**
+     * Scenario 4 (openApiNullable=true): optional+nullable field must carry
+     * {@code @JsonInclude(JsonInclude.Include.NON_ABSENT)} so that Jackson
+     * excludes {@code JsonNullable.undefined()} from serialized output.
+     */
+    @Test
+    void optionalNullableField_withOpenApiNullable_hasNonAbsentAnnotation() throws IOException {
+        Map<String, File> files = generateFromContract(
+                "src/test/resources/3_0/kotlin/required-nullable-4-states.yaml",
+                SPRING_BOOT,
+                Map.of(CodegenConstants.OPENAPI_NULLABLE, "true"));
+
+        Path modelFile = files.get("TestModel.java").toPath();
+        // NON_ABSENT must be present — only optionalNullable (JsonNullable<T>) gets this annotation
+        assertFileContains(modelFile, "@JsonInclude(JsonInclude.Include.NON_ABSENT)");
+        // JsonNullable field must be present
+        assertFileContains(modelFile, "private JsonNullable<String> optionalNullable");
+        // NON_NULL must also be present (for optionalNonNullable fields)
+        assertFileContains(modelFile, "@JsonInclude(JsonInclude.Include.NON_NULL)");
+        assertFileContains(modelFile, "import com.fasterxml.jackson.annotation.JsonInclude");
+    }
+
+    /**
+     * Without openApiNullable the optional+nullable field is a plain nullable type —
+     * no {@code @JsonInclude(NON_ABSENT)} should be emitted.
+     */
+    @Test
+    void optionalNullableField_withoutOpenApiNullable_hasNoNonAbsentAnnotation() throws IOException {
+        Map<String, File> files = generateFromContract(
+                "src/test/resources/3_0/kotlin/required-nullable-4-states.yaml",
+                SPRING_BOOT,
+                Map.of(CodegenConstants.OPENAPI_NULLABLE, "false"));
+
+        Path modelFile = files.get("TestModel.java").toPath();
+        // Without openApiNullable the field is String optionalNullable, not JsonNullable
+        assertFileNotContains(modelFile, "@JsonInclude(JsonInclude.Include.NON_ABSENT)");
+    }
+
+    /**
+     * Optional+non-nullable fields must still have {@code @JsonInclude(NON_NULL)} regardless
+     * of the openApiNullable setting.
+     */
+    @Test
+    void optionalNonNullableField_alwaysHasNonNullAnnotation() throws IOException {
+        Map<String, File> files = generateFromContract(
+                "src/test/resources/3_0/kotlin/required-nullable-4-states.yaml",
+                SPRING_BOOT,
+                Map.of(CodegenConstants.OPENAPI_NULLABLE, "true"));
+
+        Path modelFile = files.get("TestModel.java").toPath();
+        assertFileContains(modelFile, "@JsonInclude(JsonInclude.Include.NON_NULL)");
+        assertFileContains(modelFile, "private String optionalNonNullable");
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
@@ -6562,6 +6562,51 @@ public class KotlinSpringServerCodegenTest {
     }
 
     /**
+     * Scenario 4 (openApiNullable=true): optional+nullable field must carry
+     * {@code @field:JsonInclude(JsonInclude.Include.NON_ABSENT)} so that Jackson
+     * excludes {@code JsonNullable.undefined()} from serialized output.
+     */
+    @Test(description = "Scenario 4 – optional+nullable with openApiNullable=true: @JsonInclude(NON_ABSENT) guards undefined from serialization")
+    public void requiredNullable_scenario4_optionalNullable_hasNonAbsentAnnotation() throws IOException {
+        Map<String, File> files = generateFromContract(
+                "src/test/resources/3_0/kotlin/required-nullable-4-states.yaml",
+                Map.of(CodegenConstants.OPENAPI_NULLABLE, "true"));
+
+        Path modelFile = files.get("TestModel.kt").toPath();
+        String content = Files.readString(modelFile);
+        int idx = content.indexOf("val optionalNullable:");
+        Assert.assertTrue(idx >= 0, "optionalNullable property must exist");
+        // Annotations appear before the val declaration
+        String context = content.substring(Math.max(0, idx - 300), idx);
+        Assert.assertTrue(context.contains("@field:JsonInclude(JsonInclude.Include.NON_ABSENT)"),
+                "optionalNullable must have @field:JsonInclude(NON_ABSENT) to suppress JsonNullable.undefined() from output");
+        // Must NOT have NON_NULL — that annotation is only for non-nullable optional fields
+        Assert.assertFalse(context.contains("@field:JsonInclude(JsonInclude.Include.NON_NULL)"),
+                "optionalNullable must NOT have @field:JsonInclude(NON_NULL); only non-nullable optionals use NON_NULL");
+        assertFileContains(modelFile, "import com.fasterxml.jackson.annotation.JsonInclude");
+    }
+
+    /**
+     * Without openApiNullable the optional+nullable field is a plain {@code Type?} — no
+     * {@code @field:JsonInclude(NON_ABSENT)} should be emitted because {@code JsonNullable} is
+     * not used and the legacy nullable-type path doesn't need the annotation.
+     */
+    @Test(description = "Scenario 4 – optional+nullable without openApiNullable: no @JsonInclude(NON_ABSENT)")
+    public void requiredNullable_scenario4_optionalNullable_noNonAbsentWithoutOpenApiNullable() throws IOException {
+        Map<String, File> files = generateFromContract(
+                "src/test/resources/3_0/kotlin/required-nullable-4-states.yaml",
+                new HashMap<>());
+
+        Path modelFile = files.get("TestModel.kt").toPath();
+        String content = Files.readString(modelFile);
+        int idx = content.indexOf("val optionalNullable:");
+        Assert.assertTrue(idx >= 0, "optionalNullable property must exist");
+        String context = content.substring(Math.max(0, idx - 200), idx);
+        Assert.assertFalse(context.contains("@field:JsonInclude(JsonInclude.Include.NON_ABSENT)"),
+                "optionalNullable must NOT have NON_ABSENT when openApiNullable=false (no JsonNullable wrapping)");
+    }
+
+    /**
      * Scenario 4 with Jackson 3 (Spring Boot 4) + openApiNullable=true.
      * JsonNullable is in org.openapitools.jackson.nullable regardless of Jackson version
      * (jackson-databind-nullable >= 0.2.10 supports both).

--- a/samples/client/petstore/spring-http-interface-bean-validation/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
+++ b/samples/client/petstore/spring-http-interface-bean-validation/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
@@ -58,6 +58,7 @@ public class AdditionalPropertiesClassDto {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable Object anytype1;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/client/petstore/spring-http-interface-bean-validation/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
+++ b/samples/client/petstore/spring-http-interface-bean-validation/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
@@ -28,12 +28,14 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class ContainerDefaultValueDto {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   private List<String> requiredArray = new ArrayList<>();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValueDto() {

--- a/samples/client/petstore/spring-http-interface-bean-validation/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
+++ b/samples/client/petstore/spring-http-interface-bean-validation/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;

--- a/samples/client/petstore/spring-http-interface-bean-validation/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
+++ b/samples/client/petstore/spring-http-interface-bean-validation/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;

--- a/samples/client/petstore/spring-http-interface-bean-validation/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
+++ b/samples/client/petstore/spring-http-interface-bean-validation/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
@@ -28,6 +28,7 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class NullableMapPropertyDto {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
 
   public NullableMapPropertyDto languageValues(Map<String, String> languageValues) {

--- a/samples/client/petstore/spring-http-interface-bean-validation/src/main/java/org/openapitools/model/ParentWithNullableDto.java
+++ b/samples/client/petstore/spring-http-interface-bean-validation/src/main/java/org/openapitools/model/ParentWithNullableDto.java
@@ -75,6 +75,7 @@ public class ParentWithNullableDto {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable TypeEnum type;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();
 
   public ParentWithNullableDto type(@Nullable TypeEnum type) {

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
@@ -57,6 +57,7 @@ public class AdditionalPropertiesClassDto {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable Object anytype1;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
@@ -27,12 +27,14 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class ContainerDefaultValueDto {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   private List<String> requiredArray = new ArrayList<>();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValueDto() {

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
@@ -27,6 +27,7 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class NullableMapPropertyDto {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
 
   public NullableMapPropertyDto languageValues(Map<String, String> languageValues) {

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;

--- a/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ParentWithNullableDto.java
+++ b/samples/client/petstore/spring-http-interface-noResponseEntity/src/main/java/org/openapitools/model/ParentWithNullableDto.java
@@ -74,6 +74,7 @@ public class ParentWithNullableDto {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable TypeEnum type;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();
 
   public ParentWithNullableDto type(@Nullable TypeEnum type) {

--- a/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -56,6 +56,7 @@ public class AdditionalPropertiesClass {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable Object anytype1;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.ArrayList;

--- a/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -26,12 +26,14 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class ContainerDefaultValue {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   private List<String> requiredArray = new ArrayList<>();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {

--- a/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -26,6 +26,7 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class NullableMapProperty {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
 
   public NullableMapProperty languageValues(Map<String, String> languageValues) {

--- a/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;

--- a/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/client/petstore/spring-http-interface-reactive-bean-validation/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -74,6 +74,7 @@ public class ParentWithNullable {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable TypeEnum type;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();
 
   public ParentWithNullable type(@Nullable TypeEnum type) {

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -55,6 +55,7 @@ public class AdditionalPropertiesClass {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable Object anytype1;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -25,12 +25,14 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class ContainerDefaultValue {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   private List<String> requiredArray = new ArrayList<>();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.ArrayList;

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -25,6 +25,7 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class NullableMapProperty {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
 
   public NullableMapProperty languageValues(Map<String, String> languageValues) {

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;

--- a/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/client/petstore/spring-http-interface-reactive-noResponseEntity/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -73,6 +73,7 @@ public class ParentWithNullable {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable TypeEnum type;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();
 
   public ParentWithNullable type(@Nullable TypeEnum type) {

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -55,6 +55,7 @@ public class AdditionalPropertiesClass {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable Object anytype1;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -25,12 +25,14 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class ContainerDefaultValue {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   private List<String> requiredArray = new ArrayList<>();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.ArrayList;

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -25,6 +25,7 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class NullableMapProperty {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
 
   public NullableMapProperty languageValues(Map<String, String> languageValues) {

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -73,6 +73,7 @@ public class ParentWithNullable {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable TypeEnum type;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();
 
   public ParentWithNullable type(@Nullable TypeEnum type) {

--- a/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -57,6 +57,7 @@ public class AdditionalPropertiesClass {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable Object anytype1;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.ArrayList;

--- a/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -27,12 +27,14 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class ContainerDefaultValue {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   private List<String> requiredArray = new ArrayList<>();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {

--- a/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -27,6 +27,7 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class NullableMapProperty {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
 
   public NullableMapProperty languageValues(Map<String, String> languageValues) {

--- a/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;

--- a/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/client/petstore/spring-http-interface-useHttpServiceProxyFactoryInterfacesConfigurator/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -75,6 +75,7 @@ public class ParentWithNullable {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable TypeEnum type;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();
 
   public ParentWithNullable type(@Nullable TypeEnum type) {

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
@@ -57,6 +57,7 @@ public class AdditionalPropertiesClassDto {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable Object anytype1;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
@@ -27,12 +27,14 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class ContainerDefaultValueDto {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   private List<String> requiredArray = new ArrayList<>();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValueDto() {

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
@@ -27,6 +27,7 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class NullableMapPropertyDto {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
 
   public NullableMapPropertyDto languageValues(Map<String, String> languageValues) {

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ParentWithNullableDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ParentWithNullableDto.java
@@ -74,6 +74,7 @@ public class ParentWithNullableDto {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable TypeEnum type;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();
 
   public ParentWithNullableDto type(@Nullable TypeEnum type) {

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -57,6 +57,7 @@ public class AdditionalPropertiesClass {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable Object anytype1;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.ArrayList;

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -27,12 +27,14 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class ContainerDefaultValue {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   private List<String> requiredArray = new ArrayList<>();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -27,6 +27,7 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class NullableMapProperty {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
 
   public NullableMapProperty languageValues(Map<String, String> languageValues) {

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -75,6 +75,7 @@ public class ParentWithNullable {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable TypeEnum type;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();
 
   public ParentWithNullable type(@Nullable TypeEnum type) {

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -57,6 +57,7 @@ public class AdditionalPropertiesClass {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable Object anytype1;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.ArrayList;

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -27,12 +27,14 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class ContainerDefaultValue {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   private List<String> requiredArray = new ArrayList<>();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -27,6 +27,7 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class NullableMapProperty {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
 
   public NullableMapProperty languageValues(Map<String, String> languageValues) {

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -75,6 +75,7 @@ public class ParentWithNullable {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable TypeEnum type;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();
 
   public ParentWithNullable type(@Nullable TypeEnum type) {

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -57,6 +57,7 @@ public class AdditionalPropertiesClass {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable Object anytype1;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.ArrayList;

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -27,12 +27,14 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class ContainerDefaultValue {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   private List<String> requiredArray = new ArrayList<>();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -27,6 +27,7 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class NullableMapProperty {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
 
   public NullableMapProperty languageValues(Map<String, String> languageValues) {

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -75,6 +75,7 @@ public class ParentWithNullable {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable TypeEnum type;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();
 
   public ParentWithNullable type(@Nullable TypeEnum type) {

--- a/samples/server/petstore/kotlin-springboot-sort-validation/src/main/kotlin/org/openapitools/model/NullableModel.kt
+++ b/samples/server/petstore/kotlin-springboot-sort-validation/src/main/kotlin/org/openapitools/model/NullableModel.kt
@@ -36,6 +36,7 @@ data class NullableModel(
     @param:JsonProperty("optionalNonNullable")
     @get:JsonProperty("optionalNonNullable") val optionalNonNullable: kotlin.String? = null,
 
+    @field:JsonInclude(JsonInclude.Include.NON_ABSENT)
     @param:JsonProperty("optionalNullable")
     @get:JsonProperty("optionalNullable") val optionalNullable: JsonNullable<kotlin.String> = JsonNullable.undefined()
 ) : java.io.Serializable {

--- a/samples/server/petstore/kotlin-springboot-sort-validation/src/test/kotlin/org/openapitools/api/NullableApiValidationTest.kt
+++ b/samples/server/petstore/kotlin-springboot-sort-validation/src/test/kotlin/org/openapitools/api/NullableApiValidationTest.kt
@@ -1,12 +1,16 @@
 package org.openapitools.api
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.Test
+import org.openapitools.jackson.nullable.JsonNullable
+import org.openapitools.model.NullableModel
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.post
+import org.assertj.core.api.Assertions.assertThat
 
 /**
  * Verifies the runtime behaviour of the openApiNullable annotations generated onto [NullableApi]:
@@ -29,6 +33,9 @@ class NullableApiValidationTest {
 
     @Autowired
     lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
 
     // ── checkRequiredOnly — positive cases ───────────────────────────────────
     // Endpoint: POST /nullable/check-required-only
@@ -119,5 +126,45 @@ class NullableApiValidationTest {
                 }
             """.trimIndent()
         }.andExpect { status { isBadRequest() } }
+    }
+
+    // ── @JsonInclude(NON_ABSENT) serialization behaviour ─────────────────────
+    // These tests verify that the @field:JsonInclude(JsonInclude.Include.NON_ABSENT)
+    // annotation on NullableModel.optionalNullable controls serialization correctly:
+    //   - JsonNullable.undefined()  → key must be ABSENT from the JSON output
+    //   - JsonNullable.of(null)     → key must be PRESENT with a null value
+    //   - JsonNullable.of("value")  → key must be PRESENT with the given value
+
+    @Test
+    fun `serialization - optionalNullable undefined is absent from JSON output`() {
+        val model = NullableModel(
+            requiredNonNullable = "req",
+            requiredNullable = "req-null",
+            optionalNullable = JsonNullable.undefined()
+        )
+        val json = objectMapper.writeValueAsString(model)
+        assertThat(json).doesNotContain("optionalNullable")
+    }
+
+    @Test
+    fun `serialization - optionalNullable of(null) is present as null in JSON output`() {
+        val model = NullableModel(
+            requiredNonNullable = "req",
+            requiredNullable = "req-null",
+            optionalNullable = JsonNullable.of(null)
+        )
+        val json = objectMapper.writeValueAsString(model)
+        assertThat(json).contains("\"optionalNullable\":null")
+    }
+
+    @Test
+    fun `serialization - optionalNullable of(value) is present with value in JSON output`() {
+        val model = NullableModel(
+            requiredNonNullable = "req",
+            requiredNullable = "req-null",
+            optionalNullable = JsonNullable.of("hello")
+        )
+        val json = objectMapper.writeValueAsString(model)
+        assertThat(json).contains("\"optionalNullable\":\"hello\"")
     }
 }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -57,6 +57,7 @@ public class AdditionalPropertiesClass {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable Object anytype1;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.ArrayList;

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -27,12 +27,14 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class ContainerDefaultValue {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   private List<String> requiredArray = new ArrayList<>();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -27,6 +27,7 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class NullableMapProperty {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
 
   public NullableMapProperty languageValues(Map<String, String> languageValues) {

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -75,6 +75,7 @@ public class ParentWithNullable {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable TypeEnum type;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();
 
   public ParentWithNullable type(@Nullable TypeEnum type) {

--- a/samples/server/petstore/spring-boot-nullable-set/src/main/java/org/openapitools/model/ObjectWithUniqueItems.java
+++ b/samples/server/petstore/spring-boot-nullable-set/src/main/java/org/openapitools/model/ObjectWithUniqueItems.java
@@ -33,11 +33,13 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class ObjectWithUniqueItems {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Set<String>> nullSet = JsonNullable.<Set<String>>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Set<String> notNullSet = new LinkedHashSet<>();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullList = JsonNullable.<List<String>>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -57,6 +57,7 @@ public class AdditionalPropertiesClass {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable Object anytype1;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.ArrayList;

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -27,12 +27,14 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class ContainerDefaultValue {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   private List<String> requiredArray = new ArrayList<>();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -27,6 +27,7 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class NullableMapProperty {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
 
   public NullableMapProperty languageValues(Map<String, String> languageValues) {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -75,6 +75,7 @@ public class ParentWithNullable {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable TypeEnum type;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();
 
   public ParentWithNullable type(@Nullable TypeEnum type) {

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -57,6 +57,7 @@ public class AdditionalPropertiesClass {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable Object anytype1;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.ArrayList;

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -27,12 +27,14 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class ContainerDefaultValue {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   private List<String> requiredArray = new ArrayList<>();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -27,6 +27,7 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class NullableMapProperty {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
 
   public NullableMapProperty languageValues(Map<String, String> languageValues) {

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -75,6 +75,7 @@ public class ParentWithNullable {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable TypeEnum type;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();
 
   public ParentWithNullable type(@Nullable TypeEnum type) {

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -57,6 +57,7 @@ public class AdditionalPropertiesClass {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable Object anytype1;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.ArrayList;

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -27,12 +27,14 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class ContainerDefaultValue {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   private List<String> requiredArray = new ArrayList<>();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -27,6 +27,7 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class NullableMapProperty {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
 
   public NullableMapProperty languageValues(Map<String, String> languageValues) {

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -75,6 +75,7 @@ public class ParentWithNullable {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable TypeEnum type;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();
 
   public ParentWithNullable type(@Nullable TypeEnum type) {

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -57,6 +57,7 @@ public class AdditionalPropertiesClass {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable Object anytype1;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.ArrayList;

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -27,12 +27,14 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class ContainerDefaultValue {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   private List<String> requiredArray = new ArrayList<>();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -27,6 +27,7 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class NullableMapProperty {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
 
   public NullableMapProperty() {

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -75,6 +75,7 @@ public class ParentWithNullable {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable TypeEnum type;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();
 
   public ParentWithNullable() {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -57,6 +57,7 @@ public class AdditionalPropertiesClass {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable Object anytype1;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.ArrayList;

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -27,12 +27,14 @@ import javax.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class ContainerDefaultValue {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   private List<String> requiredArray = new ArrayList<>();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -27,6 +27,7 @@ import javax.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class NullableMapProperty {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
 
   public NullableMapProperty languageValues(Map<String, String> languageValues) {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -75,6 +75,7 @@ public class ParentWithNullable {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable TypeEnum type;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();
 
   public ParentWithNullable type(@Nullable TypeEnum type) {

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
@@ -59,6 +59,7 @@ public class AdditionalPropertiesClassDto {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable Object anytype1;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
@@ -29,12 +29,14 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class ContainerDefaultValueDto {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   private List<String> requiredArray = new ArrayList<>();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValueDto() {

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
@@ -29,6 +29,7 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class NullableMapPropertyDto {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
 
   public NullableMapPropertyDto languageValues(Map<String, String> languageValues) {

--- a/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ParentWithNullableDto.java
+++ b/samples/server/petstore/springboot-include-http-request-context/src/main/java/org/openapitools/model/ParentWithNullableDto.java
@@ -76,6 +76,7 @@ public class ParentWithNullableDto {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable TypeEnum type;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();
 
   public ParentWithNullableDto type(@Nullable TypeEnum type) {

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -57,6 +57,7 @@ public class AdditionalPropertiesClass {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable Object anytype1;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.ArrayList;

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -27,12 +27,14 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class ContainerDefaultValue {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   private List<String> requiredArray = new ArrayList<>();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -27,6 +27,7 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class NullableMapProperty {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
 
   public NullableMapProperty languageValues(Map<String, String> languageValues) {

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -75,6 +75,7 @@ public class ParentWithNullable {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable TypeEnum type;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();
 
   public ParentWithNullable type(@Nullable TypeEnum type) {

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -57,6 +57,7 @@ public class AdditionalPropertiesClass {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable Object anytype1;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.ArrayList;

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -27,12 +27,14 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class ContainerDefaultValue {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   private List<String> requiredArray = new ArrayList<>();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -27,6 +27,7 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class NullableMapProperty {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
 
   public NullableMapProperty languageValues(Map<String, String> languageValues) {

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -75,6 +75,7 @@ public class ParentWithNullable {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable TypeEnum type;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();
 
   public ParentWithNullable type(@Nullable TypeEnum type) {

--- a/samples/server/petstore/springboot-sort-validation/src/main/java/org/openapitools/model/NullableModel.java
+++ b/samples/server/petstore/springboot-sort-validation/src/main/java/org/openapitools/model/NullableModel.java
@@ -35,6 +35,7 @@ public class NullableModel implements Serializable {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable String optionalNonNullable;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> optionalNullable = JsonNullable.<String>undefined();
 
   public NullableModel() {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -57,6 +57,7 @@ public class AdditionalPropertiesClass {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Optional<Object> anytype1 = Optional.empty();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.ArrayList;

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -27,12 +27,14 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class ContainerDefaultValue {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   private List<String> requiredArray = new ArrayList<>();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -27,6 +27,7 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class NullableMapProperty {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
 
   public NullableMapProperty languageValues(Map<String, String> languageValues) {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -75,6 +75,7 @@ public class ParentWithNullable {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Optional<TypeEnum> type = Optional.empty();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();
 
   public ParentWithNullable type(TypeEnum type) {

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesClass.java
@@ -57,6 +57,7 @@ public class AdditionalPropertiesClass {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable Object anytype1;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ContainerDefaultValue.java
@@ -27,12 +27,14 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class ContainerDefaultValue {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   private List<String> requiredArray = new ArrayList<>();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ContainerDefaultValue.java
@@ -2,6 +2,7 @@ package org.openapitools.virtualan.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.ArrayList;

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/NullableMapProperty.java
@@ -27,6 +27,7 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class NullableMapProperty {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
 
   public NullableMapProperty languageValues(Map<String, String> languageValues) {

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/NullableMapProperty.java
@@ -2,6 +2,7 @@ package org.openapitools.virtualan.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ParentWithNullable.java
@@ -75,6 +75,7 @@ public class ParentWithNullable {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable TypeEnum type;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();
 
   public ParentWithNullable type(@Nullable TypeEnum type) {

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/EnumTestDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/EnumTestDto.java
@@ -188,6 +188,7 @@ public class EnumTestDto {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable EnumNumberEnum enumNumber;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<OuterEnumDto> outerEnum = JsonNullable.<OuterEnumDto>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/HealthCheckResultDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/HealthCheckResultDto.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/HealthCheckResultDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/HealthCheckResultDto.java
@@ -28,6 +28,7 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class HealthCheckResultDto {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> nullableMessage = JsonNullable.<String>undefined();
 
   public HealthCheckResultDto nullableMessage(String nullableMessage) {

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/NullableClassDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/NullableClassDto.java
@@ -40,29 +40,39 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class NullableClassDto {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Integer> integerProp = JsonNullable.<Integer>undefined();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<BigDecimal> numberProp = JsonNullable.<BigDecimal>undefined();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Boolean> booleanProp = JsonNullable.<Boolean>undefined();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> stringProp = JsonNullable.<String>undefined();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
   private JsonNullable<LocalDate> dateProp = JsonNullable.<LocalDate>undefined();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
   private JsonNullable<OffsetDateTime> datetimeProp = JsonNullable.<OffsetDateTime>undefined();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<Object>> arrayNullableProp = JsonNullable.<List<Object>>undefined();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<Object>> arrayAndItemsNullableProp = JsonNullable.<List<Object>>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private List<Object> arrayItemsNullable = new ArrayList<>();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Map<String, Object>> objectNullableProp = JsonNullable.<Map<String, Object>>undefined();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Map<String, Object>> objectAndItemsNullableProp = JsonNullable.<Map<String, Object>>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ParentWithNullableDto.java
+++ b/samples/server/petstore/springboot-x-implements-skip/src/main/java/org/openapitools/model/ParentWithNullableDto.java
@@ -76,6 +76,7 @@ public class ParentWithNullableDto {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable TypeEnum type;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();
 
   public ParentWithNullableDto type(@Nullable TypeEnum type) {

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
@@ -59,6 +59,7 @@ public class AdditionalPropertiesClassDto {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable Object anytype1;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
@@ -29,12 +29,14 @@ import javax.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class ContainerDefaultValueDto {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   private List<String> requiredArray = new ArrayList<>();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValueDto() {

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
@@ -29,6 +29,7 @@ import javax.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.24.0-SNAPSHOT")
 public class NullableMapPropertyDto {
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
 
   public NullableMapPropertyDto languageValues(Map<String, String> languageValues) {

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ParentWithNullableDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ParentWithNullableDto.java
@@ -77,6 +77,7 @@ public class ParentWithNullableDto {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private @Nullable TypeEnum type;
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   private JsonNullable<String> nullableProperty = JsonNullable.<String>undefined();
 
   public ParentWithNullableDto type(@Nullable TypeEnum type) {


### PR DESCRIPTION
# Fix: `@JsonInclude(NON_ABSENT)` for `JsonNullable` fields in kotlin-spring and java-spring generators

## Issue

When `openApiNullable=true`, optional+nullable fields are generated as `JsonNullable<T>` but without any `@JsonInclude` annotation. This means `JsonNullable.undefined()` (the "absent" state) could be serialized into the JSON output, defeating the purpose of the three-state wrapper.

## Fix

Added `@field:JsonInclude(JsonInclude.Include.NON_ABSENT)` to any field where `x-is-jackson-optional-nullable` is true, in `dataClassOptVar.mustache`. This ensures:

| State | Serialized? |
|---|---|
| `JsonNullable.undefined()` | ❌ excluded |
| `JsonNullable.of(null)` | ✅ included as `null` |
| `JsonNullable.of("value")` | ✅ included as `"value"` |

This is a nasty bug that should be fixed - because someone using the generated clients for patch operations might be unknowingly deleting resources even when setting JsonNullable as undefined.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. - spring: @cachescrubber (2022/02) @welshm (2022/02) @MelleD (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02) @borsch (2022/02) @banlevente (2022/02) @Zomzog (2022/09) @martin-mfg (2023/08); kotlin: @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06) @e5l (2024/10) @dennisameling (2026/02), @wing328 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes serialization of optional+nullable fields for `kotlin-spring` and `java-spring` when `openApiNullable=true` by adding `@JsonInclude(JsonInclude.Include.NON_ABSENT)` to `org.openapitools.jackson.nullable.JsonNullable` fields. Undefined values are omitted; nulls and concrete values are included.

- **Bug Fixes**
  - `kotlin-spring`: emit @field:JsonInclude(JsonInclude.Include.NON_ABSENT) in `dataClassOptVar.mustache` when `x-is-jackson-optional-nullable` is true.
  - `java-spring`: emit @JsonInclude(JsonInclude.Include.NON_ABSENT) in `JavaSpring/pojo.mustache`; ensure `JsonInclude` import in `SpringCodegen.postProcessModelProperty` for optional+nullable fields when `openApiNullable=true`.
  - Tests: expanded Java and Kotlin generator tests for `openApiNullable` true/false; added Kotlin runtime tests to verify undefined/null/value serialization.
  - Samples: regenerated Spring Boot and Spring HTTP Interface models to include NON_ABSENT on `JsonNullable` fields.

<sup>Written for commit 000a3489321bbbc90d78046e0d4a8a60ba4eb07b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



