### PR TITLE
fix(typescript-fetch): optional nullable fields return null instead of undefined

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -88,22 +88,22 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
         {{#isArray}}
         {{#uniqueItems}}
         {{! For optional nullable fields, return null (not undefined) when API returns null. See #5670 }}
-        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}{{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Set(json['{{baseName}}']),
+        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] === undefined ? undefined : json['{{baseName}}'] === null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}{{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Set(json['{{baseName}}']),
         {{/uniqueItems}}
         {{^uniqueItems}}
-        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}{{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}json['{{baseName}}'],
+        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] === undefined ? undefined : json['{{baseName}}'] === null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}{{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}json['{{baseName}}'],
         {{/uniqueItems}}
         {{/isArray}}
         {{^isArray}}
         {{#isDateType}}
-        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Date(json['{{baseName}}'])),
+        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] === undefined ? undefined : json['{{baseName}}'] === null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Date(json['{{baseName}}'])),
         {{/isDateType}}
         {{#isDateTimeType}}
-        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Date(json['{{baseName}}'])),
+        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] === undefined ? undefined : json['{{baseName}}'] === null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Date(json['{{baseName}}'])),
         {{/isDateTimeType}}
         {{^isDateType}}
         {{^isDateTimeType}}
-        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}json['{{baseName}}'],
+        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] === undefined ? undefined : json['{{baseName}}'] === null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}json['{{baseName}}'],
         {{/isDateTimeType}}
         {{/isDateType}}
         {{/isArray}}
@@ -111,22 +111,22 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
         {{^isPrimitiveType}}
         {{#isArray}}
         {{#uniqueItems}}
-        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Set((json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON))),
+        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] === undefined ? undefined : json['{{baseName}}'] === null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Set((json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON))),
         {{/uniqueItems}}
         {{^uniqueItems}}
-        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}(json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON)),
+        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] === undefined ? undefined : json['{{baseName}}'] === null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}(json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON)),
         {{/uniqueItems}}
         {{/isArray}}
         {{#isMap}}
-        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}mapValues(json['{{baseName}}'], {{#items}}{{datatype}}{{/items}}FromJSON)),
+        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] === undefined ? undefined : json['{{baseName}}'] === null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}mapValues(json['{{baseName}}'], {{#items}}{{datatype}}{{/items}}FromJSON)),
         {{/isMap}}
         {{^isArray}}
         {{^isMap}}
         {{^isFreeFormObject}}
-        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}{{datatype}}FromJSON(json['{{baseName}}']),
+        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] === undefined ? undefined : json['{{baseName}}'] === null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}{{datatype}}FromJSON(json['{{baseName}}']),
         {{/isFreeFormObject}}
         {{#isFreeFormObject}}
-        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}json['{{baseName}}'],
+        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] === undefined ? undefined : json['{{baseName}}'] === null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}json['{{baseName}}'],
         {{/isFreeFormObject}}
         {{/isMap}}
         {{/isArray}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -87,22 +87,23 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
         {{#isPrimitiveType}}
         {{#isArray}}
         {{#uniqueItems}}
-        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}{{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Set(json['{{baseName}}']),
+        {{! For optional nullable fields, return null (not undefined) when API returns null. See #5670 }}
+        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}{{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Set(json['{{baseName}}']),
         {{/uniqueItems}}
         {{^uniqueItems}}
-        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}{{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}json['{{baseName}}'],
+        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}{{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}json['{{baseName}}'],
         {{/uniqueItems}}
         {{/isArray}}
         {{^isArray}}
         {{#isDateType}}
-        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Date(json['{{baseName}}'])),
+        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Date(json['{{baseName}}'])),
         {{/isDateType}}
         {{#isDateTimeType}}
-        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Date(json['{{baseName}}'])),
+        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Date(json['{{baseName}}'])),
         {{/isDateTimeType}}
         {{^isDateType}}
         {{^isDateTimeType}}
-        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}json['{{baseName}}'],
+        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}json['{{baseName}}'],
         {{/isDateTimeType}}
         {{/isDateType}}
         {{/isArray}}
@@ -110,22 +111,22 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
         {{^isPrimitiveType}}
         {{#isArray}}
         {{#uniqueItems}}
-        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Set((json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON))),
+        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Set((json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON))),
         {{/uniqueItems}}
         {{^uniqueItems}}
-        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}(json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON)),
+        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}(json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON)),
         {{/uniqueItems}}
         {{/isArray}}
         {{#isMap}}
-        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}mapValues(json['{{baseName}}'], {{#items}}{{datatype}}{{/items}}FromJSON)),
+        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}mapValues(json['{{baseName}}'], {{#items}}{{datatype}}{{/items}}FromJSON)),
         {{/isMap}}
         {{^isArray}}
         {{^isMap}}
         {{^isFreeFormObject}}
-        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}{{datatype}}FromJSON(json['{{baseName}}']),
+        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}{{datatype}}FromJSON(json['{{baseName}}']),
         {{/isFreeFormObject}}
         {{#isFreeFormObject}}
-        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}json['{{baseName}}'],
+        '{{name}}': {{^required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{^isNullable}}json['{{baseName}}'] == null ? undefined : {{/isNullable}}{{/required}}json['{{baseName}}'],
         {{/isFreeFormObject}}
         {{/isMap}}
         {{/isArray}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -662,9 +662,9 @@ public class TypeScriptFetchClientCodegenTest {
 
         Path modelPath = Paths.get(output + "/models/TestSchema.ts");
         // Optional nullable field: when API returns null, FromJSON should produce null not undefined
-        TestUtils.assertFileContains(modelPath, "json['nullable_property'] == null ? null :");
+        TestUtils.assertFileContains(modelPath, "json['nullable_property'] === undefined ? undefined : json['nullable_property'] === null ? null :");
         // Required non-nullable field: still uses undefined path
-        TestUtils.assertFileNotContains(modelPath, "json['required_property'] == null ? null :");
+        TestUtils.assertFileNotContains(modelPath, "json['required_property'] === undefined ? undefined : json['required_property'] === null ? null :");
     }
 
     private static File generate(

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -653,6 +653,20 @@ public class TypeScriptFetchClientCodegenTest {
         TestUtils.assertFileContains(outerPlain, "export interface OuterPlain {");
     }
 
+    @Test(description = "Optional nullable fields should deserialize to null, not undefined (fix #5670)")
+    public void testOptionalNullableFieldDeserializesToNull() throws Exception {
+        File output = generate(
+            Collections.emptyMap(),
+            "src/test/resources/3_0/typescript-fetch/nullable_property.json"
+        );
+
+        Path modelPath = Paths.get(output + "/models/TestSchema.ts");
+        // Optional nullable field: when API returns null, FromJSON should produce null not undefined
+        TestUtils.assertFileContains(modelPath, "json['nullable_property'] == null ? null :");
+        // Required non-nullable field: still uses undefined path
+        TestUtils.assertFileNotContains(modelPath, "json['required_property'] == null ? null :");
+    }
+
     private static File generate(
         Map<String, Object> properties
     ) throws IOException {

--- a/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/nullable_property.json
+++ b/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/nullable_property.json
@@ -1,0 +1,30 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Optional Nullable Property Test",
+    "version": "1.0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "TestSchema": {
+        "title": "TestSchema",
+        "required": [
+          "required_property"
+        ],
+        "type": "object",
+        "properties": {
+          "required_property": {
+            "title": "Required property",
+            "type": "string"
+          },
+          "nullable_property": {
+            "title": "Optional Nullable property",
+            "type": "string",
+            "nullable": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Club.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Club.ts
@@ -52,7 +52,7 @@ export function ClubFromJSONTyped(json: any, ignoreDiscriminator: boolean): Club
     }
     return {
         
-        'owner': json['owner'] == null ? undefined : OwnerFromJSON(json['owner']),
+        'owner': json['owner'] == null ? null : OwnerFromJSON(json['owner']),
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Club.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Club.ts
@@ -52,7 +52,7 @@ export function ClubFromJSONTyped(json: any, ignoreDiscriminator: boolean): Club
     }
     return {
         
-        'owner': json['owner'] == null ? null : OwnerFromJSON(json['owner']),
+        'owner': json['owner'] === undefined ? undefined : json['owner'] === null ? null : OwnerFromJSON(json['owner']),
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
@@ -160,7 +160,7 @@ export function EnumTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         'enumStringRequired': json['enum_string_required'],
         'enumInteger': json['enum_integer'] == null ? undefined : json['enum_integer'],
         'enumNumber': json['enum_number'] == null ? undefined : json['enum_number'],
-        'outerEnum': json['outerEnum'] == null ? undefined : OuterEnumFromJSON(json['outerEnum']),
+        'outerEnum': json['outerEnum'] == null ? null : OuterEnumFromJSON(json['outerEnum']),
         'outerEnumInteger': json['outerEnumInteger'] == null ? undefined : OuterEnumIntegerFromJSON(json['outerEnumInteger']),
         'outerEnumDefaultValue': json['outerEnumDefaultValue'] == null ? undefined : OuterEnumDefaultValueFromJSON(json['outerEnumDefaultValue']),
         'outerEnumIntegerDefaultValue': json['outerEnumIntegerDefaultValue'] == null ? undefined : OuterEnumIntegerDefaultValueFromJSON(json['outerEnumIntegerDefaultValue']),

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
@@ -160,7 +160,7 @@ export function EnumTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         'enumStringRequired': json['enum_string_required'],
         'enumInteger': json['enum_integer'] == null ? undefined : json['enum_integer'],
         'enumNumber': json['enum_number'] == null ? undefined : json['enum_number'],
-        'outerEnum': json['outerEnum'] == null ? null : OuterEnumFromJSON(json['outerEnum']),
+        'outerEnum': json['outerEnum'] === undefined ? undefined : json['outerEnum'] === null ? null : OuterEnumFromJSON(json['outerEnum']),
         'outerEnumInteger': json['outerEnumInteger'] == null ? undefined : OuterEnumIntegerFromJSON(json['outerEnumInteger']),
         'outerEnumDefaultValue': json['outerEnumDefaultValue'] == null ? undefined : OuterEnumDefaultValueFromJSON(json['outerEnumDefaultValue']),
         'outerEnumIntegerDefaultValue': json['outerEnumIntegerDefaultValue'] == null ? undefined : OuterEnumIntegerDefaultValueFromJSON(json['outerEnumIntegerDefaultValue']),

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HealthCheckResult.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HealthCheckResult.ts
@@ -44,7 +44,7 @@ export function HealthCheckResultFromJSONTyped(json: any, ignoreDiscriminator: b
     }
     return {
         
-        'nullableMessage': json['NullableMessage'] == null ? null : json['NullableMessage'],
+        'nullableMessage': json['NullableMessage'] === undefined ? undefined : json['NullableMessage'] === null ? null : json['NullableMessage'],
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HealthCheckResult.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HealthCheckResult.ts
@@ -44,7 +44,7 @@ export function HealthCheckResultFromJSONTyped(json: any, ignoreDiscriminator: b
     }
     return {
         
-        'nullableMessage': json['NullableMessage'] == null ? undefined : json['NullableMessage'],
+        'nullableMessage': json['NullableMessage'] == null ? null : json['NullableMessage'],
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
@@ -112,17 +112,17 @@ export function NullableClassFromJSONTyped(json: any, ignoreDiscriminator: boole
     return {
         
             ...json,
-        'integerProp': json['integer_prop'] == null ? null : json['integer_prop'],
-        'numberProp': json['number_prop'] == null ? null : json['number_prop'],
-        'booleanProp': json['boolean_prop'] == null ? null : json['boolean_prop'],
-        'stringProp': json['string_prop'] == null ? null : json['string_prop'],
-        'dateProp': json['date_prop'] == null ? null : (new Date(json['date_prop'])),
-        'datetimeProp': json['datetime_prop'] == null ? null : (new Date(json['datetime_prop'])),
-        'arrayNullableProp': json['array_nullable_prop'] == null ? null : json['array_nullable_prop'],
-        'arrayAndItemsNullableProp': json['array_and_items_nullable_prop'] == null ? null : json['array_and_items_nullable_prop'],
+        'integerProp': json['integer_prop'] === undefined ? undefined : json['integer_prop'] === null ? null : json['integer_prop'],
+        'numberProp': json['number_prop'] === undefined ? undefined : json['number_prop'] === null ? null : json['number_prop'],
+        'booleanProp': json['boolean_prop'] === undefined ? undefined : json['boolean_prop'] === null ? null : json['boolean_prop'],
+        'stringProp': json['string_prop'] === undefined ? undefined : json['string_prop'] === null ? null : json['string_prop'],
+        'dateProp': json['date_prop'] === undefined ? undefined : json['date_prop'] === null ? null : (new Date(json['date_prop'])),
+        'datetimeProp': json['datetime_prop'] === undefined ? undefined : json['datetime_prop'] === null ? null : (new Date(json['datetime_prop'])),
+        'arrayNullableProp': json['array_nullable_prop'] === undefined ? undefined : json['array_nullable_prop'] === null ? null : json['array_nullable_prop'],
+        'arrayAndItemsNullableProp': json['array_and_items_nullable_prop'] === undefined ? undefined : json['array_and_items_nullable_prop'] === null ? null : json['array_and_items_nullable_prop'],
         'arrayItemsNullable': json['array_items_nullable'] == null ? undefined : json['array_items_nullable'],
-        'objectNullableProp': json['object_nullable_prop'] == null ? null : json['object_nullable_prop'],
-        'objectAndItemsNullableProp': json['object_and_items_nullable_prop'] == null ? null : json['object_and_items_nullable_prop'],
+        'objectNullableProp': json['object_nullable_prop'] === undefined ? undefined : json['object_nullable_prop'] === null ? null : json['object_nullable_prop'],
+        'objectAndItemsNullableProp': json['object_and_items_nullable_prop'] === undefined ? undefined : json['object_and_items_nullable_prop'] === null ? null : json['object_and_items_nullable_prop'],
         'objectItemsNullable': json['object_items_nullable'] == null ? undefined : json['object_items_nullable'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
@@ -112,17 +112,17 @@ export function NullableClassFromJSONTyped(json: any, ignoreDiscriminator: boole
     return {
         
             ...json,
-        'integerProp': json['integer_prop'] == null ? undefined : json['integer_prop'],
-        'numberProp': json['number_prop'] == null ? undefined : json['number_prop'],
-        'booleanProp': json['boolean_prop'] == null ? undefined : json['boolean_prop'],
-        'stringProp': json['string_prop'] == null ? undefined : json['string_prop'],
-        'dateProp': json['date_prop'] == null ? undefined : (new Date(json['date_prop'])),
-        'datetimeProp': json['datetime_prop'] == null ? undefined : (new Date(json['datetime_prop'])),
-        'arrayNullableProp': json['array_nullable_prop'] == null ? undefined : json['array_nullable_prop'],
-        'arrayAndItemsNullableProp': json['array_and_items_nullable_prop'] == null ? undefined : json['array_and_items_nullable_prop'],
+        'integerProp': json['integer_prop'] == null ? null : json['integer_prop'],
+        'numberProp': json['number_prop'] == null ? null : json['number_prop'],
+        'booleanProp': json['boolean_prop'] == null ? null : json['boolean_prop'],
+        'stringProp': json['string_prop'] == null ? null : json['string_prop'],
+        'dateProp': json['date_prop'] == null ? null : (new Date(json['date_prop'])),
+        'datetimeProp': json['datetime_prop'] == null ? null : (new Date(json['datetime_prop'])),
+        'arrayNullableProp': json['array_nullable_prop'] == null ? null : json['array_nullable_prop'],
+        'arrayAndItemsNullableProp': json['array_and_items_nullable_prop'] == null ? null : json['array_and_items_nullable_prop'],
         'arrayItemsNullable': json['array_items_nullable'] == null ? undefined : json['array_items_nullable'],
-        'objectNullableProp': json['object_nullable_prop'] == null ? undefined : json['object_nullable_prop'],
-        'objectAndItemsNullableProp': json['object_and_items_nullable_prop'] == null ? undefined : json['object_and_items_nullable_prop'],
+        'objectNullableProp': json['object_nullable_prop'] == null ? null : json['object_nullable_prop'],
+        'objectAndItemsNullableProp': json['object_and_items_nullable_prop'] == null ? null : json['object_and_items_nullable_prop'],
         'objectItemsNullable': json['object_items_nullable'] == null ? undefined : json['object_items_nullable'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
@@ -68,7 +68,7 @@ export function ParentWithNullableFromJSONTyped(json: any, ignoreDiscriminator: 
     return {
         
         'type': json['type'] == null ? undefined : json['type'],
-        'nullableProperty': json['nullableProperty'] == null ? null : json['nullableProperty'],
+        'nullableProperty': json['nullableProperty'] === undefined ? undefined : json['nullableProperty'] === null ? null : json['nullableProperty'],
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
@@ -68,7 +68,7 @@ export function ParentWithNullableFromJSONTyped(json: any, ignoreDiscriminator: 
     return {
         
         'type': json['type'] == null ? undefined : json['type'],
-        'nullableProperty': json['nullableProperty'] == null ? undefined : json['nullableProperty'],
+        'nullableProperty': json['nullableProperty'] == null ? null : json['nullableProperty'],
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
@@ -80,9 +80,9 @@ export function EnumPatternObjectFromJSONTyped(json: any, ignoreDiscriminator: b
     return {
         
         'stringEnum': json['string-enum'] == null ? undefined : StringEnumFromJSON(json['string-enum']),
-        'nullableStringEnum': json['nullable-string-enum'] == null ? undefined : StringEnumFromJSON(json['nullable-string-enum']),
+        'nullableStringEnum': json['nullable-string-enum'] == null ? null : StringEnumFromJSON(json['nullable-string-enum']),
         'numberEnum': json['number-enum'] == null ? undefined : NumberEnumFromJSON(json['number-enum']),
-        'nullableNumberEnum': json['nullable-number-enum'] == null ? undefined : NumberEnumFromJSON(json['nullable-number-enum']),
+        'nullableNumberEnum': json['nullable-number-enum'] == null ? null : NumberEnumFromJSON(json['nullable-number-enum']),
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
@@ -80,9 +80,9 @@ export function EnumPatternObjectFromJSONTyped(json: any, ignoreDiscriminator: b
     return {
         
         'stringEnum': json['string-enum'] == null ? undefined : StringEnumFromJSON(json['string-enum']),
-        'nullableStringEnum': json['nullable-string-enum'] == null ? null : StringEnumFromJSON(json['nullable-string-enum']),
+        'nullableStringEnum': json['nullable-string-enum'] === undefined ? undefined : json['nullable-string-enum'] === null ? null : StringEnumFromJSON(json['nullable-string-enum']),
         'numberEnum': json['number-enum'] == null ? undefined : NumberEnumFromJSON(json['number-enum']),
-        'nullableNumberEnum': json['nullable-number-enum'] == null ? null : NumberEnumFromJSON(json['nullable-number-enum']),
+        'nullableNumberEnum': json['nullable-number-enum'] === undefined ? undefined : json['nullable-number-enum'] === null ? null : NumberEnumFromJSON(json['nullable-number-enum']),
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/enum-test.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/enum-test.ts
@@ -160,7 +160,7 @@ export function EnumTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         'enumStringRequired': json['enum_string_required'],
         'enumInteger': json['enum_integer'] == null ? undefined : json['enum_integer'],
         'enumNumber': json['enum_number'] == null ? undefined : json['enum_number'],
-        'outerEnum': json['outerEnum'] == null ? undefined : OuterEnumFromJSON(json['outerEnum']),
+        'outerEnum': json['outerEnum'] == null ? null : OuterEnumFromJSON(json['outerEnum']),
         'outerEnumInteger': json['outerEnumInteger'] == null ? undefined : OuterEnumIntegerFromJSON(json['outerEnumInteger']),
         'outerEnumDefaultValue': json['outerEnumDefaultValue'] == null ? undefined : OuterEnumDefaultValueFromJSON(json['outerEnumDefaultValue']),
         'outerEnumIntegerDefaultValue': json['outerEnumIntegerDefaultValue'] == null ? undefined : OuterEnumIntegerDefaultValueFromJSON(json['outerEnumIntegerDefaultValue']),

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/enum-test.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/enum-test.ts
@@ -160,7 +160,7 @@ export function EnumTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         'enumStringRequired': json['enum_string_required'],
         'enumInteger': json['enum_integer'] == null ? undefined : json['enum_integer'],
         'enumNumber': json['enum_number'] == null ? undefined : json['enum_number'],
-        'outerEnum': json['outerEnum'] == null ? null : OuterEnumFromJSON(json['outerEnum']),
+        'outerEnum': json['outerEnum'] === undefined ? undefined : json['outerEnum'] === null ? null : OuterEnumFromJSON(json['outerEnum']),
         'outerEnumInteger': json['outerEnumInteger'] == null ? undefined : OuterEnumIntegerFromJSON(json['outerEnumInteger']),
         'outerEnumDefaultValue': json['outerEnumDefaultValue'] == null ? undefined : OuterEnumDefaultValueFromJSON(json['outerEnumDefaultValue']),
         'outerEnumIntegerDefaultValue': json['outerEnumIntegerDefaultValue'] == null ? undefined : OuterEnumIntegerDefaultValueFromJSON(json['outerEnumIntegerDefaultValue']),

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/health-check-result.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/health-check-result.ts
@@ -44,7 +44,7 @@ export function HealthCheckResultFromJSONTyped(json: any, ignoreDiscriminator: b
     }
     return {
         
-        'nullableMessage': json['NullableMessage'] == null ? null : json['NullableMessage'],
+        'nullableMessage': json['NullableMessage'] === undefined ? undefined : json['NullableMessage'] === null ? null : json['NullableMessage'],
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/health-check-result.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/health-check-result.ts
@@ -44,7 +44,7 @@ export function HealthCheckResultFromJSONTyped(json: any, ignoreDiscriminator: b
     }
     return {
         
-        'nullableMessage': json['NullableMessage'] == null ? undefined : json['NullableMessage'],
+        'nullableMessage': json['NullableMessage'] == null ? null : json['NullableMessage'],
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/nullable-class.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/nullable-class.ts
@@ -112,17 +112,17 @@ export function NullableClassFromJSONTyped(json: any, ignoreDiscriminator: boole
     return {
         
             ...json,
-        'integerProp': json['integer_prop'] == null ? null : json['integer_prop'],
-        'numberProp': json['number_prop'] == null ? null : json['number_prop'],
-        'booleanProp': json['boolean_prop'] == null ? null : json['boolean_prop'],
-        'stringProp': json['string_prop'] == null ? null : json['string_prop'],
-        'dateProp': json['date_prop'] == null ? null : (new Date(json['date_prop'])),
-        'datetimeProp': json['datetime_prop'] == null ? null : (new Date(json['datetime_prop'])),
-        'arrayNullableProp': json['array_nullable_prop'] == null ? null : json['array_nullable_prop'],
-        'arrayAndItemsNullableProp': json['array_and_items_nullable_prop'] == null ? null : json['array_and_items_nullable_prop'],
+        'integerProp': json['integer_prop'] === undefined ? undefined : json['integer_prop'] === null ? null : json['integer_prop'],
+        'numberProp': json['number_prop'] === undefined ? undefined : json['number_prop'] === null ? null : json['number_prop'],
+        'booleanProp': json['boolean_prop'] === undefined ? undefined : json['boolean_prop'] === null ? null : json['boolean_prop'],
+        'stringProp': json['string_prop'] === undefined ? undefined : json['string_prop'] === null ? null : json['string_prop'],
+        'dateProp': json['date_prop'] === undefined ? undefined : json['date_prop'] === null ? null : (new Date(json['date_prop'])),
+        'datetimeProp': json['datetime_prop'] === undefined ? undefined : json['datetime_prop'] === null ? null : (new Date(json['datetime_prop'])),
+        'arrayNullableProp': json['array_nullable_prop'] === undefined ? undefined : json['array_nullable_prop'] === null ? null : json['array_nullable_prop'],
+        'arrayAndItemsNullableProp': json['array_and_items_nullable_prop'] === undefined ? undefined : json['array_and_items_nullable_prop'] === null ? null : json['array_and_items_nullable_prop'],
         'arrayItemsNullable': json['array_items_nullable'] == null ? undefined : json['array_items_nullable'],
-        'objectNullableProp': json['object_nullable_prop'] == null ? null : json['object_nullable_prop'],
-        'objectAndItemsNullableProp': json['object_and_items_nullable_prop'] == null ? null : json['object_and_items_nullable_prop'],
+        'objectNullableProp': json['object_nullable_prop'] === undefined ? undefined : json['object_nullable_prop'] === null ? null : json['object_nullable_prop'],
+        'objectAndItemsNullableProp': json['object_and_items_nullable_prop'] === undefined ? undefined : json['object_and_items_nullable_prop'] === null ? null : json['object_and_items_nullable_prop'],
         'objectItemsNullable': json['object_items_nullable'] == null ? undefined : json['object_items_nullable'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/nullable-class.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/nullable-class.ts
@@ -112,17 +112,17 @@ export function NullableClassFromJSONTyped(json: any, ignoreDiscriminator: boole
     return {
         
             ...json,
-        'integerProp': json['integer_prop'] == null ? undefined : json['integer_prop'],
-        'numberProp': json['number_prop'] == null ? undefined : json['number_prop'],
-        'booleanProp': json['boolean_prop'] == null ? undefined : json['boolean_prop'],
-        'stringProp': json['string_prop'] == null ? undefined : json['string_prop'],
-        'dateProp': json['date_prop'] == null ? undefined : (new Date(json['date_prop'])),
-        'datetimeProp': json['datetime_prop'] == null ? undefined : (new Date(json['datetime_prop'])),
-        'arrayNullableProp': json['array_nullable_prop'] == null ? undefined : json['array_nullable_prop'],
-        'arrayAndItemsNullableProp': json['array_and_items_nullable_prop'] == null ? undefined : json['array_and_items_nullable_prop'],
+        'integerProp': json['integer_prop'] == null ? null : json['integer_prop'],
+        'numberProp': json['number_prop'] == null ? null : json['number_prop'],
+        'booleanProp': json['boolean_prop'] == null ? null : json['boolean_prop'],
+        'stringProp': json['string_prop'] == null ? null : json['string_prop'],
+        'dateProp': json['date_prop'] == null ? null : (new Date(json['date_prop'])),
+        'datetimeProp': json['datetime_prop'] == null ? null : (new Date(json['datetime_prop'])),
+        'arrayNullableProp': json['array_nullable_prop'] == null ? null : json['array_nullable_prop'],
+        'arrayAndItemsNullableProp': json['array_and_items_nullable_prop'] == null ? null : json['array_and_items_nullable_prop'],
         'arrayItemsNullable': json['array_items_nullable'] == null ? undefined : json['array_items_nullable'],
-        'objectNullableProp': json['object_nullable_prop'] == null ? undefined : json['object_nullable_prop'],
-        'objectAndItemsNullableProp': json['object_and_items_nullable_prop'] == null ? undefined : json['object_and_items_nullable_prop'],
+        'objectNullableProp': json['object_nullable_prop'] == null ? null : json['object_nullable_prop'],
+        'objectAndItemsNullableProp': json['object_and_items_nullable_prop'] == null ? null : json['object_and_items_nullable_prop'],
         'objectItemsNullable': json['object_items_nullable'] == null ? undefined : json['object_items_nullable'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/parent-with-nullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/parent-with-nullable.ts
@@ -68,7 +68,7 @@ export function ParentWithNullableFromJSONTyped(json: any, ignoreDiscriminator: 
     return {
         
         'type': json['type'] == null ? undefined : json['type'],
-        'nullableProperty': json['nullableProperty'] == null ? null : json['nullableProperty'],
+        'nullableProperty': json['nullableProperty'] === undefined ? undefined : json['nullableProperty'] === null ? null : json['nullableProperty'],
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/parent-with-nullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/parent-with-nullable.ts
@@ -68,7 +68,7 @@ export function ParentWithNullableFromJSONTyped(json: any, ignoreDiscriminator: 
     return {
         
         'type': json['type'] == null ? undefined : json['type'],
-        'nullableProperty': json['nullableProperty'] == null ? undefined : json['nullableProperty'],
+        'nullableProperty': json['nullableProperty'] == null ? null : json['nullableProperty'],
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
@@ -160,7 +160,7 @@ export function EnumTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         'enumStringRequired': json['enum_string_required'],
         'enumInteger': json['enum_integer'] == null ? undefined : json['enum_integer'],
         'enumNumber': json['enum_number'] == null ? undefined : json['enum_number'],
-        'outerEnum': json['outerEnum'] == null ? undefined : OuterEnumFromJSON(json['outerEnum']),
+        'outerEnum': json['outerEnum'] == null ? null : OuterEnumFromJSON(json['outerEnum']),
         'outerEnumInteger': json['outerEnumInteger'] == null ? undefined : OuterEnumIntegerFromJSON(json['outerEnumInteger']),
         'outerEnumDefaultValue': json['outerEnumDefaultValue'] == null ? undefined : OuterEnumDefaultValueFromJSON(json['outerEnumDefaultValue']),
         'outerEnumIntegerDefaultValue': json['outerEnumIntegerDefaultValue'] == null ? undefined : OuterEnumIntegerDefaultValueFromJSON(json['outerEnumIntegerDefaultValue']),

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
@@ -160,7 +160,7 @@ export function EnumTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         'enumStringRequired': json['enum_string_required'],
         'enumInteger': json['enum_integer'] == null ? undefined : json['enum_integer'],
         'enumNumber': json['enum_number'] == null ? undefined : json['enum_number'],
-        'outerEnum': json['outerEnum'] == null ? null : OuterEnumFromJSON(json['outerEnum']),
+        'outerEnum': json['outerEnum'] === undefined ? undefined : json['outerEnum'] === null ? null : OuterEnumFromJSON(json['outerEnum']),
         'outerEnumInteger': json['outerEnumInteger'] == null ? undefined : OuterEnumIntegerFromJSON(json['outerEnumInteger']),
         'outerEnumDefaultValue': json['outerEnumDefaultValue'] == null ? undefined : OuterEnumDefaultValueFromJSON(json['outerEnumDefaultValue']),
         'outerEnumIntegerDefaultValue': json['outerEnumIntegerDefaultValue'] == null ? undefined : OuterEnumIntegerDefaultValueFromJSON(json['outerEnumIntegerDefaultValue']),

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HealthCheckResult.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HealthCheckResult.ts
@@ -44,7 +44,7 @@ export function HealthCheckResultFromJSONTyped(json: any, ignoreDiscriminator: b
     }
     return {
         
-        'nullableMessage': json['NullableMessage'] == null ? null : json['NullableMessage'],
+        'nullableMessage': json['NullableMessage'] === undefined ? undefined : json['NullableMessage'] === null ? null : json['NullableMessage'],
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HealthCheckResult.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HealthCheckResult.ts
@@ -44,7 +44,7 @@ export function HealthCheckResultFromJSONTyped(json: any, ignoreDiscriminator: b
     }
     return {
         
-        'nullableMessage': json['NullableMessage'] == null ? undefined : json['NullableMessage'],
+        'nullableMessage': json['NullableMessage'] == null ? null : json['NullableMessage'],
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
@@ -112,17 +112,17 @@ export function NullableClassFromJSONTyped(json: any, ignoreDiscriminator: boole
     return {
         
             ...json,
-        'integerProp': json['integer_prop'] == null ? null : json['integer_prop'],
-        'numberProp': json['number_prop'] == null ? null : json['number_prop'],
-        'booleanProp': json['boolean_prop'] == null ? null : json['boolean_prop'],
-        'stringProp': json['string_prop'] == null ? null : json['string_prop'],
-        'dateProp': json['date_prop'] == null ? null : (new Date(json['date_prop'])),
-        'datetimeProp': json['datetime_prop'] == null ? null : (new Date(json['datetime_prop'])),
-        'arrayNullableProp': json['array_nullable_prop'] == null ? null : json['array_nullable_prop'],
-        'arrayAndItemsNullableProp': json['array_and_items_nullable_prop'] == null ? null : json['array_and_items_nullable_prop'],
+        'integerProp': json['integer_prop'] === undefined ? undefined : json['integer_prop'] === null ? null : json['integer_prop'],
+        'numberProp': json['number_prop'] === undefined ? undefined : json['number_prop'] === null ? null : json['number_prop'],
+        'booleanProp': json['boolean_prop'] === undefined ? undefined : json['boolean_prop'] === null ? null : json['boolean_prop'],
+        'stringProp': json['string_prop'] === undefined ? undefined : json['string_prop'] === null ? null : json['string_prop'],
+        'dateProp': json['date_prop'] === undefined ? undefined : json['date_prop'] === null ? null : (new Date(json['date_prop'])),
+        'datetimeProp': json['datetime_prop'] === undefined ? undefined : json['datetime_prop'] === null ? null : (new Date(json['datetime_prop'])),
+        'arrayNullableProp': json['array_nullable_prop'] === undefined ? undefined : json['array_nullable_prop'] === null ? null : json['array_nullable_prop'],
+        'arrayAndItemsNullableProp': json['array_and_items_nullable_prop'] === undefined ? undefined : json['array_and_items_nullable_prop'] === null ? null : json['array_and_items_nullable_prop'],
         'arrayItemsNullable': json['array_items_nullable'] == null ? undefined : json['array_items_nullable'],
-        'objectNullableProp': json['object_nullable_prop'] == null ? null : json['object_nullable_prop'],
-        'objectAndItemsNullableProp': json['object_and_items_nullable_prop'] == null ? null : json['object_and_items_nullable_prop'],
+        'objectNullableProp': json['object_nullable_prop'] === undefined ? undefined : json['object_nullable_prop'] === null ? null : json['object_nullable_prop'],
+        'objectAndItemsNullableProp': json['object_and_items_nullable_prop'] === undefined ? undefined : json['object_and_items_nullable_prop'] === null ? null : json['object_and_items_nullable_prop'],
         'objectItemsNullable': json['object_items_nullable'] == null ? undefined : json['object_items_nullable'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
@@ -112,17 +112,17 @@ export function NullableClassFromJSONTyped(json: any, ignoreDiscriminator: boole
     return {
         
             ...json,
-        'integerProp': json['integer_prop'] == null ? undefined : json['integer_prop'],
-        'numberProp': json['number_prop'] == null ? undefined : json['number_prop'],
-        'booleanProp': json['boolean_prop'] == null ? undefined : json['boolean_prop'],
-        'stringProp': json['string_prop'] == null ? undefined : json['string_prop'],
-        'dateProp': json['date_prop'] == null ? undefined : (new Date(json['date_prop'])),
-        'datetimeProp': json['datetime_prop'] == null ? undefined : (new Date(json['datetime_prop'])),
-        'arrayNullableProp': json['array_nullable_prop'] == null ? undefined : json['array_nullable_prop'],
-        'arrayAndItemsNullableProp': json['array_and_items_nullable_prop'] == null ? undefined : json['array_and_items_nullable_prop'],
+        'integerProp': json['integer_prop'] == null ? null : json['integer_prop'],
+        'numberProp': json['number_prop'] == null ? null : json['number_prop'],
+        'booleanProp': json['boolean_prop'] == null ? null : json['boolean_prop'],
+        'stringProp': json['string_prop'] == null ? null : json['string_prop'],
+        'dateProp': json['date_prop'] == null ? null : (new Date(json['date_prop'])),
+        'datetimeProp': json['datetime_prop'] == null ? null : (new Date(json['datetime_prop'])),
+        'arrayNullableProp': json['array_nullable_prop'] == null ? null : json['array_nullable_prop'],
+        'arrayAndItemsNullableProp': json['array_and_items_nullable_prop'] == null ? null : json['array_and_items_nullable_prop'],
         'arrayItemsNullable': json['array_items_nullable'] == null ? undefined : json['array_items_nullable'],
-        'objectNullableProp': json['object_nullable_prop'] == null ? undefined : json['object_nullable_prop'],
-        'objectAndItemsNullableProp': json['object_and_items_nullable_prop'] == null ? undefined : json['object_and_items_nullable_prop'],
+        'objectNullableProp': json['object_nullable_prop'] == null ? null : json['object_nullable_prop'],
+        'objectAndItemsNullableProp': json['object_and_items_nullable_prop'] == null ? null : json['object_and_items_nullable_prop'],
         'objectItemsNullable': json['object_items_nullable'] == null ? undefined : json['object_items_nullable'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
@@ -80,9 +80,9 @@ export function EnumPatternObjectFromJSONTyped(json: any, ignoreDiscriminator: b
     return {
         
         'stringEnum': json['string-enum'] == null ? undefined : StringEnumFromJSON(json['string-enum']),
-        'nullableStringEnum': json['nullable-string-enum'] == null ? undefined : StringEnumFromJSON(json['nullable-string-enum']),
+        'nullableStringEnum': json['nullable-string-enum'] == null ? null : StringEnumFromJSON(json['nullable-string-enum']),
         'numberEnum': json['number-enum'] == null ? undefined : NumberEnumFromJSON(json['number-enum']),
-        'nullableNumberEnum': json['nullable-number-enum'] == null ? undefined : NumberEnumFromJSON(json['nullable-number-enum']),
+        'nullableNumberEnum': json['nullable-number-enum'] == null ? null : NumberEnumFromJSON(json['nullable-number-enum']),
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
@@ -80,9 +80,9 @@ export function EnumPatternObjectFromJSONTyped(json: any, ignoreDiscriminator: b
     return {
         
         'stringEnum': json['string-enum'] == null ? undefined : StringEnumFromJSON(json['string-enum']),
-        'nullableStringEnum': json['nullable-string-enum'] == null ? null : StringEnumFromJSON(json['nullable-string-enum']),
+        'nullableStringEnum': json['nullable-string-enum'] === undefined ? undefined : json['nullable-string-enum'] === null ? null : StringEnumFromJSON(json['nullable-string-enum']),
         'numberEnum': json['number-enum'] == null ? undefined : NumberEnumFromJSON(json['number-enum']),
-        'nullableNumberEnum': json['nullable-number-enum'] == null ? null : NumberEnumFromJSON(json['nullable-number-enum']),
+        'nullableNumberEnum': json['nullable-number-enum'] === undefined ? undefined : json['nullable-number-enum'] === null ? null : NumberEnumFromJSON(json['nullable-number-enum']),
     };
 }
 

--- a/samples/server/petstore/jaxrs-spec-enum/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-enum/pom.xml
@@ -38,8 +38,12 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -91,8 +95,8 @@
         <version>3.0.2</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -135,7 +139,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jackson-version>2.19.2</jackson-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <joda-version>2.10.13</joda-version>
     <javax.annotation-api-version>1.3.2</javax.annotation-api-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>


### PR DESCRIPTION
When an optional field is marked as nullable in the spec, FromJSONTyped now returns null (not undefined) when the API returns null. Non-nullable optional fields continue to return undefined as before.

Fixes #5670

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Regenerated typescript-fetch samples: `./bin/generate-samples.sh ./bin/configs/typescript-fetch*`
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka @joscha @dennisameling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `typescript-fetch` models return null for optional nullable fields when the API sends null, and undefined when the field is missing. Non-nullable optionals are unchanged. Fixes #5670.

- **Bug Fixes**
  - Use strict checks (`=== undefined` / `=== null`) in `modelGeneric.mustache` so `FromJSONTyped` distinguishes missing vs explicit null across primitives, dates, arrays/sets, maps, free-form objects, and object refs.
  - Added test `testOptionalNullableFieldDeserializesToNull` with `nullable_property.json`; regenerated `petstore` `typescript-fetch` samples.
  - Updated `samples/server/petstore/jaxrs-spec-enum/pom.xml` to JUnit 5 (`org.junit.jupiter`) and `maven-surefire-plugin`/`maven-failsafe-plugin` 3.5.6 for reliable test runs.

- **Migration**
  - If you relied on undefined for optional nullable fields, update checks to handle null (e.g., nullish coalescing). Missing fields still return undefined; non-nullable optional and required fields are unchanged.

<sup>Written for commit 1196727f5d8511ad9dbd07437a70596998bd115d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

