### PR TITLE
[typescript-fetch] Fix Omit generic using baseName for readOnly fields in API requests

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -25,7 +25,7 @@ import {
 {{#allParams.0}}
 export interface {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request {
 {{#allParams}}
-    {{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{#hasReadOnly}}Omit<{{{dataType}}}, {{#readOnlyVars}}'{{baseName}}'{{^-last}}|{{/-last}}{{/readOnlyVars}}>{{/hasReadOnly}}{{^hasReadOnly}}{{{dataType}}}{{/hasReadOnly}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}};
+    {{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{#hasReadOnly}}Omit<{{{dataType}}}, {{#readOnlyVars}}'{{name}}'{{^-last}}|{{/-last}}{{/readOnlyVars}}>{{/hasReadOnly}}{{^hasReadOnly}}{{{dataType}}}{{/hasReadOnly}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}};
 {{/allParams}}
 }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -680,6 +680,20 @@ public class TypeScriptFetchClientCodegenTest {
         TestUtils.assertFileContains(modelPath, "export function MissionToJSONTyped(value?: Omit<Mission, 'id'|'taskName'|'singleCar'> | null, ignoreDiscriminator: boolean = false): any {");
     }
 
+    @Test(description = "Verify Omit uses the camelCase property name instead of the baseName for readOnly fields in API requests")
+    public void testIssue19572_OmitUsesCorrectPropertyNameInApi() throws Exception {
+        File output = generate(
+                Collections.emptyMap(),
+                "src/test/resources/3_0/typescript-fetch/issue_19572.yaml"
+        );
+
+        Path modelPath = Paths.get(output + "/apis/DefaultApi.ts");
+        TestUtils.assertFileExists(modelPath);
+        // Ensure Omit uses camelCase names like 'createdAt' and 'updatedAt' instead of snake_case 'created_at' and 'updated_at'
+        TestUtils.assertFileContains(modelPath, "export interface FinancingOptionCreateRequest {");
+        TestUtils.assertFileContains(modelPath, "    financingOption?: Omit<FinancingOption, 'id'|'createdAt'|'updatedAt'|'foo'|'bar'>;");
+    }
+
     private static File generate(
         Map<String, Object> properties
     ) throws IOException {

--- a/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/issue_19572.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/issue_19572.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /financing-options:
+    post:
+      operationId: financingOptionCreate
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FinancingOption'
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    FinancingOption:
+      type: object
+      properties:
+        id:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+        foo:
+          type: string
+          readOnly: true
+        bar:
+          type: string
+          readOnly: true


### PR DESCRIPTION
Fixes #19572
### Description

Context: In the typescript-fetch generator, the generated Omit generic in API request interfaces was incorrectly using the baseName (e.g., created_at) instead of the generated TypeScript property name for readOnly fields (e.g., createdAt).

Because **ToJSON** safely strips out **readOnly** fields at runtime anyway, this bug did not break the actual JSON payloads sent to the backend. However, it caused TypeScript typing errors because the readOnly properties were incorrectly left exposed in the TypeScript request interfaces.

(FYI: A similar fix was recently merged in #24275 for modelGeneric.mustache. This PR applies the same fix to apis.mustache to complete the resolution for issue #19572).
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04) @joscha (2024/10)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #19572 by using camelCase TypeScript property names in Omit for readOnly fields in `typescript-fetch` API request interfaces. This prevents typing errors; runtime payloads are unchanged.

- **Bug Fixes**
  - Use `'name'` instead of `'baseName'` when building `Omit` for readOnly props in `apis.mustache`.
  - Added test and sample spec to ensure camelCase fields (e.g., createdAt, updatedAt) are used in generated request types.

<sup>Written for commit 89622d6b669213481803e66e767e8ad30bd1a9a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

