### PR TITLE
fix(golang): make object values nullable when specified

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -394,7 +394,23 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
             return "[]" + typDecl;
         } else if (ModelUtils.isMapSchema(p)) {
             Schema inner = ModelUtils.getAdditionalProperties(p);
-            return getSchemaType(p) + "[string]" + getTypeDeclaration(unaliasSchema(inner));
+            if (inner != null) {
+                inner = unaliasSchema(inner);
+            }
+            String typDecl;
+            if (inner != null) {
+                typDecl = getTypeDeclaration(inner);
+            } else {
+                typDecl = "interface{}";
+            }
+
+            // when nullable and the type of the map isn't nullable already (maps, slices, ...): make it a pointer
+            if (inner != null && Boolean.TRUE.equals(inner.getNullable()) && !typDecl.startsWith("map") && !typDecl.startsWith("[]")) {
+                typDecl = "*" + typDecl;
+            }
+
+            return getSchemaType(p) + "[string]" + typDecl;
+
         }
 
         //return super.getTypeDeclaration(p);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/AbstractGoCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/AbstractGoCodegenTest.java
@@ -119,6 +119,35 @@ public class AbstractGoCodegenTest {
         ModelUtils.setGenerateAliasAsModel(false);
         defaultValue = codegen.getTypeDeclaration(schema);
         Assert.assertEquals(defaultValue, "map[string]interface{}");
+
+        // Create object schema with nullable set to false
+        ModelUtils.setGenerateAliasAsModel(false);
+        schema = new ObjectSchema().additionalProperties(new StringSchema().nullable(false));
+        defaultValue = codegen.getTypeDeclaration(schema);
+        Assert.assertEquals(defaultValue, "map[string]string");
+
+        // Create object schema with nullable set to true
+        ModelUtils.setGenerateAliasAsModel(false);
+        schema = new ObjectSchema().additionalProperties(new StringSchema().nullable(true));
+        defaultValue = codegen.getTypeDeclaration(schema);
+        Assert.assertEquals(defaultValue, "map[string]*string");
+
+        // slice in object schema is no pointer, even if nullable (slices are already nullable by default in Golang)
+        ModelUtils.setGenerateAliasAsModel(false);
+        schema = new ObjectSchema().additionalProperties(new ArraySchema().nullable(true).items(new IntegerSchema().format("int32")));
+        defaultValue = codegen.getTypeDeclaration(schema);
+        Assert.assertEquals(defaultValue, "map[string][]int32");
+
+        // map in nested object schema is no pointer, even if nullable (maps are already nullable by default in Golang)
+        ModelUtils.setGenerateAliasAsModel(false);
+        schema = new ObjectSchema().additionalProperties(new ObjectSchema().nullable(true));
+        defaultValue = codegen.getTypeDeclaration(schema);
+        Assert.assertEquals(defaultValue, "map[string]map[string]interface{}");
+
+        // nested object schema with nullable set to true (maps itself are already nullable by default in Golang, so no pointer type needed there)
+        schema = new ObjectSchema().additionalProperties(new ObjectSchema().nullable(true).additionalProperties(new StringSchema().nullable(true)));
+        defaultValue = codegen.getTypeDeclaration(schema);
+        Assert.assertEquals(defaultValue, "map[string]map[string]*string");
     }
 
     @Test(description = "test that os import is added for array of binary parameters in operations")


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

relates to #24264

Detailed description and testing instructions can be found in the [GitHub issue](https://github.com/OpenAPITools/openapi-generator/issues/24264).

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@antihax @grokify @kemokemo @jirikuncar @ph4r5h4d @lwj5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Go codegen to respect nullable for `additionalProperties` values. Generates `map[string]*T` when the value schema is `nullable: true`, skips pointers for map/slice values, and defaults to `interface{}` when no value schema is provided.

- **Bug Fixes**
  - Map values use pointers only when the inner schema is nullable and not a map/slice.
  - Nested objects honor nullable on inner values (e.g., `map[string]map[string]*string`).

<sup>Written for commit e3624b64e33192e61147652922bb2edf197f6090. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

