### PR TITLE
fix(go-server): skip readOnly fields in AssertXxxRequired

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/model.mustache
@@ -80,8 +80,8 @@ type {{classname}} struct {
 func Assert{{classname}}Required(obj {{classname}}) error {
 {{#hasRequired}}
 	elements := map[string]interface{}{
-{{#requiredVars}}		"{{baseName}}": obj.{{name}},
-{{/requiredVars}}	}
+{{#requiredVars}}{{^isReadOnly}}		"{{baseName}}": obj.{{name}},
+{{/isReadOnly}}{{/requiredVars}}	}
 	for name, el := range elements {
 		if isZero := IsZeroValue(el); isZero {
 			return &RequiredError{Field: name}
@@ -100,6 +100,7 @@ func Assert{{classname}}Required(obj {{classname}}) error {
 	{{/isMap}}
 {{/parent}}
 {{#Vars}}
+{{^isReadOnly}}
 	{{#isNullable}}
 		{{#isModel}}
 	if obj.{{name}} != nil {
@@ -157,6 +158,7 @@ func Assert{{classname}}Required(obj {{classname}}) error {
 			{{/items.isModel}}
 		{{/isArray}}
 	{{/isNullable}}
+{{/isReadOnly}}
 {{/Vars}}
 	return nil
 }
@@ -164,6 +166,7 @@ func Assert{{classname}}Required(obj {{classname}}) error {
 // Assert{{classname}}Constraints checks if the values respects the defined constraints
 func Assert{{classname}}Constraints(obj {{classname}}) error {
 {{#Vars}}
+{{^isReadOnly}}
 {{#minimum}}
 	if {{#isNullable}}obj.{{name}} != nil && *{{/isNullable}}obj.{{name}} < {{minimum}} {
 		return &ParsingError{Param: "{{name}}", Err: errors.New(errMsgMinValueConstraint)}
@@ -229,6 +232,7 @@ func Assert{{classname}}Constraints(obj {{classname}}) error {
 {{/items.isModel}}
 {{/isArray}}
 {{/isNullable}}
+{{/isReadOnly}}
 {{/Vars}}
 	return nil
 }{{/model}}{{/models}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/goserver/GoServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/goserver/GoServerCodegenTest.java
@@ -74,6 +74,37 @@ public class GoServerCodegenTest {
 
     }
 
+    @Test
+    public void verifyReadOnlyRequiredFieldsNotEnforced() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = createDefaultCodegenConfigurator(output)
+                .setInputSpec("src/test/resources/3_0/go-server/readonly-required.yaml");
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        // AssertThingRequired must not reference the readOnly "id" field, so a
+        // request body that legitimately omits it is accepted. The non-readOnly
+        // required "name" field must still be enforced.
+        java.nio.file.Path modelPath = Paths.get(output + "/go/model_thing.go");
+        TestUtils.assertFileExists(modelPath);
+        TestUtils.assertFileContains(modelPath,
+                "func AssertThingRequired(obj Thing) error {");
+        TestUtils.assertFileContains(modelPath,
+                "\"name\": obj.Name,");
+        // readOnly "id" must be skipped
+        TestUtils.assertFileNotContains(modelPath,
+                "\"id\": obj.Id,");
+        // readOnly nested model "meta" must not be recursed into, so a
+        // request body that omits it (and thus omits Meta's own required
+        // fields) is accepted.
+        TestUtils.assertFileNotContains(modelPath,
+                "if err := AssertMetaRequired(obj.Meta); err != nil {");
+    }
+
     private static CodegenConfigurator createDefaultCodegenConfigurator(File output) {
         return new CodegenConfigurator()
                 .setGeneratorName("go-server")

--- a/modules/openapi-generator/src/test/resources/3_0/go-server/readonly-required.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/go-server/readonly-required.yaml
@@ -1,0 +1,45 @@
+openapi: 3.0.1
+
+info:
+  version: 1.0.0
+  title: readOnly required fields must not be enforced on request bodies
+
+paths:
+  /thing:
+    post:
+      operationId: createThing
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Thing'
+      responses:
+        '201':
+          description: created
+
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        id:
+          type: string
+          readOnly: true
+        name:
+          type: string
+        meta:
+          readOnly: true
+          allOf:
+            - $ref: '#/components/schemas/Meta'
+      required:
+        - id
+        - name
+        - meta
+    Meta:
+      type: object
+      properties:
+        createdBy:
+          type: string
+      required:
+        - createdBy


### PR DESCRIPTION
based on #24170 with resolved merge conflicts

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
