### PR TITLE
[Crystal] Add request-signing seam (`Configuration#sign_request`)

### DIFF
--- a/modules/openapi-generator/src/main/resources/crystal/README.mustache
+++ b/modules/openapi-generator/src/main/resources/crystal/README.mustache
@@ -60,11 +60,16 @@ config.sign_request = ->(method : Symbol, url : String, body : String?,
 end
 ```
 
-Design note: the hook runs **before** Crest re-encodes `query` into the final URL, so `url`
-here does not yet include the query string. If your API requires the signature to cover the
-query string, rebuild the URL from the params (the 5th argument) inside the hook, or rely on
-a native Crest hook — evaluate per target API. For a GET/write without query params, the
-current insertion point is sufficient.
+Design notes:
+
+- `url` is the base URL + path **without** the query string — the hook runs before Crest
+  re-encodes `query` into the final URL. If your signature must cover the query string,
+  rebuild it from the `query` argument (5th param) inside the hook, matching Crest's
+  `params_encoder`, or rely on a native Crest hook.
+- `body` is **nil for form/multipart operations** (`application/x-www-form-urlencoded`,
+  file uploads): the form is encoded by Crest after this hook, so a body-hashing signer
+  cannot see it here. Signing is therefore supported for JSON-body and query/path requests;
+  form-body signing would need a hook at the Crest layer.
 
 ## Development
 

--- a/modules/openapi-generator/src/main/resources/crystal/README.mustache
+++ b/modules/openapi-generator/src/main/resources/crystal/README.mustache
@@ -32,6 +32,40 @@ dependencies:
     version: ~> {{shardVersion}}
 ```
 
+## Request signing / custom auth
+
+Static credentials (`apiKey`, `basic`, `bearer`, `oauth`) are applied from the OpenAPI
+spec by `Configuration#apply_auth!`. A **request signature** — a hash computed per request
+over the method, full URL, body and a timestamp (OVH, AWS SigV4, RFC 9421, ...) — cannot be
+modeled as an OpenAPI security scheme, so it is injected via the `sign_request` hook on
+`Configuration`. It runs on every request, after `apply_auth!` and just before the HTTP
+call, with `(method, full_url, body, headers, query)`; mutate `headers`/`query` in place:
+
+```crystal
+require "digest/sha1"
+
+config = {{moduleName}}::Configuration.new
+app_key, app_secret, consumer_key = "...", "...", "..."
+config.sign_request = ->(method : Symbol, url : String, body : String?,
+                         headers : HTTP::Headers,
+                         _query : Hash(String, String | Array(String))) do
+  ts  = Time.utc.to_unix.to_s
+  sig = "$1$" + Digest::SHA1.hexdigest(
+    {app_secret, consumer_key, method.to_s.upcase, url, body || "", ts}.join("+"))
+  headers["X-Ovh-Application"] = app_key
+  headers["X-Ovh-Consumer"]    = consumer_key
+  headers["X-Ovh-Timestamp"]   = ts
+  headers["X-Ovh-Signature"]   = sig
+  nil
+end
+```
+
+Design note: the hook runs **before** Crest re-encodes `query` into the final URL, so `url`
+here does not yet include the query string. If your API requires the signature to cover the
+query string, rebuild the URL from the params (the 5th argument) inside the hook, or rely on
+a native Crest hook — evaluate per target API. For a GET/write without query params, the
+current insertion point is sufficient.
+
 ## Development
 
 Install dependencies

--- a/modules/openapi-generator/src/main/resources/crystal/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/crystal/configuration.mustache
@@ -127,10 +127,13 @@ module {{moduleName}}
     property params_encoder : Crest::ParamsEncoder.class = {{paramsEncoder}}
 
     # Optional request-signing hook. Called on every request, after apply_auth! and
-    # just before the HTTP call, with (method, full_url, body, headers, query). Mutate
-    # `headers`/`query` in place to inject a computed signature (OVH `$1$`+SHA1,
-    # AWS SigV4, ...). Left nil = no signing. Not expressible as an OpenAPI security
-    # scheme, hence this seam rather than apply_auth!.
+    # just before the HTTP call, with (method, url, body, headers, query). `url` is the
+    # base URL + path WITHOUT the query string (Crest re-encodes `query` into the final
+    # URL after this hook); rebuild it from the `query` argument if your signature must
+    # cover it. `body` is nil for form/multipart operations (the form is encoded by Crest
+    # later). Mutate `headers`/`query` in place to inject a computed signature (OVH
+    # `$1$`+SHA1, AWS SigV4, ...). Left nil = no signing. Not expressible as an OpenAPI
+    # security scheme, hence this seam rather than apply_auth!.
     property sign_request : Proc(Symbol, String, String?, HTTP::Headers,
                                  Hash(String, String | Array(String)), Nil)? = nil
 

--- a/modules/openapi-generator/src/main/resources/crystal/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/crystal/configuration.mustache
@@ -126,6 +126,14 @@ module {{moduleName}}
     # Default: Crest::NestedParamsEncoder (encodes arrays as key=a&key=b).
     property params_encoder : Crest::ParamsEncoder.class = {{paramsEncoder}}
 
+    # Optional request-signing hook. Called on every request, after apply_auth! and
+    # just before the HTTP call, with (method, full_url, body, headers, query). Mutate
+    # `headers`/`query` in place to inject a computed signature (OVH `$1$`+SHA1,
+    # AWS SigV4, ...). Left nil = no signing. Not expressible as an OpenAPI security
+    # scheme, hence this seam rather than apply_auth!.
+    property sign_request : Proc(Symbol, String, String?, HTTP::Headers,
+                                 Hash(String, String | Array(String)), Nil)? = nil
+
     # Create a new `Configuration`.
     def initialize
       @scheme = "{{scheme}}"
@@ -145,6 +153,7 @@ module {{moduleName}}
       @password = nil
       @access_token = nil
       @temp_folder_path = nil
+      @sign_request = nil
     end
 
     # Create a new `Configuration` with block.

--- a/modules/openapi-generator/src/main/resources/crystal/connection.mustache
+++ b/modules/openapi-generator/src/main/resources/crystal/connection.mustache
@@ -46,6 +46,10 @@ module {{moduleName}}
       body_str : String? = body.nil? ? nil : body.to_json
       headers["Content-Type"] = content_type.first if body_str && !content_type.empty?
 
+      # Request-signing seam: runs after apply_auth!, sees the final method/URL/body so a
+      # consumer can compute a per-request signature (OVH, AWS SigV4, ...).
+      config.sign_request.try &.call(method, config.base_url + path, body_str, headers, q)
+
       crest_form : Hash(String, Crest::ParamsValue) | String | Nil =
         if body_str
           body_str

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/crystal/CrystalClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/crystal/CrystalClientCodegenTest.java
@@ -726,4 +726,30 @@ public class CrystalClientCodegenTest {
         assertTrue(src.contains("\"multi_ids\" => multi_ids,") || src.contains("\"multi_ids\" => multi_ids "),
             "multi array param must stay an array (no join)");
     }
+
+    @Test
+    public void testConfigurationExposesSignRequestSeam() throws Exception {
+        final File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/crystal/petstore.yaml");
+        CodegenConfig codegen = new CrystalClientCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        List<File> files = new DefaultGenerator()
+            .opts(new ClientOptInput().openAPI(openAPI).config(codegen)).generate();
+
+        boolean configSeen = false, connSeen = false;
+        for (File f : files) {
+            if (f.getName().equals("configuration.cr")) {
+                configSeen = true;
+                String c = FileUtils.readFileToString(f, StandardCharsets.UTF_8);
+                assertTrue(c.contains("property sign_request"), "Configuration must expose sign_request seam");
+            }
+            if (f.getName().equals("connection.cr")) {
+                connSeen = true;
+                String c = FileUtils.readFileToString(f, StandardCharsets.UTF_8);
+                assertTrue(c.contains("config.sign_request.try"), "Connection must invoke the sign_request hook");
+            }
+        }
+        assertTrue(configSeen && connSeen, "configuration.cr and connection.cr must be generated");
+    }
 }

--- a/samples/client/others/crystal-qdrant/README.md
+++ b/samples/client/others/crystal-qdrant/README.md
@@ -171,6 +171,40 @@ dependencies:
     version: ~> 1.0.0
 ```
 
+## Request signing / custom auth
+
+Static credentials (`apiKey`, `basic`, `bearer`, `oauth`) are applied from the OpenAPI
+spec by `Configuration#apply_auth!`. A **request signature** — a hash computed per request
+over the method, full URL, body and a timestamp (OVH, AWS SigV4, RFC 9421, ...) — cannot be
+modeled as an OpenAPI security scheme, so it is injected via the `sign_request` hook on
+`Configuration`. It runs on every request, after `apply_auth!` and just before the HTTP
+call, with `(method, full_url, body, headers, query)`; mutate `headers`/`query` in place:
+
+```crystal
+require "digest/sha1"
+
+config = Qdrant::Api::Configuration.new
+app_key, app_secret, consumer_key = "...", "...", "..."
+config.sign_request = ->(method : Symbol, url : String, body : String?,
+                         headers : HTTP::Headers,
+                         _query : Hash(String, String | Array(String))) do
+  ts  = Time.utc.to_unix.to_s
+  sig = "$1$" + Digest::SHA1.hexdigest(
+    {app_secret, consumer_key, method.to_s.upcase, url, body || "", ts}.join("+"))
+  headers["X-Ovh-Application"] = app_key
+  headers["X-Ovh-Consumer"]    = consumer_key
+  headers["X-Ovh-Timestamp"]   = ts
+  headers["X-Ovh-Signature"]   = sig
+  nil
+end
+```
+
+Design note: the hook runs **before** Crest re-encodes `query` into the final URL, so `url`
+here does not yet include the query string. If your API requires the signature to cover the
+query string, rebuild the URL from the params (the 5th argument) inside the hook, or rely on
+a native Crest hook — evaluate per target API. For a GET/write without query params, the
+current insertion point is sufficient.
+
 ## Development
 
 Install dependencies

--- a/samples/client/others/crystal-qdrant/README.md
+++ b/samples/client/others/crystal-qdrant/README.md
@@ -199,11 +199,16 @@ config.sign_request = ->(method : Symbol, url : String, body : String?,
 end
 ```
 
-Design note: the hook runs **before** Crest re-encodes `query` into the final URL, so `url`
-here does not yet include the query string. If your API requires the signature to cover the
-query string, rebuild the URL from the params (the 5th argument) inside the hook, or rely on
-a native Crest hook — evaluate per target API. For a GET/write without query params, the
-current insertion point is sufficient.
+Design notes:
+
+- `url` is the base URL + path **without** the query string — the hook runs before Crest
+  re-encodes `query` into the final URL. If your signature must cover the query string,
+  rebuild it from the `query` argument (5th param) inside the hook, matching Crest's
+  `params_encoder`, or rely on a native Crest hook.
+- `body` is **nil for form/multipart operations** (`application/x-www-form-urlencoded`,
+  file uploads): the form is encoded by Crest after this hook, so a body-hashing signer
+  cannot see it here. Signing is therefore supported for JSON-body and query/path requests;
+  form-body signing would need a hook at the Crest layer.
 
 ## Development
 

--- a/samples/client/others/crystal-qdrant/src/qdrant-api/configuration.cr
+++ b/samples/client/others/crystal-qdrant/src/qdrant-api/configuration.cr
@@ -133,10 +133,13 @@ module Qdrant::Api
     property params_encoder : Crest::ParamsEncoder.class = Crest::NestedParamsEncoder
 
     # Optional request-signing hook. Called on every request, after apply_auth! and
-    # just before the HTTP call, with (method, full_url, body, headers, query). Mutate
-    # `headers`/`query` in place to inject a computed signature (OVH `$1$`+SHA1,
-    # AWS SigV4, ...). Left nil = no signing. Not expressible as an OpenAPI security
-    # scheme, hence this seam rather than apply_auth!.
+    # just before the HTTP call, with (method, url, body, headers, query). `url` is the
+    # base URL + path WITHOUT the query string (Crest re-encodes `query` into the final
+    # URL after this hook); rebuild it from the `query` argument if your signature must
+    # cover it. `body` is nil for form/multipart operations (the form is encoded by Crest
+    # later). Mutate `headers`/`query` in place to inject a computed signature (OVH
+    # `$1$`+SHA1, AWS SigV4, ...). Left nil = no signing. Not expressible as an OpenAPI
+    # security scheme, hence this seam rather than apply_auth!.
     property sign_request : Proc(Symbol, String, String?, HTTP::Headers,
                                  Hash(String, String | Array(String)), Nil)? = nil
 

--- a/samples/client/others/crystal-qdrant/src/qdrant-api/configuration.cr
+++ b/samples/client/others/crystal-qdrant/src/qdrant-api/configuration.cr
@@ -132,6 +132,14 @@ module Qdrant::Api
     # Default: Crest::NestedParamsEncoder (encodes arrays as key=a&key=b).
     property params_encoder : Crest::ParamsEncoder.class = Crest::NestedParamsEncoder
 
+    # Optional request-signing hook. Called on every request, after apply_auth! and
+    # just before the HTTP call, with (method, full_url, body, headers, query). Mutate
+    # `headers`/`query` in place to inject a computed signature (OVH `$1$`+SHA1,
+    # AWS SigV4, ...). Left nil = no signing. Not expressible as an OpenAPI security
+    # scheme, hence this seam rather than apply_auth!.
+    property sign_request : Proc(Symbol, String, String?, HTTP::Headers,
+                                 Hash(String, String | Array(String)), Nil)? = nil
+
     # Create a new `Configuration`.
     def initialize
       @scheme = "http"
@@ -151,6 +159,7 @@ module Qdrant::Api
       @password = nil
       @access_token = nil
       @temp_folder_path = nil
+      @sign_request = nil
     end
 
     # Create a new `Configuration` with block.

--- a/samples/client/others/crystal-qdrant/src/qdrant-api/connection.cr
+++ b/samples/client/others/crystal-qdrant/src/qdrant-api/connection.cr
@@ -46,6 +46,10 @@ module Qdrant::Api
       body_str : String? = body.nil? ? nil : body.to_json
       headers["Content-Type"] = content_type.first if body_str && !content_type.empty?
 
+      # Request-signing seam: runs after apply_auth!, sees the final method/URL/body so a
+      # consumer can compute a per-request signature (OVH, AWS SigV4, ...).
+      config.sign_request.try &.call(method, config.base_url + path, body_str, headers, q)
+
       crest_form : Hash(String, Crest::ParamsValue) | String | Nil =
         if body_str
           body_str

--- a/samples/client/petstore/crystal/README.md
+++ b/samples/client/petstore/crystal/README.md
@@ -52,11 +52,16 @@ config.sign_request = ->(method : Symbol, url : String, body : String?,
 end
 ```
 
-Design note: the hook runs **before** Crest re-encodes `query` into the final URL, so `url`
-here does not yet include the query string. If your API requires the signature to cover the
-query string, rebuild the URL from the params (the 5th argument) inside the hook, or rely on
-a native Crest hook — evaluate per target API. For a GET/write without query params, the
-current insertion point is sufficient.
+Design notes:
+
+- `url` is the base URL + path **without** the query string — the hook runs before Crest
+  re-encodes `query` into the final URL. If your signature must cover the query string,
+  rebuild it from the `query` argument (5th param) inside the hook, matching Crest's
+  `params_encoder`, or rely on a native Crest hook.
+- `body` is **nil for form/multipart operations** (`application/x-www-form-urlencoded`,
+  file uploads): the form is encoded by Crest after this hook, so a body-hashing signer
+  cannot see it here. Signing is therefore supported for JSON-body and query/path requests;
+  form-body signing would need a hook at the Crest layer.
 
 ## Development
 

--- a/samples/client/petstore/crystal/README.md
+++ b/samples/client/petstore/crystal/README.md
@@ -24,6 +24,40 @@ dependencies:
     version: ~> 1.0.0
 ```
 
+## Request signing / custom auth
+
+Static credentials (`apiKey`, `basic`, `bearer`, `oauth`) are applied from the OpenAPI
+spec by `Configuration#apply_auth!`. A **request signature** — a hash computed per request
+over the method, full URL, body and a timestamp (OVH, AWS SigV4, RFC 9421, ...) — cannot be
+modeled as an OpenAPI security scheme, so it is injected via the `sign_request` hook on
+`Configuration`. It runs on every request, after `apply_auth!` and just before the HTTP
+call, with `(method, full_url, body, headers, query)`; mutate `headers`/`query` in place:
+
+```crystal
+require "digest/sha1"
+
+config = Petstore::Configuration.new
+app_key, app_secret, consumer_key = "...", "...", "..."
+config.sign_request = ->(method : Symbol, url : String, body : String?,
+                         headers : HTTP::Headers,
+                         _query : Hash(String, String | Array(String))) do
+  ts  = Time.utc.to_unix.to_s
+  sig = "$1$" + Digest::SHA1.hexdigest(
+    {app_secret, consumer_key, method.to_s.upcase, url, body || "", ts}.join("+"))
+  headers["X-Ovh-Application"] = app_key
+  headers["X-Ovh-Consumer"]    = consumer_key
+  headers["X-Ovh-Timestamp"]   = ts
+  headers["X-Ovh-Signature"]   = sig
+  nil
+end
+```
+
+Design note: the hook runs **before** Crest re-encodes `query` into the final URL, so `url`
+here does not yet include the query string. If your API requires the signature to cover the
+query string, rebuild the URL from the params (the 5th argument) inside the hook, or rely on
+a native Crest hook — evaluate per target API. For a GET/write without query params, the
+current insertion point is sufficient.
+
 ## Development
 
 Install dependencies

--- a/samples/client/petstore/crystal/src/petstore/configuration.cr
+++ b/samples/client/petstore/crystal/src/petstore/configuration.cr
@@ -132,6 +132,14 @@ module Petstore
     # Default: Crest::NestedParamsEncoder (encodes arrays as key=a&key=b).
     property params_encoder : Crest::ParamsEncoder.class = Crest::NestedParamsEncoder
 
+    # Optional request-signing hook. Called on every request, after apply_auth! and
+    # just before the HTTP call, with (method, full_url, body, headers, query). Mutate
+    # `headers`/`query` in place to inject a computed signature (OVH `$1$`+SHA1,
+    # AWS SigV4, ...). Left nil = no signing. Not expressible as an OpenAPI security
+    # scheme, hence this seam rather than apply_auth!.
+    property sign_request : Proc(Symbol, String, String?, HTTP::Headers,
+                                 Hash(String, String | Array(String)), Nil)? = nil
+
     # Create a new `Configuration`.
     def initialize
       @scheme = "http"
@@ -151,6 +159,7 @@ module Petstore
       @password = nil
       @access_token = nil
       @temp_folder_path = nil
+      @sign_request = nil
     end
 
     # Create a new `Configuration` with block.

--- a/samples/client/petstore/crystal/src/petstore/configuration.cr
+++ b/samples/client/petstore/crystal/src/petstore/configuration.cr
@@ -133,10 +133,13 @@ module Petstore
     property params_encoder : Crest::ParamsEncoder.class = Crest::NestedParamsEncoder
 
     # Optional request-signing hook. Called on every request, after apply_auth! and
-    # just before the HTTP call, with (method, full_url, body, headers, query). Mutate
-    # `headers`/`query` in place to inject a computed signature (OVH `$1$`+SHA1,
-    # AWS SigV4, ...). Left nil = no signing. Not expressible as an OpenAPI security
-    # scheme, hence this seam rather than apply_auth!.
+    # just before the HTTP call, with (method, url, body, headers, query). `url` is the
+    # base URL + path WITHOUT the query string (Crest re-encodes `query` into the final
+    # URL after this hook); rebuild it from the `query` argument if your signature must
+    # cover it. `body` is nil for form/multipart operations (the form is encoded by Crest
+    # later). Mutate `headers`/`query` in place to inject a computed signature (OVH
+    # `$1$`+SHA1, AWS SigV4, ...). Left nil = no signing. Not expressible as an OpenAPI
+    # security scheme, hence this seam rather than apply_auth!.
     property sign_request : Proc(Symbol, String, String?, HTTP::Headers,
                                  Hash(String, String | Array(String)), Nil)? = nil
 

--- a/samples/client/petstore/crystal/src/petstore/connection.cr
+++ b/samples/client/petstore/crystal/src/petstore/connection.cr
@@ -46,6 +46,10 @@ module Petstore
       body_str : String? = body.nil? ? nil : body.to_json
       headers["Content-Type"] = content_type.first if body_str && !content_type.empty?
 
+      # Request-signing seam: runs after apply_auth!, sees the final method/URL/body so a
+      # consumer can compute a per-request signature (OVH, AWS SigV4, ...).
+      config.sign_request.try &.call(method, config.base_url + path, body_str, headers, q)
+
       crest_form : Hash(String, Crest::ParamsValue) | String | Nil =
         if body_str
           body_str


### PR DESCRIPTION
## Description

Adds a public **request-signing seam** to the `crystal` client generator. It lets a
consumer inject a per-request signature (OVH `$1$`+SHA1, AWS SigV4, RFC 9421, ...) without
subclassing or patching the generated code.

### Why
`Configuration#apply_auth!` applies the **static** credentials declared in the OpenAPI spec
(apiKey / basic / bearer / oauth). A **request signature** is a hash computed per request over
the method, full URL, body and a timestamp — recomputed on every call. It is not expressible
as an OpenAPI security scheme, so `apply_auth!` cannot carry it and a procedural extension
point is needed.

### How
`Configuration` gains an optional `sign_request` hook:

```crystal
property sign_request : Proc(Symbol, String, String?, HTTP::Headers,
                             Hash(String, String | Array(String)), Nil)? = nil
```

`Connection#request` invokes it **after** `apply_auth!` and **just before** the Crest call, so
the hook sees the serialized body and the final method/URL and can mutate `headers`/`query` in
place. Left `nil` = no signing. `apply_auth!` is unchanged (fully backward compatible).

The Crest client has no middleware stack, so this differs in form from a Faraday middleware
pile — it is a single callback at the one point in `Connection#request` where everything a
signature needs is already in local scope.

### Scope
Pure template change — **no codegen Java**. Touches `configuration.mustache` +
`connection.mustache`, adds a README section with an illustrative OVH example (and a note that
the hook runs before Crest re-encodes the query string), and regenerates the `crystal` and
`crystal-qdrant` samples. No OVH-specific code lives in the generator.

### Testing
- New unit test `CrystalClientCodegenTest#testConfigurationExposesSignRequestSeam` (red → green); full class 28 tests, 0 failures.
- Regenerated samples: diff limited to `configuration.cr` + `connection.cr` (+ README) in both `crystal` and `crystal-qdrant`. The added lines are `crystal tool format`-clean.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Rebuilt and regenerated the affected Crystal samples (`./bin/generate-samples.sh bin/configs/crystal.yaml bin/configs/crystal-qdrant.yaml`). Only the Crystal generator's output changes.
- [ ] @mention the technical committee for review.

cc @wing328 — small, backward-compatible extension point for the Crystal generator (request signing that OpenAPI security schemes cannot model).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a request-signing hook to the Crystal client generator so consumers can compute per-request signatures (e.g., OVH, AWS SigV4, RFC 9421) without patching generated code. Backward compatible; static auth via `apply_auth!` is unchanged.

- New Features
  - Added `Configuration#sign_request` Proc(method, url, body, headers, query).
  - Invoked from `Connection#request` after `apply_auth!` and before the Crest call; mutate `headers`/`query` to sign.
  - Off by default (`nil`) with no behavior change.
  - Clarified docs: `url` excludes the query string; `body` is `nil` for form/multipart. Updated README with example and notes, added unit test, and regenerated Crystal and Qdrant samples.

<sup>Written for commit 0e3404e68dfb3b6342c123056f279e32b7e2c0d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

