### PR TITLE
[Kotlin Spring] fix: Omit example field if not set

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -384,6 +384,14 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
         }
     }
 
+    @Override
+    public String toExampleValue(Schema schema) {
+        if (schema.getExample() != null) {
+            return super.toExampleValue(schema);
+        }
+        return null;
+    }
+
     /**
      * returns the OpenAPI type for the property
      *

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
@@ -788,24 +788,31 @@ public class KotlinSpringServerCodegenTest {
                 Paths.get(outputPath + "/src/main/kotlin/org/openapitools/model/Animal.kt"),
                 "@Schema(example = \"null\", description = \"\")"
         );
-        assertFileContains(
+        assertFileNotContains(
                 Paths.get(outputPath + "/src/main/kotlin/org/openapitools/model/Animal.kt"),
                 "@get:Schema(example = \"null\", description = \"\")"
+        );
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/kotlin/org/openapitools/model/Animal.kt"),
+                "@get:Schema(description = \"\")"
         );
         assertFileNotContains(
                 Paths.get(outputPath + "/src/main/kotlin/org/openapitools/model/Animal.kt"),
                 "@Schema(example = \"null\", requiredMode = Schema.RequiredMode.REQUIRED, description = \"\")"
         );
-        assertFileContains(
+        assertFileNotContains(
                 Paths.get(outputPath + "/src/main/kotlin/org/openapitools/model/Animal.kt"),
                 "@get:Schema(example = \"null\", requiredMode = Schema.RequiredMode.REQUIRED, description = \"\")"
+        );
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/kotlin/org/openapitools/model/Animal.kt"),
+                "@get:Schema(requiredMode = Schema.RequiredMode.REQUIRED, description = \"\")"
         );
     }
 
     @Test(description = "use get Annotation use-site target on kotlin interface attributes (swagger1)")
     public void useTargetOnInterfaceAnnotationsWithSwagger1() throws IOException {
         File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
-        output.deleteOnExit();
         String outputPath = output.getAbsolutePath().replace('\\', '/');
 
         KotlinSpringServerCodegen codegen = new KotlinSpringServerCodegen();
@@ -823,17 +830,25 @@ public class KotlinSpringServerCodegenTest {
                 Paths.get(outputPath + "/src/main/kotlin/org/openapitools/model/Animal.kt"),
                 "@ApiModelProperty(example = \"null\", value = \"\")"
         );
-        assertFileContains(
+        assertFileNotContains(
                 Paths.get(outputPath + "/src/main/kotlin/org/openapitools/model/Animal.kt"),
                 "@get:ApiModelProperty(example = \"null\", value = \"\")"
+        );
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/kotlin/org/openapitools/model/Animal.kt"),
+                "@get:ApiModelProperty(value = \"\")"
         );
         assertFileNotContains(
                 Paths.get(outputPath + "/src/main/kotlin/org/openapitools/model/Animal.kt"),
                 "@ApiModelProperty(example = \"null\", required = true, value = \"\")"
         );
-        assertFileContains(
+        assertFileNotContains(
                 Paths.get(outputPath + "/src/main/kotlin/org/openapitools/model/Animal.kt"),
                 "@get:ApiModelProperty(example = \"null\", required = true, value = \"\")"
+        );
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/kotlin/org/openapitools/model/Animal.kt"),
+                "@get:ApiModelProperty(required = true, value = \"\")"
         );
     }
 

--- a/samples/server/petstore/kotlin-spring-declarative-interface-bean-validation/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-bean-validation/src/main/kotlin/org/openapitools/model/Category.kt
@@ -23,14 +23,14 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Category(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @get:Pattern(regexp="^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$")
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-bean-validation/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-bean-validation/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -24,19 +24,19 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class ModelApiResponse(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("code")
     @get:JsonProperty("code") val code: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("type")
     @get:JsonProperty("type") val type: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("message")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-bean-validation/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-bean-validation/src/main/kotlin/org/openapitools/model/Order.kt
@@ -29,37 +29,37 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Order(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("petId")
     @get:JsonProperty("petId") val petId: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("quantity")
     @get:JsonProperty("quantity") val quantity: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("shipDate")
     @get:JsonProperty("shipDate") val shipDate: java.time.OffsetDateTime? = null,
 
-    @Schema(example = "null", description = "Order Status")
+    @Schema(description = "Order Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("status")
     @get:JsonProperty("status") val status: Order.Status? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("complete")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-bean-validation/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-bean-validation/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -35,31 +35,31 @@ data class Pet(
     @param:JsonProperty("name")
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
-    @Schema(example = "null", required = true, description = "")
+    @Schema(required = true, description = "")
     @param:JsonProperty("photoUrls")
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("category")
     @get:JsonProperty("category") val category: Category? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("tags")
     @get:JsonProperty("tags") val tags: kotlin.collections.List<Tag>? = null,
 
-    @Schema(example = "null", description = "pet status in the store")
+    @Schema(description = "pet status in the store")
     @Deprecated(message = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)

--- a/samples/server/petstore/kotlin-spring-declarative-interface-bean-validation/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-bean-validation/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -23,13 +23,13 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Tag(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-bean-validation/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-bean-validation/src/main/kotlin/org/openapitools/model/User.kt
@@ -29,49 +29,49 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class User(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("username")
     @get:JsonProperty("username") val username: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("firstName")
     @get:JsonProperty("firstName") val firstName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("lastName")
     @get:JsonProperty("lastName") val lastName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("email")
     @get:JsonProperty("email") val email: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("password")
     @get:JsonProperty("password") val password: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("phone")
     @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
-    @Schema(example = "null", description = "User Status")
+    @Schema(description = "User Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("userStatus")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/src/main/kotlin/org/openapitools/model/Category.kt
@@ -23,14 +23,14 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Category(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @get:Pattern(regexp="^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$")
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -24,19 +24,19 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class ModelApiResponse(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("code")
     @get:JsonProperty("code") val code: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("type")
     @get:JsonProperty("type") val type: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("message")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/src/main/kotlin/org/openapitools/model/Order.kt
@@ -29,37 +29,37 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Order(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("petId")
     @get:JsonProperty("petId") val petId: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("quantity")
     @get:JsonProperty("quantity") val quantity: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("shipDate")
     @get:JsonProperty("shipDate") val shipDate: java.time.OffsetDateTime? = null,
 
-    @Schema(example = "null", description = "Order Status")
+    @Schema(description = "Order Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("status")
     @get:JsonProperty("status") val status: Order.Status? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("complete")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -35,31 +35,31 @@ data class Pet(
     @param:JsonProperty("name")
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
-    @Schema(example = "null", required = true, description = "")
+    @Schema(required = true, description = "")
     @param:JsonProperty("photoUrls")
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("category")
     @get:JsonProperty("category") val category: Category? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("tags")
     @get:JsonProperty("tags") val tags: kotlin.collections.List<Tag>? = null,
 
-    @Schema(example = "null", description = "pet status in the store")
+    @Schema(description = "pet status in the store")
     @Deprecated(message = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -23,13 +23,13 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Tag(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-coroutines/src/main/kotlin/org/openapitools/model/User.kt
@@ -29,49 +29,49 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class User(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("username")
     @get:JsonProperty("username") val username: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("firstName")
     @get:JsonProperty("firstName") val firstName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("lastName")
     @get:JsonProperty("lastName") val lastName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("email")
     @get:JsonProperty("email") val email: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("password")
     @get:JsonProperty("password") val password: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("phone")
     @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
-    @Schema(example = "null", description = "User Status")
+    @Schema(description = "User Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("userStatus")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/src/main/kotlin/org/openapitools/model/Category.kt
@@ -23,14 +23,14 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Category(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @get:Pattern(regexp="^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$")
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -24,19 +24,19 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class ModelApiResponse(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("code")
     @get:JsonProperty("code") val code: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("type")
     @get:JsonProperty("type") val type: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("message")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/src/main/kotlin/org/openapitools/model/Order.kt
@@ -29,37 +29,37 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Order(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("petId")
     @get:JsonProperty("petId") val petId: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("quantity")
     @get:JsonProperty("quantity") val quantity: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("shipDate")
     @get:JsonProperty("shipDate") val shipDate: java.time.OffsetDateTime? = null,
 
-    @Schema(example = "null", description = "Order Status")
+    @Schema(description = "Order Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("status")
     @get:JsonProperty("status") val status: Order.Status? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("complete")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -35,31 +35,31 @@ data class Pet(
     @param:JsonProperty("name")
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
-    @Schema(example = "null", required = true, description = "")
+    @Schema(required = true, description = "")
     @param:JsonProperty("photoUrls")
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("category")
     @get:JsonProperty("category") val category: Category? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("tags")
     @get:JsonProperty("tags") val tags: kotlin.collections.List<Tag>? = null,
 
-    @Schema(example = "null", description = "pet status in the store")
+    @Schema(description = "pet status in the store")
     @Deprecated(message = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -23,13 +23,13 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Tag(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-reactive-reactor-wrapped/src/main/kotlin/org/openapitools/model/User.kt
@@ -29,49 +29,49 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class User(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("username")
     @get:JsonProperty("username") val username: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("firstName")
     @get:JsonProperty("firstName") val firstName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("lastName")
     @get:JsonProperty("lastName") val lastName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("email")
     @get:JsonProperty("email") val email: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("password")
     @get:JsonProperty("password") val password: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("phone")
     @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
-    @Schema(example = "null", description = "User Status")
+    @Schema(description = "User Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("userStatus")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/src/main/kotlin/org/openapitools/model/Category.kt
@@ -23,14 +23,14 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Category(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @get:Pattern(regexp="^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$")
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -24,19 +24,19 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class ModelApiResponse(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("code")
     @get:JsonProperty("code") val code: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("type")
     @get:JsonProperty("type") val type: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("message")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/src/main/kotlin/org/openapitools/model/Order.kt
@@ -29,37 +29,37 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Order(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("petId")
     @get:JsonProperty("petId") val petId: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("quantity")
     @get:JsonProperty("quantity") val quantity: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("shipDate")
     @get:JsonProperty("shipDate") val shipDate: java.time.OffsetDateTime? = null,
 
-    @Schema(example = "null", description = "Order Status")
+    @Schema(description = "Order Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("status")
     @get:JsonProperty("status") val status: Order.Status? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("complete")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -35,31 +35,31 @@ data class Pet(
     @param:JsonProperty("name")
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
-    @Schema(example = "null", required = true, description = "")
+    @Schema(required = true, description = "")
     @param:JsonProperty("photoUrls")
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("category")
     @get:JsonProperty("category") val category: Category? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("tags")
     @get:JsonProperty("tags") val tags: kotlin.collections.List<Tag>? = null,
 
-    @Schema(example = "null", description = "pet status in the store")
+    @Schema(description = "pet status in the store")
     @Deprecated(message = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)

--- a/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -23,13 +23,13 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Tag(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface-wrapped/src/main/kotlin/org/openapitools/model/User.kt
@@ -29,49 +29,49 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class User(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("username")
     @get:JsonProperty("username") val username: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("firstName")
     @get:JsonProperty("firstName") val firstName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("lastName")
     @get:JsonProperty("lastName") val lastName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("email")
     @get:JsonProperty("email") val email: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("password")
     @get:JsonProperty("password") val password: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("phone")
     @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
-    @Schema(example = "null", description = "User Status")
+    @Schema(description = "User Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("userStatus")

--- a/samples/server/petstore/kotlin-spring-declarative-interface/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface/src/main/kotlin/org/openapitools/model/Category.kt
@@ -23,14 +23,14 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Category(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @get:Pattern(regexp="^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$")
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-spring-declarative-interface/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -24,19 +24,19 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class ModelApiResponse(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("code")
     @get:JsonProperty("code") val code: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("type")
     @get:JsonProperty("type") val type: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("message")

--- a/samples/server/petstore/kotlin-spring-declarative-interface/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface/src/main/kotlin/org/openapitools/model/Order.kt
@@ -29,37 +29,37 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Order(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("petId")
     @get:JsonProperty("petId") val petId: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("quantity")
     @get:JsonProperty("quantity") val quantity: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("shipDate")
     @get:JsonProperty("shipDate") val shipDate: java.time.OffsetDateTime? = null,
 
-    @Schema(example = "null", description = "Order Status")
+    @Schema(description = "Order Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("status")
     @get:JsonProperty("status") val status: Order.Status? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("complete")

--- a/samples/server/petstore/kotlin-spring-declarative-interface/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -35,31 +35,31 @@ data class Pet(
     @param:JsonProperty("name")
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
-    @Schema(example = "null", required = true, description = "")
+    @Schema(required = true, description = "")
     @param:JsonProperty("photoUrls")
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("category")
     @get:JsonProperty("category") val category: Category? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("tags")
     @get:JsonProperty("tags") val tags: kotlin.collections.List<Tag>? = null,
 
-    @Schema(example = "null", description = "pet status in the store")
+    @Schema(description = "pet status in the store")
     @Deprecated(message = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)

--- a/samples/server/petstore/kotlin-spring-declarative-interface/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -23,13 +23,13 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Tag(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-spring-declarative-interface/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-spring-declarative-interface/src/main/kotlin/org/openapitools/model/User.kt
@@ -29,49 +29,49 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class User(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("username")
     @get:JsonProperty("username") val username: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("firstName")
     @get:JsonProperty("firstName") val firstName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("lastName")
     @get:JsonProperty("lastName") val lastName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("email")
     @get:JsonProperty("email") val email: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("password")
     @get:JsonProperty("password") val password: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("phone")
     @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
-    @Schema(example = "null", description = "User Status")
+    @Schema(description = "User Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("userStatus")

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/Annotation.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/Annotation.kt
@@ -22,7 +22,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Annotation(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/AnyOfUserOrPet.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/AnyOfUserOrPet.kt
@@ -40,7 +40,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class AnyOfUserOrPet(
 
-    @Schema(example = "null", required = true, description = "")
+    @Schema(required = true, description = "")
     @param:JsonProperty("username")
     @get:JsonProperty("username", required = true) val username: kotlin.String,
 
@@ -48,67 +48,67 @@ data class AnyOfUserOrPet(
     @param:JsonProperty("name")
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
-    @Schema(example = "null", required = true, description = "")
+    @Schema(required = true, description = "")
     @param:JsonProperty("photoUrls")
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("firstName")
     @get:JsonProperty("firstName") val firstName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("lastName")
     @get:JsonProperty("lastName") val lastName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("email")
     @get:JsonProperty("email") val email: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("password")
     @get:JsonProperty("password") val password: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("phone")
     @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
-    @Schema(example = "null", description = "User Status")
+    @Schema(description = "User Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("userStatus")
     @get:JsonProperty("userStatus") val userStatus: kotlin.Int? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("category")
     @get:JsonProperty("category") val category: Category? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("tags")
     @get:JsonProperty("tags") val tags: kotlin.collections.List<Tag>? = null,
 
-    @Schema(example = "null", description = "pet status in the store")
+    @Schema(description = "pet status in the store")
     @Deprecated(message = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/AnyOfUserOrPetOrArrayString.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/AnyOfUserOrPetOrArrayString.kt
@@ -40,7 +40,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class AnyOfUserOrPetOrArrayString(
 
-    @Schema(example = "null", required = true, description = "")
+    @Schema(required = true, description = "")
     @param:JsonProperty("username")
     @get:JsonProperty("username", required = true) val username: kotlin.String,
 
@@ -48,67 +48,67 @@ data class AnyOfUserOrPetOrArrayString(
     @param:JsonProperty("name")
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
-    @Schema(example = "null", required = true, description = "")
+    @Schema(required = true, description = "")
     @param:JsonProperty("photoUrls")
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("firstName")
     @get:JsonProperty("firstName") val firstName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("lastName")
     @get:JsonProperty("lastName") val lastName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("email")
     @get:JsonProperty("email") val email: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("password")
     @get:JsonProperty("password") val password: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("phone")
     @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
-    @Schema(example = "null", description = "User Status")
+    @Schema(description = "User Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("userStatus")
     @get:JsonProperty("userStatus") val userStatus: kotlin.Int? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("category")
     @get:JsonProperty("category") val category: Category? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("tags")
     @get:JsonProperty("tags") val tags: kotlin.collections.List<Tag>? = null,
 
-    @Schema(example = "null", description = "pet status in the store")
+    @Schema(description = "pet status in the store")
     @Deprecated(message = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/Category.kt
@@ -23,14 +23,14 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Category(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @get:Pattern(regexp="^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$")
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -24,19 +24,19 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class ModelApiResponse(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("code")
     @get:JsonProperty("code") val code: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("type")
     @get:JsonProperty("type") val type: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("message")

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/Order.kt
@@ -29,37 +29,37 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Order(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("petId")
     @get:JsonProperty("petId") val petId: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("quantity")
     @get:JsonProperty("quantity") val quantity: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("shipDate")
     @get:JsonProperty("shipDate") val shipDate: java.time.OffsetDateTime? = null,
 
-    @Schema(example = "null", description = "Order Status")
+    @Schema(description = "Order Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("status")
     @get:JsonProperty("status") val status: Order.Status? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("complete")

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -35,31 +35,31 @@ data class Pet(
     @param:JsonProperty("name")
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
-    @Schema(example = "null", required = true, description = "")
+    @Schema(required = true, description = "")
     @param:JsonProperty("photoUrls")
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("category")
     @get:JsonProperty("category") val category: Category? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("tags")
     @get:JsonProperty("tags") val tags: kotlin.collections.List<Tag>? = null,
 
-    @Schema(example = "null", description = "pet status in the store")
+    @Schema(description = "pet status in the store")
     @Deprecated(message = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -23,13 +23,13 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Tag(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/model/User.kt
@@ -31,47 +31,47 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class User(
 
-    @Schema(example = "null", required = true, description = "")
+    @Schema(required = true, description = "")
     @param:JsonProperty("username")
     @get:JsonProperty("username", required = true) val username: kotlin.String,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("firstName")
     @get:JsonProperty("firstName") val firstName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("lastName")
     @get:JsonProperty("lastName") val lastName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("email")
     @get:JsonProperty("email") val email: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("password")
     @get:JsonProperty("password") val password: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("phone")
     @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
-    @Schema(example = "null", description = "User Status")
+    @Schema(description = "User Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("userStatus")

--- a/samples/server/petstore/kotlin-springboot-bigdecimal-default/src/main/kotlin/org/openapitools/model/Apa.kt
+++ b/samples/server/petstore/kotlin-springboot-bigdecimal-default/src/main/kotlin/org/openapitools/model/Apa.kt
@@ -27,32 +27,32 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Apa(
 
-    @Schema(example = "null", required = true, description = "")
+    @Schema(required = true, description = "")
     @param:JsonProperty("bepa")
     @get:JsonProperty("bepa", required = true) val bepa: java.math.BigDecimal = java.math.BigDecimal("0"),
 
-    @Schema(example = "null", required = true, description = "")
+    @Schema(required = true, description = "")
     @param:JsonProperty("cepa")
     @get:JsonProperty("cepa", required = true) val cepa: java.math.BigDecimal = java.math.BigDecimal("6.28318"),
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("depa")
     @get:JsonProperty("depa") val depa: java.math.BigDecimal? = java.math.BigDecimal("71"),
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("epa")
     @get:JsonProperty("epa") val epa: java.math.BigDecimal? = java.math.BigDecimal("-71"),
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @Deprecated(message = "")
     @param:JsonProperty("fepa")
     @get:JsonProperty("fepa") val fepa: java.math.BigDecimal? = java.math.BigDecimal("100"),
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @param:JsonProperty("gepa")
     @get:JsonProperty("gepa") val gepa: java.math.BigDecimal? = null
 ) {

--- a/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/Category.kt
@@ -23,14 +23,14 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Category(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @get:Pattern(regexp="^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$")
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -24,19 +24,19 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class ModelApiResponse(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("code")
     @get:JsonProperty("code") val code: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("type")
     @get:JsonProperty("type") val type: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("message")

--- a/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/Order.kt
@@ -29,37 +29,37 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Order(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("petId")
     @get:JsonProperty("petId") val petId: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("quantity")
     @get:JsonProperty("quantity") val quantity: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("shipDate")
     @get:JsonProperty("shipDate") val shipDate: java.time.OffsetDateTime? = null,
 
-    @Schema(example = "null", description = "Order Status")
+    @Schema(description = "Order Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("status")
     @get:JsonProperty("status") val status: Order.Status? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("complete")

--- a/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -35,31 +35,31 @@ data class Pet(
     @param:JsonProperty("name")
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
-    @Schema(example = "null", required = true, description = "")
+    @Schema(required = true, description = "")
     @param:JsonProperty("photoUrls")
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("category")
     @get:JsonProperty("category") val category: Category? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("tags")
     @get:JsonProperty("tags") val tags: kotlin.collections.List<Tag>? = null,
 
-    @Schema(example = "null", description = "pet status in the store")
+    @Schema(description = "pet status in the store")
     @Deprecated(message = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)

--- a/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -23,13 +23,13 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Tag(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/model/User.kt
@@ -29,49 +29,49 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class User(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("username")
     @get:JsonProperty("username") val username: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("firstName")
     @get:JsonProperty("firstName") val firstName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("lastName")
     @get:JsonProperty("lastName") val lastName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("email")
     @get:JsonProperty("email") val email: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("password")
     @get:JsonProperty("password") val password: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("phone")
     @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
-    @Schema(example = "null", description = "User Status")
+    @Schema(description = "User Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("userStatus")

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Category.kt
@@ -23,14 +23,14 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Category(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @get:Pattern(regexp="^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$")
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -24,19 +24,19 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class ModelApiResponse(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("code")
     @get:JsonProperty("code") val code: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("type")
     @get:JsonProperty("type") val type: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("message")

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Order.kt
@@ -29,37 +29,37 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Order(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("petId")
     @get:JsonProperty("petId") val petId: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("quantity")
     @get:JsonProperty("quantity") val quantity: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("shipDate")
     @get:JsonProperty("shipDate") val shipDate: java.time.OffsetDateTime? = null,
 
-    @Schema(example = "null", description = "Order Status")
+    @Schema(description = "Order Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("status")
     @get:JsonProperty("status") val status: Order.Status? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("complete")

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -35,31 +35,31 @@ data class Pet(
     @param:JsonProperty("name")
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
-    @Schema(example = "null", required = true, description = "")
+    @Schema(required = true, description = "")
     @param:JsonProperty("photoUrls")
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("category")
     @get:JsonProperty("category") val category: Category? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("tags")
     @get:JsonProperty("tags") val tags: kotlin.collections.List<Tag>? = null,
 
-    @Schema(example = "null", description = "pet status in the store")
+    @Schema(description = "pet status in the store")
     @Deprecated(message = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -23,13 +23,13 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Tag(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/User.kt
@@ -29,49 +29,49 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class User(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("username")
     @get:JsonProperty("username") val username: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("firstName")
     @get:JsonProperty("firstName") val firstName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("lastName")
     @get:JsonProperty("lastName") val lastName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("email")
     @get:JsonProperty("email") val email: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("password")
     @get:JsonProperty("password") val password: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("phone")
     @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
-    @Schema(example = "null", description = "User Status")
+    @Schema(description = "User Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("userStatus")

--- a/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/model/Cat.kt
+++ b/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/model/Cat.kt
@@ -36,52 +36,52 @@ import io.swagger.annotations.ApiModelProperty
  */
 data class Cat(
 
-    @ApiModelProperty(example = "null", required = true, value = "")
+    @ApiModelProperty(required = true, value = "")
     @param:JsonProperty("name")
     @get:JsonProperty("name", required = true) override val name: kotlin.String,
 
-    @ApiModelProperty(example = "null", required = true, value = "")
+    @ApiModelProperty(required = true, value = "")
     @param:JsonProperty("photoUrls")
     @get:JsonProperty("photoUrls", required = true) override val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @ApiModelProperty(example = "null", required = true, value = "")
+    @ApiModelProperty(required = true, value = "")
     @param:JsonProperty("petType")
     @get:JsonProperty("petType", required = true) override val petType: kotlin.String,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("hunts")
     @get:JsonProperty("hunts") val hunts: kotlin.Boolean? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("age")
     @get:JsonProperty("age") val age: kotlin.Int? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") override val id: kotlin.Long? = null,
 
     @field:Valid
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("category")
     @get:JsonProperty("category") override val category: Category? = null,
 
     @field:Valid
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("tags")
     @get:JsonProperty("tags") override val tags: kotlin.collections.List<Tag>? = null,
 
     @field:Valid
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("color")

--- a/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/model/Category.kt
@@ -23,13 +23,13 @@ import io.swagger.annotations.ApiModelProperty
  */
 data class Category(
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/model/Dog.kt
+++ b/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/model/Dog.kt
@@ -37,52 +37,52 @@ import io.swagger.annotations.ApiModelProperty
  */
 data class Dog(
 
-    @ApiModelProperty(example = "null", required = true, value = "")
+    @ApiModelProperty(required = true, value = "")
     @param:JsonProperty("bark")
     @get:JsonProperty("bark", required = true) val bark: kotlin.Boolean,
 
-    @ApiModelProperty(example = "null", required = true, value = "")
+    @ApiModelProperty(required = true, value = "")
     @param:JsonProperty("breed")
     @get:JsonProperty("breed", required = true) val breed: Dog.Breed,
 
-    @ApiModelProperty(example = "null", required = true, value = "Whether the dog enjoys fetching")
+    @ApiModelProperty(required = true, value = "Whether the dog enjoys fetching")
     @param:JsonProperty("likesFetch")
     @get:JsonProperty("likesFetch", required = true) override val likesFetch: kotlin.Boolean,
 
-    @ApiModelProperty(example = "null", required = true, value = "")
+    @ApiModelProperty(required = true, value = "")
     @param:JsonProperty("name")
     @get:JsonProperty("name", required = true) override val name: kotlin.String,
 
-    @ApiModelProperty(example = "null", required = true, value = "")
+    @ApiModelProperty(required = true, value = "")
     @param:JsonProperty("photoUrls")
     @get:JsonProperty("photoUrls", required = true) override val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @ApiModelProperty(example = "null", required = true, value = "")
+    @ApiModelProperty(required = true, value = "")
     @param:JsonProperty("petType")
     @get:JsonProperty("petType", required = true) override val petType: kotlin.String,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") override val id: kotlin.Long? = null,
 
     @field:Valid
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("category")
     @get:JsonProperty("category") override val category: Category? = null,
 
     @field:Valid
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("tags")
     @get:JsonProperty("tags") override val tags: kotlin.collections.List<Tag>? = null,
 
     @field:Valid
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("color")

--- a/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -24,19 +24,19 @@ import io.swagger.annotations.ApiModelProperty
  */
 data class ModelApiResponse(
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("code")
     @get:JsonProperty("code") val code: kotlin.Int? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("type")
     @get:JsonProperty("type") val type: kotlin.String? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("message")

--- a/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/model/Order.kt
@@ -29,37 +29,37 @@ import io.swagger.annotations.ApiModelProperty
  */
 data class Order(
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("petId")
     @get:JsonProperty("petId") val petId: kotlin.Long? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("quantity")
     @get:JsonProperty("quantity") val quantity: kotlin.Int? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("shipDate")
     @get:JsonProperty("shipDate") val shipDate: java.time.OffsetDateTime? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("status")
     @get:JsonProperty("status") val status: Order.Status? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("complete")

--- a/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -46,31 +46,31 @@ import io.swagger.annotations.ApiModelProperty
 
 interface Pet : com.some.pack.Named, com.some.pack.WithCategory, com.some.pack.WithDefaultMethods, com.some.pack.WithPhotoUrls, java.io.Serializable {
         
-        @get:ApiModelProperty(example = "null", required = true, value = "")
+        @get:ApiModelProperty(required = true, value = "")
         override val name: kotlin.String
 
         
-        @get:ApiModelProperty(example = "null", required = true, value = "")
+        @get:ApiModelProperty(required = true, value = "")
         override val photoUrls: kotlin.collections.List<kotlin.String>
 
         
-        @get:ApiModelProperty(example = "null", required = true, value = "")
+        @get:ApiModelProperty(required = true, value = "")
         val petType: kotlin.String
 
         
-        @get:ApiModelProperty(example = "null", value = "")
+        @get:ApiModelProperty(value = "")
         val id: kotlin.Long? 
 
         
-        @get:ApiModelProperty(example = "null", value = "")
+        @get:ApiModelProperty(value = "")
         override val category: Category? 
 
         
-        @get:ApiModelProperty(example = "null", value = "")
+        @get:ApiModelProperty(value = "")
         val tags: kotlin.collections.List<Tag>? 
 
         
-        @get:ApiModelProperty(example = "null", value = "")
+        @get:ApiModelProperty(value = "")
         val color: Color? 
 
 

--- a/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -23,13 +23,13 @@ import io.swagger.annotations.ApiModelProperty
  */
 data class Tag(
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/model/User.kt
@@ -29,49 +29,49 @@ import io.swagger.annotations.ApiModelProperty
  */
 data class User(
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("username")
     @get:JsonProperty("username") val username: kotlin.String? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("firstName")
     @get:JsonProperty("firstName") val firstName: kotlin.String? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("lastName")
     @get:JsonProperty("lastName") val lastName: kotlin.String? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("email")
     @get:JsonProperty("email") val email: kotlin.String? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("password")
     @get:JsonProperty("password") val password: kotlin.String? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("phone")
     @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("userStatus")

--- a/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Category.kt
@@ -23,13 +23,13 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Category(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") var id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -24,19 +24,19 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class ModelApiResponse(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("code")
     @get:JsonProperty("code") var code: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("type")
     @get:JsonProperty("type") var type: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("message")

--- a/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Order.kt
@@ -29,37 +29,37 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Order(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") var id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("petId")
     @get:JsonProperty("petId") var petId: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("quantity")
     @get:JsonProperty("quantity") var quantity: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("shipDate")
     @get:JsonProperty("shipDate") var shipDate: java.time.OffsetDateTime? = null,
 
-    @Schema(example = "null", description = "Order Status")
+    @Schema(description = "Order Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("status")
     @get:JsonProperty("status") var status: Order.Status? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("complete")

--- a/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -35,31 +35,31 @@ data class Pet(
     @param:JsonProperty("name")
     @get:JsonProperty("name", required = true) var name: kotlin.String,
 
-    @Schema(example = "null", required = true, description = "")
+    @Schema(required = true, description = "")
     @param:JsonProperty("photoUrls")
     @get:JsonProperty("photoUrls", required = true) var photoUrls: kotlin.collections.MutableList<kotlin.String>,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") var id: kotlin.Long? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("category")
     @get:JsonProperty("category") var category: Category? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("tags")
     @get:JsonProperty("tags") var tags: kotlin.collections.MutableList<Tag>? = null,
 
-    @Schema(example = "null", description = "pet status in the store")
+    @Schema(description = "pet status in the store")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("status")

--- a/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -23,13 +23,13 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Tag(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") var id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/User.kt
@@ -29,49 +29,49 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class User(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") var id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("username")
     @get:JsonProperty("username") var username: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("firstName")
     @get:JsonProperty("firstName") var firstName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("lastName")
     @get:JsonProperty("lastName") var lastName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("email")
     @get:JsonProperty("email") var email: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("password")
     @get:JsonProperty("password") var password: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("phone")
     @get:JsonProperty("phone") var phone: kotlin.String? = null,
 
-    @Schema(example = "null", description = "User Status")
+    @Schema(description = "User Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("userStatus")

--- a/samples/server/petstore/kotlin-springboot-multipart-request-model/src/main/kotlin/org/openapitools/model/MultipartMixedRequestMarker.kt
+++ b/samples/server/petstore/kotlin-springboot-multipart-request-model/src/main/kotlin/org/openapitools/model/MultipartMixedRequestMarker.kt
@@ -22,7 +22,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class MultipartMixedRequestMarker(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-springboot-reactive-without-flow/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive-without-flow/src/main/kotlin/org/openapitools/model/Category.kt
@@ -23,14 +23,14 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Category(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @get:Pattern(regexp="^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$")
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-springboot-reactive-without-flow/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive-without-flow/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -24,19 +24,19 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class ModelApiResponse(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("code")
     @get:JsonProperty("code") val code: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("type")
     @get:JsonProperty("type") val type: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("message")

--- a/samples/server/petstore/kotlin-springboot-reactive-without-flow/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive-without-flow/src/main/kotlin/org/openapitools/model/Order.kt
@@ -29,37 +29,37 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Order(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("petId")
     @get:JsonProperty("petId") val petId: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("quantity")
     @get:JsonProperty("quantity") val quantity: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("shipDate")
     @get:JsonProperty("shipDate") val shipDate: java.time.OffsetDateTime? = null,
 
-    @Schema(example = "null", description = "Order Status")
+    @Schema(description = "Order Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("status")
     @get:JsonProperty("status") val status: Order.Status? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("complete")

--- a/samples/server/petstore/kotlin-springboot-reactive-without-flow/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive-without-flow/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -35,31 +35,31 @@ data class Pet(
     @param:JsonProperty("name")
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
-    @Schema(example = "null", required = true, description = "")
+    @Schema(required = true, description = "")
     @param:JsonProperty("photoUrls")
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("category")
     @get:JsonProperty("category") val category: Category? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("tags")
     @get:JsonProperty("tags") val tags: kotlin.collections.List<Tag>? = null,
 
-    @Schema(example = "null", description = "pet status in the store")
+    @Schema(description = "pet status in the store")
     @Deprecated(message = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)

--- a/samples/server/petstore/kotlin-springboot-reactive-without-flow/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive-without-flow/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -23,13 +23,13 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Tag(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-springboot-reactive-without-flow/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive-without-flow/src/main/kotlin/org/openapitools/model/User.kt
@@ -29,49 +29,49 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class User(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("username")
     @get:JsonProperty("username") val username: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("firstName")
     @get:JsonProperty("firstName") val firstName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("lastName")
     @get:JsonProperty("lastName") val lastName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("email")
     @get:JsonProperty("email") val email: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("password")
     @get:JsonProperty("password") val password: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("phone")
     @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
-    @Schema(example = "null", description = "User Status")
+    @Schema(description = "User Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("userStatus")

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Category.kt
@@ -23,14 +23,14 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Category(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @get:Pattern(regexp="^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$")
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -24,19 +24,19 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class ModelApiResponse(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("code")
     @get:JsonProperty("code") val code: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("type")
     @get:JsonProperty("type") val type: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("message")

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Order.kt
@@ -29,37 +29,37 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Order(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("petId")
     @get:JsonProperty("petId") val petId: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("quantity")
     @get:JsonProperty("quantity") val quantity: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("shipDate")
     @get:JsonProperty("shipDate") val shipDate: java.time.OffsetDateTime? = null,
 
-    @Schema(example = "null", description = "Order Status")
+    @Schema(description = "Order Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("status")
     @get:JsonProperty("status") val status: Order.Status? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("complete")

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -35,31 +35,31 @@ data class Pet(
     @param:JsonProperty("name")
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
-    @Schema(example = "null", required = true, description = "")
+    @Schema(required = true, description = "")
     @param:JsonProperty("photoUrls")
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("category")
     @get:JsonProperty("category") val category: Category? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("tags")
     @get:JsonProperty("tags") val tags: kotlin.collections.List<Tag>? = null,
 
-    @Schema(example = "null", description = "pet status in the store")
+    @Schema(description = "pet status in the store")
     @Deprecated(message = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -23,13 +23,13 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Tag(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/User.kt
@@ -29,49 +29,49 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class User(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("username")
     @get:JsonProperty("username") val username: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("firstName")
     @get:JsonProperty("firstName") val firstName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("lastName")
     @get:JsonProperty("lastName") val lastName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("email")
     @get:JsonProperty("email") val email: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("password")
     @get:JsonProperty("password") val password: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("phone")
     @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
-    @Schema(example = "null", description = "User Status")
+    @Schema(description = "User Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("userStatus")

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Animal.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Animal.kt
@@ -35,10 +35,10 @@ import io.swagger.v3.oas.annotations.media.Schema
 )
 
 interface Animal {
-                @get:Schema(example = "null", requiredMode = Schema.RequiredMode.REQUIRED, description = "")
+                @get:Schema(requiredMode = Schema.RequiredMode.REQUIRED, description = "")
         val className: kotlin.String
 
-                @get:Schema(example = "null", description = "")
+                @get:Schema(description = "")
         val color: kotlin.String? 
 
 

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Cat.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Cat.kt
@@ -25,17 +25,17 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Cat(
 
-    @Schema(example = "null", required = true, description = "")
+    @Schema(required = true, description = "")
     @param:JsonProperty("className")
     @get:JsonProperty("className", required = true) override val className: kotlin.String,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("declawed")
     @get:JsonProperty("declawed") val declawed: kotlin.Boolean? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("color")

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Category.kt
@@ -23,11 +23,11 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Category(
 
-    @Schema(example = "null", required = true, description = "")
+    @Schema(required = true, description = "")
     @param:JsonProperty("name")
     @get:JsonProperty("name", required = true) val name: kotlin.String = "default-name",
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Client.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Client.kt
@@ -22,7 +22,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Client(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("client")

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Dog.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Dog.kt
@@ -25,17 +25,17 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Dog(
 
-    @Schema(example = "null", required = true, description = "")
+    @Schema(required = true, description = "")
     @param:JsonProperty("className")
     @get:JsonProperty("className", required = true) override val className: kotlin.String,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("breed")
     @get:JsonProperty("breed") val breed: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("color")

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Foo.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Foo.kt
@@ -22,7 +22,7 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Foo(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("bar")

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/FooGetDefaultResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/FooGetDefaultResponse.kt
@@ -24,7 +24,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class FooGetDefaultResponse(
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("string")

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -24,19 +24,19 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class ModelApiResponse(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("code")
     @get:JsonProperty("code") val code: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("type")
     @get:JsonProperty("type") val type: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("message")

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Order.kt
@@ -29,37 +29,37 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Order(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("petId")
     @get:JsonProperty("petId") val petId: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("quantity")
     @get:JsonProperty("quantity") val quantity: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("shipDate")
     @get:JsonProperty("shipDate") val shipDate: java.time.OffsetDateTime? = null,
 
-    @Schema(example = "null", description = "Order Status")
+    @Schema(description = "Order Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("status")
     @get:JsonProperty("status") val status: Order.Status? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("complete")

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -35,31 +35,31 @@ data class Pet(
     @param:JsonProperty("name")
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
-    @Schema(example = "null", required = true, description = "")
+    @Schema(required = true, description = "")
     @param:JsonProperty("photoUrls")
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.Set<kotlin.String>,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("category")
     @get:JsonProperty("category") val category: Category? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("tags")
     @get:JsonProperty("tags") val tags: kotlin.collections.List<Tag>? = null,
 
-    @Schema(example = "null", description = "pet status in the store")
+    @Schema(description = "pet status in the store")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("status")

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -23,13 +23,13 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Tag(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/src/main/kotlin/org/openapitools/model/User.kt
@@ -29,49 +29,49 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class User(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("username")
     @get:JsonProperty("username") val username: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("firstName")
     @get:JsonProperty("firstName") val firstName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("lastName")
     @get:JsonProperty("lastName") val lastName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("email")
     @get:JsonProperty("email") val email: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("password")
     @get:JsonProperty("password") val password: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("phone")
     @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
-    @Schema(example = "null", description = "User Status")
+    @Schema(description = "User Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("userStatus")

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Category.kt
@@ -23,13 +23,13 @@ import io.swagger.annotations.ApiModelProperty
  */
 data class Category(
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -24,19 +24,19 @@ import io.swagger.annotations.ApiModelProperty
  */
 data class ModelApiResponse(
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("code")
     @get:JsonProperty("code") val code: kotlin.Int? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("type")
     @get:JsonProperty("type") val type: kotlin.String? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("message")

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Order.kt
@@ -29,37 +29,37 @@ import io.swagger.annotations.ApiModelProperty
  */
 data class Order(
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("petId")
     @get:JsonProperty("petId") val petId: kotlin.Long? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("quantity")
     @get:JsonProperty("quantity") val quantity: kotlin.Int? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("shipDate")
     @get:JsonProperty("shipDate") val shipDate: java.time.OffsetDateTime? = null,
 
-    @ApiModelProperty(example = "null", value = "Order Status")
+    @ApiModelProperty(value = "Order Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("status")
     @get:JsonProperty("status") val status: Order.Status? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("complete")

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -35,31 +35,31 @@ data class Pet(
     @param:JsonProperty("name")
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
-    @ApiModelProperty(example = "null", required = true, value = "")
+    @ApiModelProperty(required = true, value = "")
     @param:JsonProperty("photoUrls")
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @field:Valid
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("category")
     @get:JsonProperty("category") val category: Category? = null,
 
     @field:Valid
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("tags")
     @get:JsonProperty("tags") val tags: kotlin.collections.List<Tag>? = null,
 
-    @ApiModelProperty(example = "null", value = "pet status in the store")
+    @ApiModelProperty(value = "pet status in the store")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("status")

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -23,13 +23,13 @@ import io.swagger.annotations.ApiModelProperty
  */
 data class Tag(
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/User.kt
@@ -29,49 +29,49 @@ import io.swagger.annotations.ApiModelProperty
  */
 data class User(
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("username")
     @get:JsonProperty("username") val username: kotlin.String? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("firstName")
     @get:JsonProperty("firstName") val firstName: kotlin.String? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("lastName")
     @get:JsonProperty("lastName") val lastName: kotlin.String? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("email")
     @get:JsonProperty("email") val email: kotlin.String? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("password")
     @get:JsonProperty("password") val password: kotlin.String? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("phone")
     @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
-    @ApiModelProperty(example = "null", value = "User Status")
+    @ApiModelProperty(value = "User Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("userStatus")

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Category.kt
@@ -23,13 +23,13 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Category(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -24,19 +24,19 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class ModelApiResponse(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("code")
     @get:JsonProperty("code") val code: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("type")
     @get:JsonProperty("type") val type: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("message")

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Order.kt
@@ -29,37 +29,37 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Order(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("petId")
     @get:JsonProperty("petId") val petId: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("quantity")
     @get:JsonProperty("quantity") val quantity: kotlin.Int? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("shipDate")
     @get:JsonProperty("shipDate") val shipDate: java.time.OffsetDateTime? = null,
 
-    @Schema(example = "null", description = "Order Status")
+    @Schema(description = "Order Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("status")
     @get:JsonProperty("status") val status: Order.Status? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("complete")

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -35,31 +35,31 @@ data class Pet(
     @param:JsonProperty("name")
     @get:JsonProperty("name", required = true) val name: kotlin.String,
 
-    @Schema(example = "null", required = true, description = "")
+    @Schema(required = true, description = "")
     @param:JsonProperty("photoUrls")
     @get:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("category")
     @get:JsonProperty("category") val category: Category? = null,
 
     @field:Valid
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("tags")
     @get:JsonProperty("tags") val tags: kotlin.collections.List<Tag>? = null,
 
-    @Schema(example = "null", description = "pet status in the store")
+    @Schema(description = "pet status in the store")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("status")

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -23,13 +23,13 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class Tag(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/User.kt
@@ -29,49 +29,49 @@ import io.swagger.v3.oas.annotations.media.Schema
  */
 data class User(
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("username")
     @get:JsonProperty("username") val username: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("firstName")
     @get:JsonProperty("firstName") val firstName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("lastName")
     @get:JsonProperty("lastName") val lastName: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("email")
     @get:JsonProperty("email") val email: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("password")
     @get:JsonProperty("password") val password: kotlin.String? = null,
 
-    @Schema(example = "null", description = "")
+    @Schema(description = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("phone")
     @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
-    @Schema(example = "null", description = "User Status")
+    @Schema(description = "User Status")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("userStatus")

--- a/samples/server/petstore/kotlin-springboot-x-kotlin-implements/src/main/kotlin/org/openapitools/model/Cat.kt
+++ b/samples/server/petstore/kotlin-springboot-x-kotlin-implements/src/main/kotlin/org/openapitools/model/Cat.kt
@@ -36,52 +36,52 @@ import io.swagger.annotations.ApiModelProperty
  */
 data class Cat(
 
-    @ApiModelProperty(example = "null", required = true, value = "")
+    @ApiModelProperty(required = true, value = "")
     @param:JsonProperty("name")
     @get:JsonProperty("name", required = true) override val name: kotlin.String,
 
-    @ApiModelProperty(example = "null", required = true, value = "")
+    @ApiModelProperty(required = true, value = "")
     @param:JsonProperty("photoUrls")
     @get:JsonProperty("photoUrls", required = true) override val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @ApiModelProperty(example = "null", required = true, value = "")
+    @ApiModelProperty(required = true, value = "")
     @param:JsonProperty("petType")
     @get:JsonProperty("petType", required = true) override val petType: kotlin.String,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("hunts")
     @get:JsonProperty("hunts") val hunts: kotlin.Boolean? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("age")
     @get:JsonProperty("age") val age: kotlin.Int? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") override val id: kotlin.Long? = null,
 
     @field:Valid
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("category")
     @get:JsonProperty("category") override val category: Category? = null,
 
     @field:Valid
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("tags")
     @get:JsonProperty("tags") override val tags: kotlin.collections.List<Tag>? = null,
 
     @field:Valid
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("color")

--- a/samples/server/petstore/kotlin-springboot-x-kotlin-implements/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-x-kotlin-implements/src/main/kotlin/org/openapitools/model/Category.kt
@@ -23,13 +23,13 @@ import io.swagger.annotations.ApiModelProperty
  */
 data class Category(
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") override val id: kotlin.Long? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-springboot-x-kotlin-implements/src/main/kotlin/org/openapitools/model/Dog.kt
+++ b/samples/server/petstore/kotlin-springboot-x-kotlin-implements/src/main/kotlin/org/openapitools/model/Dog.kt
@@ -37,52 +37,52 @@ import io.swagger.annotations.ApiModelProperty
  */
 data class Dog(
 
-    @ApiModelProperty(example = "null", required = true, value = "")
+    @ApiModelProperty(required = true, value = "")
     @param:JsonProperty("bark")
     @get:JsonProperty("bark", required = true) override val bark: kotlin.Boolean,
 
-    @ApiModelProperty(example = "null", required = true, value = "")
+    @ApiModelProperty(required = true, value = "")
     @param:JsonProperty("breed")
     @get:JsonProperty("breed", required = true) override val breed: Dog.Breed,
 
-    @ApiModelProperty(example = "null", required = true, value = "Whether the dog enjoys fetching")
+    @ApiModelProperty(required = true, value = "Whether the dog enjoys fetching")
     @param:JsonProperty("likesFetch")
     @get:JsonProperty("likesFetch", required = true) override val likesFetch: kotlin.Boolean,
 
-    @ApiModelProperty(example = "null", required = true, value = "")
+    @ApiModelProperty(required = true, value = "")
     @param:JsonProperty("name")
     @get:JsonProperty("name", required = true) override val name: kotlin.String,
 
-    @ApiModelProperty(example = "null", required = true, value = "")
+    @ApiModelProperty(required = true, value = "")
     @param:JsonProperty("photoUrls")
     @get:JsonProperty("photoUrls", required = true) override val photoUrls: kotlin.collections.List<kotlin.String>,
 
-    @ApiModelProperty(example = "null", required = true, value = "")
+    @ApiModelProperty(required = true, value = "")
     @param:JsonProperty("petType")
     @get:JsonProperty("petType", required = true) override val petType: kotlin.String,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") override val id: kotlin.Long? = null,
 
     @field:Valid
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("category")
     @get:JsonProperty("category") override val category: Category? = null,
 
     @field:Valid
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("tags")
     @get:JsonProperty("tags") override val tags: kotlin.collections.List<Tag>? = null,
 
     @field:Valid
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("color")

--- a/samples/server/petstore/kotlin-springboot-x-kotlin-implements/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-x-kotlin-implements/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -24,19 +24,19 @@ import io.swagger.annotations.ApiModelProperty
  */
 data class ModelApiResponse(
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("code")
     @get:JsonProperty("code") val code: kotlin.Int? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("type")
     @get:JsonProperty("type") val type: kotlin.String? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("message")

--- a/samples/server/petstore/kotlin-springboot-x-kotlin-implements/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-x-kotlin-implements/src/main/kotlin/org/openapitools/model/Order.kt
@@ -29,37 +29,37 @@ import io.swagger.annotations.ApiModelProperty
  */
 data class Order(
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("petId")
     @get:JsonProperty("petId") val petId: kotlin.Long? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("quantity")
     @get:JsonProperty("quantity") val quantity: kotlin.Int? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("shipDate")
     @get:JsonProperty("shipDate") val shipDate: java.time.OffsetDateTime? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("status")
     @get:JsonProperty("status") val status: Order.Status? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("complete")

--- a/samples/server/petstore/kotlin-springboot-x-kotlin-implements/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-x-kotlin-implements/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -46,31 +46,31 @@ import io.swagger.annotations.ApiModelProperty
 
 interface Pet : com.some.pack.Named, com.some.pack.WithCategory, com.some.pack.WithDefaultMethods, com.some.pack.WithId, java.io.Serializable {
         
-        @get:ApiModelProperty(example = "null", required = true, value = "")
+        @get:ApiModelProperty(required = true, value = "")
         override val name: kotlin.String
 
         
-        @get:ApiModelProperty(example = "null", required = true, value = "")
+        @get:ApiModelProperty(required = true, value = "")
         val photoUrls: kotlin.collections.List<kotlin.String>
 
         
-        @get:ApiModelProperty(example = "null", required = true, value = "")
+        @get:ApiModelProperty(required = true, value = "")
         val petType: kotlin.String
 
         
-        @get:ApiModelProperty(example = "null", value = "")
+        @get:ApiModelProperty(value = "")
         override val id: kotlin.Long? 
 
         
-        @get:ApiModelProperty(example = "null", value = "")
+        @get:ApiModelProperty(value = "")
         override val category: Category? 
 
         
-        @get:ApiModelProperty(example = "null", value = "")
+        @get:ApiModelProperty(value = "")
         val tags: kotlin.collections.List<Tag>? 
 
         
-        @get:ApiModelProperty(example = "null", value = "")
+        @get:ApiModelProperty(value = "")
         val color: Color? 
 
 

--- a/samples/server/petstore/kotlin-springboot-x-kotlin-implements/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-x-kotlin-implements/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -23,13 +23,13 @@ import io.swagger.annotations.ApiModelProperty
  */
 data class Tag(
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("name")

--- a/samples/server/petstore/kotlin-springboot-x-kotlin-implements/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-x-kotlin-implements/src/main/kotlin/org/openapitools/model/User.kt
@@ -29,49 +29,49 @@ import io.swagger.annotations.ApiModelProperty
  */
 data class User(
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("id")
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("username")
     @get:JsonProperty("username") val username: kotlin.String? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("firstName")
     @get:JsonProperty("firstName") val firstName: kotlin.String? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("lastName")
     @get:JsonProperty("lastName") val lastName: kotlin.String? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("email")
     @get:JsonProperty("email") val email: kotlin.String? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("password")
     @get:JsonProperty("password") val password: kotlin.String? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("phone")
     @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
-    @ApiModelProperty(example = "null", value = "")
+    @ApiModelProperty(value = "")
     @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonSetter(nulls = Nulls.SKIP)
     @param:JsonProperty("userStatus")


### PR DESCRIPTION
Fixes #24227.
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop emitting empty example attributes in Kotlin Spring–generated annotations. Only include `example` when the schema defines one; removes `example = "null"` and `example = ""` from outputs. Fixes #24227.

- **Bug Fixes**
  - Overrode `AbstractKotlinCodegen#toExampleValue` to return `null` unless `schema.example` is set, omitting default/empty examples in annotations like `@Schema`/`@ApiModelProperty`.
  - Updated `KotlinSpringServerCodegenTest` expectations and regenerated Kotlin Spring samples so annotations now include only `description`/`required` when no example is provided.

<sup>Written for commit e2da581e1df9b87d3448ced43883f0f8a542c7d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

