### PR TITLE
Add JavaClientCodegen RxJava option tests

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -4596,4 +4596,41 @@ public class JavaClientCodegenTest {
                 .contains("@Tag(");
     }
 
+    @DataProvider(name = "rxJavaOptions")
+    public static Object[][] rxJavaOptions() {
+        return new Object[][]{
+                {Map.of(USE_RX_JAVA2, true, USE_RX_JAVA3, true), Map.of(USE_RX_JAVA2, false, USE_RX_JAVA3, true)},
+                {Map.of(USE_RX_JAVA2, true), Map.of(USE_RX_JAVA2, true)}
+        };
+    }
+
+    @Test(dataProvider = "rxJavaOptions")
+    public void processOptsConfiguresRxJavaOptions(Map<String, Object> properties, Map<String, Object> expectedProperties) {
+        JavaClientCodegen codegen = newRetrofit2Codegen(properties);
+
+        codegen.processOpts();
+
+        assertThat(codegen.additionalProperties())
+                .containsAllEntriesOf(expectedProperties)
+                .doesNotContainKey(DO_NOT_USE_RX);
+    }
+
+    @Test
+    public void processOptsConvertsConfiguredSupportUrlQuery() {
+        JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.setLibrary(JavaClientCodegen.APACHE);
+        codegen.additionalProperties().put(SUPPORT_URL_QUERY, "false");
+
+        codegen.processOpts();
+
+        assertThat(codegen.additionalProperties())
+                .containsEntry(SUPPORT_URL_QUERY, false);
+    }
+
+    private static JavaClientCodegen newRetrofit2Codegen(Map<String, Object> properties) {
+        JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.setLibrary(JavaClientCodegen.RETROFIT_2);
+        codegen.additionalProperties().putAll(properties);
+        return codegen;
+    }
 }


### PR DESCRIPTION
# test: add JavaClientCodegen processOpts coverage

Hi,

I added a couple of focused `processOpts()` checks for `JavaClientCodegen`. They cover RxJava option normalization, including the case where RxJava 2 and 3 are both configured, and the explicit `supportUrlQuery` conversion for the Apache client.

The main covered areas are the RxJava handling at [JavaClientCodegen.java:425-428](https://github.com/amirdeljouyi/openapi-generator/blob/83cc8cab90941e05fe5ee7535c9e6c73847e0336/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java#L425-L428) and the `supportUrlQuery` conversion at [JavaClientCodegen.java:512-518](https://github.com/amirdeljouyi/openapi-generator/blob/83cc8cab90941e05fe5ee7535c9e6c73847e0336/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java#L512-L518). Branch coverage for `JavaClientCodegen` increases by about 2%.

<!-- I ran:

```bash
./mvnw -pl modules/openapi-generator -am -Dtest=JavaClientCodegenTest -Dsurefire.failIfNoSpecifiedTests=false test
``` -->

I hope you find these tests useful. 😄 Please let me know if you have any questions or concerns.

Thanks,
Amir

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `JavaClientCodegen.processOpts` to validate RxJava option handling and `supportUrlQuery` conversion for the Apache client. Tests cover the case where both RxJava2 and RxJava3 are set (RxJava3 wins) and ensure `supportUrlQuery` string values convert to booleans; branch coverage increases ~2%.

<sup>Written for commit 83cc8cab90941e05fe5ee7535c9e6c73847e0336. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

