### PR TITLE
Update jaxrs logback to newer versions

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/pom.mustache
@@ -220,7 +220,7 @@ for this project used jakarta.validation-api -->
     <swagger-core-version>1.5.22</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <junit-version>4.13.2</junit-version>
-    <logback-version>1.5.25</logback-version>
+    <logback-version>1.5.33</logback-version>
 {{#useBeanValidation}}
     <beanvalidation-version>2.0.2</beanvalidation-version>
 {{/useBeanValidation}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/server/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/server/pom.mustache
@@ -342,7 +342,7 @@ for this project used jakarta.validation-api -->
 {{/generateSpringApplication}}
 {{^generateSpringBootApplication}}
     <junit-version>4.13.2</junit-version>
-    <logback-version>1.5.25</logback-version>
+    <logback-version>1.5.33</logback-version>
 {{/generateSpringBootApplication}}
     <cxf-version>3.5.9</cxf-version>
     <jackson-jaxrs-version>2.17.1</jackson-jaxrs-version>

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/pom.mustache
@@ -254,7 +254,7 @@ for this project used jakarta.validation-api -->
 {{/swagger2AnnotationLibrary}}
     <jetty-version>9.2.9.v20150224</jetty-version>
     <junit-version>4.13.2</junit-version>
-    <logback-version>1.5.25</logback-version>
+    <logback-version>1.5.33</logback-version>
 {{#useBeanValidation}}
     <beanvalidation-version>2.0.2</beanvalidation-version>
 {{/useBeanValidation}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
@@ -311,7 +311,7 @@ for this project used jakarta.validation-api -->
 {{/swagger2AnnotationLibrary}}
     <jetty-version>9.2.9.v20150224</jetty-version>
     <junit-version>4.13.2</junit-version>
-    <logback-version>1.5.25</logback-version>
+    <logback-version>1.5.33</logback-version>
 {{#useBeanValidation}}
     <beanvalidation-version>2.0.2</beanvalidation-version>
 {{/useBeanValidation}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/libraries/jersey3/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/libraries/jersey3/pom.mustache
@@ -222,7 +222,7 @@
     <jersey3-version>3.1.3</jersey3-version>
     <jackson-version>2.17.1</jackson-version>
     <junit-version>4.13.2</junit-version>
-    <logback-version>1.5.25</logback-version>
+    <logback-version>1.5.33</logback-version>
     <servlet-api-version>5.0.0</servlet-api-version>    
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/pom.mustache
@@ -222,7 +222,7 @@ for this project used jakarta.validation-api -->
     <jersey2-version>2.35</jersey2-version>
     <jackson-version>2.17.1</jackson-version>
     <junit-version>4.13.2</junit-version>
-    <logback-version>1.5.25</logback-version>
+    <logback-version>1.5.33</logback-version>
     <servlet-api-version>4.0.4</servlet-api-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/samples/client/petstore/jaxrs-cxf-client-jackson/pom.xml
+++ b/samples/client/petstore/jaxrs-cxf-client-jackson/pom.xml
@@ -189,7 +189,7 @@ for this project used jakarta.validation-api -->
     <swagger-core-version>1.6.6</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <junit-version>4.13.2</junit-version>
-    <logback-version>1.5.25</logback-version>
+    <logback-version>1.5.33</logback-version>
     <cxf-version>4.2.0</cxf-version>
     <jackson-jaxrs-version>3.1.2</jackson-jaxrs-version>
     <jakarta-annotation-version>2.1.1</jakarta-annotation-version>

--- a/samples/client/petstore/jaxrs-cxf-client-swagger2/pom.xml
+++ b/samples/client/petstore/jaxrs-cxf-client-swagger2/pom.xml
@@ -185,7 +185,7 @@
     <swagger-annotations-version>2.2.7</swagger-annotations-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <junit-version>4.13.2</junit-version>
-    <logback-version>1.5.25</logback-version>
+    <logback-version>1.5.33</logback-version>
     <cxf-version>3.5.9</cxf-version>
     <jackson-jaxrs-version>2.17.1</jackson-jaxrs-version>
     <jakarta-annotation-version>1.3.5</jakarta-annotation-version>

--- a/samples/client/petstore/jaxrs-cxf-client/pom.xml
+++ b/samples/client/petstore/jaxrs-cxf-client/pom.xml
@@ -194,7 +194,7 @@ for this project used jakarta.validation-api -->
     <swagger-core-version>1.6.6</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <junit-version>4.13.2</junit-version>
-    <logback-version>1.5.25</logback-version>
+    <logback-version>1.5.33</logback-version>
     <cxf-version>3.5.9</cxf-version>
     <jackson-jaxrs-version>2.17.1</jackson-jaxrs-version>
     <jakarta-annotation-version>1.3.5</jakarta-annotation-version>

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/pom.xml
@@ -226,7 +226,7 @@ for this project used jakarta.validation-api -->
     <swagger-core-version>1.6.6</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <junit-version>4.13.2</junit-version>
-    <logback-version>1.5.25</logback-version>
+    <logback-version>1.5.33</logback-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>
     <cxf-version>3.5.9</cxf-version>
     <jackson-jaxrs-version>2.17.1</jackson-jaxrs-version>

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/pom.xml
@@ -226,7 +226,7 @@ for this project used jakarta.validation-api -->
     <swagger-core-version>1.6.6</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <junit-version>4.13.2</junit-version>
-    <logback-version>1.5.25</logback-version>
+    <logback-version>1.5.33</logback-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>
     <cxf-version>3.5.9</cxf-version>
     <jackson-jaxrs-version>2.17.1</jackson-jaxrs-version>

--- a/samples/server/petstore/jaxrs-cxf/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf/pom.xml
@@ -226,7 +226,7 @@ for this project used jakarta.validation-api -->
     <swagger-core-version>1.6.6</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <junit-version>4.13.2</junit-version>
-    <logback-version>1.5.25</logback-version>
+    <logback-version>1.5.33</logback-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>
     <cxf-version>3.5.9</cxf-version>
     <jackson-jaxrs-version>2.17.1</jackson-jaxrs-version>

--- a/samples/server/petstore/jaxrs-datelib-j8/pom.xml
+++ b/samples/server/petstore/jaxrs-datelib-j8/pom.xml
@@ -209,7 +209,7 @@ for this project used jakarta.validation-api -->
     <jersey2-version>2.35</jersey2-version>
     <jackson-version>2.17.1</jackson-version>
     <junit-version>4.13.2</junit-version>
-    <logback-version>1.5.25</logback-version>
+    <logback-version>1.5.33</logback-version>
     <servlet-api-version>4.0.4</servlet-api-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/samples/server/petstore/jaxrs-jersey/pom.xml
+++ b/samples/server/petstore/jaxrs-jersey/pom.xml
@@ -209,7 +209,7 @@ for this project used jakarta.validation-api -->
     <jersey2-version>2.35</jersey2-version>
     <jackson-version>2.17.1</jackson-version>
     <junit-version>4.13.2</junit-version>
-    <logback-version>1.5.25</logback-version>
+    <logback-version>1.5.33</logback-version>
     <servlet-api-version>4.0.4</servlet-api-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/samples/server/petstore/jaxrs/jersey2-useTags/pom.xml
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/pom.xml
@@ -209,7 +209,7 @@ for this project used jakarta.validation-api -->
     <jersey2-version>2.35</jersey2-version>
     <jackson-version>2.17.1</jackson-version>
     <junit-version>4.13.2</junit-version>
-    <logback-version>1.5.25</logback-version>
+    <logback-version>1.5.33</logback-version>
     <servlet-api-version>4.0.4</servlet-api-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/samples/server/petstore/jaxrs/jersey2/pom.xml
+++ b/samples/server/petstore/jaxrs/jersey2/pom.xml
@@ -209,7 +209,7 @@ for this project used jakarta.validation-api -->
     <jersey2-version>2.35</jersey2-version>
     <jackson-version>2.17.1</jackson-version>
     <junit-version>4.13.2</junit-version>
-    <logback-version>1.5.25</logback-version>
+    <logback-version>1.5.33</logback-version>
     <servlet-api-version>4.0.4</servlet-api-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/samples/server/petstore/jaxrs/jersey3/pom.xml
+++ b/samples/server/petstore/jaxrs/jersey3/pom.xml
@@ -209,7 +209,7 @@
     <jersey3-version>3.1.3</jersey3-version>
     <jackson-version>2.17.1</jackson-version>
     <junit-version>4.13.2</junit-version>
-    <logback-version>1.5.25</logback-version>
+    <logback-version>1.5.33</logback-version>
     <servlet-api-version>5.0.0</servlet-api-version>    
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>


### PR DESCRIPTION
to close https://github.com/OpenAPITools/openapi-generator/pull/24204

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Logback to 1.5.33 across JAX-RS generator templates and samples. This pulls in the latest fixes and keeps generated projects consistent.

- **Dependencies**
  - Set `<logback-version>` property across `JavaJaxRS` CXF, CXF-ext, Jersey2/3 templates and related petstore sample POMs.

<sup>Written for commit 510e7e06540d59a351b6b06bc1dc5ddd31ee2851. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

