### PR TITLE
[PHP] Skip length validation for DateTime model properties

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/model_generic.mustache
@@ -292,6 +292,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
         {{/isContainer}}
         {{/isEnum}}
         {{#hasValidation}}
+        {{^isDate}}{{^isDateTime}}
         {{#maxLength}}
         if ({{#notRequiredOrIsNullable}}!is_null($this->container['{{name}}']) && {{/notRequiredOrIsNullable}}(mb_strlen($this->container['{{name}}']) > {{maxLength}})) {
             $invalidProperties[] = "invalid value for '{{name}}', the character length must be smaller than or equal to {{{maxLength}}}.";
@@ -304,6 +305,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
         }
 
         {{/minLength}}
+        {{/isDateTime}}{{/isDate}}
         {{#maximum}}
         if ({{#notRequiredOrIsNullable}}!is_null($this->container['{{name}}']) && {{/notRequiredOrIsNullable}}($this->container['{{name}}'] >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{maximum}})) {
             $invalidProperties[] = "invalid value for '{{name}}', must be smaller than {{^exclusiveMaximum}}or equal to {{/exclusiveMaximum}}{{maximum}}.";
@@ -421,6 +423,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
         {{/isContainer}}
         {{/isEnum}}
         {{#hasValidation}}
+        {{^isDate}}{{^isDateTime}}
         {{#maxLength}}
         if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}(mb_strlen(${{name}}) > {{maxLength}})) {
             throw new InvalidArgumentException('invalid length for ${{name}} when calling {{classname}}.{{operationId}}, must be smaller than or equal to {{maxLength}}.');
@@ -430,6 +433,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
             throw new InvalidArgumentException('invalid length for ${{name}} when calling {{classname}}.{{operationId}}, must be bigger than or equal to {{minLength}}.');
         }
         {{/minLength}}
+        {{/isDateTime}}{{/isDate}}
         {{#maximum}}
         if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}(${{name}} >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{maximum}})) {
             throw new InvalidArgumentException('invalid value for ${{name}} when calling {{classname}}.{{operationId}}, must be smaller than {{^exclusiveMaximum}}or equal to {{/exclusiveMaximum}}{{maximum}}.');

--- a/modules/openapi-generator/src/main/resources/php-nextgen/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/model_generic.mustache
@@ -292,7 +292,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
         {{/isContainer}}
         {{/isEnum}}
         {{#hasValidation}}
-        {{^isDate}}{{^isDateTime}}
+{{#isString}}
         {{#maxLength}}
         if ({{#notRequiredOrIsNullable}}!is_null($this->container['{{name}}']) && {{/notRequiredOrIsNullable}}(mb_strlen($this->container['{{name}}']) > {{maxLength}})) {
             $invalidProperties[] = "invalid value for '{{name}}', the character length must be smaller than or equal to {{{maxLength}}}.";
@@ -305,7 +305,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
         }
 
         {{/minLength}}
-        {{/isDateTime}}{{/isDate}}
+{{/isString}}
         {{#maximum}}
         if ({{#notRequiredOrIsNullable}}!is_null($this->container['{{name}}']) && {{/notRequiredOrIsNullable}}($this->container['{{name}}'] >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{maximum}})) {
             $invalidProperties[] = "invalid value for '{{name}}', must be smaller than {{^exclusiveMaximum}}or equal to {{/exclusiveMaximum}}{{maximum}}.";
@@ -423,7 +423,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
         {{/isContainer}}
         {{/isEnum}}
         {{#hasValidation}}
-        {{^isDate}}{{^isDateTime}}
+{{#isString}}
         {{#maxLength}}
         if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}(mb_strlen(${{name}}) > {{maxLength}})) {
             throw new InvalidArgumentException('invalid length for ${{name}} when calling {{classname}}.{{operationId}}, must be smaller than or equal to {{maxLength}}.');
@@ -433,7 +433,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
             throw new InvalidArgumentException('invalid length for ${{name}} when calling {{classname}}.{{operationId}}, must be bigger than or equal to {{minLength}}.');
         }
         {{/minLength}}
-        {{/isDateTime}}{{/isDate}}
+{{/isString}}
         {{#maximum}}
         if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}(${{name}} >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{maximum}})) {
             throw new InvalidArgumentException('invalid value for ${{name}} when calling {{classname}}.{{operationId}}, must be smaller than {{^exclusiveMaximum}}or equal to {{/exclusiveMaximum}}{{maximum}}.');

--- a/modules/openapi-generator/src/main/resources/php/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_generic.mustache
@@ -302,7 +302,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
         {{/isContainer}}
         {{/isEnum}}
         {{#hasValidation}}
-        {{^isDate}}{{^isDateTime}}
+{{#isString}}
         {{#maxLength}}
         if ({{#notRequiredOrIsNullable}}!is_null($this->container['{{name}}']) && {{/notRequiredOrIsNullable}}(mb_strlen($this->container['{{name}}']) > {{maxLength}})) {
             $invalidProperties[] = "invalid value for '{{name}}', the character length must be smaller than or equal to {{{maxLength}}}.";
@@ -315,7 +315,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
         }
 
         {{/minLength}}
-        {{/isDateTime}}{{/isDate}}
+{{/isString}}
         {{#maximum}}
         if ({{#notRequiredOrIsNullable}}!is_null($this->container['{{name}}']) && {{/notRequiredOrIsNullable}}($this->container['{{name}}'] >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{maximum}})) {
             $invalidProperties[] = "invalid value for '{{name}}', must be smaller than {{^exclusiveMaximum}}or equal to {{/exclusiveMaximum}}{{maximum}}.";
@@ -436,7 +436,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
         {{/isContainer}}
         {{/isEnum}}
         {{#hasValidation}}
-        {{^isDate}}{{^isDateTime}}
+{{#isString}}
         {{#maxLength}}
         if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}(mb_strlen(${{name}}) > {{maxLength}})) {
             throw new \InvalidArgumentException('invalid length for ${{name}} when calling {{classname}}.{{operationId}}, must be smaller than or equal to {{maxLength}}.');
@@ -446,7 +446,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
             throw new \InvalidArgumentException('invalid length for ${{name}} when calling {{classname}}.{{operationId}}, must be bigger than or equal to {{minLength}}.');
         }
         {{/minLength}}
-        {{/isDateTime}}{{/isDate}}
+{{/isString}}
         {{#maximum}}
         if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}(${{name}} >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{maximum}})) {
             throw new \InvalidArgumentException('invalid value for ${{name}} when calling {{classname}}.{{operationId}}, must be smaller than {{^exclusiveMaximum}}or equal to {{/exclusiveMaximum}}{{maximum}}.');

--- a/modules/openapi-generator/src/main/resources/php/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_generic.mustache
@@ -302,6 +302,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
         {{/isContainer}}
         {{/isEnum}}
         {{#hasValidation}}
+        {{^isDate}}{{^isDateTime}}
         {{#maxLength}}
         if ({{#notRequiredOrIsNullable}}!is_null($this->container['{{name}}']) && {{/notRequiredOrIsNullable}}(mb_strlen($this->container['{{name}}']) > {{maxLength}})) {
             $invalidProperties[] = "invalid value for '{{name}}', the character length must be smaller than or equal to {{{maxLength}}}.";
@@ -314,6 +315,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
         }
 
         {{/minLength}}
+        {{/isDateTime}}{{/isDate}}
         {{#maximum}}
         if ({{#notRequiredOrIsNullable}}!is_null($this->container['{{name}}']) && {{/notRequiredOrIsNullable}}($this->container['{{name}}'] >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{maximum}})) {
             $invalidProperties[] = "invalid value for '{{name}}', must be smaller than {{^exclusiveMaximum}}or equal to {{/exclusiveMaximum}}{{maximum}}.";
@@ -434,6 +436,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
         {{/isContainer}}
         {{/isEnum}}
         {{#hasValidation}}
+        {{^isDate}}{{^isDateTime}}
         {{#maxLength}}
         if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}(mb_strlen(${{name}}) > {{maxLength}})) {
             throw new \InvalidArgumentException('invalid length for ${{name}} when calling {{classname}}.{{operationId}}, must be smaller than or equal to {{maxLength}}.');
@@ -443,6 +446,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
             throw new \InvalidArgumentException('invalid length for ${{name}} when calling {{classname}}.{{operationId}}, must be bigger than or equal to {{minLength}}.');
         }
         {{/minLength}}
+        {{/isDateTime}}{{/isDate}}
         {{#maximum}}
         if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}(${{name}} >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{maximum}})) {
             throw new \InvalidArgumentException('invalid value for ${{name}} when calling {{classname}}.{{operationId}}, must be smaller than {{^exclusiveMaximum}}or equal to {{/exclusiveMaximum}}{{maximum}}.');

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpClientCodegenTest.java
@@ -19,6 +19,9 @@ package org.openapitools.codegen.php;
 
 import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.DateTimeSchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.parser.core.models.ParseOptions;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.languages.PhpClientCodegen;
@@ -161,5 +164,32 @@ public class PhpClientCodegenTest {
 
         Assert.assertListNotContains(modelContent, a -> a.equals("$color = self::COLOR_UNKNOWN_DEFAULT_OPEN_API;"), "");
         Assert.assertListContains(modelContent, a -> a.equalsIgnoreCase("\"Invalid value '%s' for 'color', must be one of '%s'\","), "");
+    }
+    @Test
+    public void testDateTimeLengthValidationIsNotGenerated() throws Exception {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        ObjectSchema model = new ObjectSchema();
+        model.addProperties("startsAt", new DateTimeSchema().minLength(20).maxLength(25));
+        model.addProperties("title", new StringSchema().minLength(2).maxLength(10));
+
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("ProductDeal", model);
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput input = new ClientOptInput()
+                .openAPI(openAPI)
+                .config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        Map<String, File> files = generator.opts(input).generate().stream()
+                .collect(Collectors.toMap(File::getName, Function.identity()));
+
+        String modelPhp = String.join("\n", Files.readAllLines(files.get("ProductDeal.php").toPath()));
+
+        Assert.assertFalse(modelPhp.contains("mb_strlen($this->container['starts_at'])"), modelPhp);
+        Assert.assertFalse(modelPhp.contains("mb_strlen($starts_at)"), modelPhp);
+        Assert.assertTrue(modelPhp.contains("mb_strlen($this->container['title']) > 10"), modelPhp);
+        Assert.assertTrue(modelPhp.contains("mb_strlen($title) > 10"), modelPhp);
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpNextgenClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpNextgenClientCodegenTest.java
@@ -25,6 +25,7 @@ import io.swagger.v3.parser.core.models.ParseOptions;
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.languages.PhpNextgenClientCodegen;
 import org.openapitools.codegen.testutils.ConfigAssert;
 import org.testng.Assert;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpNextgenClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpNextgenClientCodegenTest.java
@@ -18,6 +18,9 @@ package org.openapitools.codegen.php;
 
 import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.DateTimeSchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.parser.core.models.ParseOptions;
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.CodegenConstants;
@@ -572,5 +575,32 @@ public class PhpNextgenClientCodegenTest {
             next = content.indexOf("\n    protected function ", start + 1);
         }
         return next < 0 ? content.substring(start) : content.substring(start, next);
+    }
+    @Test
+    public void testDateTimeLengthValidationIsNotGenerated() throws Exception {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        ObjectSchema model = new ObjectSchema();
+        model.addProperties("startsAt", new DateTimeSchema().minLength(20).maxLength(25));
+        model.addProperties("title", new StringSchema().minLength(2).maxLength(10));
+
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("ProductDeal", model);
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput input = new ClientOptInput()
+                .openAPI(openAPI)
+                .config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        Map<String, File> files = generator.opts(input).generate().stream()
+                .collect(Collectors.toMap(File::getName, Function.identity()));
+
+        String modelPhp = String.join("\n", Files.readAllLines(files.get("ProductDeal.php").toPath()));
+
+        Assert.assertFalse(modelPhp.contains("mb_strlen($this->container['starts_at'])"), modelPhp);
+        Assert.assertFalse(modelPhp.contains("mb_strlen($starts_at)"), modelPhp);
+        Assert.assertTrue(modelPhp.contains("mb_strlen($this->container['title']) > 10"), modelPhp);
+        Assert.assertTrue(modelPhp.contains("mb_strlen($title) > 10"), modelPhp);
     }
 }

--- a/samples/client/echo_api/php-nextgen-streaming/src/Model/NumberPropertiesOnly.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Model/NumberPropertiesOnly.php
@@ -362,7 +362,6 @@ class NumberPropertiesOnly implements ModelInterface, ArrayAccess, JsonSerializa
         if (is_null($double)) {
             throw new InvalidArgumentException('non-nullable double cannot be null');
         }
-
         if (($double > 50.2)) {
             throw new InvalidArgumentException('invalid value for $double when calling NumberPropertiesOnly., must be smaller than or equal to 50.2.');
         }

--- a/samples/client/echo_api/php-nextgen/src/Model/NumberPropertiesOnly.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/NumberPropertiesOnly.php
@@ -362,7 +362,6 @@ class NumberPropertiesOnly implements ModelInterface, ArrayAccess, JsonSerializa
         if (is_null($double)) {
             throw new InvalidArgumentException('non-nullable double cannot be null');
         }
-
         if (($double > 50.2)) {
             throw new InvalidArgumentException('invalid value for $double when calling NumberPropertiesOnly., must be smaller than or equal to 50.2.');
         }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayTest.php
@@ -307,7 +307,6 @@ class ArrayTest implements ModelInterface, ArrayAccess, JsonSerializable
         if (is_null($array_of_string)) {
             throw new InvalidArgumentException('non-nullable array_of_string cannot be null');
         }
-
         if ((count($array_of_string) > 3)) {
             throw new InvalidArgumentException('invalid value for $array_of_string when calling ArrayTest., number of items must be less than or equal to 3.');
         }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FormatTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FormatTest.php
@@ -469,7 +469,6 @@ class FormatTest implements ModelInterface, ArrayAccess, JsonSerializable
         if (is_null($integer)) {
             throw new InvalidArgumentException('non-nullable integer cannot be null');
         }
-
         if (($integer > 100)) {
             throw new InvalidArgumentException('invalid value for $integer when calling FormatTest., must be smaller than or equal to 100.');
         }
@@ -504,7 +503,6 @@ class FormatTest implements ModelInterface, ArrayAccess, JsonSerializable
         if (is_null($int32)) {
             throw new InvalidArgumentException('non-nullable int32 cannot be null');
         }
-
         if (($int32 > 200)) {
             throw new InvalidArgumentException('invalid value for $int32 when calling FormatTest., must be smaller than or equal to 200.');
         }
@@ -566,7 +564,6 @@ class FormatTest implements ModelInterface, ArrayAccess, JsonSerializable
         if (is_null($number)) {
             throw new InvalidArgumentException('non-nullable number cannot be null');
         }
-
         if (($number > 543.2)) {
             throw new InvalidArgumentException('invalid value for $number when calling FormatTest., must be smaller than or equal to 543.2.');
         }
@@ -601,7 +598,6 @@ class FormatTest implements ModelInterface, ArrayAccess, JsonSerializable
         if (is_null($float)) {
             throw new InvalidArgumentException('non-nullable float cannot be null');
         }
-
         if (($float > 987.6)) {
             throw new InvalidArgumentException('invalid value for $float when calling FormatTest., must be smaller than or equal to 987.6.');
         }
@@ -636,7 +632,6 @@ class FormatTest implements ModelInterface, ArrayAccess, JsonSerializable
         if (is_null($double)) {
             throw new InvalidArgumentException('non-nullable double cannot be null');
         }
-
         if (($double > 123.4)) {
             throw new InvalidArgumentException('invalid value for $double when calling FormatTest., must be smaller than or equal to 123.4.');
         }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Pet.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Pet.php
@@ -434,7 +434,6 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
             throw new InvalidArgumentException('non-nullable photo_urls cannot be null');
         }
 
-
         $this->container['photo_urls'] = $photo_urls;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayTest.php
@@ -333,7 +333,6 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($array_of_string)) {
             throw new \InvalidArgumentException('non-nullable array_of_string cannot be null');
         }
-
         if ((count($array_of_string) > 3)) {
             throw new \InvalidArgumentException('invalid value for $array_of_string when calling ArrayTest., number of items must be less than or equal to 3.');
         }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
@@ -488,7 +488,6 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($integer)) {
             throw new \InvalidArgumentException('non-nullable integer cannot be null');
         }
-
         if (($integer > 100)) {
             throw new \InvalidArgumentException('invalid value for $integer when calling FormatTest., must be smaller than or equal to 100.');
         }
@@ -523,7 +522,6 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($int32)) {
             throw new \InvalidArgumentException('non-nullable int32 cannot be null');
         }
-
         if (($int32 > 200)) {
             throw new \InvalidArgumentException('invalid value for $int32 when calling FormatTest., must be smaller than or equal to 200.');
         }
@@ -585,7 +583,6 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($number)) {
             throw new \InvalidArgumentException('non-nullable number cannot be null');
         }
-
         if (($number > 543.2)) {
             throw new \InvalidArgumentException('invalid value for $number when calling FormatTest., must be smaller than or equal to 543.2.');
         }
@@ -620,7 +617,6 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($float)) {
             throw new \InvalidArgumentException('non-nullable float cannot be null');
         }
-
         if (($float > 987.6)) {
             throw new \InvalidArgumentException('invalid value for $float when calling FormatTest., must be smaller than or equal to 987.6.');
         }
@@ -655,7 +651,6 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($double)) {
             throw new \InvalidArgumentException('non-nullable double cannot be null');
         }
-
         if (($double > 123.4)) {
             throw new \InvalidArgumentException('invalid value for $double when calling FormatTest., must be smaller than or equal to 123.4.');
         }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
@@ -460,7 +460,6 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable photo_urls cannot be null');
         }
 
-
         $this->container['photo_urls'] = $photo_urls;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/PetWithFile.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/PetWithFile.php
@@ -474,7 +474,6 @@ class PetWithFile implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable photo_urls cannot be null');
         }
 
-
         $this->container['photo_urls'] = $photo_urls;
 
         return $this;

--- a/samples/client/petstore/php/psr-18/lib/Model/ArrayTest.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/ArrayTest.php
@@ -333,7 +333,6 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($array_of_string)) {
             throw new \InvalidArgumentException('non-nullable array_of_string cannot be null');
         }
-
         if ((count($array_of_string) > 3)) {
             throw new \InvalidArgumentException('invalid value for $array_of_string when calling ArrayTest., number of items must be less than or equal to 3.');
         }

--- a/samples/client/petstore/php/psr-18/lib/Model/FormatTest.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/FormatTest.php
@@ -488,7 +488,6 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($integer)) {
             throw new \InvalidArgumentException('non-nullable integer cannot be null');
         }
-
         if (($integer > 100)) {
             throw new \InvalidArgumentException('invalid value for $integer when calling FormatTest., must be smaller than or equal to 100.');
         }
@@ -523,7 +522,6 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($int32)) {
             throw new \InvalidArgumentException('non-nullable int32 cannot be null');
         }
-
         if (($int32 > 200)) {
             throw new \InvalidArgumentException('invalid value for $int32 when calling FormatTest., must be smaller than or equal to 200.');
         }
@@ -585,7 +583,6 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($number)) {
             throw new \InvalidArgumentException('non-nullable number cannot be null');
         }
-
         if (($number > 543.2)) {
             throw new \InvalidArgumentException('invalid value for $number when calling FormatTest., must be smaller than or equal to 543.2.');
         }
@@ -620,7 +617,6 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($float)) {
             throw new \InvalidArgumentException('non-nullable float cannot be null');
         }
-
         if (($float > 987.6)) {
             throw new \InvalidArgumentException('invalid value for $float when calling FormatTest., must be smaller than or equal to 987.6.');
         }
@@ -655,7 +651,6 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($double)) {
             throw new \InvalidArgumentException('non-nullable double cannot be null');
         }
-
         if (($double > 123.4)) {
             throw new \InvalidArgumentException('invalid value for $double when calling FormatTest., must be smaller than or equal to 123.4.');
         }

--- a/samples/client/petstore/php/psr-18/lib/Model/Pet.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/Pet.php
@@ -460,7 +460,6 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable photo_urls cannot be null');
         }
 
-
         $this->container['photo_urls'] = $photo_urls;
 
         return $this;

--- a/samples/client/petstore/php/psr-18/lib/Model/PetWithFile.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/PetWithFile.php
@@ -474,7 +474,6 @@ class PetWithFile implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable photo_urls cannot be null');
         }
 
-
         $this->container['photo_urls'] = $photo_urls;
 
         return $this;


### PR DESCRIPTION
Fixes #24229.

### What changed
- Skips generated `minLength` / `maxLength` `mb_strlen()` checks for PHP model properties generated as `\DateTime` (`date` / `date-time`).
- Keeps string length validation intact for normal `string` properties.
- Applies the same template fix to `php` and `php-nextgen`.
- Adds generator regression coverage for both PHP clients so a `date-time` field with length constraints does not emit `mb_strlen()`, while a regular string field still does.

### Validation
- Passed locally on Windows with Temurin JDK 17:

```bash
./mvnw -pl modules/openapi-generator -am \
  -Dtest=org.openapitools.codegen.php.PhpClientCodegenTest#testDateTimeLengthValidationIsNotGenerated,org.openapitools.codegen.php.PhpNextgenClientCodegenTest#testDateTimeLengthValidationIsNotGenerated \
  -Dsurefire.failIfNoSpecifiedTests=false test
```

Result: `Tests run: 2, Failures: 0, Errors: 0, Skipped: 0`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip length validation for PHP `\DateTime` model properties (`date`/`date-time`) so we don’t call `mb_strlen` on dates while keeping string checks. Applies to `php` and `php-nextgen`; fixes #24229.

- **Bug Fixes**
  - Wrapped `maxLength`/`minLength` in `{{#isString}} ... {{/isString}}` in both `model_generic.mustache` templates.
  - Added regression tests for `php` and `php-nextgen` (plus `TestUtils` import fix) and refreshed PHP samples to avoid drift.

<sup>Written for commit 95ed31da73e880a2d88b2ce0f24d6b122ffa9f83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

