### PR TITLE
[python][flask] Honor defaultController option for untagged operations

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonConnexionServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonConnexionServerCodegen.java
@@ -308,8 +308,13 @@ public abstract class AbstractPythonConnexionServerCodegen extends AbstractPytho
 
     @Override
     public String toApiName(String name) {
-        if (name == null || name.length() == 0) {
-            return "DefaultController";
+        if (name == null || name.length() == 0 || "default".equalsIgnoreCase(name)) {
+            // Operations without a tag are grouped under the "default" tag. Honor the
+            // configurable defaultController module name for them (issue #1891); this
+            // drives both the generated controller file name and connexion's
+            // x-openapi-router-controller routing, keeping the two consistent.
+            String controller = defaultController != null ? defaultController : "default_controller";
+            return camelize(controller);
         }
         return camelize(name) + "Controller";
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonFlaskConnexionServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonFlaskConnexionServerCodegenTest.java
@@ -67,4 +67,25 @@ public class PythonFlaskConnexionServerCodegenTest {
         assertFileContains(p4, "def with_path_param_required(param1, body):");
         assertFileContains(p4, "test_request = body");
     }
+
+    @Test(description = "the defaultController option controls the module name for untagged operations (issue #1891)")
+    public void testDefaultController() throws IOException {
+        final PythonFlaskConnexionServerCodegen codegen = new PythonFlaskConnexionServerCodegen();
+        codegen.additionalProperties().put("defaultController", "my_default_controller");
+        final String outputPath = generateFiles(codegen, "src/test/resources/bugs/issue_1891.yaml");
+
+        // The untagged operation should land in the configured controller module...
+        final Path expected = Paths.get(outputPath + "openapi_server/controllers/my_default_controller.py");
+        assertFileExists(expected);
+        assertFileContains(expected, "def ping():");
+
+        // ...and connexion's routing must point at the same module, not the hardcoded default.
+        final Path openapiYaml = Paths.get(outputPath + "openapi_server/openapi/openapi.yaml");
+        assertFileContains(openapiYaml, "x-openapi-router-controller: openapi_server.controllers.my_default_controller");
+
+        // The hardcoded default_controller.py must no longer be emitted.
+        final Path old = Paths.get(outputPath + "openapi_server/controllers/default_controller.py");
+        Assert.assertFalse(Files.exists(old),
+                "Untagged operations should honor defaultController, not fall back to default_controller.py");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/bugs/issue_1891.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/issue_1891.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.0
+info:
+  title: Issue 1891 - defaultController
+  version: 1.0.0
+paths:
+  /ping:
+    get:
+      operationId: ping
+      responses:
+        '200':
+          description: ok


### PR DESCRIPTION
### Description

The `defaultController` additional property was parsed but had no effect for the `python-flask` (Connexion) server generator: the controller module for untagged operations was always named `default_controller.py`, regardless of the option. (Open since 2019.)

**Root cause:** operations without a tag are grouped under the hardcoded `"default"` tag, and the controller filename is derived from that tag via `toApiName`. `this.defaultController` was stored during `processOpts` but never consumed.

**Fix:** route the `default` tag through the configured `defaultController` in `AbstractPythonConnexionServerCodegen.toApiName`. Because both the generated controller **filename** and Connexion's **`x-openapi-router-controller`** routing derive from `toApiName`, this single change keeps the file and the runtime routing consistent.

**Verification**
- New unit test `PythonFlaskConnexionServerCodegenTest#testDefaultController` (added a minimal spec `issue_1891.yaml` with an untagged operation): the untagged handler lands in the configured module, the routing extension points at the same module, and `default_controller.py` is no longer emitted.
- Backward compatible: with the default value, output is **byte-identical** — regenerating all affected samples (`python-flask`, `python-flask-connexion3`, `python-aiohttp`, `python-aiohttp-srclayout`, `python-blueplanet`) produced **no diffs**.
- Verified end-to-end at runtime: generated a Connexion 3 server with a custom `defaultController`, started it, and confirmed Connexion imports the renamed module and routes to it successfully.

Fixes #1891

This also resolves the `defaultController` half of #10765. The other half of #10765 — honoring a per-operation `x-openapi-router-controller` for **file placement** (currently the handler is written into the tag-derived file rather than the referenced module) — is a larger, separate change and will be proposed in a follow-up PR.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran `./mvnw clean package`, `./bin/generate-samples.sh` (affected python configs), and `./bin/utils/export_docs_generators.sh` — no sample or docs changes result from this fix.
- [x] Filed the PR against the `master` branch.
- [x] Python technical committee: @cbornet @tomplus @krjakbrjak @fa0311


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors the `defaultController` option for untagged operations in the `python-flask` generator so the controller file and `connexion` routing use the configured module instead of `default_controller.py`. Behavior is unchanged when using the default value.

- **Bug Fixes**
  - Route the `"default"` tag through `defaultController` in `toApiName`, aligning the generated filename and `x-openapi-router-controller`.
  - Added a unit test with a minimal spec to confirm the handler lands in the custom module and `default_controller.py` is not generated.
  - Backward compatible: default output remains identical (no sample diffs).

<sup>Written for commit f7c4afad33a3fd43725bef02bacee7d226d8019f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

