### PR TITLE
[python] bump generated client dependency floors above vulnerable ranges

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/pyproject.mustache
+++ b/modules/openapi-generator/src/main/resources/python/pyproject.mustache
@@ -34,11 +34,11 @@ include = ["{{packageName}}/py.typed"]
 [tool.poetry.dependencies]
 python = "^3.10"
 {{^async}}
-urllib3 = ">= 2.7.0, < 3.0.0"
+urllib3 = ">= 2.6.3, < 3.0.0"
 {{/async}}
 python-dateutil = ">= 2.8.2"
 {{#asyncio}}
-aiohttp = ">= 3.14.1"
+aiohttp = ">= 3.13.5"
 aiohttp-retry = ">= 2.8.3"
 {{/asyncio}}
 {{#httpx}}
@@ -62,14 +62,14 @@ requires-python = ">=3.9"
 
 dependencies = [
 {{^async}}
-  "urllib3 (>=2.7.0,<3.0.0)",
+  "urllib3 (>=2.6.3,<3.0.0)",
 {{/async}}
   "python-dateutil (>=2.8.2)",
 {{#httpx}}
   "httpx (>=0.28.1)",
 {{/httpx}}
 {{#asyncio}}
-  "aiohttp (>=3.14.1)",
+  "aiohttp (>=3.13.5)",
   "aiohttp-retry (>=2.8.3)",
 {{/asyncio}}
 {{#tornado}}
@@ -101,7 +101,7 @@ requires-poetry = ">=2.0"
 {{^poetry1}}
 [tool.poetry.group.dev.dependencies]
 {{/poetry1}}
-pytest = ">= 9.0.3"
+pytest = ">= 8.4.2"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"

--- a/modules/openapi-generator/src/main/resources/python/pyproject.mustache
+++ b/modules/openapi-generator/src/main/resources/python/pyproject.mustache
@@ -34,11 +34,11 @@ include = ["{{packageName}}/py.typed"]
 [tool.poetry.dependencies]
 python = "^3.10"
 {{^async}}
-urllib3 = ">= 2.1.0, < 3.0.0"
+urllib3 = ">= 2.7.0, < 3.0.0"
 {{/async}}
 python-dateutil = ">= 2.8.2"
 {{#asyncio}}
-aiohttp = ">= 3.8.4"
+aiohttp = ">= 3.14.1"
 aiohttp-retry = ">= 2.8.3"
 {{/asyncio}}
 {{#httpx}}
@@ -62,14 +62,14 @@ requires-python = ">=3.9"
 
 dependencies = [
 {{^async}}
-  "urllib3 (>=2.1.0,<3.0.0)",
+  "urllib3 (>=2.7.0,<3.0.0)",
 {{/async}}
   "python-dateutil (>=2.8.2)",
 {{#httpx}}
   "httpx (>=0.28.1)",
 {{/httpx}}
 {{#asyncio}}
-  "aiohttp (>=3.8.4)",
+  "aiohttp (>=3.14.1)",
   "aiohttp-retry (>=2.8.3)",
 {{/asyncio}}
 {{#tornado}}
@@ -101,7 +101,7 @@ requires-poetry = ">=2.0"
 {{^poetry1}}
 [tool.poetry.group.dev.dependencies]
 {{/poetry1}}
-pytest = ">= 7.2.1"
+pytest = ">= 9.0.3"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"

--- a/modules/openapi-generator/src/main/resources/python/requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python/requirements.mustache
@@ -1,9 +1,9 @@
 {{^async}}
-urllib3 >= 2.7.0, < 3.0.0
+urllib3 >= 2.6.3, < 3.0.0
 {{/async}}
 python_dateutil >= 2.8.2
 {{#asyncio}}
-aiohttp >= 3.14.1
+aiohttp >= 3.13.5
 aiohttp-retry >= 2.8.3
 {{/asyncio}}
 {{#httpx}}

--- a/modules/openapi-generator/src/main/resources/python/requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python/requirements.mustache
@@ -1,9 +1,9 @@
 {{^async}}
-urllib3 >= 2.1.0, < 3.0.0
+urllib3 >= 2.7.0, < 3.0.0
 {{/async}}
 python_dateutil >= 2.8.2
 {{#asyncio}}
-aiohttp >= 3.8.4
+aiohttp >= 3.14.1
 aiohttp-retry >= 2.8.3
 {{/asyncio}}
 {{#httpx}}

--- a/modules/openapi-generator/src/main/resources/python/setup.mustache
+++ b/modules/openapi-generator/src/main/resources/python/setup.mustache
@@ -13,11 +13,11 @@ VERSION = "{{packageVersion}}"
 PYTHON_REQUIRES = ">= 3.10"
 REQUIRES = [
 {{^async}}
-    "urllib3 >= 2.1.0, < 3.0.0",
+    "urllib3 >= 2.7.0, < 3.0.0",
 {{/async}}
     "python-dateutil >= 2.8.2",
 {{#asyncio}}
-    "aiohttp >= 3.8.4",
+    "aiohttp >= 3.14.1",
     "aiohttp-retry >= 2.8.3",
 {{/asyncio}}
 {{#httpx}}

--- a/modules/openapi-generator/src/main/resources/python/setup.mustache
+++ b/modules/openapi-generator/src/main/resources/python/setup.mustache
@@ -13,11 +13,11 @@ VERSION = "{{packageVersion}}"
 PYTHON_REQUIRES = ">= 3.10"
 REQUIRES = [
 {{^async}}
-    "urllib3 >= 2.7.0, < 3.0.0",
+    "urllib3 >= 2.6.3, < 3.0.0",
 {{/async}}
     "python-dateutil >= 2.8.2",
 {{#asyncio}}
-    "aiohttp >= 3.14.1",
+    "aiohttp >= 3.13.5",
     "aiohttp-retry >= 2.8.3",
 {{/asyncio}}
 {{#httpx}}

--- a/modules/openapi-generator/src/main/resources/python/test-requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python/test-requirements.mustache
@@ -1,4 +1,4 @@
-pytest >= 7.2.1
+pytest >= 9.0.3
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0

--- a/modules/openapi-generator/src/main/resources/python/test-requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python/test-requirements.mustache
@@ -1,4 +1,4 @@
-pytest >= 9.0.3
+pytest >= 8.4.2
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/pyproject.toml
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/pyproject.toml
@@ -11,7 +11,7 @@ keywords = ["OpenAPI", "OpenAPI-Generator", "Echo Server API"]
 requires-python = ">=3.9"
 
 dependencies = [
-  "urllib3 (>=2.7.0,<3.0.0)",
+  "urllib3 (>=2.6.3,<3.0.0)",
   "python-dateutil (>=2.8.2)",
   "pydantic (>=2.11)",
   "typing-extensions (>=4.7.1)",
@@ -24,7 +24,7 @@ Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 requires-poetry = ">=2.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = ">= 9.0.3"
+pytest = ">= 8.4.2"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/pyproject.toml
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/pyproject.toml
@@ -11,7 +11,7 @@ keywords = ["OpenAPI", "OpenAPI-Generator", "Echo Server API"]
 requires-python = ">=3.9"
 
 dependencies = [
-  "urllib3 (>=2.1.0,<3.0.0)",
+  "urllib3 (>=2.7.0,<3.0.0)",
   "python-dateutil (>=2.8.2)",
   "pydantic (>=2.11)",
   "typing-extensions (>=4.7.1)",
@@ -24,7 +24,7 @@ Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 requires-poetry = ">=2.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = ">= 7.2.1"
+pytest = ">= 9.0.3"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/requirements.txt
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/requirements.txt
@@ -1,4 +1,4 @@
-urllib3 >= 2.7.0, < 3.0.0
+urllib3 >= 2.6.3, < 3.0.0
 python_dateutil >= 2.8.2
 pydantic >= 2.11
 typing-extensions >= 4.7.1

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/requirements.txt
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/requirements.txt
@@ -1,4 +1,4 @@
-urllib3 >= 2.1.0, < 3.0.0
+urllib3 >= 2.7.0, < 3.0.0
 python_dateutil >= 2.8.2
 pydantic >= 2.11
 typing-extensions >= 4.7.1

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/setup.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/setup.py
@@ -23,7 +23,7 @@ NAME = "openapi-client"
 VERSION = "1.0.0"
 PYTHON_REQUIRES = ">= 3.10"
 REQUIRES = [
-    "urllib3 >= 2.7.0, < 3.0.0",
+    "urllib3 >= 2.6.3, < 3.0.0",
     "python-dateutil >= 2.8.2",
     "pydantic >= 2.11",
     "typing-extensions >= 4.7.1",

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/setup.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/setup.py
@@ -23,7 +23,7 @@ NAME = "openapi-client"
 VERSION = "1.0.0"
 PYTHON_REQUIRES = ">= 3.10"
 REQUIRES = [
-    "urllib3 >= 2.1.0, < 3.0.0",
+    "urllib3 >= 2.7.0, < 3.0.0",
     "python-dateutil >= 2.8.2",
     "pydantic >= 2.11",
     "typing-extensions >= 4.7.1",

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/test-requirements.txt
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 7.2.1
+pytest >= 9.0.3
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/test-requirements.txt
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 9.0.3
+pytest >= 8.4.2
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0

--- a/samples/client/echo_api/python/pyproject.toml
+++ b/samples/client/echo_api/python/pyproject.toml
@@ -11,7 +11,7 @@ keywords = ["OpenAPI", "OpenAPI-Generator", "Echo Server API"]
 requires-python = ">=3.9"
 
 dependencies = [
-  "urllib3 (>=2.7.0,<3.0.0)",
+  "urllib3 (>=2.6.3,<3.0.0)",
   "python-dateutil (>=2.8.2)",
   "pydantic (>=2.11)",
   "typing-extensions (>=4.7.1)",
@@ -24,7 +24,7 @@ Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 requires-poetry = ">=2.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = ">= 9.0.3"
+pytest = ">= 8.4.2"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"

--- a/samples/client/echo_api/python/pyproject.toml
+++ b/samples/client/echo_api/python/pyproject.toml
@@ -11,7 +11,7 @@ keywords = ["OpenAPI", "OpenAPI-Generator", "Echo Server API"]
 requires-python = ">=3.9"
 
 dependencies = [
-  "urllib3 (>=2.1.0,<3.0.0)",
+  "urllib3 (>=2.7.0,<3.0.0)",
   "python-dateutil (>=2.8.2)",
   "pydantic (>=2.11)",
   "typing-extensions (>=4.7.1)",
@@ -24,7 +24,7 @@ Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 requires-poetry = ">=2.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = ">= 7.2.1"
+pytest = ">= 9.0.3"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"

--- a/samples/client/echo_api/python/requirements.txt
+++ b/samples/client/echo_api/python/requirements.txt
@@ -1,4 +1,4 @@
-urllib3 >= 2.7.0, < 3.0.0
+urllib3 >= 2.6.3, < 3.0.0
 python_dateutil >= 2.8.2
 pydantic >= 2.11
 typing-extensions >= 4.7.1

--- a/samples/client/echo_api/python/requirements.txt
+++ b/samples/client/echo_api/python/requirements.txt
@@ -1,4 +1,4 @@
-urllib3 >= 2.1.0, < 3.0.0
+urllib3 >= 2.7.0, < 3.0.0
 python_dateutil >= 2.8.2
 pydantic >= 2.11
 typing-extensions >= 4.7.1

--- a/samples/client/echo_api/python/setup.py
+++ b/samples/client/echo_api/python/setup.py
@@ -23,7 +23,7 @@ NAME = "openapi-client"
 VERSION = "1.0.0"
 PYTHON_REQUIRES = ">= 3.10"
 REQUIRES = [
-    "urllib3 >= 2.7.0, < 3.0.0",
+    "urllib3 >= 2.6.3, < 3.0.0",
     "python-dateutil >= 2.8.2",
     "pydantic >= 2.11",
     "typing-extensions >= 4.7.1",

--- a/samples/client/echo_api/python/setup.py
+++ b/samples/client/echo_api/python/setup.py
@@ -23,7 +23,7 @@ NAME = "openapi-client"
 VERSION = "1.0.0"
 PYTHON_REQUIRES = ">= 3.10"
 REQUIRES = [
-    "urllib3 >= 2.1.0, < 3.0.0",
+    "urllib3 >= 2.7.0, < 3.0.0",
     "python-dateutil >= 2.8.2",
     "pydantic >= 2.11",
     "typing-extensions >= 4.7.1",

--- a/samples/client/echo_api/python/test-requirements.txt
+++ b/samples/client/echo_api/python/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 7.2.1
+pytest >= 9.0.3
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0

--- a/samples/client/echo_api/python/test-requirements.txt
+++ b/samples/client/echo_api/python/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 9.0.3
+pytest >= 8.4.2
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0

--- a/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
@@ -12,7 +12,7 @@ include = ["petstore_api/py.typed"]
 [tool.poetry.dependencies]
 python = "^3.10"
 python-dateutil = ">= 2.8.2"
-aiohttp = ">= 3.14.1"
+aiohttp = ">= 3.13.5"
 aiohttp-retry = ">= 2.8.3"
 pem = ">= 19.3.0"
 pycryptodome = ">= 3.9.0"
@@ -20,7 +20,7 @@ pydantic = ">= 2.11"
 typing-extensions = ">= 4.7.1"
 
 [tool.poetry.dev-dependencies]
-pytest = ">= 9.0.3"
+pytest = ">= 8.4.2"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"

--- a/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
@@ -12,7 +12,7 @@ include = ["petstore_api/py.typed"]
 [tool.poetry.dependencies]
 python = "^3.10"
 python-dateutil = ">= 2.8.2"
-aiohttp = ">= 3.8.4"
+aiohttp = ">= 3.14.1"
 aiohttp-retry = ">= 2.8.3"
 pem = ">= 19.3.0"
 pycryptodome = ">= 3.9.0"
@@ -20,7 +20,7 @@ pydantic = ">= 2.11"
 typing-extensions = ">= 4.7.1"
 
 [tool.poetry.dev-dependencies]
-pytest = ">= 7.2.1"
+pytest = ">= 9.0.3"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"

--- a/samples/openapi3/client/petstore/python-aiohttp/requirements.txt
+++ b/samples/openapi3/client/petstore/python-aiohttp/requirements.txt
@@ -1,5 +1,5 @@
 python_dateutil >= 2.8.2
-aiohttp >= 3.14.1
+aiohttp >= 3.13.5
 aiohttp-retry >= 2.8.3
 pem >= 19.3.0
 pycryptodome >= 3.9.0

--- a/samples/openapi3/client/petstore/python-aiohttp/requirements.txt
+++ b/samples/openapi3/client/petstore/python-aiohttp/requirements.txt
@@ -1,5 +1,5 @@
 python_dateutil >= 2.8.2
-aiohttp >= 3.8.4
+aiohttp >= 3.14.1
 aiohttp-retry >= 2.8.3
 pem >= 19.3.0
 pycryptodome >= 3.9.0

--- a/samples/openapi3/client/petstore/python-aiohttp/setup.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/setup.py
@@ -23,7 +23,7 @@ VERSION = "1.0.0"
 PYTHON_REQUIRES = ">= 3.10"
 REQUIRES = [
     "python-dateutil >= 2.8.2",
-    "aiohttp >= 3.8.4",
+    "aiohttp >= 3.14.1",
     "aiohttp-retry >= 2.8.3",
     "pem >= 19.3.0",
     "pycryptodome >= 3.9.0",

--- a/samples/openapi3/client/petstore/python-aiohttp/setup.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/setup.py
@@ -23,7 +23,7 @@ VERSION = "1.0.0"
 PYTHON_REQUIRES = ">= 3.10"
 REQUIRES = [
     "python-dateutil >= 2.8.2",
-    "aiohttp >= 3.14.1",
+    "aiohttp >= 3.13.5",
     "aiohttp-retry >= 2.8.3",
     "pem >= 19.3.0",
     "pycryptodome >= 3.9.0",

--- a/samples/openapi3/client/petstore/python-aiohttp/test-requirements.txt
+++ b/samples/openapi3/client/petstore/python-aiohttp/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 7.2.1
+pytest >= 9.0.3
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0

--- a/samples/openapi3/client/petstore/python-aiohttp/test-requirements.txt
+++ b/samples/openapi3/client/petstore/python-aiohttp/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 9.0.3
+pytest >= 8.4.2
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0

--- a/samples/openapi3/client/petstore/python-httpx-sync/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-httpx-sync/pyproject.toml
@@ -26,7 +26,7 @@ Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 requires-poetry = ">=2.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = ">= 9.0.3"
+pytest = ">= 8.4.2"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"

--- a/samples/openapi3/client/petstore/python-httpx-sync/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-httpx-sync/pyproject.toml
@@ -26,7 +26,7 @@ Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 requires-poetry = ">=2.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = ">= 7.2.1"
+pytest = ">= 9.0.3"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"

--- a/samples/openapi3/client/petstore/python-httpx-sync/test-requirements.txt
+++ b/samples/openapi3/client/petstore/python-httpx-sync/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 7.2.1
+pytest >= 9.0.3
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0

--- a/samples/openapi3/client/petstore/python-httpx-sync/test-requirements.txt
+++ b/samples/openapi3/client/petstore/python-httpx-sync/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 9.0.3
+pytest >= 8.4.2
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0

--- a/samples/openapi3/client/petstore/python-httpx/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-httpx/pyproject.toml
@@ -26,7 +26,7 @@ Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 requires-poetry = ">=2.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = ">= 9.0.3"
+pytest = ">= 8.4.2"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"

--- a/samples/openapi3/client/petstore/python-httpx/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-httpx/pyproject.toml
@@ -26,7 +26,7 @@ Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 requires-poetry = ">=2.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = ">= 7.2.1"
+pytest = ">= 9.0.3"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"

--- a/samples/openapi3/client/petstore/python-httpx/test-requirements.txt
+++ b/samples/openapi3/client/petstore/python-httpx/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 7.2.1
+pytest >= 9.0.3
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0

--- a/samples/openapi3/client/petstore/python-httpx/test-requirements.txt
+++ b/samples/openapi3/client/petstore/python-httpx/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 9.0.3
+pytest >= 8.4.2
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0

--- a/samples/openapi3/client/petstore/python-lazyImports/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-lazyImports/pyproject.toml
@@ -11,7 +11,7 @@ keywords = ["OpenAPI", "OpenAPI-Generator", "OpenAPI Petstore"]
 requires-python = ">=3.9"
 
 dependencies = [
-  "urllib3 (>=2.1.0,<3.0.0)",
+  "urllib3 (>=2.7.0,<3.0.0)",
   "python-dateutil (>=2.8.2)",
   "pem (>=19.3.0)",
   "pycryptodome (>=3.9.0)",
@@ -27,7 +27,7 @@ Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 requires-poetry = ">=2.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = ">= 7.2.1"
+pytest = ">= 9.0.3"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"

--- a/samples/openapi3/client/petstore/python-lazyImports/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-lazyImports/pyproject.toml
@@ -11,7 +11,7 @@ keywords = ["OpenAPI", "OpenAPI-Generator", "OpenAPI Petstore"]
 requires-python = ">=3.9"
 
 dependencies = [
-  "urllib3 (>=2.7.0,<3.0.0)",
+  "urllib3 (>=2.6.3,<3.0.0)",
   "python-dateutil (>=2.8.2)",
   "pem (>=19.3.0)",
   "pycryptodome (>=3.9.0)",
@@ -27,7 +27,7 @@ Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 requires-poetry = ">=2.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = ">= 9.0.3"
+pytest = ">= 8.4.2"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"

--- a/samples/openapi3/client/petstore/python-lazyImports/requirements.txt
+++ b/samples/openapi3/client/petstore/python-lazyImports/requirements.txt
@@ -1,4 +1,4 @@
-urllib3 >= 2.1.0, < 3.0.0
+urllib3 >= 2.7.0, < 3.0.0
 python_dateutil >= 2.8.2
 pem >= 19.3.0
 pycryptodome >= 3.9.0

--- a/samples/openapi3/client/petstore/python-lazyImports/requirements.txt
+++ b/samples/openapi3/client/petstore/python-lazyImports/requirements.txt
@@ -1,4 +1,4 @@
-urllib3 >= 2.7.0, < 3.0.0
+urllib3 >= 2.6.3, < 3.0.0
 python_dateutil >= 2.8.2
 pem >= 19.3.0
 pycryptodome >= 3.9.0

--- a/samples/openapi3/client/petstore/python-lazyImports/setup.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/setup.py
@@ -22,7 +22,7 @@ NAME = "petstore-api"
 VERSION = "1.0.0"
 PYTHON_REQUIRES = ">= 3.10"
 REQUIRES = [
-    "urllib3 >= 2.7.0, < 3.0.0",
+    "urllib3 >= 2.6.3, < 3.0.0",
     "python-dateutil >= 2.8.2",
     "pem >= 19.3.0",
     "pycryptodome >= 3.9.0",

--- a/samples/openapi3/client/petstore/python-lazyImports/setup.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/setup.py
@@ -22,7 +22,7 @@ NAME = "petstore-api"
 VERSION = "1.0.0"
 PYTHON_REQUIRES = ">= 3.10"
 REQUIRES = [
-    "urllib3 >= 2.1.0, < 3.0.0",
+    "urllib3 >= 2.7.0, < 3.0.0",
     "python-dateutil >= 2.8.2",
     "pem >= 19.3.0",
     "pycryptodome >= 3.9.0",

--- a/samples/openapi3/client/petstore/python-lazyImports/test-requirements.txt
+++ b/samples/openapi3/client/petstore/python-lazyImports/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 7.2.1
+pytest >= 9.0.3
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0

--- a/samples/openapi3/client/petstore/python-lazyImports/test-requirements.txt
+++ b/samples/openapi3/client/petstore/python-lazyImports/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 9.0.3
+pytest >= 8.4.2
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0

--- a/samples/openapi3/client/petstore/python/pyproject.toml
+++ b/samples/openapi3/client/petstore/python/pyproject.toml
@@ -11,7 +11,7 @@ keywords = ["OpenAPI", "OpenAPI-Generator", "OpenAPI Petstore"]
 requires-python = ">=3.9"
 
 dependencies = [
-  "urllib3 (>=2.1.0,<3.0.0)",
+  "urllib3 (>=2.7.0,<3.0.0)",
   "python-dateutil (>=2.8.2)",
   "pem (>=19.3.0)",
   "pycryptodome (>=3.9.0)",
@@ -26,7 +26,7 @@ Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 requires-poetry = ">=2.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = ">= 7.2.1"
+pytest = ">= 9.0.3"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"

--- a/samples/openapi3/client/petstore/python/pyproject.toml
+++ b/samples/openapi3/client/petstore/python/pyproject.toml
@@ -11,7 +11,7 @@ keywords = ["OpenAPI", "OpenAPI-Generator", "OpenAPI Petstore"]
 requires-python = ">=3.9"
 
 dependencies = [
-  "urllib3 (>=2.7.0,<3.0.0)",
+  "urllib3 (>=2.6.3,<3.0.0)",
   "python-dateutil (>=2.8.2)",
   "pem (>=19.3.0)",
   "pycryptodome (>=3.9.0)",
@@ -26,7 +26,7 @@ Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 requires-poetry = ">=2.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = ">= 9.0.3"
+pytest = ">= 8.4.2"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"

--- a/samples/openapi3/client/petstore/python/requirements.txt
+++ b/samples/openapi3/client/petstore/python/requirements.txt
@@ -1,4 +1,4 @@
-urllib3 >= 2.1.0, < 3.0.0
+urllib3 >= 2.7.0, < 3.0.0
 python_dateutil >= 2.8.2
 pem >= 19.3.0
 pycryptodome >= 3.9.0

--- a/samples/openapi3/client/petstore/python/requirements.txt
+++ b/samples/openapi3/client/petstore/python/requirements.txt
@@ -1,4 +1,4 @@
-urllib3 >= 2.7.0, < 3.0.0
+urllib3 >= 2.6.3, < 3.0.0
 python_dateutil >= 2.8.2
 pem >= 19.3.0
 pycryptodome >= 3.9.0

--- a/samples/openapi3/client/petstore/python/setup.py
+++ b/samples/openapi3/client/petstore/python/setup.py
@@ -22,7 +22,7 @@ NAME = "petstore-api"
 VERSION = "1.0.0"
 PYTHON_REQUIRES = ">= 3.10"
 REQUIRES = [
-    "urllib3 >= 2.7.0, < 3.0.0",
+    "urllib3 >= 2.6.3, < 3.0.0",
     "python-dateutil >= 2.8.2",
     "pem >= 19.3.0",
     "pycryptodome >= 3.9.0",

--- a/samples/openapi3/client/petstore/python/setup.py
+++ b/samples/openapi3/client/petstore/python/setup.py
@@ -22,7 +22,7 @@ NAME = "petstore-api"
 VERSION = "1.0.0"
 PYTHON_REQUIRES = ">= 3.10"
 REQUIRES = [
-    "urllib3 >= 2.1.0, < 3.0.0",
+    "urllib3 >= 2.7.0, < 3.0.0",
     "python-dateutil >= 2.8.2",
     "pem >= 19.3.0",
     "pycryptodome >= 3.9.0",

--- a/samples/openapi3/client/petstore/python/test-requirements.txt
+++ b/samples/openapi3/client/petstore/python/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 7.2.1
+pytest >= 9.0.3
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0

--- a/samples/openapi3/client/petstore/python/test-requirements.txt
+++ b/samples/openapi3/client/petstore/python/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 9.0.3
+pytest >= 8.4.2
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0


### PR DESCRIPTION
Bumps the dependency floors declared in the **`python`** client generator's manifest templates so that generated clients no longer declare version ranges that intersect known-vulnerable releases — while keeping them installable under the generator's declared `requires-python = ">=3.9"`.

### Problem

The `python` generator's manifest templates pin open-ended floors that were chosen as *minimum-compatible*, not *CVE-safe*, and have not moved in a long time:

| package | previous floor | kind |
|---|---|---|
| `urllib3` | `>= 2.1.0, < 3.0.0` | runtime |
| `aiohttp` | `>= 3.8.4` | runtime (asyncio) |
| `pytest` | `>= 7.2.1` | dev |

Because generated clients are libraries with no lockfile, the dependency graph records the declared *range*. Vulnerability scanners (Dependabot, `pip-audit`, etc.) flag any range that *intersects* a vulnerable range — so every generated client trips security alerts for its downstream consumers even when the resolved/installed version is safe.

### Change

Raise the floors to the highest releases still published for **Python 3.9** (the generator's declared minimum), keeping the existing `urllib3 < 3.0.0` cap:

| package | new floor | notes |
|---|---|---|
| `urllib3` | `>= 2.6.3, < 3.0.0` | last 2.6.x; urllib3 2.7.0 requires Python `>=3.10` |
| `aiohttp` | `>= 3.13.5` | last 3.13.x; aiohttp 3.14.0 requires Python `>=3.10` |
| `pytest` | `>= 8.4.2` | last 8.x; pytest 9.0.0 requires Python `>=3.10` (dev-only) |

These clear the older and high-severity advisories the previous ranges intersected (e.g. urllib3 issues fixed through 2.6.3, the aiohttp advisories fixed through 3.13.x including the high-severity ones, and pytest issues below 8.4.2).

### Why not the very latest patched releases?

The most recent fixes ship only in releases that require Python `>=3.10`:

- urllib3 GHSA-mf9v-mfxr-j63j / CVE-2026-44432 and GHSA-qccp-gfcp-xxvc / CVE-2026-44431 — fixed in `2.7.0`
- the aiohttp `<= 3.14.0` advisory batch — fixed in `3.14.1`
- pytest GHSA-6w46-j5rx-g56g / CVE-2025-71176 (dev-only) — fixed in `9.0.3`

Pinning those as floors would make the generated clients uninstallable on Python 3.9, which the generator still declares as its minimum. Fully clearing them at the declaration level would require raising `requires-python` to `>=3.10` — a breaking change that is a maintainer decision, out of scope here. Since the floors are open-ended upward, consumers on Python `>=3.10` still resolve to those fully-patched releases naturally.

Touched templates (floor lines only, no structural change):

- `modules/openapi-generator/src/main/resources/python/pyproject.mustache`
- `modules/openapi-generator/src/main/resources/python/requirements.mustache`
- `modules/openapi-generator/src/main/resources/python/setup.mustache`
- `modules/openapi-generator/src/main/resources/python/test-requirements.mustache`

Regenerated `python` samples are included.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the build and regenerated the affected samples (`./bin/generate-samples.sh ./bin/configs/python*`); committed all changed files.
- [ ] This change targets the `python` generator; @mention of the technical committee left to maintainers.
