### PR TITLE
fix(docker): update base image to eclipse-temurin 17.0.19 on Ubuntu 24.04 (noble)

### DIFF
--- a/modules/openapi-generator-cli/Dockerfile
+++ b/modules/openapi-generator-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.9_9-jre-focal
+FROM eclipse-temurin:17.0.19_10-jre-resolute
 
 ADD target/openapi-generator-cli.jar /opt/openapi-generator/modules/openapi-generator-cli/target/openapi-generator-cli.jar
 

--- a/modules/openapi-generator-cli/Dockerfile
+++ b/modules/openapi-generator-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.19_10-jre-resolute
+FROM eclipse-temurin:17.0.19_10-jre-noble
 
 ADD target/openapi-generator-cli.jar /opt/openapi-generator/modules/openapi-generator-cli/target/openapi-generator-cli.jar
 

--- a/modules/openapi-generator-online/Dockerfile
+++ b/modules/openapi-generator-online/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.19_10-jre-resolute
+FROM eclipse-temurin:17.0.19_10-jre-noble
 
 WORKDIR /generator
 

--- a/modules/openapi-generator-online/Dockerfile
+++ b/modules/openapi-generator-online/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.9_9-jre-focal
+FROM eclipse-temurin:17.0.19_10-jre-resolute
 
 WORKDIR /generator
 


### PR DESCRIPTION
## Summary

- Bumps the published `openapi-generator-cli` and `openapi-generator-online` Docker base images from `eclipse-temurin:17.0.9_9-jre-focal` (Ubuntu 20.04) to `eclipse-temurin:17.0.19_10-jre-noble` (Ubuntu 24.04 LTS).
- Ubuntu 20.04 (focal) reached end of standard support, so Canonical no longer publishes security advisories for it — `trivy` explicitly flags detection against it as unreliable. Snyk, which doesn't rely on distro-published advisories, was still reporting real critical/high CVEs in the outdated system libraries (glibc, libcurl, krb5, sqlite, zlib, expat, libxml2, etc.), per #16791.
- Ubuntu 24.04 is a current, fully-supported LTS (security updates through 2029) and ships the same JRE build (17.0.19_10) already used elsewhere.

## Verification

Built the actual images from this branch and compared against the currently published images with `trivy image --severity HIGH,CRITICAL`:

| | `openapitools/openapi-generator-cli:v7.23.0` (published, focal) | This branch, built (noble) |
|---|---|---|
| OS support status | EOL | in-support LTS (through 2029) |
| OS-layer HIGH/CRITICAL | 0, but unreliable — trivy warns detection is insufficient on EOL Ubuntu | 0, reliable |
| App-layer (bundled jar) HIGH/CRITICAL | 3 | 1 (unrelated `jackson-databind` bump already in master) |

Also scanned `openapi-generator-online` built the same way. Its OS layer is likewise clean on noble, but the image still carries ~37 HIGH/CRITICAL findings (Tomcat, Spring Framework/Boot, snakeyaml, logback) from stale bundled dependencies — unrelated to the Docker base image and unchanged by this PR. That's separate follow-up work, not in scope here.

## Test plan

- [x] `docker build modules/openapi-generator-cli/` succeeds against the new base
- [x] `docker build modules/openapi-generator-online/` succeeds against the new base
- [x] `trivy image` shows 0 HIGH/CRITICAL OS-package findings on both built images

Fixes #16791

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Docker base images for `openapi-generator-cli` and `openapi-generator-online` to `eclipse-temurin:17.0.19_10-jre-noble` (Ubuntu 24.04 LTS) to move off EOL Ubuntu 20.04 and remove OS-level CVEs. `trivy` shows 0 HIGH/CRITICAL OS findings on both images, and this avoids the Ubuntu 26.04 `pebble` CVEs; fixes #16791.

<sup>Written for commit 4a5ce602f1dac8ef7108a12c605b792bbe2b4fd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

