### PR TITLE
fix(typescript-fetch): add anyToJSON to runtime.ts

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -279,7 +279,7 @@ export class {{classname}} extends runtime.BaseAPI {
             {{^isEnumRef}}
             {{^withoutRuntimeChecks}}
             {{^isContainer}}
-            formParams.append('{{baseName}}', new Blob([JSON.stringify({{{dataType}}}ToJSON(requestParameters['{{paramName}}']))], { type: "application/json", }));
+            formParams.append('{{baseName}}', new Blob([JSON.stringify({{#isFreeFormObject}}runtime.anyToJSON{{/isFreeFormObject}}{{^isFreeFormObject}}{{{dataType}}}ToJSON{{/isFreeFormObject}}(requestParameters['{{paramName}}']))], { type: "application/json", }));
             {{/isContainer}}
             {{#isContainer}}
             formParams.append('{{baseName}}', new Blob([JSON.stringify(requestParameters['{{paramName}}'])], { type: "application/json", }));

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -357,6 +357,11 @@ export function mapValues(data: any, fn: (item: any) => any) {
     }
     return result;
 }
+
+// Pass-through serializer for `any`-typed properties in form data. See #1877.
+export function anyToJSON(value: any): any {
+    return value;
+}
 {{/withoutRuntimeChecks}}
 
 export function canConsumeForm(consumes: Consume[]): boolean {

--- a/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/any_type_property.json
+++ b/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/any_type_property.json
@@ -1,0 +1,39 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Any Type Property Test",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/upload": {
+      "post": {
+        "operationId": "uploadFile",
+        "tags": ["Upload"],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "file": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}

--- a/samples/client/others/typescript-fetch/additional-properties-in-multipart-issue/runtime.ts
+++ b/samples/client/others/typescript-fetch/additional-properties-in-multipart-issue/runtime.ts
@@ -367,6 +367,11 @@ export function mapValues(data: any, fn: (item: any) => any) {
     return result;
 }
 
+// Pass-through serializer for `any`-typed properties in form data. See #1877.
+export function anyToJSON(value: any): any {
+    return value;
+}
+
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
         if (consume.contentType?.startsWith('multipart/form-data') == true) {

--- a/samples/client/others/typescript-fetch/infinite-recursion-issue/runtime.ts
+++ b/samples/client/others/typescript-fetch/infinite-recursion-issue/runtime.ts
@@ -367,6 +367,11 @@ export function mapValues(data: any, fn: (item: any) => any) {
     return result;
 }
 
+// Pass-through serializer for `any`-typed properties in form data. See #1877.
+export function anyToJSON(value: any): any {
+    return value;
+}
+
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
         if (consume.contentType?.startsWith('multipart/form-data') == true) {

--- a/samples/client/others/typescript-fetch/multipart-file-array/runtime.ts
+++ b/samples/client/others/typescript-fetch/multipart-file-array/runtime.ts
@@ -367,6 +367,11 @@ export function mapValues(data: any, fn: (item: any) => any) {
     return result;
 }
 
+// Pass-through serializer for `any`-typed properties in form data. See #1877.
+export function anyToJSON(value: any): any {
+    return value;
+}
+
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
         if (consume.contentType?.startsWith('multipart/form-data') == true) {

--- a/samples/client/others/typescript-fetch/self-import-issue/runtime.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/runtime.ts
@@ -367,6 +367,11 @@ export function mapValues(data: any, fn: (item: any) => any) {
     return result;
 }
 
+// Pass-through serializer for `any`-typed properties in form data. See #1877.
+export function anyToJSON(value: any): any {
+    return value;
+}
+
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
         if (consume.contentType?.startsWith('multipart/form-data') == true) {

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/runtime.ts
@@ -367,6 +367,11 @@ export function mapValues(data: any, fn: (item: any) => any) {
     return result;
 }
 
+// Pass-through serializer for `any`-typed properties in form data. See #1877.
+export function anyToJSON(value: any): any {
+    return value;
+}
+
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
         if (consume.contentType?.startsWith('multipart/form-data') == true) {

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/runtime.ts
@@ -367,6 +367,11 @@ export function mapValues(data: any, fn: (item: any) => any) {
     return result;
 }
 
+// Pass-through serializer for `any`-typed properties in form data. See #1877.
+export function anyToJSON(value: any): any {
+    return value;
+}
+
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
         if (consume.contentType?.startsWith('multipart/form-data') == true) {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
@@ -367,6 +367,11 @@ export function mapValues(data: any, fn: (item: any) => any) {
     return result;
 }
 
+// Pass-through serializer for `any`-typed properties in form data. See #1877.
+export function anyToJSON(value: any): any {
+    return value;
+}
+
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
         if (consume.contentType?.startsWith('multipart/form-data') == true) {

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -367,6 +367,11 @@ export function mapValues(data: any, fn: (item: any) => any) {
     return result;
 }
 
+// Pass-through serializer for `any`-typed properties in form data. See #1877.
+export function anyToJSON(value: any): any {
+    return value;
+}
+
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
         if (consume.contentType?.startsWith('multipart/form-data') == true) {

--- a/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
@@ -367,6 +367,11 @@ export function mapValues(data: any, fn: (item: any) => any) {
     return result;
 }
 
+// Pass-through serializer for `any`-typed properties in form data. See #1877.
+export function anyToJSON(value: any): any {
+    return value;
+}
+
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
         if (consume.contentType?.startsWith('multipart/form-data') == true) {

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -367,6 +367,11 @@ export function mapValues(data: any, fn: (item: any) => any) {
     return result;
 }
 
+// Pass-through serializer for `any`-typed properties in form data. See #1877.
+export function anyToJSON(value: any): any {
+    return value;
+}
+
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
         if (consume.contentType?.startsWith('multipart/form-data') == true) {

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/runtime.ts
@@ -367,6 +367,11 @@ export function mapValues(data: any, fn: (item: any) => any) {
     return result;
 }
 
+// Pass-through serializer for `any`-typed properties in form data. See #1877.
+export function anyToJSON(value: any): any {
+    return value;
+}
+
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
         if (consume.contentType?.startsWith('multipart/form-data') == true) {

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -367,6 +367,11 @@ export function mapValues(data: any, fn: (item: any) => any) {
     return result;
 }
 
+// Pass-through serializer for `any`-typed properties in form data. See #1877.
+export function anyToJSON(value: any): any {
+    return value;
+}
+
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
         if (consume.contentType?.startsWith('multipart/form-data') == true) {

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/runtime.ts
@@ -367,6 +367,11 @@ export function mapValues(data: any, fn: (item: any) => any) {
     return result;
 }
 
+// Pass-through serializer for `any`-typed properties in form data. See #1877.
+export function anyToJSON(value: any): any {
+    return value;
+}
+
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
         if (consume.contentType?.startsWith('multipart/form-data') == true) {

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
@@ -367,6 +367,11 @@ export function mapValues(data: any, fn: (item: any) => any) {
     return result;
 }
 
+// Pass-through serializer for `any`-typed properties in form data. See #1877.
+export function anyToJSON(value: any): any {
+    return value;
+}
+
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
         if (consume.contentType?.startsWith('multipart/form-data') == true) {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
@@ -367,6 +367,11 @@ export function mapValues(data: any, fn: (item: any) => any) {
     return result;
 }
 
+// Pass-through serializer for `any`-typed properties in form data. See #1877.
+export function anyToJSON(value: any): any {
+    return value;
+}
+
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
         if (consume.contentType?.startsWith('multipart/form-data') == true) {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/runtime.ts
@@ -367,6 +367,11 @@ export function mapValues(data: any, fn: (item: any) => any) {
     return result;
 }
 
+// Pass-through serializer for `any`-typed properties in form data. See #1877.
+export function anyToJSON(value: any): any {
+    return value;
+}
+
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
         if (consume.contentType?.startsWith('multipart/form-data') == true) {

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/runtime.ts
@@ -367,6 +367,11 @@ export function mapValues(data: any, fn: (item: any) => any) {
     return result;
 }
 
+// Pass-through serializer for `any`-typed properties in form data. See #1877.
+export function anyToJSON(value: any): any {
+    return value;
+}
+
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
         if (consume.contentType?.startsWith('multipart/form-data') == true) {

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -367,6 +367,11 @@ export function mapValues(data: any, fn: (item: any) => any) {
     return result;
 }
 
+// Pass-through serializer for `any`-typed properties in form data. See #1877.
+export function anyToJSON(value: any): any {
+    return value;
+}
+
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
         if (consume.contentType?.startsWith('multipart/form-data') == true) {

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -367,6 +367,11 @@ export function mapValues(data: any, fn: (item: any) => any) {
     return result;
 }
 
+// Pass-through serializer for `any`-typed properties in form data. See #1877.
+export function anyToJSON(value: any): any {
+    return value;
+}
+
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
         if (consume.contentType?.startsWith('multipart/form-data') == true) {

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
@@ -367,6 +367,11 @@ export function mapValues(data: any, fn: (item: any) => any) {
     return result;
 }
 
+// Pass-through serializer for `any`-typed properties in form data. See #1877.
+export function anyToJSON(value: any): any {
+    return value;
+}
+
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {
         if (consume.contentType?.startsWith('multipart/form-data') == true) {

--- a/samples/server/petstore/jaxrs-spec-enum/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-enum/pom.xml
@@ -38,8 +38,12 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -91,8 +95,8 @@
         <version>3.0.2</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -135,7 +139,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jackson-version>2.19.2</jackson-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <joda-version>2.10.13</joda-version>
     <javax.annotation-api-version>1.3.2</javax.annotation-api-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>


### PR DESCRIPTION
The generated API code calls `anyToJSON()` for `any`-typed properties in form data (e.g. photo, file uploads), but the function was never defined in `runtime.ts`, causing a `ReferenceError` at runtime.

Fixes #1877

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Regenerated typescript-fetch samples: `./bin/generate-samples.sh ./bin/configs/typescript-fetch*`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka @joscha @dennisameling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pass-through `anyToJSON` to the `typescript-fetch` runtime and uses it for free-form object fields in multipart form data to prevent a runtime ReferenceError. Fixes #1877.

- **Bug Fixes**
  - Define `anyToJSON(value: any): any` in `runtime.ts`.
  - Update `apis.mustache` to call `runtime.anyToJSON` for free-form object fields; regenerate samples; add `3_0/typescript-fetch/any_type_property.json`.

- **Dependencies**
  - Update sample `jaxrs-spec-enum` `pom.xml`: upgrade `maven-surefire-plugin`/`maven-failsafe-plugin` to 3.5.6 and switch tests to JUnit 5 (`org.junit.jupiter:junit-jupiter-engine` 5.14.4).

<sup>Written for commit 37c949cea4e3e413d1e3dfba63256a9697a43e68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

