### PR TITLE
fix(cpp-httplib-server): serialize enums using spec values

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppHttplibServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppHttplibServerCodegen.java
@@ -1728,13 +1728,10 @@ public class CppHttplibServerCodegen extends AbstractCppCodegen {
         }
 
         // Set vendor extensions for enum properties
-        if (property.isEnum) {
-            property.vendorExtensions.put("isEnum", true);
-            // Convert numeric enum values to have underscore prefix
-            convertNumericEnumValues(property);
-        } else {
-            property.vendorExtensions.put("isEnum", false);
-        }
+        // Note: enum identifier derivation (numeric prefixing, upper-casing) for
+        // (de)serialization happens later, in setEnumVendorExtensions(), which is the
+        // single place that builds both the C++ identifier and the original spec value.
+        property.vendorExtensions.put("isEnum", property.isEnum);
 
         // Set vendor extension for nullable/optional properties
         if (property.isNullable) {
@@ -1763,9 +1760,19 @@ public class CppHttplibServerCodegen extends AbstractCppCodegen {
             return p.getDefault() != null ? p.getDefault().toString() : "false";
         }
         if (ModelUtils.isIntegerSchema(p)) {
+            // For enum types, don't synthesize a "0" placeholder default - it will be
+            // handled in processModelVariable. A synthetic default here is indistinguishable
+            // from a real spec-declared default of 0, which would incorrectly suppress
+            // std::optional wrapping for optional numeric enums without an explicit default.
+            if (p.getEnum() != null && !p.getEnum().isEmpty()) {
+                return null;
+            }
             return p.getDefault() != null ? p.getDefault().toString() : "0";
         }
         if (ModelUtils.isNumberSchema(p)) {
+            if (p.getEnum() != null && !p.getEnum().isEmpty()) {
+                return null;
+            }
             if (ModelUtils.isFloatSchema(p)) {
                 return p.getDefault() != null ? p.getDefault().toString() + "f" : "0.0f";
             }
@@ -2342,58 +2349,16 @@ public class CppHttplibServerCodegen extends AbstractCppCodegen {
     }
 
     /**
-     * Converts numeric enum values to valid C++ enum names by prefixing with underscore.
-     * This is needed because C++ enum identifiers cannot start with digits.
-     * This method processes enum values in a CodegenProperty and prefixes any purely numeric
-     * enum values with an underscore. This is necessary because in C++, enum identifiers cannot
-     * start with a digit, so numeric enum values must be transformed to valid C++ identifiers.
-     * <p>
-     * For example:
-     * - "200" becomes "_200"
-     * - "404" becomes "_404"
-     * - "OK" remains "OK"
-     * <p>
-     * The method retrieves enum values from either the property's {@code _enum} field or from
-     * the {@code allowableValues} map, then updates all three locations with the converted values
-     * to maintain consistency across the property's internal state.
-     *
-     * @param property the CodegenProperty containing enum values to convert
-     */
-    private void convertNumericEnumValues(CodegenProperty property) {
-        // Get enum values from property._enum or allowableValues
-        List<?> enumValues = property._enum;
-        if ((enumValues == null || enumValues.isEmpty()) && property.allowableValues != null) {
-            Object valuesObj = property.allowableValues.get("values");
-            if (valuesObj instanceof List) {
-                enumValues = (List<?>) valuesObj;
-            }
-        }
-
-        if (enumValues != null && !enumValues.isEmpty()) {
-            List<String> convertedValues = new ArrayList<>();
-            for (Object enumVal : enumValues) {
-                String enumValStr = enumVal != null ? enumVal.toString() : "";
-                String convertedVal = enumValStr;
-                // Convert numeric values to have underscore prefix
-                if (enumValStr.matches("^[0-9]+$")) {
-                    convertedVal = "_" + enumValStr;
-                }
-                // Convert to UPPERCASE for C++ enum standards (clang style)
-                convertedVal = convertedVal.toUpperCase(Locale.ROOT);
-                convertedValues.add(convertedVal);
-            }
-            // Update the property with converted values
-            property._enum = convertedValues;
-            property.vendorExtensions.put("values", convertedValues);
-            if (property.allowableValues != null) {
-                property.allowableValues.put("values", convertedValues);
-            }
-        }
-    }
-
-    /**
      * Helper to set vendorExtensions for enum properties and parameters.
      * Handles enum value conversion and helper function naming.
+     * <p>
+     * Enum identifiers (the C++ enum member names) are derived here from the raw,
+     * unmodified OpenAPI enum values: numeric values are prefixed with an underscore
+     * (e.g. "200" -> "_200", since C++ identifiers cannot start with a digit) and the
+     * result is upper-cased for C++ enum naming conventions (clang style). The original
+     * spec value (e.g. "available") is kept as-is in {@code enumCases[i].value} so that
+     * {@code EnumToString}/{@code EnumFromString} serialize using the value defined in
+     * the OpenAPI document rather than the derived C++ identifier.
      */
     private void setEnumVendorExtensions(Object varObj, CodegenModel model) {
         if (varObj == null) {
@@ -2462,6 +2427,12 @@ public class CppHttplibServerCodegen extends AbstractCppCodegen {
                     // Convert number to enum name
                     convertedVal = "_" + enumVal;  // Prefix with underscore for numeric values
                 }
+                // Convert to UPPERCASE for C++ enum naming conventions (clang style).
+                // This only affects the derived C++ identifier (caseMap "name" below,
+                // and var._enum/allowableValues used for declaring the enum); the
+                // original spec value is preserved separately in enumValues/enumCases
+                // "value" for (de)serialization.
+                convertedVal = convertedVal.toUpperCase(Locale.ROOT);
                 convertedValues.add(convertedVal);
             }
         } else {

--- a/modules/openapi-generator/src/main/resources/cpp-httplib-server/model-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-httplib-server/model-header.mustache
@@ -153,9 +153,16 @@ public:
     // ===================
     {{/-first}}
     enum class {{enumName}} {
+        {{^isArray}}
         {{#allowableValues.values}}
         {{.}}{{^-last}},{{/-last}}
         {{/allowableValues.values}}
+        {{/isArray}}
+        {{#isArray}}
+        {{#items.allowableValues.values}}
+        {{.}}{{^-last}},{{/-last}}
+        {{/items.allowableValues.values}}
+        {{/isArray}}
     };
 
     // Enum conversion functions (definitions in .cpp)

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/cpphttplibserver/CppHttplibServerCodegenModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/cpphttplibserver/CppHttplibServerCodegenModelTest.java
@@ -17,12 +17,35 @@ package org.openapitools.codegen.cpphttplib;
 
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.languages.CppHttplibServerCodegen;
+import org.openapitools.codegen.model.ModelMap;
+import org.openapitools.codegen.model.ModelsMap;
 import io.swagger.v3.oas.models.media.*;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 @SuppressWarnings("static-method")
 public class CppHttplibServerCodegenModelTest {
+
+    /**
+     * Wraps a single model the way {@link org.openapitools.codegen.DefaultGenerator}
+     * does before calling {@code postProcessAllModels}, so tests can exercise the full
+     * enum vendor-extension pipeline (identifier + original-value derivation), not just
+     * the intermediate state produced by {@code fromModel}.
+     */
+    private Map<String, ModelsMap> wrapForPostProcessAllModels(String name, CodegenModel model) {
+        final ModelMap modelMap = new ModelMap();
+        modelMap.setModel(model);
+        final ModelsMap modelsMap = new ModelsMap();
+        modelsMap.setModels(Collections.singletonList(modelMap));
+        final HashMap<String, ModelsMap> allModels = new HashMap<>();
+        allModels.put(name, modelsMap);
+        return allModels;
+    }
     @Test(description = "convert model with enum property")
     public void enumPropertyTest() {
         final CppHttplibServerCodegen codegen = new CppHttplibServerCodegen();
@@ -135,6 +158,31 @@ public class CppHttplibServerCodegenModelTest {
             "isArrayOfEnum vendor extension should be true");
     }
 
+    @Test(description = "the enum class declared for an array-of-enum property must use valid, "
+            + "upper-cased C++ identifiers, sourced from items (which setEnumVendorExtensions() derives)")
+    public void arrayOfEnumsDeclaresValidUpperCaseIdentifiersTest() {
+        final CppHttplibServerCodegen codegen = new CppHttplibServerCodegen();
+        codegen.processOpts();
+
+        ObjectSchema schema = new ObjectSchema();
+        StringSchema enumItemSchema = new StringSchema();
+        // lower-case spec values, like issue #24052's Pet.status, exercise the
+        // identifier-vs-serialized-value distinction for array items too.
+        enumItemSchema.setEnum(java.util.Arrays.asList("red", "green", "blue"));
+        schema.addProperty("colors", new ArraySchema().items(enumItemSchema));
+
+        final CodegenModel model = codegen.fromModel("ModelWithColorArray", schema);
+        final CodegenModel processedModel = codegen.postProcessAllModels(
+                wrapForPostProcessAllModels("ModelWithColorArray", model))
+                .get("ModelWithColorArray").getModels().get(0).getModel();
+
+        CodegenProperty arrayProp = processedModel.vars.get(0);
+        // model-header.mustache declares `enum class {{enumName}} { {{items.allowableValues.values}} };`
+        // for array-of-enum properties, so items must independently hold valid C++ identifiers.
+        List<?> declaredIdentifiers = (List<?>) arrayProp.items.allowableValues.get("values");
+        Assert.assertEquals(declaredIdentifiers, java.util.Arrays.asList("UNSPECIFIED", "RED", "GREEN", "BLUE"));
+    }
+
     @Test(description = "convert model with map property")
     public void mapPropertyTest() {
         final CppHttplibServerCodegen codegen = new CppHttplibServerCodegen();
@@ -166,17 +214,54 @@ public class CppHttplibServerCodegenModelTest {
         schema.addProperty("userStatus", statusSchema);
 
         final CodegenModel model = codegen.fromModel("UserStatusModel", schema);
-
         Assert.assertEquals(model.vars.size(), 1);
-        CodegenProperty statusProp = model.vars.get(0);
-        Assert.assertTrue(statusProp.isEnum);
+        Assert.assertTrue(model.vars.get(0).isEnum);
+
+        // The C++ identifier (numeric prefixing + upper-casing) is only finalized during
+        // postProcessAllModels, since that's the single place both the identifier and the
+        // original spec value are derived together (see enumSerializationUsesOriginalSpecValueTest).
+        final CodegenModel processedModel = codegen.postProcessAllModels(
+                wrapForPostProcessAllModels("UserStatusModel", model))
+                .get("UserStatusModel").getModels().get(0).getModel();
+        CodegenProperty statusProp = processedModel.vars.get(0);
         Assert.assertTrue((boolean) statusProp.vendorExtensions.getOrDefault("isEnum", false));
-        // Numeric enum values should be converted to valid C++ names (prefixed with underscore)
-        java.util.List<?> enumValues = (java.util.List<?>) statusProp.vendorExtensions.getOrDefault("values", statusProp._enum);
+        List<?> enumValues = (List<?>) statusProp.vendorExtensions.get("values");
         Assert.assertNotNull(enumValues);
         // Check that numeric values are properly converted
         Assert.assertTrue(enumValues.stream().anyMatch(v -> v.toString().startsWith("_")),
             "Numeric enum values should be prefixed with underscore");
+    }
+
+    @Test(description = "issue #24052: enum (de)serialization must use the original spec value, not the derived C++ identifier")
+    public void enumSerializationUsesOriginalSpecValueTest() {
+        final CppHttplibServerCodegen codegen = new CppHttplibServerCodegen();
+        codegen.processOpts();
+
+        ObjectSchema schema = new ObjectSchema();
+        StringSchema statusSchema = new StringSchema();
+        statusSchema.setEnum(java.util.Arrays.asList("available", "pending", "sold"));
+        schema.addProperty("status", statusSchema);
+
+        final CodegenModel model = codegen.fromModel("Pet", schema);
+        final CodegenModel processedModel = codegen.postProcessAllModels(
+                wrapForPostProcessAllModels("Pet", model))
+                .get("Pet").getModels().get(0).getModel();
+
+        CodegenProperty statusProp = processedModel.vars.get(0);
+        @SuppressWarnings("unchecked")
+        List<Map<String, String>> enumCases = (List<Map<String, String>>) statusProp.vendorExtensions.get("enumCases");
+        Assert.assertNotNull(enumCases);
+
+        Map<String, String> availableCase = enumCases.stream()
+                .filter(c -> "available".equals(c.get("value")))
+                .findFirst()
+                .orElse(null);
+        Assert.assertNotNull(availableCase,
+                "expected an enumCases entry whose value is the original spec text \"available\": " + enumCases);
+        // The C++ identifier is upper-cased for enum naming conventions...
+        Assert.assertEquals(availableCase.get("name"), "AVAILABLE");
+        // ...but the serialized value must remain exactly what the OpenAPI spec declared.
+        Assert.assertEquals(availableCase.get("value"), "available");
     }
 
     @Test(description = "convert enum model")

--- a/samples/server/petstore/cpp-httplib-server/feature-test/models/ArrayTypes.h
+++ b/samples/server/petstore/cpp-httplib-server/feature-test/models/ArrayTypes.h
@@ -21,6 +21,7 @@ class ArrayTypes
 {
 public:
     enum class EnumArrayEnum {
+        UNSPECIFIED,
         RED,
         GREEN,
         BLUE

--- a/samples/server/petstore/cpp-httplib-server/feature-test/models/CreditCard.cpp
+++ b/samples/server/petstore/cpp-httplib-server/feature-test/models/CreditCard.cpp
@@ -58,9 +58,9 @@ std::string CreditCard::CardTypeEnumToString(CreditCard::CardTypeEnum value)
     switch (value)
     {
         case CardTypeEnum::UNSPECIFIED: return "UNSPECIFIED";
-        case CardTypeEnum::VISA: return "VISA";
-        case CardTypeEnum::MASTERCARD: return "MASTERCARD";
-        case CardTypeEnum::AMEX: return "AMEX";
+        case CardTypeEnum::VISA: return "visa";
+        case CardTypeEnum::MASTERCARD: return "mastercard";
+        case CardTypeEnum::AMEX: return "amex";
         default: return {};
     }
 }
@@ -71,15 +71,15 @@ CreditCard::CardTypeEnum CreditCard::CardTypeEnumFromString(const std::string& s
     {
         return CardTypeEnum::UNSPECIFIED;
     }
-    if (str == "VISA")
+    if (str == "visa")
     {
         return CardTypeEnum::VISA;
     }
-    if (str == "MASTERCARD")
+    if (str == "mastercard")
     {
         return CardTypeEnum::MASTERCARD;
     }
-    if (str == "AMEX")
+    if (str == "amex")
     {
         return CardTypeEnum::AMEX;
     }

--- a/samples/server/petstore/cpp-httplib-server/feature-test/models/EnumTypes.cpp
+++ b/samples/server/petstore/cpp-httplib-server/feature-test/models/EnumTypes.cpp
@@ -58,9 +58,9 @@ std::string EnumTypes::StringEnumEnumToString(EnumTypes::StringEnumEnum value)
     switch (value)
     {
         case StringEnumEnum::UNSPECIFIED: return "UNSPECIFIED";
-        case StringEnumEnum::PENDING: return "PENDING";
-        case StringEnumEnum::APPROVED: return "APPROVED";
-        case StringEnumEnum::REJECTED: return "REJECTED";
+        case StringEnumEnum::PENDING: return "pending";
+        case StringEnumEnum::APPROVED: return "approved";
+        case StringEnumEnum::REJECTED: return "rejected";
         default: return {};
     }
 }
@@ -71,15 +71,15 @@ EnumTypes::StringEnumEnum EnumTypes::StringEnumEnumFromString(const std::string&
     {
         return StringEnumEnum::UNSPECIFIED;
     }
-    if (str == "PENDING")
+    if (str == "pending")
     {
         return StringEnumEnum::PENDING;
     }
-    if (str == "APPROVED")
+    if (str == "approved")
     {
         return StringEnumEnum::APPROVED;
     }
-    if (str == "REJECTED")
+    if (str == "rejected")
     {
         return StringEnumEnum::REJECTED;
     }
@@ -94,11 +94,11 @@ std::string EnumTypes::NumericEnumEnumToString(EnumTypes::NumericEnumEnum value)
     switch (value)
     {
         case NumericEnumEnum::UNSPECIFIED: return "UNSPECIFIED";
-        case NumericEnumEnum::_100: return "_100";
-        case NumericEnumEnum::_200: return "_200";
-        case NumericEnumEnum::_300: return "_300";
-        case NumericEnumEnum::_404: return "_404";
-        case NumericEnumEnum::_500: return "_500";
+        case NumericEnumEnum::_100: return "100";
+        case NumericEnumEnum::_200: return "200";
+        case NumericEnumEnum::_300: return "300";
+        case NumericEnumEnum::_404: return "404";
+        case NumericEnumEnum::_500: return "500";
         default: return {};
     }
 }
@@ -109,23 +109,23 @@ EnumTypes::NumericEnumEnum EnumTypes::NumericEnumEnumFromString(const std::strin
     {
         return NumericEnumEnum::UNSPECIFIED;
     }
-    if (str == "_100")
+    if (str == "100")
     {
         return NumericEnumEnum::_100;
     }
-    if (str == "_200")
+    if (str == "200")
     {
         return NumericEnumEnum::_200;
     }
-    if (str == "_300")
+    if (str == "300")
     {
         return NumericEnumEnum::_300;
     }
-    if (str == "_404")
+    if (str == "404")
     {
         return NumericEnumEnum::_404;
     }
-    if (str == "_500")
+    if (str == "500")
     {
         return NumericEnumEnum::_500;
     }
@@ -140,9 +140,9 @@ std::string EnumTypes::StatusCodeEnumToString(EnumTypes::StatusCodeEnum value)
     switch (value)
     {
         case StatusCodeEnum::UNSPECIFIED: return "UNSPECIFIED";
-        case StatusCodeEnum::_200: return "_200";
-        case StatusCodeEnum::_404: return "_404";
-        case StatusCodeEnum::_500: return "_500";
+        case StatusCodeEnum::_200: return "200";
+        case StatusCodeEnum::_404: return "404";
+        case StatusCodeEnum::_500: return "500";
         default: return {};
     }
 }
@@ -153,15 +153,15 @@ EnumTypes::StatusCodeEnum EnumTypes::StatusCodeEnumFromString(const std::string&
     {
         return StatusCodeEnum::UNSPECIFIED;
     }
-    if (str == "_200")
+    if (str == "200")
     {
         return StatusCodeEnum::_200;
     }
-    if (str == "_404")
+    if (str == "404")
     {
         return StatusCodeEnum::_404;
     }
-    if (str == "_500")
+    if (str == "500")
     {
         return StatusCodeEnum::_500;
     }

--- a/samples/server/petstore/cpp-httplib-server/petstore/models/ComplexParamsResponse.cpp
+++ b/samples/server/petstore/cpp-httplib-server/petstore/models/ComplexParamsResponse.cpp
@@ -157,8 +157,8 @@ std::string ComplexParamsResponse::CookieEnumEnumToString(ComplexParamsResponse:
     switch (value)
     {
         case CookieEnumEnum::UNSPECIFIED: return "UNSPECIFIED";
-        case CookieEnumEnum::COOKIEA: return "COOKIEA";
-        case CookieEnumEnum::COOKIEB: return "COOKIEB";
+        case CookieEnumEnum::COOKIEA: return "cookieA";
+        case CookieEnumEnum::COOKIEB: return "cookieB";
         default: return {};
     }
 }
@@ -169,11 +169,11 @@ ComplexParamsResponse::CookieEnumEnum ComplexParamsResponse::CookieEnumEnumFromS
     {
         return CookieEnumEnum::UNSPECIFIED;
     }
-    if (str == "COOKIEA")
+    if (str == "cookieA")
     {
         return CookieEnumEnum::COOKIEA;
     }
-    if (str == "COOKIEB")
+    if (str == "cookieB")
     {
         return CookieEnumEnum::COOKIEB;
     }

--- a/samples/server/petstore/cpp-httplib-server/petstore/models/Order.cpp
+++ b/samples/server/petstore/cpp-httplib-server/petstore/models/Order.cpp
@@ -85,9 +85,9 @@ std::string Order::StatusEnumToString(Order::StatusEnum value)
     switch (value)
     {
         case StatusEnum::UNSPECIFIED: return "UNSPECIFIED";
-        case StatusEnum::PLACED: return "PLACED";
-        case StatusEnum::APPROVED: return "APPROVED";
-        case StatusEnum::DELIVERED: return "DELIVERED";
+        case StatusEnum::PLACED: return "placed";
+        case StatusEnum::APPROVED: return "approved";
+        case StatusEnum::DELIVERED: return "delivered";
         default: return {};
     }
 }
@@ -98,15 +98,15 @@ Order::StatusEnum Order::StatusEnumFromString(const std::string& str)
     {
         return StatusEnum::UNSPECIFIED;
     }
-    if (str == "PLACED")
+    if (str == "placed")
     {
         return StatusEnum::PLACED;
     }
-    if (str == "APPROVED")
+    if (str == "approved")
     {
         return StatusEnum::APPROVED;
     }
-    if (str == "DELIVERED")
+    if (str == "delivered")
     {
         return StatusEnum::DELIVERED;
     }

--- a/samples/server/petstore/cpp-httplib-server/petstore/models/Pet.cpp
+++ b/samples/server/petstore/cpp-httplib-server/petstore/models/Pet.cpp
@@ -85,9 +85,9 @@ std::string Pet::StatusEnumToString(Pet::StatusEnum value)
     switch (value)
     {
         case StatusEnum::UNSPECIFIED: return "UNSPECIFIED";
-        case StatusEnum::AVAILABLE: return "AVAILABLE";
-        case StatusEnum::PENDING: return "PENDING";
-        case StatusEnum::SOLD: return "SOLD";
+        case StatusEnum::AVAILABLE: return "available";
+        case StatusEnum::PENDING: return "pending";
+        case StatusEnum::SOLD: return "sold";
         default: return {};
     }
 }
@@ -98,15 +98,15 @@ Pet::StatusEnum Pet::StatusEnumFromString(const std::string& str)
     {
         return StatusEnum::UNSPECIFIED;
     }
-    if (str == "AVAILABLE")
+    if (str == "available")
     {
         return StatusEnum::AVAILABLE;
     }
-    if (str == "PENDING")
+    if (str == "pending")
     {
         return StatusEnum::PENDING;
     }
-    if (str == "SOLD")
+    if (str == "sold")
     {
         return StatusEnum::SOLD;
     }

--- a/samples/server/petstore/cpp-httplib-server/petstore/models/User.cpp
+++ b/samples/server/petstore/cpp-httplib-server/petstore/models/User.cpp
@@ -103,9 +103,9 @@ std::string User::UserStatusEnumToString(User::UserStatusEnum value)
     switch (value)
     {
         case UserStatusEnum::UNSPECIFIED: return "UNSPECIFIED";
-        case UserStatusEnum::_0: return "_0";
-        case UserStatusEnum::_1: return "_1";
-        case UserStatusEnum::_2: return "_2";
+        case UserStatusEnum::_0: return "0";
+        case UserStatusEnum::_1: return "1";
+        case UserStatusEnum::_2: return "2";
         default: return {};
     }
 }
@@ -116,15 +116,15 @@ User::UserStatusEnum User::UserStatusEnumFromString(const std::string& str)
     {
         return UserStatusEnum::UNSPECIFIED;
     }
-    if (str == "_0")
+    if (str == "0")
     {
         return UserStatusEnum::_0;
     }
-    if (str == "_1")
+    if (str == "1")
     {
         return UserStatusEnum::_1;
     }
-    if (str == "_2")
+    if (str == "2")
     {
         return UserStatusEnum::_2;
     }


### PR DESCRIPTION
### Summary

Fixes enum serialization for the `cpp-httplib-server` generator.

Previously, `convertNumericEnumValues()` modified the original OpenAPI enum values during model processing. For example, a spec value like `"available"` was changed to `"AVAILABLE"` before enum serialization helpers were generated. As a result, generated `EnumToString` / `EnumFromString` code used the C++ enum identifier instead of the actual OpenAPI value.

This change keeps the two concepts separate:

- C++ enum identifier: `AVAILABLE`
- OpenAPI serialized value: `"available"`

### Changes

- Removed the destructive `convertNumericEnumValues()` mutation.
- Moved C++ enum identifier derivation into `setEnumVendorExtensions()`.
- Preserved raw OpenAPI enum values for serialization and deserialization.
- Fixed numeric enum default handling where a synthetic `"0"` default could incorrectly suppress `std::optional`.
- Fixed array-of-enum identifier generation to use the enum values from `items`.
- Added regression test coverage.
- Regenerated the `cpp-httplib-server-petstore` and `cpp-httplib-server-feature-test` samples.

### Verification

- Generated code from the issue spec now serializes:
  - `"available"`
  - `"pending"`
  - `"sold"`

  instead of:

  - `"AVAILABLE"`
  - `"PENDING"`
  - `"SOLD"`

- Ran cpp-httplib-server tests successfully.
- Regenerated affected cpp-httplib-server samples.

Fixes #24052

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes enum serialization in `cpp-httplib-server` to use the OpenAPI value, not the derived C++ enum identifier. Restores correct wire values for strings and numerics (e.g., "available", "200"). Fixes #24052.

- **Bug Fixes**
  - Removed destructive `convertNumericEnumValues()` and derive C++ identifiers in `setEnumVendorExtensions()`, preserving original spec values for `EnumToString`/`EnumFromString`.
  - Prevented synthetic "0" defaults for numeric enums so optional wrapping isn’t incorrectly suppressed.
  - For array-of-enum properties, declare enum members from `items.allowableValues.values`; updated `model-header.mustache`.
  - Added regression tests and regenerated `cpp-httplib-server` samples.

<sup>Written for commit a5bda3e338d1fabd684d0e9838935eb213c4c6de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

