### PR TITLE
[typescript-fetch] Fix Omit generic using baseName for readOnly fields

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -145,7 +145,7 @@ export function {{classname}}ToJSON(json: any): {{classname}} {
     return {{classname}}ToJSONTyped(json, false);
 }
 
-export function {{classname}}ToJSONTyped(value?: {{#hasReadOnly}}Omit<{{classname}}, {{#readOnlyVars}}'{{baseName}}'{{^-last}}|{{/-last}}{{/readOnlyVars}}>{{/hasReadOnly}}{{^hasReadOnly}}{{classname}}{{/hasReadOnly}} | null, ignoreDiscriminator: boolean = false): any {
+export function {{classname}}ToJSONTyped(value?: {{#hasReadOnly}}Omit<{{classname}}, {{#readOnlyVars}}'{{name}}'{{^-last}}|{{/-last}}{{/readOnlyVars}}>{{/hasReadOnly}}{{^hasReadOnly}}{{classname}}{{/hasReadOnly}} | null, ignoreDiscriminator: boolean = false): any {
     {{#hasVars}}
     if (value == null) {
         return value;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -667,6 +667,19 @@ public class TypeScriptFetchClientCodegenTest {
         TestUtils.assertFileNotContains(modelPath, "json['required_property'] === undefined ? undefined : json['required_property'] === null ? null :");
     }
 
+    @Test(description = "Verify Omit uses the camelCase property name instead of the baseName for readOnly fields")
+    public void testIssue23380_OmitUsesCorrectPropertyName() throws Exception {
+        File output = generate(
+            Collections.emptyMap(),
+            "src/test/resources/3_0/typescript-fetch/issue_23380.yaml"
+        );
+
+        Path modelPath = Paths.get(output + "/models/Mission.ts");
+        TestUtils.assertFileExists(modelPath);
+        // Ensure Omit uses camelCase names like 'singleCar' and 'taskName' instead of snake_case 'single_car' and 'TaskName'
+        TestUtils.assertFileContains(modelPath, "export function MissionToJSONTyped(value?: Omit<Mission, 'id'|'taskName'|'singleCar'> | null, ignoreDiscriminator: boolean = false): any {");
+    }
+
     private static File generate(
         Map<String, Object> properties
     ) throws IOException {

--- a/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/issue_23380.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/issue_23380.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /missions:
+    post:
+      operationId: createMission
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                mission:
+                  $ref: '#/components/schemas/Mission'
+              required:
+                - mission
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Mission:
+      type: object
+      properties:
+        id:
+          type: string
+          readOnly: true
+        name:
+          type: string
+        TaskName:
+          type: string
+          readOnly: true
+        single_car:
+          type: object
+          readOnly: true

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Name.ts
@@ -74,7 +74,7 @@ export function NameToJSON(json: any): Name {
     return NameToJSONTyped(json, false);
 }
 
-export function NameToJSONTyped(value?: Omit<Name, 'snake_case'|'123Number'> | null, ignoreDiscriminator: boolean = false): any {
+export function NameToJSONTyped(value?: Omit<Name, 'snakeCase'|'_123number'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/models/name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/models/name.ts
@@ -74,7 +74,7 @@ export function NameToJSON(json: any): Name {
     return NameToJSONTyped(json, false);
 }
 
-export function NameToJSONTyped(value?: Omit<Name, 'snake_case'|'123Number'> | null, ignoreDiscriminator: boolean = false): any {
+export function NameToJSONTyped(value?: Omit<Name, 'snakeCase'|'_123number'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Name.ts
@@ -74,7 +74,7 @@ export function NameToJSON(json: any): Name {
     return NameToJSONTyped(json, false);
 }
 
-export function NameToJSONTyped(value?: Omit<Name, 'snake_case'|'123Number'> | null, ignoreDiscriminator: boolean = false): any {
+export function NameToJSONTyped(value?: Omit<Name, 'snakeCase'|'_123number'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }


### PR DESCRIPTION
Fixes #23380

When generating the `Omit<...>` utility type for readOnly fields in models, the typescript-fetch generator incorrectly used `baseName` instead of `name`. This resulted in invalid TypeScript compiler errors when the model property naming strategy diverged from the raw OpenAPI property name (e.g. `single_car` in the spec vs `singleCar` in the generated interface).

This commit fixes `modelGeneric.mustache` to properly use the generated property name (`{{name}}`) instead of `{{baseName}}` for read-only fields, and adds test coverage to ensure the fix is maintained.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04) @joscha (2024/10)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #23380. The `typescript-fetch` generator now uses generated property names in the `Omit<...>` for readOnly fields, preventing TypeScript errors when spec names differ from interface names.

- **Bug Fixes**
  - Use `{{name}}` instead of `{{baseName}}` when building `Omit<...>` for read-only properties in `modelGeneric.mustache`.
  - Add a test (`issue_23380.yaml`) to verify camelCase names are used in `Omit`, and update `petstore` samples accordingly.

<sup>Written for commit 63f0d9c01539731289cebb0c76f63e49923c0b1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

