### PR TITLE
[JAVA-SPRING] Fix missing nullable on all args constructor and fluent setters

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/nullableDatatypeWithEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/nullableDatatypeWithEnum.mustache
@@ -1,0 +1,1 @@
+{{#lambda.jSpecifyDatatype}}{{{datatypeWithEnum}}}{{/lambda.jSpecifyDatatype}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
@@ -134,7 +134,7 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
   /**
    * Constructor with all args parameters
    */
-  public {{classname}}({{#vendorExtensions.x-java-all-args-constructor-vars}}{{>nullableAnnotation}}{{{datatypeWithEnum}}} {{name}}{{^-last}}, {{/-last}}{{/vendorExtensions.x-java-all-args-constructor-vars}}) {
+  public {{classname}}({{#vendorExtensions.x-java-all-args-constructor-vars}}{{>nullableAnnotation}}{{>nullableDatatypeWithEnum}} {{name}}{{^-last}}, {{/-last}}{{/vendorExtensions.x-java-all-args-constructor-vars}}) {
   {{#parent}}
       super({{#parentVars}}{{name}}{{^-last}}, {{/-last}}{{/parentVars}});
   {{/parent}}
@@ -153,7 +153,7 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
   {{^lombok.Data}}
 
   {{! begin feature: fluent setter methods }}
-  public {{classname}} {{name}}({{>nullableAnnotation}}{{{datatypeWithEnum}}} {{name}}) {
+  public {{classname}} {{name}}({{>nullableAnnotation}}{{>nullableDatatypeWithEnum}} {{name}}) {
     {{#openApiNullable}}
     this.{{name}} = {{#isNullable}}JsonNullable.of({{/isNullable}}{{#useOptional}}{{^required}}{{^isNullable}}{{^isContainer}}Optional.of{{#optionalAcceptNullable}}Nullable{{/optionalAcceptNullable}}({{/isContainer}}{{/isNullable}}{{/required}}{{/useOptional}}{{name}}{{#isNullable}}){{/isNullable}}{{#useOptional}}{{^required}}{{^isNullable}}{{^isContainer}}){{/isContainer}}{{/isNullable}}{{/required}}{{/useOptional}};
     {{/openApiNullable}}

--- a/samples/openapi3/server/petstore/springboot-4-jspecify/src/main/java/org/openapitools/model/Foo.java
+++ b/samples/openapi3/server/petstore/springboot-4-jspecify/src/main/java/org/openapitools/model/Foo.java
@@ -70,7 +70,7 @@ public class Foo {
   /**
    * Constructor with all args parameters
    */
-  public Foo(OffsetDateTime dt, org.springframework.core.io.Resource binary, List<OffsetDateTime> listOfDt, List<OffsetDateTime> listMinIntems, OffsetDateTime requiredDt, BigDecimal number) {
+  public Foo(@Nullable OffsetDateTime dt, org.springframework.core.io.@Nullable Resource binary, List<OffsetDateTime> listOfDt, List<OffsetDateTime> listMinIntems, OffsetDateTime requiredDt, @Nullable BigDecimal number) {
       this.dt = dt;
       this.binary = binary;
       this.listOfDt = listOfDt;
@@ -79,7 +79,7 @@ public class Foo {
       this.number = number;
   }
 
-  public Foo dt(OffsetDateTime dt) {
+  public Foo dt(@Nullable OffsetDateTime dt) {
     this.dt = dt;
     return this;
   }
@@ -104,7 +104,7 @@ public class Foo {
     this.dt = dt;
   }
 
-  public Foo binary(org.springframework.core.io.Resource binary) {
+  public Foo binary(org.springframework.core.io.@Nullable Resource binary) {
     this.binary = binary;
     return this;
   }
@@ -223,7 +223,7 @@ public class Foo {
     this.requiredDt = requiredDt;
   }
 
-  public Foo number(BigDecimal number) {
+  public Foo number(@Nullable BigDecimal number) {
     this.number = number;
     return this;
   }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

JavaSpring:
@cachescrubber (2022/02) @welshm (2022/02) @MelleD (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02) @borsch (2022/02) @banlevente (2022/02) @Zomzog (2022/09) @martin-mfg (2023/08)

Fixes https://github.com/OpenAPITools/openapi-generator/issues/23681
Fixes https://github.com/OpenAPITools/openapi-generator/issues/24109

Supersedes https://github.com/OpenAPITools/openapi-generator/pull/24114
Supersedes https://github.com/OpenAPITools/openapi-generator/pull/23688
Both PRs seem to try to fix respective issues but are wrong

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing `@Nullable` on all-args constructors and fluent setters in JavaSpring models when using JSpecify. Places annotations correctly on qualified types and enums; fixes #23681 and #24109.

- **Bug Fixes**
  - Add `@Nullable` to constructor and fluent setter parameters for nullable fields (including enums).
  - Add `nullableDatatypeWithEnum` partial using `lambda.jSpecifyDatatype` and use it in `pojo.mustache` to insert annotations within qualified types (e.g., `org.springframework.core.io.@Nullable Resource`); refresh samples.

<sup>Written for commit a49d634c21a8f50ef9b952faff3048d40ce896f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

