### PR TITLE
typescript-fetch: default to es6 support

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -605,10 +605,10 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
         supportingFiles.add(new SupportingFile("package.mustache", "", "package.json"));
         supportingFiles.add(new SupportingFile("tsconfig.mustache", "", "tsconfig.json"));
-        // in case ECMAScript 6 is supported add another tsconfig for an ESM (ECMAScript Module)
-        if (supportsES6) {
-            supportingFiles.add(new SupportingFile("tsconfig.esm.mustache", "", "tsconfig.esm.json"));
-        }
+
+        // by default ECMAScript 6 is supported add another tsconfig for an ESM (ECMAScript Module)
+        supportingFiles.add(new SupportingFile("tsconfig.esm.mustache", "", "tsconfig.esm.json"));
+
         supportingFiles.add(new SupportingFile("npmignore.mustache", "", ".npmignore"));
         supportingFiles.add(new SupportingFile("gitignore", "", ".gitignore"));
     }

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/package.mustache
@@ -16,12 +16,10 @@
 {{^packageAsSourceOnlyLibrary}}
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-{{#supportsES6}}
   "module": "./dist/esm/index.js",
   "sideEffects": false,
-{{/supportsES6}}
   "scripts": {
-    "build": "tsc{{#supportsES6}} && tsc -p tsconfig.esm.json{{/supportsES6}}"{{^sagasAndRecords}},
+    "build": "tsc && tsc -p tsconfig.esm.json"{{^sagasAndRecords}},
     "prepare": "npm run build"{{/sagasAndRecords}}
   },
 {{/packageAsSourceOnlyLibrary}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/tsconfig.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/tsconfig.mustache
@@ -8,12 +8,6 @@
     "module": "commonjs",
     "outDir": "dist",
     "rootDir": "src",
-    {{^supportsES6}}
-    "lib": [
-      "es6",
-      "dom"
-    ],
-    {{/supportsES6}}
     "typeRoots": [
       "node_modules/@types"
     ]

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -209,21 +209,6 @@ public class TypeScriptFetchClientCodegenTest {
         assertThat(codegen.supportingFiles()).contains(new SupportingFile("tsconfig.esm.mustache", "", "tsconfig.esm.json"));
     }
 
-    @Test
-    public void doesNotContainESMTSConfigFileInCaseOfES5AndNPM() {
-        TypeScriptFetchClientCodegen codegen = new TypeScriptFetchClientCodegen();
-
-        codegen.additionalProperties().put("npmName", "@openapi/typescript-fetch-petstore");
-        codegen.additionalProperties().put("snapshot", false);
-        codegen.additionalProperties().put("npmVersion", "1.0.0-SNAPSHOT");
-        codegen.additionalProperties().put("supportsES6", false);
-
-        codegen.processOpts();
-
-        assertThat(codegen.supportingFiles()).contains(new SupportingFile("tsconfig.mustache", "", "tsconfig.json"));
-        assertThat(codegen.supportingFiles()).doesNotContain(new SupportingFile("tsconfig.esm.mustache", "", "tsconfig.esm.json"));
-    }
-
     @Test(description = "Verify file name formatting from model name in PascalCase")
     public void testModelFileNameInPascalCase() {
         final TypeScriptFetchClientCodegen codegen = new TypeScriptFetchClientCodegen();

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/.openapi-generator/FILES
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/.openapi-generator/FILES
@@ -24,4 +24,5 @@ src/models/Tag.ts
 src/models/User.ts
 src/models/index.ts
 src/runtime.ts
+tsconfig.esm.json
 tsconfig.json

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/package.json
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/package.json
@@ -9,8 +9,10 @@
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "module": "./dist/esm/index.js",
+  "sideEffects": false,
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsc -p tsconfig.esm.json",
     "prepare": "npm run build"
   },
   "devDependencies": {

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/tsconfig.esm.json
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "dist/esm"
+  }
+}

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/tsconfig.json
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/tsconfig.json
@@ -5,10 +5,6 @@
     "module": "commonjs",
     "outDir": "dist",
     "rootDir": "src",
-    "lib": [
-      "es6",
-      "dom"
-    ],
     "typeRoots": [
       "node_modules/@types"
     ]

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/.openapi-generator/FILES
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/.openapi-generator/FILES
@@ -24,4 +24,5 @@ src/models/Tag.ts
 src/models/User.ts
 src/models/index.ts
 src/runtime.ts
+tsconfig.esm.json
 tsconfig.json

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/package.json
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/package.json
@@ -9,8 +9,10 @@
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "module": "./dist/esm/index.js",
+  "sideEffects": false,
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsc -p tsconfig.esm.json",
     "prepare": "npm run build"
   },
   "devDependencies": {

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/tsconfig.esm.json
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "dist/esm"
+  }
+}

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/tsconfig.json
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/tsconfig.json
@@ -5,10 +5,6 @@
     "module": "commonjs",
     "outDir": "dist",
     "rootDir": "src",
-    "lib": [
-      "es6",
-      "dom"
-    ],
     "typeRoots": [
       "node_modules/@types"
     ]

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/.openapi-generator/FILES
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/.openapi-generator/FILES
@@ -18,4 +18,5 @@ src/apis/index.ts
 src/index.ts
 src/models/index.ts
 src/runtime.ts
+tsconfig.esm.json
 tsconfig.json

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/package.json
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/package.json
@@ -9,8 +9,10 @@
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "module": "./dist/esm/index.js",
+  "sideEffects": false,
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsc -p tsconfig.esm.json",
     "prepare": "npm run build"
   },
   "devDependencies": {

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/tsconfig.esm.json
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "dist/esm"
+  }
+}

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/tsconfig.json
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/tsconfig.json
@@ -5,10 +5,6 @@
     "module": "commonjs",
     "outDir": "dist",
     "rootDir": "src",
-    "lib": [
-      "es6",
-      "dom"
-    ],
     "typeRoots": [
       "node_modules/@types"
     ]


### PR DESCRIPTION
default to ES6 support as ES5 support has been deprecated in TypeScript

FYI @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04) @joscha (2024/10) @dennisameling (2026/02)

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defaulted the `typescript-fetch` generator to ES2015+ and now produce dual builds (CommonJS + ESM) by default. This adds ESM output and package fields, and removes ES5-specific config.

- **New Features**
  - Always generate `tsconfig.esm.json` and build ESM to `dist/esm` via `tsc && tsc -p tsconfig.esm.json`.
  - `package.json`: add `"module": "./dist/esm/index.js"` and `"sideEffects": false`.
  - Remove legacy ES5 `lib` settings from `tsconfig`.
  - Update samples to reflect the new defaults.
  - Update tests to drop the ES5 path and expect ESM config by default.

- **Migration**
  - No changes needed for CommonJS consumers (`main` stays the same).
  - If you relied on ES5 targets, move to ES2015+ or add polyfills.
  - Remove any tooling that assumes a `supportsES6`-conditional output.

<sup>Written for commit 4496a07eed4bca1c3c05b6f8050fedfd3a4e3506. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

