### PR TITLE
[ruby-nextgen] update readme, reformat code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1099,6 +1099,7 @@ Here is a list of template creators:
    * R: @ramnov
    * Ruby (Faraday): @meganemura @dkliban
    * Ruby (HTTPX): @honeyryderchuck
+   * Ruby (ruby-nextgen): @n-rodriguez
    * Rust: @farcaller
    * Rust (rust-server): @metaswitch
    * Scala (scalaz & http4s): @tbrown1979

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyNextgenClientCodegen.java
@@ -14,6 +14,7 @@ import org.openapitools.codegen.meta.features.WireFormatFeature;
 import org.openapitools.codegen.templating.mustache.IndentedLambda;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.util.*;
 
@@ -236,18 +237,53 @@ public class RubyNextgenClientCodegen extends AbstractRubyCodegen {
         supportingFiles.add(new SupportingFile("bin_rubocop.mustache", "bin", "rubocop"));
     }
 
-    public void setGemName(String gemName) { this.gemName = gemName; }
-    public void setModuleName(String moduleName) { this.moduleName = moduleName; }
-    public void setGemVersion(String v) { this.gemVersion = v; }
-    public void setApiNamespace(String apiNamespace) { this.apiNamespace = apiNamespace; }
-    public void setGemAuthor(String gemAuthor) { this.gemAuthor = gemAuthor; }
-    public void setGemAuthorEmail(String gemAuthorEmail) { this.gemAuthorEmail = gemAuthorEmail; }
-    public void setGemHomepage(String gemHomepage) { this.gemHomepage = gemHomepage; }
-    public void setGemSummary(String gemSummary) { this.gemSummary = gemSummary; }
-    public void setGemDescription(String gemDescription) { this.gemDescription = gemDescription; }
-    public void setGemLicense(String gemLicense) { this.gemLicense = gemLicense; }
-    public String generateModuleName(String gemName) { return camelize(gemName.replaceAll("[^\\w]+", "_")); }
-    public String generateGemName(String moduleName) { return underscore(moduleName.replaceAll("[^\\w]+", "")); }
+    public void setGemName(String gemName) {
+        this.gemName = gemName;
+    }
+
+    public void setModuleName(String moduleName) {
+        this.moduleName = moduleName;
+    }
+
+    public void setGemVersion(String v) {
+        this.gemVersion = v;
+    }
+
+    public void setApiNamespace(String apiNamespace) {
+        this.apiNamespace = apiNamespace;
+    }
+
+    public void setGemAuthor(String gemAuthor) {
+        this.gemAuthor = gemAuthor;
+    }
+
+    public void setGemAuthorEmail(String gemAuthorEmail) {
+        this.gemAuthorEmail = gemAuthorEmail;
+    }
+
+    public void setGemHomepage(String gemHomepage) {
+        this.gemHomepage = gemHomepage;
+    }
+
+    public void setGemSummary(String gemSummary) {
+        this.gemSummary = gemSummary;
+    }
+
+    public void setGemDescription(String gemDescription) {
+        this.gemDescription = gemDescription;
+    }
+
+    public void setGemLicense(String gemLicense) {
+        this.gemLicense = gemLicense;
+    }
+
+    public String generateModuleName(String gemName) {
+        return camelize(gemName.replaceAll("[^\\w]+", "_"));
+    }
+
+    public String generateGemName(String moduleName) {
+        return underscore(moduleName.replaceAll("[^\\w]+", ""));
+    }
 
     @Override
     public String apiFileFolder() {
@@ -513,7 +549,7 @@ public class RubyNextgenClientCodegen extends AbstractRubyCodegen {
         boolean clash = uniqueClash(opList, unique);
         while (clash) {
             unique = co.operationId + "_" + co.httpMethod.toLowerCase(Locale.ROOT)
-                     + (counter == 0 ? "" : "_" + counter);
+                    + (counter == 0 ? "" : "_" + counter);
             counter++;
             clash = uniqueClash(opList, unique);
         }
@@ -524,7 +560,9 @@ public class RubyNextgenClientCodegen extends AbstractRubyCodegen {
         opList.add(co);
     }
 
-    /** Returns true if any operation in {@code opList} already uses {@code candidate} as its operationId. */
+    /**
+     * Returns true if any operation in {@code opList} already uses {@code candidate} as its operationId.
+     */
     private static boolean uniqueClash(List<CodegenOperation> opList, String candidate) {
         for (CodegenOperation op : opList) {
             if (op.operationId.equals(candidate)) return true;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyNextgenClientCodegen.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.openapitools.codegen.languages;
 
 import io.swagger.v3.oas.models.*;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/rubynextgen/RubyApiRouting.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/rubynextgen/RubyApiRouting.java
@@ -1,4 +1,18 @@
-// RubyApiRouting.java
+/*
+ * Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openapitools.codegen.languages.rubynextgen;
 
 import java.util.*;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/rubynextgen/RubyApiRouting.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/rubynextgen/RubyApiRouting.java
@@ -2,16 +2,23 @@
 package org.openapitools.codegen.languages.rubynextgen;
 
 import java.util.*;
+
 import org.openapitools.codegen.utils.StringUtils;
 
 // NOTE: Intentional copy of CrystalApiRouting. The path->route logic is
 // language-agnostic; it is duplicated (not shared) to keep each generator
 // fully decoupled and avoid modifying the already-shipped Crystal generator.
-/** Pure routing logic for the ruby-nextgengenerator: path -> (namespace, resource, action). */
-public final class RubyApiRouting {
-    private RubyApiRouting() {}
 
-    private static boolean isParam(String seg) { return seg.startsWith("{") && seg.endsWith("}"); }
+/**
+ * Pure routing logic for the ruby-nextgen generator: path -> (namespace, resource, action).
+ */
+public final class RubyApiRouting {
+    private RubyApiRouting() {
+    }
+
+    private static boolean isParam(String seg) {
+        return seg.startsWith("{") && seg.endsWith("}");
+    }
 
     private static List<String> segments(String path) {
         List<String> out = new ArrayList<>();
@@ -21,7 +28,9 @@ public final class RubyApiRouting {
         return out;
     }
 
-    /** Segments that appear immediately before a {param} in at least one path. */
+    /**
+     * Segments that appear immediately before a {param} in at least one path.
+     */
     public static Set<String> resourceSegments(Collection<String> paths) {
         Set<String> r = new HashSet<>();
         for (String path : paths) {
@@ -35,7 +44,9 @@ public final class RubyApiRouting {
         return r;
     }
 
-    /** Longest leading run of identical literal segments shared by all paths. */
+    /**
+     * Longest leading run of identical literal segments shared by all paths.
+     */
     public static String commonBasePrefix(Collection<String> paths) {
         List<List<String>> all = new ArrayList<>();
         for (String p : paths) all.add(segments(p));
@@ -55,7 +66,9 @@ public final class RubyApiRouting {
         }
     }
 
-    /** Literal segments after stripping the base prefix and dropping {param} segments. */
+    /**
+     * Literal segments after stripping the base prefix and dropping {param} segments.
+     */
     public static List<String> literals(String path, String basePrefix) {
         List<String> segs = segments(path);
         List<String> prefix = basePrefix.isEmpty() ? Collections.emptyList() : segments(basePrefix);
@@ -71,11 +84,14 @@ public final class RubyApiRouting {
         return out;
     }
 
-    /** Route triple: (namespace, resource, action). Resource may be null. */
+    /**
+     * Route triple: (namespace, resource, action). Resource may be null.
+     */
     public static final class Route {
         public final String namespace;
         public final String resource;   // nullable
         public final String action;
+
         public Route(String namespace, String resource, String action) {
             this.namespace = namespace;
             this.resource = resource;
@@ -135,12 +151,18 @@ public final class RubyApiRouting {
 
     private static String verbAction(String httpMethod, boolean item) {
         switch (httpMethod.toUpperCase(java.util.Locale.ROOT)) {
-            case "GET":    return item ? "get" : "list";
-            case "POST":   return "create";
-            case "PUT":    return item ? "update" : "bulk_update";
-            case "PATCH":  return item ? "partial_update" : "bulk_partial_update";
-            case "DELETE": return item ? "delete" : "bulk_destroy";
-            default:       return httpMethod.toLowerCase(java.util.Locale.ROOT);
+            case "GET":
+                return item ? "get" : "list";
+            case "POST":
+                return "create";
+            case "PUT":
+                return item ? "update" : "bulk_update";
+            case "PATCH":
+                return item ? "partial_update" : "bulk_partial_update";
+            case "DELETE":
+                return item ? "delete" : "bulk_destroy";
+            default:
+                return httpMethod.toLowerCase(java.util.Locale.ROOT);
         }
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/rubynextgen/RubyApiRoutingTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/rubynextgen/RubyApiRoutingTest.java
@@ -1,56 +1,81 @@
+/*
+ * Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ * Copyright 2018 SmartBear Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.openapitools.codegen.rubynextgen;
 
 import org.openapitools.codegen.languages.rubynextgen.RubyApiRouting;
 import org.testng.annotations.Test;
+
 import java.util.*;
+
 import static org.testng.Assert.assertEquals;
 
 public class RubyApiRoutingTest {
     private static final List<String> NETBOX = Arrays.asList(
-        "/api/dcim/cable-terminations/", "/api/dcim/cable-terminations/{id}/",
-        "/api/dcim/cable-terminations/{id}/paths/", "/api/ipam/vlans/{id}/");
+            "/api/dcim/cable-terminations/", "/api/dcim/cable-terminations/{id}/",
+            "/api/dcim/cable-terminations/{id}/paths/", "/api/ipam/vlans/{id}/");
     private static final List<String> QDRANT = Arrays.asList(
-        "/collections", "/collections/{collection_name}",
-        "/collections/{collection_name}/points/query",
-        "/collections/{collection_name}/points/{id}",
-        "/collections/{collection_name}/exists",
-        "/cluster/recover", "/cluster/peer/{peer_id}", "/");
+            "/collections", "/collections/{collection_name}",
+            "/collections/{collection_name}/points/query",
+            "/collections/{collection_name}/points/{id}",
+            "/collections/{collection_name}/exists",
+            "/cluster/recover", "/cluster/peer/{peer_id}", "/");
 
-    @Test public void testResourceSegments() {
+    @Test
+    public void testResourceSegments() {
         assertEquals(RubyApiRouting.resourceSegments(NETBOX),
-            new HashSet<>(Arrays.asList("cable-terminations", "vlans")));
+                new HashSet<>(Arrays.asList("cable-terminations", "vlans")));
         assertEquals(RubyApiRouting.resourceSegments(QDRANT),
-            new HashSet<>(Arrays.asList("collections", "points", "peer")));
+                new HashSet<>(Arrays.asList("collections", "points", "peer")));
     }
 
-    @Test public void testCommonBasePrefix() {
+    @Test
+    public void testCommonBasePrefix() {
         assertEquals(RubyApiRouting.commonBasePrefix(NETBOX), "api");
         assertEquals(RubyApiRouting.commonBasePrefix(QDRANT), "");
     }
 
-    @Test public void testLiterals() {
+    @Test
+    public void testLiterals() {
         assertEquals(RubyApiRouting.literals("/api/dcim/cable-terminations/{id}/paths/", "api"),
-            Arrays.asList("dcim", "cable-terminations", "paths"));
+                Arrays.asList("dcim", "cable-terminations", "paths"));
         assertEquals(RubyApiRouting.literals("/", ""), Collections.emptyList());
     }
 
-    @Test public void testRouteItemUsesOperationIdAction() {
+    @Test
+    public void testRouteItemUsesOperationIdAction() {
         Set<String> r = RubyApiRouting.resourceSegments(NETBOX);
         RubyApiRouting.Route route = RubyApiRouting.route(
-            "/api/dcim/cable-terminations/{id}/", "PATCH",
-            "dcim_cable_terminations_partial_update", r, "api");
+                "/api/dcim/cable-terminations/{id}/", "PATCH",
+                "dcim_cable_terminations_partial_update", r, "api");
         assertEquals(route.namespace, "dcim");
         assertEquals(route.resource, "cable-terminations");
         assertEquals(route.action, "partial_update");
     }
 
-    @Test public void testRouteVerbFallbackCollectionVsItem() {
+    @Test
+    public void testRouteVerbFallbackCollectionVsItem() {
         Set<String> r = RubyApiRouting.resourceSegments(QDRANT);
         assertEquals(RubyApiRouting.route("/collections", "GET", "", r, "").action, "list");
         assertEquals(RubyApiRouting.route("/collections/{collection_name}", "GET", "", r, "").action, "get");
     }
 
-    @Test public void testRouteRootPath() {
+    @Test
+    public void testRouteRootPath() {
         Set<String> r = RubyApiRouting.resourceSegments(QDRANT);
         RubyApiRouting.Route route = RubyApiRouting.route("/", "GET", "", r, "");
         assertEquals(route.namespace, "root");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/rubynextgen/RubyNextgenClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/rubynextgen/RubyNextgenClientCodegenTest.java
@@ -1,7 +1,23 @@
+/*
+ * Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openapitools.codegen.rubynextgen;
 
 import org.openapitools.codegen.languages.RubyNextgenClientCodegen;
 import org.testng.annotations.Test;
+
 import static org.testng.Assert.assertEquals;
 
 public class RubyNextgenClientCodegenTest {
@@ -179,32 +195,32 @@ public class RubyNextgenClientCodegenTest {
     @Test
     public void testModelPropertyValidationFlags() {
         io.swagger.v3.oas.models.OpenAPI openAPI = org.openapitools.codegen.TestUtils
-            .parseSpec("src/test/resources/3_0/petstore.yaml");
+                .parseSpec("src/test/resources/3_0/petstore.yaml");
         RubyNextgenClientCodegen codegen = new RubyNextgenClientCodegen();
         codegen.setOpenAPI(openAPI);
         org.openapitools.codegen.CodegenModel cm = codegen.fromModel("Pet",
-            openAPI.getComponents().getSchemas().get("Pet"));
+                openAPI.getComponents().getSchemas().get("Pet"));
         org.openapitools.codegen.model.ModelsMap mm = org.openapitools.codegen.TestUtils
-            .createCodegenModelWrapper(cm);
+                .createCodegenModelWrapper(cm);
         codegen.postProcessModels(mm);
         org.openapitools.codegen.CodegenProperty status = cm.vars.stream()
-            .filter(v -> v.baseName.equals("status")).findFirst().orElseThrow(RuntimeException::new);
+                .filter(v -> v.baseName.equals("status")).findFirst().orElseThrow(RuntimeException::new);
         org.testng.Assert.assertEquals(status.vendorExtensions.get("x-rb-validated"), Boolean.TRUE);
     }
 
     @Test
     public void testArrayItemsValidation() {
         io.swagger.v3.oas.models.OpenAPI openAPI = org.openapitools.codegen.TestUtils
-            .parseSpec("src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml");
+                .parseSpec("src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml");
         RubyNextgenClientCodegen codegen = new RubyNextgenClientCodegen();
         codegen.setOpenAPI(openAPI);
         org.openapitools.codegen.CodegenModel cm = codegen.fromModel("ArrayTest",
-            openAPI.getComponents().getSchemas().get("ArrayTest"));
+                openAPI.getComponents().getSchemas().get("ArrayTest"));
         org.openapitools.codegen.model.ModelsMap mm = org.openapitools.codegen.TestUtils
-            .createCodegenModelWrapper(cm);
+                .createCodegenModelWrapper(cm);
         codegen.postProcessModels(mm);
         org.openapitools.codegen.CodegenProperty arrayOfString = cm.vars.stream()
-            .filter(v -> v.baseName.equals("array_of_string")).findFirst().orElseThrow(RuntimeException::new);
+                .filter(v -> v.baseName.equals("array_of_string")).findFirst().orElseThrow(RuntimeException::new);
         org.testng.Assert.assertTrue(arrayOfString.isArray);
         org.testng.Assert.assertEquals(arrayOfString.maxItems, Integer.valueOf(3));
         org.testng.Assert.assertEquals(arrayOfString.vendorExtensions.get("x-rb-validated"), Boolean.TRUE);
@@ -213,25 +229,25 @@ public class RubyNextgenClientCodegenTest {
     @Test
     public void testAdditionalPropertiesExtension() {
         io.swagger.v3.oas.models.OpenAPI openAPI = org.openapitools.codegen.TestUtils
-            .parseSpec("src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml");
+                .parseSpec("src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml");
         RubyNextgenClientCodegen codegen = new RubyNextgenClientCodegen();
         codegen.setOpenAPI(openAPI);
 
         // FreeFormObject is `additionalProperties: true` with no declared properties --
         // exercises isAdditionalPropertiesTrue.
         org.openapitools.codegen.CodegenModel freeForm = codegen.fromModel("FreeFormObject",
-            openAPI.getComponents().getSchemas().get("FreeFormObject"));
+                openAPI.getComponents().getSchemas().get("FreeFormObject"));
         org.openapitools.codegen.model.ModelsMap freeFormMap = org.openapitools.codegen.TestUtils
-            .createCodegenModelWrapper(freeForm);
+                .createCodegenModelWrapper(freeForm);
         codegen.postProcessModels(freeFormMap);
         assertEquals(freeForm.vendorExtensions.get("x-rb-additional-properties"), Boolean.TRUE);
 
         // Pet has no additionalProperties at all -- the extension must be absent so
         // partial_model_generic.mustache does not emit the overflow accessor.
         org.openapitools.codegen.CodegenModel pet = codegen.fromModel("Pet",
-            openAPI.getComponents().getSchemas().get("Pet"));
+                openAPI.getComponents().getSchemas().get("Pet"));
         org.openapitools.codegen.model.ModelsMap petMap = org.openapitools.codegen.TestUtils
-            .createCodegenModelWrapper(pet);
+                .createCodegenModelWrapper(pet);
         codegen.postProcessModels(petMap);
         org.testng.Assert.assertNull(pet.vendorExtensions.get("x-rb-additional-properties"));
     }
@@ -339,17 +355,17 @@ public class RubyNextgenClientCodegenTest {
         java.nio.file.Path target = java.nio.file.Files.createTempDirectory("test");
         target.toFile().deleteOnExit();
         org.openapitools.codegen.ClientOptInput input =
-            new org.openapitools.codegen.config.CodegenConfigurator()
-                .setGeneratorName("ruby-nextgen")
-                .setInputSpec("src/test/resources/3_0/petstore.yaml")
-                .setOutputDir(target.toString())
-                .addAdditionalProperty("gemName", "petstore")
-                .addAdditionalProperty("moduleName", "Petstore")
-                .toClientOptInput();
+                new org.openapitools.codegen.config.CodegenConfigurator()
+                        .setGeneratorName("ruby-nextgen")
+                        .setInputSpec("src/test/resources/3_0/petstore.yaml")
+                        .setOutputDir(target.toString())
+                        .addAdditionalProperty("gemName", "petstore")
+                        .addAdditionalProperty("moduleName", "Petstore")
+                        .toClientOptInput();
         new org.openapitools.codegen.DefaultGenerator(false).opts(input).generate();
         org.openapitools.codegen.TestUtils.assertFileContains(
-            target.resolve("lib/petstore/configuration.rb"),
-            "def use(", "@middlewares.each");
+                target.resolve("lib/petstore/configuration.rb"),
+                "def use(", "@middlewares.each");
     }
 
     @Test
@@ -357,29 +373,29 @@ public class RubyNextgenClientCodegenTest {
         java.nio.file.Path target = java.nio.file.Files.createTempDirectory("test");
         target.toFile().deleteOnExit();
         org.openapitools.codegen.ClientOptInput input =
-            new org.openapitools.codegen.config.CodegenConfigurator()
-                .setGeneratorName("ruby-nextgen")
-                .setInputSpec("src/test/resources/3_0/ruby-nextgen/acronym.yaml")
-                .setOutputDir(target.toString())
-                .addAdditionalProperty("gemName", "acme")
-                .addAdditionalProperty("moduleName", "Acme")
-                .toClientOptInput();
+                new org.openapitools.codegen.config.CodegenConfigurator()
+                        .setGeneratorName("ruby-nextgen")
+                        .setInputSpec("src/test/resources/3_0/ruby-nextgen/acronym.yaml")
+                        .setOutputDir(target.toString())
+                        .addAdditionalProperty("gemName", "acme")
+                        .addAdditionalProperty("moduleName", "Acme")
+                        .toClientOptInput();
         new org.openapitools.codegen.DefaultGenerator(false).opts(input).generate();
         // gem.rb must register the acronym exception so Zeitwerk can autoload it: the model
         // class is HTTPConfig but the file is http_config.rb, which Zeitwerk would otherwise
         // expect to define HttpConfig.
         org.openapitools.codegen.TestUtils.assertFileContains(
-            target.resolve("lib/acme.rb"),
-            "@loader.inflector.inflect(", "\"http_config\" => \"HTTPConfig\"");
+                target.resolve("lib/acme.rb"),
+                "@loader.inflector.inflect(", "\"http_config\" => \"HTTPConfig\"");
         // and the model file itself must define the acronym-cased constant
         org.openapitools.codegen.TestUtils.assertFileContains(
-            target.resolve("lib/acme/models/http_config.rb"), "HTTPConfig");
+                target.resolve("lib/acme/models/http_config.rb"), "HTTPConfig");
         // Acronyms in API resource classes must be registered too: the file
         // api/dedicated_cloud/two_fa_whitelist.rb defines DedicatedCloud::TwoFAWhitelist,
         // which the default inflector (expecting TwoFaWhitelist) would fail to autoload.
         org.openapitools.codegen.TestUtils.assertFileContains(
-            target.resolve("lib/acme.rb"), "\"two_fa_whitelist\" => \"TwoFAWhitelist\"");
+                target.resolve("lib/acme.rb"), "\"two_fa_whitelist\" => \"TwoFAWhitelist\"");
         org.openapitools.codegen.TestUtils.assertFileContains(
-            target.resolve("lib/acme/api/dedicated_cloud/two_fa_whitelist.rb"), "TwoFAWhitelist");
+                target.resolve("lib/acme/api/dedicated_cloud/two_fa_whitelist.rb"), "TwoFAWhitelist");
     }
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `ruby-nextgen` maintainer to README and apply consistent formatting and license headers across the Ruby next-gen generator and tests. No functional changes.

<sup>Written for commit f453b0331772bda8127debad7e930d1261663e24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

