### PR TITLE
[jaxrs-spec] Emit @Email bean validation for string with format: email

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/beanValidationCore.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/beanValidationCore.mustache
@@ -1,4 +1,5 @@
-{{#pattern}} @Pattern(regexp="{{{.}}}"){{/pattern}}{{!
+{{#isEmail}} @Email {{/isEmail}}{{!
+}}{{#pattern}} @Pattern(regexp="{{{.}}}"){{/pattern}}{{!
 minLength && maxLength set
 }}{{#minLength}}{{#maxLength}} @Size(min={{minLength}},max={{maxLength}}){{/maxLength}}{{/minLength}}{{!
 minLength set, maxLength not

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
@@ -2323,4 +2323,105 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
         assertFileContains(Paths.get(modelDir + "DogRequest.java"), "@JsonTypeName(\"DOG\")");
         assertFileNotContains(Paths.get(modelDir + "DogRequest.java"), "@JsonTypeName(\"DogRequest\")");
     }
+
+    @Test
+    public void generatesEmailAnnotationWhenBeanValidationEnabled() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/issue_4876_format_email.yaml", null, new ParseOptions()).getOpenAPI();
+
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.setUseBeanValidation(true);
+
+        ClientOptInput input = new ClientOptInput()
+                .openAPI(openAPI)
+                .config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.opts(input).generate();
+
+        Path person = Paths.get(outputPath + "/src/gen/java/org/openapitools/model/PersonWithEmail.java");
+        // format: email string is validated with jakarta.validation.constraints.@Email,
+        // covered by the wildcard "import {javaxPackage}.validation.constraints.*;"
+        assertFileContains(person, "@Email");
+        assertFileContains(person, "import javax.validation.constraints.*;");
+    }
+
+    @Test
+    public void generatesJakartaEmailAnnotationWhenBeanValidationAndJakartaEnabled() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/issue_4876_format_email.yaml", null, new ParseOptions()).getOpenAPI();
+
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.setUseBeanValidation(true);
+        codegen.additionalProperties().put(USE_JAKARTA_EE, true);
+
+        ClientOptInput input = new ClientOptInput()
+                .openAPI(openAPI)
+                .config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.opts(input).generate();
+
+        Path person = Paths.get(outputPath + "/src/gen/java/org/openapitools/model/PersonWithEmail.java");
+        assertFileContains(person, "@Email");
+        assertFileContains(person, "import jakarta.validation.constraints.*;");
+    }
+
+    @Test
+    public void doesNotGenerateEmailAnnotationWhenBeanValidationDisabled() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/issue_4876_format_email.yaml", null, new ParseOptions()).getOpenAPI();
+
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.setUseBeanValidation(false);
+
+        ClientOptInput input = new ClientOptInput()
+                .openAPI(openAPI)
+                .config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.opts(input).generate();
+
+        Path person = Paths.get(outputPath + "/src/gen/java/org/openapitools/model/PersonWithEmail.java");
+        Path api = Paths.get(outputPath + "/src/gen/java/org/openapitools/api/PersonApi.java");
+        assertFileNotContains(person, "@Email");
+        assertFileNotContains(api, "@Email");
+    }
+
+    @Test
+    public void generatesEmailAnnotationOnQueryParameterWhenBeanValidationEnabled() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/issue_4876_format_email.yaml", null, new ParseOptions()).getOpenAPI();
+
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.setUseBeanValidation(true);
+
+        ClientOptInput input = new ClientOptInput()
+                .openAPI(openAPI)
+                .config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.opts(input).generate();
+
+        // a format: email query parameter is validated with @Email alongside @NotNull
+        Path api = Paths.get(outputPath + "/src/gen/java/org/openapitools/api/PersonApi.java");
+        assertFileContains(api, "import javax.validation.constraints.*;");
+        assertFileContains(api, "@QueryParam(\"email\")", "@Email", "String email");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/issue_4876_format_email.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_4876_format_email.yaml
@@ -17,6 +17,23 @@ paths:
       responses:
         '204':
           description: No Content
+  /person/search:
+    get:
+      operationId: searchPersonByEmail
+      parameters:
+        - name: email
+          in: query
+          required: true
+          schema:
+            type: string
+            format: email
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/personWithEmail'
 components:
   schemas:
     personWithEmail:

--- a/modules/openapi-generator/src/test/resources/3_0/required-and-readonly-property.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/required-and-readonly-property.yaml
@@ -23,6 +23,7 @@ components:
       required:
         - requiredYesReadonlyYes
         - requiredYesReadonlyNo
+        - requiredEmail
       properties:
         requiredYesReadonlyYes:
           type: string
@@ -34,5 +35,11 @@ components:
           readOnly: true
         requiredNoReadonlyNo:
           type: string
+        requiredEmail:
+          type: string
+          format: email
+        optionalEmail:
+          type: string
+          format: email
 
   

--- a/samples/server/petstore/jaxrs-spec-required-and-readonly-property/src/gen/java/org/openapitools/model/ReadonlyAndRequiredProperties.java
+++ b/samples/server/petstore/jaxrs-spec-required-and-readonly-property/src/gen/java/org/openapitools/model/ReadonlyAndRequiredProperties.java
@@ -23,12 +23,16 @@ public class ReadonlyAndRequiredProperties  implements Serializable {
   private String requiredYesReadonlyNo;
   private String requiredNoReadonlyYes;
   private String requiredNoReadonlyNo;
+  private String requiredEmail;
+  private String optionalEmail;
 
   protected ReadonlyAndRequiredProperties(ReadonlyAndRequiredPropertiesBuilder<?, ?> b) {
     this.requiredYesReadonlyYes = b.requiredYesReadonlyYes;
     this.requiredYesReadonlyNo = b.requiredYesReadonlyNo;
     this.requiredNoReadonlyYes = b.requiredNoReadonlyYes;
     this.requiredNoReadonlyNo = b.requiredNoReadonlyNo;
+    this.requiredEmail = b.requiredEmail;
+    this.optionalEmail = b.optionalEmail;
   }
 
   public ReadonlyAndRequiredProperties() {
@@ -37,10 +41,12 @@ public class ReadonlyAndRequiredProperties  implements Serializable {
   @JsonCreator
   public ReadonlyAndRequiredProperties(
     @JsonProperty(required = true, value = "requiredYesReadonlyYes") String requiredYesReadonlyYes,
-    @JsonProperty(required = true, value = "requiredYesReadonlyNo") String requiredYesReadonlyNo
+    @JsonProperty(required = true, value = "requiredYesReadonlyNo") String requiredYesReadonlyNo,
+    @JsonProperty(required = true, value = "requiredEmail") String requiredEmail
   ) {
     this.requiredYesReadonlyYes = requiredYesReadonlyYes;
     this.requiredYesReadonlyNo = requiredYesReadonlyNo;
+    this.requiredEmail = requiredEmail;
   }
 
   /**
@@ -119,6 +125,44 @@ public class ReadonlyAndRequiredProperties  implements Serializable {
     this.requiredNoReadonlyNo = requiredNoReadonlyNo;
   }
 
+  /**
+   **/
+  public ReadonlyAndRequiredProperties requiredEmail(String requiredEmail) {
+    this.requiredEmail = requiredEmail;
+    return this;
+  }
+
+  
+  @ApiModelProperty(required = true, value = "")
+  @JsonProperty(required = true, value = "requiredEmail")
+  @NotNull  @Email public String getRequiredEmail() {
+    return requiredEmail;
+  }
+
+  @JsonProperty(required = true, value = "requiredEmail")
+  public void setRequiredEmail(String requiredEmail) {
+    this.requiredEmail = requiredEmail;
+  }
+
+  /**
+   **/
+  public ReadonlyAndRequiredProperties optionalEmail(String optionalEmail) {
+    this.optionalEmail = optionalEmail;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("optionalEmail")
+   @Email public String getOptionalEmail() {
+    return optionalEmail;
+  }
+
+  @JsonProperty("optionalEmail")
+  public void setOptionalEmail(String optionalEmail) {
+    this.optionalEmail = optionalEmail;
+  }
+
 
   @Override
   public boolean equals(Object o) {
@@ -132,12 +176,14 @@ public class ReadonlyAndRequiredProperties  implements Serializable {
     return Objects.equals(this.requiredYesReadonlyYes, readonlyAndRequiredProperties.requiredYesReadonlyYes) &&
         Objects.equals(this.requiredYesReadonlyNo, readonlyAndRequiredProperties.requiredYesReadonlyNo) &&
         Objects.equals(this.requiredNoReadonlyYes, readonlyAndRequiredProperties.requiredNoReadonlyYes) &&
-        Objects.equals(this.requiredNoReadonlyNo, readonlyAndRequiredProperties.requiredNoReadonlyNo);
+        Objects.equals(this.requiredNoReadonlyNo, readonlyAndRequiredProperties.requiredNoReadonlyNo) &&
+        Objects.equals(this.requiredEmail, readonlyAndRequiredProperties.requiredEmail) &&
+        Objects.equals(this.optionalEmail, readonlyAndRequiredProperties.optionalEmail);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(requiredYesReadonlyYes, requiredYesReadonlyNo, requiredNoReadonlyYes, requiredNoReadonlyNo);
+    return Objects.hash(requiredYesReadonlyYes, requiredYesReadonlyNo, requiredNoReadonlyYes, requiredNoReadonlyNo, requiredEmail, optionalEmail);
   }
 
   @Override
@@ -149,6 +195,8 @@ public class ReadonlyAndRequiredProperties  implements Serializable {
     sb.append("    requiredYesReadonlyNo: ").append(toIndentedString(requiredYesReadonlyNo)).append("\n");
     sb.append("    requiredNoReadonlyYes: ").append(toIndentedString(requiredNoReadonlyYes)).append("\n");
     sb.append("    requiredNoReadonlyNo: ").append(toIndentedString(requiredNoReadonlyNo)).append("\n");
+    sb.append("    requiredEmail: ").append(toIndentedString(requiredEmail)).append("\n");
+    sb.append("    optionalEmail: ").append(toIndentedString(optionalEmail)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -184,6 +232,8 @@ public class ReadonlyAndRequiredProperties  implements Serializable {
     private String requiredYesReadonlyNo;
     private String requiredNoReadonlyYes;
     private String requiredNoReadonlyNo;
+    private String requiredEmail;
+    private String optionalEmail;
     protected abstract B self();
 
     public abstract C build();
@@ -202,6 +252,14 @@ public class ReadonlyAndRequiredProperties  implements Serializable {
     }
     public B requiredNoReadonlyNo(String requiredNoReadonlyNo) {
       this.requiredNoReadonlyNo = requiredNoReadonlyNo;
+      return self();
+    }
+    public B requiredEmail(String requiredEmail) {
+      this.requiredEmail = requiredEmail;
+      return self();
+    }
+    public B optionalEmail(String optionalEmail) {
+      this.optionalEmail = optionalEmail;
       return self();
     }
   }

--- a/samples/server/petstore/jaxrs-spec-required-and-readonly-property/src/main/openapi/openapi.yaml
+++ b/samples/server/petstore/jaxrs-spec-required-and-readonly-property/src/main/openapi/openapi.yaml
@@ -25,6 +25,8 @@ components:
         requiredYesReadonlyNo: requiredYesReadonlyNo
         requiredNoReadonlyYes: requiredNoReadonlyYes
         requiredNoReadonlyNo: requiredNoReadonlyNo
+        requiredEmail: requiredEmail
+        optionalEmail: optionalEmail
       properties:
         requiredYesReadonlyYes:
           readOnly: true
@@ -36,7 +38,14 @@ components:
           type: string
         requiredNoReadonlyNo:
           type: string
+        requiredEmail:
+          format: email
+          type: string
+        optionalEmail:
+          format: email
+          type: string
       required:
+      - requiredEmail
       - requiredYesReadonlyNo
       - requiredYesReadonlyYes
       type: object


### PR DESCRIPTION
Adds `@Email` bean-validation support to the **jaxrs-spec** server generator so that `type: string` / `format: email` properties and parameters are validated at runtime, matching the behaviour already provided by the Spring generator.

### Background
`DefaultCodegen` already sets `isEmail = true` for `format: email` schemas across every Java generator, but jaxrs-spec's `beanValidationCore.mustache` never consumed the flag. As a result email fields/parameters were emitted as a plain `String` with no `@Email` constraint (documentation-only), unlike Spring which renders `@Email`.

### Change
- emit `@Email` when `isEmail` is set under `useBeanValidation`
- No new import is required — `javax`/`jakarta` package is selected automatically (including under `useJakartaEe=true`).

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@Email` bean validation to the jaxrs-spec server generator for `type: string` with `format: email` so models and query params are validated at runtime, matching Spring. Active only when `useBeanValidation` is enabled.

- **New Features**
  - Emit `@Email` when `isEmail` is set in `beanValidationCore.mustache`.
  - Uses existing wildcard import `{{javaxPackage}}.validation.constraints.*` for `javax`/`jakarta`.
  - Applies to models and query parameters; inherited by all jaxrs-spec libraries.

- **Tests**
  - Expanded `issue_4876_format_email.yaml` with a required `format: email` query parameter; added tests for `javax`, `jakarta`, and disabled `useBeanValidation`.
  - Updated `required-and-readonly-property.yaml` and regenerated the `jaxrs-spec-required-and-readonly-property` sample with required/optional email fields to verify `@Email` output compiles.

<sup>Written for commit aecbe3d9e204e3d82833885a8ea0f1a850905fa1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



