### PR TITLE
Update php laravel to latest stable version

### DIFF
--- a/.github/workflows/samples-php8.yaml
+++ b/.github/workflows/samples-php8.yaml
@@ -21,8 +21,6 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - "8.1"
-          - "8.2"
           - "8.3"
           - "8.4"
         sample:

--- a/.github/workflows/samples-php8.yaml
+++ b/.github/workflows/samples-php8.yaml
@@ -41,4 +41,13 @@ jobs:
         run: composer install
       - name: phpunit
         working-directory: ${{ matrix.sample }}
-        run: vendor/bin/phpunit
+        run: |
+          if [ -f phpunit.xml ] || [ -f phpunit.xml.dist ]; then
+            vendor/bin/phpunit -c "$( [ -f phpunit.xml ] && echo phpunit.xml || echo phpunit.xml.dist )"
+          elif [ -d tests ]; then
+            vendor/bin/phpunit tests
+          elif [ -d test ]; then
+            vendor/bin/phpunit test
+          else
+            echo "No PHPUnit config or tests directory in ${{ matrix.sample }}; skipping."
+          fi

--- a/modules/openapi-generator/src/main/resources/php-laravel/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-laravel/composer.mustache
@@ -24,8 +24,8 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "laravel/framework": "^10.0",
+        "php": "^8.3",
+        "laravel/framework": "^13.0",
         "crell/serde": "^1.0"
     },
     "require-dev": {

--- a/modules/openapi-generator/src/main/resources/php-laravel/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-laravel/composer.mustache
@@ -29,7 +29,7 @@
         "crell/serde": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^12.0"
     },
     "autoload": {
         "psr-4": {

--- a/samples/server/petstore/php-laravel-issue-21334/composer.json
+++ b/samples/server/petstore/php-laravel-issue-21334/composer.json
@@ -16,8 +16,8 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "laravel/framework": "^10.0",
+        "php": "^8.3",
+        "laravel/framework": "^13.0",
         "crell/serde": "^1.0"
     },
     "require-dev": {

--- a/samples/server/petstore/php-laravel-issue-21334/composer.json
+++ b/samples/server/petstore/php-laravel-issue-21334/composer.json
@@ -21,7 +21,7 @@
         "crell/serde": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^12.0"
     },
     "autoload": {
         "psr-4": {

--- a/samples/server/petstore/php-laravel/.openapi-generator-ignore
+++ b/samples/server/petstore/php-laravel/.openapi-generator-ignore
@@ -21,3 +21,5 @@
 #docs/*.md
 # Then explicitly reverse the ignore rule for a single file:
 #!docs/README.md
+#
+#

--- a/samples/server/petstore/php-laravel/composer.json
+++ b/samples/server/petstore/php-laravel/composer.json
@@ -16,8 +16,8 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "laravel/framework": "^10.0",
+        "php": "^8.3",
+        "laravel/framework": "^13.0",
         "crell/serde": "^1.0"
     },
     "require-dev": {

--- a/samples/server/petstore/php-laravel/composer.json
+++ b/samples/server/petstore/php-laravel/composer.json
@@ -21,7 +21,7 @@
         "crell/serde": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^12.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
update php laravel to latest stable version
test php with php 8.3, 8.4 (8.2 will be reached EOL in ~6 months)

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded PHP to `^8.3`, `laravel/framework` to `^13.0`, and `phpunit/phpunit` to `^12.0` in the Laravel generator and samples; CI tests 8.3/8.4 and runs PHPUnit only when config/tests exist; added comments to `.openapi-generator-ignore`.

<sup>Written for commit eb62aa397f0f9bb94c00ead7f35130b1f55642e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



