### PR TITLE
[python] Fix unquoted string enum defaults causing NameError in python-fastapi

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -216,6 +216,13 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
             if (p.getDefault() != null) {
                 String defaultValue = String.valueOf(p.getDefault());
                 if (defaultValue != null) {
+                    // String enums (type: string + enum) must be quoted: templates embed defaultValue
+                    // directly into Query()/Header()/Cookie() calls (e.g. Query('B', ...)). Without
+                    // quotes, values like uploadTime or desc become bare identifiers and cause NameError.
+                    // See https://github.com/OpenAPITools/openapi-generator/issues/23774
+                    if (ModelUtils.isStringSchema(p)) {
+                        return formatPythonStringLiteral(defaultValue);
+                    }
                     return defaultValue;
                 }
             }
@@ -223,13 +230,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
             if (p.getDefault() != null) {
                 String defaultValue = String.valueOf(p.getDefault());
                 if (defaultValue != null) {
-                    defaultValue = defaultValue.replace("\\", "\\\\")
-                            .replace("'", "\\'");
-                    if (Pattern.compile("\r\n|\r|\n").matcher(defaultValue).find()) {
-                        return "'''" + defaultValue + "'''";
-                    } else {
-                        return "'" + defaultValue + "'";
-                    }
+                    return formatPythonStringLiteral(defaultValue);
                 }
             }
         } else if (ModelUtils.isArraySchema(p)) {
@@ -242,6 +243,55 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
         return null;
     }
 
+    /**
+     * Format a string as a Python string literal (single-quoted).
+     * Shared by plain string and string-enum default value paths in {@link #toDefaultValue(Schema)}.
+     */
+    protected String formatPythonStringLiteral(String defaultValue) {
+        defaultValue = defaultValue.replace("\\", "\\\\")
+                .replace("'", "\\'");
+        if (Pattern.compile("\r\n|\r|\n").matcher(defaultValue).find()) {
+            return "'''" + defaultValue + "'''";
+        }
+        return "'" + defaultValue + "'";
+    }
+
+    /**
+     * If {@code value} is already a Python string literal, return the unescaped inner content.
+     * Used when reconciling quoted defaults from {@link #toDefaultValue(Schema)} with enum-var
+     * matching in {@link #getEnumDefaultValue(String, String)}.
+     */
+    protected String unwrapPythonStringLiteral(String value) {
+        if (value == null) {
+            return null;
+        }
+        if (value.length() >= 6 && value.startsWith("'''") && value.endsWith("'''")) {
+            return value.substring(3, value.length() - 3);
+        }
+        if (value.length() >= 2 && value.startsWith("'") && value.endsWith("'")) {
+            return value.substring(1, value.length() - 1)
+                    .replace("\\'", "'")
+                    .replace("\\\\", "\\");
+        }
+        return null;
+    }
+
+    /**
+     * Normalize enum default values before matching against enum member literals.
+     * {@link #toDefaultValue(Schema)} now quotes string-enum defaults (e.g. {@code 'B'}), but
+     * {@code updateCodegenPropertyEnum} compares against unquoted enum values via
+     * {@code toEnumValue}. Unwrap first so model properties still resolve to EnumClass.MEMBER.
+     */
+    @Override
+    protected String getEnumDefaultValue(String defaultValue, String dataType) {
+        if (isDataTypeString(dataType)) {
+            String unquoted = unwrapPythonStringLiteral(defaultValue);
+            if (unquoted != null) {
+                defaultValue = unquoted;
+            }
+        }
+        return super.getEnumDefaultValue(defaultValue, dataType);
+    }
 
     @Override
     public String toVarName(String name) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -266,7 +266,11 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
             return null;
         }
         if (value.length() >= 6 && value.startsWith("'''") && value.endsWith("'''")) {
-            return value.substring(3, value.length() - 3);
+            // formatPythonStringLiteral() escapes \ and ' for both single- and triple-quoted
+            // forms; unwrap must reverse those escapes so enum-member matching still works.
+            return value.substring(3, value.length() - 3)
+                    .replace("\\'", "'")
+                    .replace("\\\\", "\\");
         }
         if (value.length() >= 2 && value.startsWith("'") && value.endsWith("'")) {
             return value.substring(1, value.length() - 1)

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
@@ -150,6 +150,26 @@ public class PythonClientCodegenTest {
         Assert.assertEquals("'\\\\'", defaultValue);
     }
 
+    @Test(description = "test string enum default is quoted")
+    public void testStringEnumDefaultIsQuoted() {
+        final PythonClientCodegen codegen = new PythonClientCodegen();
+        StringSchema schema = new StringSchema();
+        schema.setEnum(Arrays.asList("uploadTime", "duration", "fileSize"));
+        schema.setDefault("uploadTime");
+        String defaultValue = codegen.toDefaultValue(schema);
+        Assert.assertEquals("'uploadTime'", defaultValue);
+    }
+
+    @Test(description = "test string enum default with special chars is quoted")
+    public void testStringEnumDefaultFalseIsQuoted() {
+        final PythonClientCodegen codegen = new PythonClientCodegen();
+        StringSchema schema = new StringSchema();
+        schema.setEnum(Arrays.asList("true", "false"));
+        schema.setDefault("false");
+        String defaultValue = codegen.toDefaultValue(schema);
+        Assert.assertEquals("'false'", defaultValue);
+    }
+
     @Test(description = "convert a python model with dots")
     public void modelTest() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/v1beta3.yaml");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
@@ -170,9 +170,22 @@ public class PythonClientCodegenTest {
         Assert.assertEquals("'false'", defaultValue);
     }
 
+    /**
+     * Exposes protected helpers for unit tests without setAccessible() (forbiddenapis).
+     */
+    private static final class TestablePythonClientCodegen extends PythonClientCodegen {
+        String unwrapPythonStringLiteralForTest(String value) {
+            return unwrapPythonStringLiteral(value);
+        }
+
+        String getEnumDefaultValueForTest(String defaultValue, String dataType) {
+            return getEnumDefaultValue(defaultValue, dataType);
+        }
+    }
+
     @Test(description = "multiline string enum default with apostrophe/backslash is quoted and unwraps for enum matching")
-    public void testMultilineStringEnumDefaultUnwrapsEscapes() throws Exception {
-        final PythonClientCodegen codegen = new PythonClientCodegen();
+    public void testMultilineStringEnumDefaultUnwrapsEscapes() {
+        final TestablePythonClientCodegen codegen = new TestablePythonClientCodegen();
         // Multiline forces triple quotes; apostrophe/backslash are escaped by formatPythonStringLiteral.
         final String multilineDefault = "line1\\it's\nline2";
         StringSchema schema = new StringSchema();
@@ -184,18 +197,10 @@ public class PythonClientCodegenTest {
 
         // Triple-quoted unwrap must reverse the same escapes as the single-quoted path so
         // getEnumDefaultValue() can match against enumVars (see issue review on #23774).
-        java.lang.reflect.Method unwrap = codegen.getClass()
-                .getSuperclass()
-                .getDeclaredMethod("unwrapPythonStringLiteral", String.class);
-        unwrap.setAccessible(true);
-        Assert.assertEquals(multilineDefault, unwrap.invoke(codegen, defaultValue));
-
-        java.lang.reflect.Method getEnumDefault = codegen.getClass()
-                .getSuperclass()
-                .getDeclaredMethod("getEnumDefaultValue", String.class, String.class);
-        getEnumDefault.setAccessible(true);
-        String enumDefaultValue = (String) getEnumDefault.invoke(codegen, defaultValue, "str");
-        Assert.assertEquals(codegen.toEnumValue(multilineDefault, "str"), enumDefaultValue);
+        Assert.assertEquals(multilineDefault, codegen.unwrapPythonStringLiteralForTest(defaultValue));
+        Assert.assertEquals(
+                codegen.toEnumValue(multilineDefault, "str"),
+                codegen.getEnumDefaultValueForTest(defaultValue, "str"));
     }
 
     @Test(description = "convert a python model with dots")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
@@ -170,6 +170,34 @@ public class PythonClientCodegenTest {
         Assert.assertEquals("'false'", defaultValue);
     }
 
+    @Test(description = "multiline string enum default with apostrophe/backslash is quoted and unwraps for enum matching")
+    public void testMultilineStringEnumDefaultUnwrapsEscapes() throws Exception {
+        final PythonClientCodegen codegen = new PythonClientCodegen();
+        // Multiline forces triple quotes; apostrophe/backslash are escaped by formatPythonStringLiteral.
+        final String multilineDefault = "line1\\it's\nline2";
+        StringSchema schema = new StringSchema();
+        schema.setEnum(Arrays.asList(multilineDefault, "other"));
+        schema.setDefault(multilineDefault);
+
+        String defaultValue = codegen.toDefaultValue(schema);
+        Assert.assertEquals("'''line1\\\\it\\'s\nline2'''", defaultValue);
+
+        // Triple-quoted unwrap must reverse the same escapes as the single-quoted path so
+        // getEnumDefaultValue() can match against enumVars (see issue review on #23774).
+        java.lang.reflect.Method unwrap = codegen.getClass()
+                .getSuperclass()
+                .getDeclaredMethod("unwrapPythonStringLiteral", String.class);
+        unwrap.setAccessible(true);
+        Assert.assertEquals(multilineDefault, unwrap.invoke(codegen, defaultValue));
+
+        java.lang.reflect.Method getEnumDefault = codegen.getClass()
+                .getSuperclass()
+                .getDeclaredMethod("getEnumDefaultValue", String.class, String.class);
+        getEnumDefault.setAccessible(true);
+        String enumDefaultValue = (String) getEnumDefault.invoke(codegen, defaultValue, "str");
+        Assert.assertEquals(codegen.toEnumValue(multilineDefault, "str"), enumDefaultValue);
+    }
+
     @Test(description = "convert a python model with dots")
     public void modelTest() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/v1beta3.yaml");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonFastapiCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonFastapiCodegenTest.java
@@ -73,6 +73,36 @@ public class PythonFastapiCodegenTest {
     }
 
     @Test
+    public void testStringEnumQueryParameterDefaultsAreQuoted() throws IOException {
+        // Regression for https://github.com/OpenAPITools/openapi-generator/issues/23774
+        // Repro spec: src/test/resources/3_0/parameter-test-spec.yaml (query_default_enum, etc.)
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("python-fastapi")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"))
+                .setInputSpec("src/test/resources/3_0/parameter-test-spec.yaml");
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        final String apiFile = output + "/src/openapi_server/apis/default_api.py";
+        TestUtils.assertFileContains(Paths.get(apiFile),
+                "= Query('available', description=\"query default\", alias=\"query_default\"),");
+        TestUtils.assertFileContains(Paths.get(apiFile),
+                "= Query('B', description=\"query default enum\", alias=\"query_default_enum\"),");
+        TestUtils.assertFileContains(Paths.get(apiFile),
+                "= Header('B', description=\"header default enum\"),");
+        TestUtils.assertFileContains(Paths.get(apiFile),
+                "= Cookie('B', description=\"cookie default enum\"),");
+        TestUtils.assertFileNotContains(Paths.get(apiFile), "= Query(B, description=\"query default enum\"");
+        TestUtils.assertFileNotContains(Paths.get(apiFile), "= Header(B, description=\"header default enum\"");
+        TestUtils.assertFileNotContains(Paths.get(apiFile), "= Cookie(B, description=\"cookie default enum\"");
+    }
+
+    @Test
     public void testRegexPatternCheckedForArrayItems() throws IOException {
         File output = Files.createTempDirectory("test").toFile();
         output.deleteOnExit();

--- a/samples/openapi3/client/petstore/python-aiohttp/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python-aiohttp/docs/FakeApi.md
@@ -131,7 +131,7 @@ configuration = petstore_api.Configuration(
 async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
-    enum_ref = -efg # EnumClass | enum reference (optional) (default to -efg)
+    enum_ref = '-efg' # EnumClass | enum reference (optional) (default to '-efg')
 
     try:
         # test enum reference query parameter
@@ -147,7 +147,7 @@ async with petstore_api.ApiClient(configuration) as api_client:
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **enum_ref** | [**EnumClass**](.md)| enum reference | [optional] [default to -efg]
+ **enum_ref** | [**EnumClass**](.md)| enum reference | [optional] [default to &#39;-efg&#39;]
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python-httpx-sync/docs/FakeApi.md
@@ -135,7 +135,7 @@ configuration = petstore_api.Configuration(
 async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
-    enum_ref = -efg # EnumClass | enum reference (optional) (default to -efg)
+    enum_ref = '-efg' # EnumClass | enum reference (optional) (default to '-efg')
 
     try:
         # test enum reference query parameter
@@ -151,7 +151,7 @@ async with petstore_api.ApiClient(configuration) as api_client:
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **enum_ref** | [**EnumClass**](.md)| enum reference | [optional] [default to -efg]
+ **enum_ref** | [**EnumClass**](.md)| enum reference | [optional] [default to &#39;-efg&#39;]
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/python-httpx/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python-httpx/docs/FakeApi.md
@@ -131,7 +131,7 @@ configuration = petstore_api.Configuration(
 async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
-    enum_ref = -efg # EnumClass | enum reference (optional) (default to -efg)
+    enum_ref = '-efg' # EnumClass | enum reference (optional) (default to '-efg')
 
     try:
         # test enum reference query parameter
@@ -147,7 +147,7 @@ async with petstore_api.ApiClient(configuration) as api_client:
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **enum_ref** | [**EnumClass**](.md)| enum reference | [optional] [default to -efg]
+ **enum_ref** | [**EnumClass**](.md)| enum reference | [optional] [default to &#39;-efg&#39;]
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/python-lazyImports/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python-lazyImports/docs/FakeApi.md
@@ -131,7 +131,7 @@ configuration = petstore_api.Configuration(
 with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
-    enum_ref = -efg # EnumClass | enum reference (optional) (default to -efg)
+    enum_ref = '-efg' # EnumClass | enum reference (optional) (default to '-efg')
 
     try:
         # test enum reference query parameter
@@ -147,7 +147,7 @@ with petstore_api.ApiClient(configuration) as api_client:
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **enum_ref** | [**EnumClass**](.md)| enum reference | [optional] [default to -efg]
+ **enum_ref** | [**EnumClass**](.md)| enum reference | [optional] [default to &#39;-efg&#39;]
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/python/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python/docs/FakeApi.md
@@ -131,7 +131,7 @@ configuration = petstore_api.Configuration(
 with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
-    enum_ref = -efg # EnumClass | enum reference (optional) (default to -efg)
+    enum_ref = '-efg' # EnumClass | enum reference (optional) (default to '-efg')
 
     try:
         # test enum reference query parameter
@@ -147,7 +147,7 @@ with petstore_api.ApiClient(configuration) as api_client:
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **enum_ref** | [**EnumClass**](.md)| enum reference | [optional] [default to -efg]
+ **enum_ref** | [**EnumClass**](.md)| enum reference | [optional] [default to &#39;-efg&#39;]
 
 ### Return type
 


### PR DESCRIPTION
## Summary

- Quote string enum default values in `AbstractPythonCodegen.toDefaultValue()` so
  `python-fastapi` emits valid Python in `Query()`/`Header()`/`Cookie()` (fixes #23774).
- Unwrap quoted defaults in `getEnumDefaultValue()` so model enum member resolution still works.
- Add unit + integration tests using `parameter-test-spec.yaml`.
- Regenerate Python client samples (FakeApi.md enum default examples).

## Test plan

- [x] `./mvnw clean package -DskipTests`
- [x] `./bin/generate-samples.sh ./bin/configs/python*.yaml`
- [x] `./bin/utils/export_docs_generators.sh`
- [x] `mvn -pl modules/openapi-generator -am -Dtest=PythonFastapiCodegenTest#testStringEnumQueryParameterDefaultsAreQuoted,PythonClientCodegenTest#testStringEnumDefaultIsQuoted,PythonClientCodegenTest#testStringEnumDefaultFalseIsQuoted -Dsurefire.failIfNoSpecifiedTests=false test`

cc Python technical committee: @cbornet @tomplus @krjakbrjak @fa0311
cc Python FastAPI: @krjakbrjak

Fixes #23774

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quote string enum defaults in `python-fastapi` parameters to prevent NameError from bare identifiers. Ensure enum default resolution works for single- and triple-quoted cases. Fixes #23774.

- **Bug Fixes**
  - Quote string enum defaults in `AbstractPythonCodegen.toDefaultValue()` so `Query()`/`Header()`/`Cookie()` receive string literals.
  - Unwrap quoted defaults in `getEnumDefaultValue()` via `unwrapPythonStringLiteral`, reversing apostrophe/backslash escapes for triple-quoted values so enum matching works.
  - Add `formatPythonStringLiteral()`, update tests (including a subclass-based test to avoid reflection), and regenerate Python client docs to show quoted defaults in `FakeApi.md`.

<sup>Written for commit 6a90baed2ce189ea9addbc7d2182bd09fd0aa1e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

