### PR TITLE
[python] require Python >= 3.10 and restore full dependency floors

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/pyproject.mustache
+++ b/modules/openapi-generator/src/main/resources/python/pyproject.mustache
@@ -34,11 +34,11 @@ include = ["{{packageName}}/py.typed"]
 [tool.poetry.dependencies]
 python = "^3.10"
 {{^async}}
-urllib3 = ">= 2.6.3, < 3.0.0"
+urllib3 = ">= 2.7.0, < 3.0.0"
 {{/async}}
 python-dateutil = ">= 2.8.2"
 {{#asyncio}}
-aiohttp = ">= 3.13.5"
+aiohttp = ">= 3.14.1"
 aiohttp-retry = ">= 2.8.3"
 {{/asyncio}}
 {{#httpx}}
@@ -58,18 +58,18 @@ lazy-imports = ">= 1, < 2"
 {{/lazyImports}}
 {{/poetry1}}
 {{^poetry1}}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 dependencies = [
 {{^async}}
-  "urllib3 (>=2.6.3,<3.0.0)",
+  "urllib3 (>=2.7.0,<3.0.0)",
 {{/async}}
   "python-dateutil (>=2.8.2)",
 {{#httpx}}
   "httpx (>=0.28.1)",
 {{/httpx}}
 {{#asyncio}}
-  "aiohttp (>=3.13.5)",
+  "aiohttp (>=3.14.1)",
   "aiohttp-retry (>=2.8.3)",
 {{/asyncio}}
 {{#tornado}}
@@ -101,7 +101,7 @@ requires-poetry = ">=2.0"
 {{^poetry1}}
 [tool.poetry.group.dev.dependencies]
 {{/poetry1}}
-pytest = ">= 8.4.2"
+pytest = ">= 9.0.3"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"

--- a/modules/openapi-generator/src/main/resources/python/requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python/requirements.mustache
@@ -1,9 +1,9 @@
 {{^async}}
-urllib3 >= 2.6.3, < 3.0.0
+urllib3 >= 2.7.0, < 3.0.0
 {{/async}}
 python_dateutil >= 2.8.2
 {{#asyncio}}
-aiohttp >= 3.13.5
+aiohttp >= 3.14.1
 aiohttp-retry >= 2.8.3
 {{/asyncio}}
 {{#httpx}}

--- a/modules/openapi-generator/src/main/resources/python/setup.mustache
+++ b/modules/openapi-generator/src/main/resources/python/setup.mustache
@@ -13,11 +13,11 @@ VERSION = "{{packageVersion}}"
 PYTHON_REQUIRES = ">= 3.10"
 REQUIRES = [
 {{^async}}
-    "urllib3 >= 2.6.3, < 3.0.0",
+    "urllib3 >= 2.7.0, < 3.0.0",
 {{/async}}
     "python-dateutil >= 2.8.2",
 {{#asyncio}}
-    "aiohttp >= 3.13.5",
+    "aiohttp >= 3.14.1",
     "aiohttp-retry >= 2.8.3",
 {{/asyncio}}
 {{#httpx}}

--- a/modules/openapi-generator/src/main/resources/python/test-requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python/test-requirements.mustache
@@ -1,4 +1,4 @@
-pytest >= 8.4.2
+pytest >= 9.0.3
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/pyproject.toml
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/pyproject.toml
@@ -8,10 +8,10 @@ authors = [
 license = { text = "Apache 2.0" }
 readme = "README.md"
 keywords = ["OpenAPI", "OpenAPI-Generator", "Echo Server API"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 dependencies = [
-  "urllib3 (>=2.6.3,<3.0.0)",
+  "urllib3 (>=2.7.0,<3.0.0)",
   "python-dateutil (>=2.8.2)",
   "pydantic (>=2.11)",
   "typing-extensions (>=4.7.1)",
@@ -24,7 +24,7 @@ Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 requires-poetry = ">=2.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = ">= 8.4.2"
+pytest = ">= 9.0.3"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/requirements.txt
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/requirements.txt
@@ -1,4 +1,4 @@
-urllib3 >= 2.6.3, < 3.0.0
+urllib3 >= 2.7.0, < 3.0.0
 python_dateutil >= 2.8.2
 pydantic >= 2.11
 typing-extensions >= 4.7.1

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/setup.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/setup.py
@@ -23,7 +23,7 @@ NAME = "openapi-client"
 VERSION = "1.0.0"
 PYTHON_REQUIRES = ">= 3.10"
 REQUIRES = [
-    "urllib3 >= 2.6.3, < 3.0.0",
+    "urllib3 >= 2.7.0, < 3.0.0",
     "python-dateutil >= 2.8.2",
     "pydantic >= 2.11",
     "typing-extensions >= 4.7.1",

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/test-requirements.txt
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 8.4.2
+pytest >= 9.0.3
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0

--- a/samples/client/echo_api/python/pyproject.toml
+++ b/samples/client/echo_api/python/pyproject.toml
@@ -8,10 +8,10 @@ authors = [
 license = { text = "Apache 2.0" }
 readme = "README.md"
 keywords = ["OpenAPI", "OpenAPI-Generator", "Echo Server API"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 dependencies = [
-  "urllib3 (>=2.6.3,<3.0.0)",
+  "urllib3 (>=2.7.0,<3.0.0)",
   "python-dateutil (>=2.8.2)",
   "pydantic (>=2.11)",
   "typing-extensions (>=4.7.1)",
@@ -24,7 +24,7 @@ Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 requires-poetry = ">=2.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = ">= 8.4.2"
+pytest = ">= 9.0.3"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"

--- a/samples/client/echo_api/python/requirements.txt
+++ b/samples/client/echo_api/python/requirements.txt
@@ -1,4 +1,4 @@
-urllib3 >= 2.6.3, < 3.0.0
+urllib3 >= 2.7.0, < 3.0.0
 python_dateutil >= 2.8.2
 pydantic >= 2.11
 typing-extensions >= 4.7.1

--- a/samples/client/echo_api/python/setup.py
+++ b/samples/client/echo_api/python/setup.py
@@ -23,7 +23,7 @@ NAME = "openapi-client"
 VERSION = "1.0.0"
 PYTHON_REQUIRES = ">= 3.10"
 REQUIRES = [
-    "urllib3 >= 2.6.3, < 3.0.0",
+    "urllib3 >= 2.7.0, < 3.0.0",
     "python-dateutil >= 2.8.2",
     "pydantic >= 2.11",
     "typing-extensions >= 4.7.1",

--- a/samples/client/echo_api/python/test-requirements.txt
+++ b/samples/client/echo_api/python/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 8.4.2
+pytest >= 9.0.3
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0

--- a/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
@@ -12,7 +12,7 @@ include = ["petstore_api/py.typed"]
 [tool.poetry.dependencies]
 python = "^3.10"
 python-dateutil = ">= 2.8.2"
-aiohttp = ">= 3.13.5"
+aiohttp = ">= 3.14.1"
 aiohttp-retry = ">= 2.8.3"
 pem = ">= 19.3.0"
 pycryptodome = ">= 3.9.0"
@@ -20,7 +20,7 @@ pydantic = ">= 2.11"
 typing-extensions = ">= 4.7.1"
 
 [tool.poetry.dev-dependencies]
-pytest = ">= 8.4.2"
+pytest = ">= 9.0.3"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"

--- a/samples/openapi3/client/petstore/python-aiohttp/requirements.txt
+++ b/samples/openapi3/client/petstore/python-aiohttp/requirements.txt
@@ -1,5 +1,5 @@
 python_dateutil >= 2.8.2
-aiohttp >= 3.13.5
+aiohttp >= 3.14.1
 aiohttp-retry >= 2.8.3
 pem >= 19.3.0
 pycryptodome >= 3.9.0

--- a/samples/openapi3/client/petstore/python-aiohttp/setup.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/setup.py
@@ -23,7 +23,7 @@ VERSION = "1.0.0"
 PYTHON_REQUIRES = ">= 3.10"
 REQUIRES = [
     "python-dateutil >= 2.8.2",
-    "aiohttp >= 3.13.5",
+    "aiohttp >= 3.14.1",
     "aiohttp-retry >= 2.8.3",
     "pem >= 19.3.0",
     "pycryptodome >= 3.9.0",

--- a/samples/openapi3/client/petstore/python-aiohttp/test-requirements.txt
+++ b/samples/openapi3/client/petstore/python-aiohttp/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 8.4.2
+pytest >= 9.0.3
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0

--- a/samples/openapi3/client/petstore/python-httpx-sync/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-httpx-sync/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 license = { text = "Apache-2.0" }
 readme = "README.md"
 keywords = ["OpenAPI", "OpenAPI-Generator", "OpenAPI Petstore"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 dependencies = [
   "python-dateutil (>=2.8.2)",
@@ -26,7 +26,7 @@ Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 requires-poetry = ">=2.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = ">= 8.4.2"
+pytest = ">= 9.0.3"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"

--- a/samples/openapi3/client/petstore/python-httpx-sync/test-requirements.txt
+++ b/samples/openapi3/client/petstore/python-httpx-sync/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 8.4.2
+pytest >= 9.0.3
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0

--- a/samples/openapi3/client/petstore/python-httpx/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-httpx/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 license = { text = "Apache-2.0" }
 readme = "README.md"
 keywords = ["OpenAPI", "OpenAPI-Generator", "OpenAPI Petstore"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 dependencies = [
   "python-dateutil (>=2.8.2)",
@@ -26,7 +26,7 @@ Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 requires-poetry = ">=2.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = ">= 8.4.2"
+pytest = ">= 9.0.3"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"

--- a/samples/openapi3/client/petstore/python-httpx/test-requirements.txt
+++ b/samples/openapi3/client/petstore/python-httpx/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 8.4.2
+pytest >= 9.0.3
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0

--- a/samples/openapi3/client/petstore/python-lazyImports/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-lazyImports/pyproject.toml
@@ -8,10 +8,10 @@ authors = [
 license = { text = "Apache-2.0" }
 readme = "README.md"
 keywords = ["OpenAPI", "OpenAPI-Generator", "OpenAPI Petstore"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 dependencies = [
-  "urllib3 (>=2.6.3,<3.0.0)",
+  "urllib3 (>=2.7.0,<3.0.0)",
   "python-dateutil (>=2.8.2)",
   "pem (>=19.3.0)",
   "pycryptodome (>=3.9.0)",
@@ -27,7 +27,7 @@ Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 requires-poetry = ">=2.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = ">= 8.4.2"
+pytest = ">= 9.0.3"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"

--- a/samples/openapi3/client/petstore/python-lazyImports/requirements.txt
+++ b/samples/openapi3/client/petstore/python-lazyImports/requirements.txt
@@ -1,4 +1,4 @@
-urllib3 >= 2.6.3, < 3.0.0
+urllib3 >= 2.7.0, < 3.0.0
 python_dateutil >= 2.8.2
 pem >= 19.3.0
 pycryptodome >= 3.9.0

--- a/samples/openapi3/client/petstore/python-lazyImports/setup.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/setup.py
@@ -22,7 +22,7 @@ NAME = "petstore-api"
 VERSION = "1.0.0"
 PYTHON_REQUIRES = ">= 3.10"
 REQUIRES = [
-    "urllib3 >= 2.6.3, < 3.0.0",
+    "urllib3 >= 2.7.0, < 3.0.0",
     "python-dateutil >= 2.8.2",
     "pem >= 19.3.0",
     "pycryptodome >= 3.9.0",

--- a/samples/openapi3/client/petstore/python-lazyImports/test-requirements.txt
+++ b/samples/openapi3/client/petstore/python-lazyImports/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 8.4.2
+pytest >= 9.0.3
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0

--- a/samples/openapi3/client/petstore/python/pyproject.toml
+++ b/samples/openapi3/client/petstore/python/pyproject.toml
@@ -8,10 +8,10 @@ authors = [
 license = { text = "Apache-2.0" }
 readme = "README.md"
 keywords = ["OpenAPI", "OpenAPI-Generator", "OpenAPI Petstore"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 dependencies = [
-  "urllib3 (>=2.6.3,<3.0.0)",
+  "urllib3 (>=2.7.0,<3.0.0)",
   "python-dateutil (>=2.8.2)",
   "pem (>=19.3.0)",
   "pycryptodome (>=3.9.0)",
@@ -26,7 +26,7 @@ Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 requires-poetry = ">=2.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = ">= 8.4.2"
+pytest = ">= 9.0.3"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"
 flake8 = ">= 4.0.0"

--- a/samples/openapi3/client/petstore/python/requirements.txt
+++ b/samples/openapi3/client/petstore/python/requirements.txt
@@ -1,4 +1,4 @@
-urllib3 >= 2.6.3, < 3.0.0
+urllib3 >= 2.7.0, < 3.0.0
 python_dateutil >= 2.8.2
 pem >= 19.3.0
 pycryptodome >= 3.9.0

--- a/samples/openapi3/client/petstore/python/setup.py
+++ b/samples/openapi3/client/petstore/python/setup.py
@@ -22,7 +22,7 @@ NAME = "petstore-api"
 VERSION = "1.0.0"
 PYTHON_REQUIRES = ">= 3.10"
 REQUIRES = [
-    "urllib3 >= 2.6.3, < 3.0.0",
+    "urllib3 >= 2.7.0, < 3.0.0",
     "python-dateutil >= 2.8.2",
     "pem >= 19.3.0",
     "pycryptodome >= 3.9.0",

--- a/samples/openapi3/client/petstore/python/test-requirements.txt
+++ b/samples/openapi3/client/petstore/python/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 8.4.2
+pytest >= 9.0.3
 pytest-cov >= 2.8.1
 tox >= 3.9.0
 flake8 >= 4.0.0


### PR DESCRIPTION
## Follow-up to #24186 — raise `requires-python` to `>=3.10` and restore the full dependency floors

#24186 raised the generated Python client dependency floors above known-vulnerable ranges, but had to *lower* three of them to keep the generated clients installable under the declared `requires-python`:

| package | #24186 shipped | fully-patched floor |
|---------|----------------|---------------------|
| `urllib3` | `>= 2.6.3, < 3.0.0` | `>= 2.7.0, < 3.0.0` |
| `aiohttp` | `>= 3.13.5` | `>= 3.14.1` |
| `pytest` (dev) | `>= 8.4.2` | `>= 9.0.3` |

The safest patched releases of these packages are published only for **Python ≥ 3.10**, so at `requires-python = ">=3.9"` the resolver would still be free to pick vulnerable versions on 3.9. That left the newest advisories uncleared at the declaration level:

- **urllib3** — GHSA-mf9v-mfxr-j63j, GHSA-qccp-gfcp-xxvc (fixed in 2.7.0)
- **aiohttp** — the `<= 3.14.0` advisory batch (fixed in 3.14.1)
- **pytest** — GHSA-6w46-j5rx-g56g / CVE-2025-71176 (fixed in 9.0.3)

### What this PR does

1. **Raises `requires-python` from `>=3.9` to `>=3.10`** in the Python generator templates. This aligns the PEP-621 `[project]` metadata with the poetry (`python = "^3.10"`) and `setup.py` (`PYTHON_REQUIRES = ">= 3.10"`) declarations, which already dropped 3.9 in #22926 — the PEP-621 `requires-python` line was the one spot left at `>=3.9`.
2. **Restores the higher floors** (`urllib3 >= 2.7.0`, `aiohttp >= 3.14.1`, `pytest >= 9.0.3`) so the declared ranges fully exclude the vulnerable versions for every supported interpreter.

With the minimum interpreter at 3.10, the restored floors resolve cleanly and the declared ranges no longer admit any of the advisory-affected releases.

### Breaking change

Dropping **Python 3.9** support from the generated clients is intentional and is the mechanism by which the floors can be raised. Generated-client consumers still on 3.9 would need to stay on an older generator version.

### Samples

Regenerated the affected Python client samples (`python`, `python-aiohttp`, `python-httpx`, `python-httpx-sync`, `python-lazyImports`, `python-echo-api`, and the `disallowAdditionalPropertiesIfNotPresent` echo variant) — the same set touched by #24186. The diff is limited to the floor lines and the `requires-python` line.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise Python requirement for generated Python clients to >=3.10 and restore secure floors for `urllib3`, `aiohttp`, and `pytest`. This aligns PEP-621 metadata with `poetry`/`setup.py` and prevents installs from picking vulnerable versions.

- **Dependencies**
  - `urllib3 >= 2.7.0, < 3.0.0`
  - `aiohttp >= 3.14.1`
  - `pytest >= 9.0.3` (dev)

- **Migration**
  - Python 3.9 is no longer supported. Pin to an older generator if you must support 3.9.

<sup>Written for commit 56efc73198afc925ff1b3f656764b22edbdb794b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

