### PR TITLE
fix(typescript-fetch): skip scalar enum comparison for array-typed properties in instanceOf

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -32,6 +32,7 @@ export function instanceOf{{classname}}(value: object): value is {{classname}} {
     if (!('{{name}}' in value) || value['{{name}}'] === undefined) return false;
     {{/hasSanitizedName}}
     {{#isEnum}}
+    {{^isContainer}}
     {{#allowableValues}}
     {{#values}}
     {{#-first}}
@@ -48,6 +49,7 @@ export function instanceOf{{classname}}(value: object): value is {{classname}} {
     {{/-first}}
     {{/values}}
     {{/allowableValues}}
+    {{/isContainer}}
     {{/isEnum}}
     {{/required}}
     {{/vars}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -653,6 +653,21 @@ public class TypeScriptFetchClientCodegenTest {
         TestUtils.assertFileContains(outerPlain, "export interface OuterPlain {");
     }
 
+    @Test(description = "instanceOf guard must not emit scalar enum comparison for array-typed enum properties")
+    public void testInstanceOfArrayEnumNoScalarComparison() throws Exception {
+        File output = generate(
+            Collections.emptyMap(),
+            "src/test/resources/3_0/typescript-fetch/array_of_single_value_enum.json"
+        );
+
+        Path modelPath = Paths.get(output + "/models/TestSchema.ts");
+        // Must NOT emit a scalar !== comparison for an array-typed enum property
+        TestUtils.assertFileNotContains(modelPath, "value['types'] !== 'boatbooker_activities'");
+        TestUtils.assertFileNotContains(modelPath, "value['types'] !== boatbooker_activities");
+        // Must still check for presence of the field
+        TestUtils.assertFileContains(modelPath, "'types' in value");
+    }
+
     private static File generate(
         Map<String, Object> properties
     ) throws IOException {

--- a/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/array_of_single_value_enum.json
+++ b/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/array_of_single_value_enum.json
@@ -1,0 +1,25 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Array of Single-Value Enum Test",
+    "version": "1.0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "TestSchema": {
+        "required": ["types"],
+        "type": "object",
+        "properties": {
+          "types": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["boatbooker_activities"]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/samples/server/petstore/jaxrs-spec-enum/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-enum/pom.xml
@@ -38,8 +38,12 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -91,8 +95,8 @@
         <version>3.0.2</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
@@ -135,7 +139,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jackson-version>2.19.2</jackson-version>
-    <junit-version>4.13.2</junit-version>
+    <junit-version>5.14.4</junit-version>
     <joda-version>2.10.13</joda-version>
     <javax.annotation-api-version>1.3.2</javax.annotation-api-version>
     <beanvalidation-version>2.0.2</beanvalidation-version>


### PR DESCRIPTION
Required properties typed as `Array<SingleValueEnum>` triggered two bugs in the `instanceOf` guard (side effect of #23497):

1. The enum-literal check fired for array properties — comparing `value['types'] !== 'x'` against an array is always truthy, permanently breaking `instanceOf`.
2. For array properties, `isString` resolves against the container type (Array), not the item type, so the literal was emitted unquoted (`boatbooker_activities` instead of `'boatbooker_activities'`), causing `TS2304: Cannot find name`.

Fix: wrap the enum-literal block in `{{^isContainer}}` so it only fires for scalar properties. Scalar enum behavior is unchanged.

---

Apologies for the burst of PRs in a short time — we are integrating this generator into production at [FishingBooker](https://fishingbooker.com) and kept uncovering issues along the way. 
Also sorry for skipping a prior issue on this one; if a release is coming soon we'd love to see it included. Happy to open a follow-up issue if preferred.

Fixes a regression introduced by #23497.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran unit tests: `./mvnw test -pl modules/openapi-generator -Dtest=TypeScriptFetchClientCodegenTest`
- [x] Regenerated typescript-fetch samples: `./bin/generate-samples.sh ./bin/configs/typescript-fetch*`
- [x] @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members.

cc @TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka @joscha @dennisameling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `instanceOf` guard in `typescript-fetch` to skip scalar enum comparisons for array-typed enum properties (e.g., `Array<SingleValueEnum>`), preventing false negatives and TypeScript literal name errors. Scalar enum behavior is unchanged.

- **Bug Fixes**
  - Wrapped the enum-literal check with `{{^isContainer}}` in `modelGeneric.mustache` so array enums no longer emit invalid `!==` comparisons or unquoted literals.
  - Added a test (`testInstanceOfArrayEnumNoScalarComparison`) with a minimal OpenAPI fixture to verify no scalar comparison is emitted and the field presence check remains.

<sup>Written for commit 6018a9d6175727b3381318ade0954c5705442628. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

