### PR TITLE
[Java][apache-httpclient] Apply connect timeout to requests, add read timeout support

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/ApiClient.mustache
@@ -31,6 +31,7 @@ import org.openapitools.jackson.nullable.JsonNullableJackson3Module;
 {{/useJackson3}}
 {{/openApiNullable}}
 
+import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.BasicCookieStore;
 import org.apache.hc.client5.http.cookie.Cookie;
 import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
@@ -53,6 +54,7 @@ import org.apache.hc.core5.http.io.entity.FileEntity;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
+import org.apache.hc.core5.util.Timeout;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -135,6 +137,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   protected Map<String, String> serverVariables = null;
   protected boolean debugging = false;
   protected int connectionTimeout = 0;
+  protected int readTimeout = 0;
 
   protected CloseableHttpClient httpClient;
   protected ObjectMapper objectMapper;
@@ -555,15 +558,40 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
 
   /**
    * Set the connect timeout (in milliseconds).
-   * A value of 0 means no timeout, otherwise values must be between 1 and
-   * {@link Integer#MAX_VALUE}.
+   * A value of 0 means the HTTP client's default connect timeout is used,
+   * otherwise values must be between 1 and {@link Integer#MAX_VALUE}.
+   * The timeout is applied to each request via its request configuration
+   * and takes precedence over the defaults of the underlying HTTP client.
    * @param connectionTimeout Connection timeout in milliseconds
    * @return API client
    */
-   public ApiClient setConnectTimeout(int connectionTimeout) {
-     this.connectionTimeout = connectionTimeout;
-     return this;
-   }
+  public ApiClient setConnectTimeout(int connectionTimeout) {
+    this.connectionTimeout = connectionTimeout;
+    return this;
+  }
+
+  /**
+   * Read timeout (in milliseconds).
+   * @return Read timeout
+   */
+  public int getReadTimeout() {
+    return readTimeout;
+  }
+
+  /**
+   * Set the read timeout (in milliseconds), i.e. the response timeout
+   * while waiting for data after the connection is established.
+   * A value of 0 means the HTTP client's default response timeout is used,
+   * otherwise values must be between 1 and {@link Integer#MAX_VALUE}.
+   * The timeout is applied to each request via its request configuration
+   * and takes precedence over the defaults of the underlying HTTP client.
+   * @param readTimeout Read timeout in milliseconds
+   * @return API client
+   */
+  public ApiClient setReadTimeout(int readTimeout) {
+    this.readTimeout = readTimeout;
+    return this;
+  }
 
   /**
    * Get the date format used to parse/format date parameters.
@@ -1149,6 +1177,17 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
 
     HttpClientContext context = HttpClientContext.create();
     context.setCookieStore(store);
+
+    if (connectionTimeout > 0 || readTimeout > 0) {
+      RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
+      if (connectionTimeout > 0) {
+        requestConfigBuilder.setConnectTimeout(Timeout.ofMilliseconds(connectionTimeout));
+      }
+      if (readTimeout > 0) {
+        requestConfigBuilder.setResponseTimeout(Timeout.ofMilliseconds(readTimeout));
+      }
+      context.setRequestConfig(requestConfigBuilder.build());
+    }
 
     ContentType contentTypeObj = getContentType(contentType);
     if (body != null || !formParams.isEmpty()) {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/ApiClient.mustache
@@ -31,6 +31,7 @@ import org.openapitools.jackson.nullable.JsonNullableJackson3Module;
 {{/useJackson3}}
 {{/openApiNullable}}
 
+import org.apache.hc.client5.http.config.Configurable;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.BasicCookieStore;
 import org.apache.hc.client5.http.cookie.Cookie;
@@ -560,12 +561,17 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * Set the connect timeout (in milliseconds).
    * A value of 0 means the HTTP client's default connect timeout is used,
    * otherwise values must be between 1 and {@link Integer#MAX_VALUE}.
-   * The timeout is applied to each request via its request configuration
-   * and takes precedence over the defaults of the underlying HTTP client.
+   * The timeout is applied to each request via its request configuration;
+   * other request configuration defaults of the underlying HTTP client
+   * are preserved.
    * @param connectionTimeout Connection timeout in milliseconds
    * @return API client
+   * @throws IllegalArgumentException if connectionTimeout is negative
    */
   public ApiClient setConnectTimeout(int connectionTimeout) {
+    if (connectionTimeout < 0) {
+      throw new IllegalArgumentException("connectionTimeout must not be negative");
+    }
     this.connectionTimeout = connectionTimeout;
     return this;
   }
@@ -583,12 +589,17 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * while waiting for data after the connection is established.
    * A value of 0 means the HTTP client's default response timeout is used,
    * otherwise values must be between 1 and {@link Integer#MAX_VALUE}.
-   * The timeout is applied to each request via its request configuration
-   * and takes precedence over the defaults of the underlying HTTP client.
+   * The timeout is applied to each request via its request configuration;
+   * other request configuration defaults of the underlying HTTP client
+   * are preserved.
    * @param readTimeout Read timeout in milliseconds
    * @return API client
+   * @throws IllegalArgumentException if readTimeout is negative
    */
   public ApiClient setReadTimeout(int readTimeout) {
+    if (readTimeout < 0) {
+      throw new IllegalArgumentException("readTimeout must not be negative");
+    }
     this.readTimeout = readTimeout;
     return this;
   }
@@ -1179,7 +1190,10 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     context.setCookieStore(store);
 
     if (connectionTimeout > 0 || readTimeout > 0) {
-      RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
+      // start from the default request configuration of the underlying HTTP client, if
+      // accessible, so that only the configured timeouts are overridden
+      RequestConfig defaultConfig = httpClient instanceof Configurable ? ((Configurable) httpClient).getConfig() : null;
+      RequestConfig.Builder requestConfigBuilder = defaultConfig == null ? RequestConfig.custom() : RequestConfig.copy(defaultConfig);
       if (connectionTimeout > 0) {
         requestConfigBuilder.setConnectTimeout(Timeout.ofMilliseconds(connectionTimeout));
       }

--- a/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.openapitools.jackson.nullable.JsonNullableModule;
 
+import org.apache.hc.client5.http.config.Configurable;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.BasicCookieStore;
 import org.apache.hc.client5.http.cookie.Cookie;
@@ -435,12 +436,17 @@ public class ApiClient extends JavaTimeFormatter {
    * Set the connect timeout (in milliseconds).
    * A value of 0 means the HTTP client's default connect timeout is used,
    * otherwise values must be between 1 and {@link Integer#MAX_VALUE}.
-   * The timeout is applied to each request via its request configuration
-   * and takes precedence over the defaults of the underlying HTTP client.
+   * The timeout is applied to each request via its request configuration;
+   * other request configuration defaults of the underlying HTTP client
+   * are preserved.
    * @param connectionTimeout Connection timeout in milliseconds
    * @return API client
+   * @throws IllegalArgumentException if connectionTimeout is negative
    */
   public ApiClient setConnectTimeout(int connectionTimeout) {
+    if (connectionTimeout < 0) {
+      throw new IllegalArgumentException("connectionTimeout must not be negative");
+    }
     this.connectionTimeout = connectionTimeout;
     return this;
   }
@@ -458,12 +464,17 @@ public class ApiClient extends JavaTimeFormatter {
    * while waiting for data after the connection is established.
    * A value of 0 means the HTTP client's default response timeout is used,
    * otherwise values must be between 1 and {@link Integer#MAX_VALUE}.
-   * The timeout is applied to each request via its request configuration
-   * and takes precedence over the defaults of the underlying HTTP client.
+   * The timeout is applied to each request via its request configuration;
+   * other request configuration defaults of the underlying HTTP client
+   * are preserved.
    * @param readTimeout Read timeout in milliseconds
    * @return API client
+   * @throws IllegalArgumentException if readTimeout is negative
    */
   public ApiClient setReadTimeout(int readTimeout) {
+    if (readTimeout < 0) {
+      throw new IllegalArgumentException("readTimeout must not be negative");
+    }
     this.readTimeout = readTimeout;
     return this;
   }
@@ -1045,7 +1056,10 @@ public class ApiClient extends JavaTimeFormatter {
     context.setCookieStore(store);
 
     if (connectionTimeout > 0 || readTimeout > 0) {
-      RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
+      // start from the default request configuration of the underlying HTTP client, if
+      // accessible, so that only the configured timeouts are overridden
+      RequestConfig defaultConfig = httpClient instanceof Configurable ? ((Configurable) httpClient).getConfig() : null;
+      RequestConfig.Builder requestConfigBuilder = defaultConfig == null ? RequestConfig.custom() : RequestConfig.copy(defaultConfig);
       if (connectionTimeout > 0) {
         requestConfigBuilder.setConnectTimeout(Timeout.ofMilliseconds(connectionTimeout));
       }

--- a/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.openapitools.jackson.nullable.JsonNullableModule;
 
+import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.BasicCookieStore;
 import org.apache.hc.client5.http.cookie.Cookie;
 import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
@@ -42,6 +43,7 @@ import org.apache.hc.core5.http.io.entity.FileEntity;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
+import org.apache.hc.core5.util.Timeout;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -95,6 +97,7 @@ public class ApiClient extends JavaTimeFormatter {
   protected Map<String, String> serverVariables = null;
   protected boolean debugging = false;
   protected int connectionTimeout = 0;
+  protected int readTimeout = 0;
 
   protected CloseableHttpClient httpClient;
   protected ObjectMapper objectMapper;
@@ -430,15 +433,40 @@ public class ApiClient extends JavaTimeFormatter {
 
   /**
    * Set the connect timeout (in milliseconds).
-   * A value of 0 means no timeout, otherwise values must be between 1 and
-   * {@link Integer#MAX_VALUE}.
+   * A value of 0 means the HTTP client's default connect timeout is used,
+   * otherwise values must be between 1 and {@link Integer#MAX_VALUE}.
+   * The timeout is applied to each request via its request configuration
+   * and takes precedence over the defaults of the underlying HTTP client.
    * @param connectionTimeout Connection timeout in milliseconds
    * @return API client
    */
-   public ApiClient setConnectTimeout(int connectionTimeout) {
-     this.connectionTimeout = connectionTimeout;
-     return this;
-   }
+  public ApiClient setConnectTimeout(int connectionTimeout) {
+    this.connectionTimeout = connectionTimeout;
+    return this;
+  }
+
+  /**
+   * Read timeout (in milliseconds).
+   * @return Read timeout
+   */
+  public int getReadTimeout() {
+    return readTimeout;
+  }
+
+  /**
+   * Set the read timeout (in milliseconds), i.e. the response timeout
+   * while waiting for data after the connection is established.
+   * A value of 0 means the HTTP client's default response timeout is used,
+   * otherwise values must be between 1 and {@link Integer#MAX_VALUE}.
+   * The timeout is applied to each request via its request configuration
+   * and takes precedence over the defaults of the underlying HTTP client.
+   * @param readTimeout Read timeout in milliseconds
+   * @return API client
+   */
+  public ApiClient setReadTimeout(int readTimeout) {
+    this.readTimeout = readTimeout;
+    return this;
+  }
 
   /**
    * Get the date format used to parse/format date parameters.
@@ -1015,6 +1043,17 @@ public class ApiClient extends JavaTimeFormatter {
 
     HttpClientContext context = HttpClientContext.create();
     context.setCookieStore(store);
+
+    if (connectionTimeout > 0 || readTimeout > 0) {
+      RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
+      if (connectionTimeout > 0) {
+        requestConfigBuilder.setConnectTimeout(Timeout.ofMilliseconds(connectionTimeout));
+      }
+      if (readTimeout > 0) {
+        requestConfigBuilder.setResponseTimeout(Timeout.ofMilliseconds(readTimeout));
+      }
+      context.setRequestConfig(requestConfigBuilder.build());
+    }
 
     ContentType contentTypeObj = getContentType(contentType);
     if (body != null || !formParams.isEmpty()) {

--- a/samples/client/petstore/java/apache-httpclient-jackson3/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/apache-httpclient-jackson3/src/main/java/org/openapitools/client/ApiClient.java
@@ -22,6 +22,7 @@ import tools.jackson.core.type.TypeReference;
 import tools.jackson.core.JacksonException;
 import org.openapitools.jackson.nullable.JsonNullableJackson3Module;
 
+import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.BasicCookieStore;
 import org.apache.hc.client5.http.cookie.Cookie;
 import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
@@ -44,6 +45,7 @@ import org.apache.hc.core5.http.io.entity.FileEntity;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
+import org.apache.hc.core5.util.Timeout;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -142,6 +144,7 @@ public class ApiClient extends JavaTimeFormatter {
   protected Map<String, String> serverVariables = null;
   protected boolean debugging = false;
   protected int connectionTimeout = 0;
+  protected int readTimeout = 0;
 
   protected CloseableHttpClient httpClient;
   protected ObjectMapper objectMapper;
@@ -525,15 +528,40 @@ public class ApiClient extends JavaTimeFormatter {
 
   /**
    * Set the connect timeout (in milliseconds).
-   * A value of 0 means no timeout, otherwise values must be between 1 and
-   * {@link Integer#MAX_VALUE}.
+   * A value of 0 means the HTTP client's default connect timeout is used,
+   * otherwise values must be between 1 and {@link Integer#MAX_VALUE}.
+   * The timeout is applied to each request via its request configuration
+   * and takes precedence over the defaults of the underlying HTTP client.
    * @param connectionTimeout Connection timeout in milliseconds
    * @return API client
    */
-   public ApiClient setConnectTimeout(int connectionTimeout) {
-     this.connectionTimeout = connectionTimeout;
-     return this;
-   }
+  public ApiClient setConnectTimeout(int connectionTimeout) {
+    this.connectionTimeout = connectionTimeout;
+    return this;
+  }
+
+  /**
+   * Read timeout (in milliseconds).
+   * @return Read timeout
+   */
+  public int getReadTimeout() {
+    return readTimeout;
+  }
+
+  /**
+   * Set the read timeout (in milliseconds), i.e. the response timeout
+   * while waiting for data after the connection is established.
+   * A value of 0 means the HTTP client's default response timeout is used,
+   * otherwise values must be between 1 and {@link Integer#MAX_VALUE}.
+   * The timeout is applied to each request via its request configuration
+   * and takes precedence over the defaults of the underlying HTTP client.
+   * @param readTimeout Read timeout in milliseconds
+   * @return API client
+   */
+  public ApiClient setReadTimeout(int readTimeout) {
+    this.readTimeout = readTimeout;
+    return this;
+  }
 
   /**
    * Get the date format used to parse/format date parameters.
@@ -1114,6 +1142,17 @@ public class ApiClient extends JavaTimeFormatter {
 
     HttpClientContext context = HttpClientContext.create();
     context.setCookieStore(store);
+
+    if (connectionTimeout > 0 || readTimeout > 0) {
+      RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
+      if (connectionTimeout > 0) {
+        requestConfigBuilder.setConnectTimeout(Timeout.ofMilliseconds(connectionTimeout));
+      }
+      if (readTimeout > 0) {
+        requestConfigBuilder.setResponseTimeout(Timeout.ofMilliseconds(readTimeout));
+      }
+      context.setRequestConfig(requestConfigBuilder.build());
+    }
 
     ContentType contentTypeObj = getContentType(contentType);
     if (body != null || !formParams.isEmpty()) {

--- a/samples/client/petstore/java/apache-httpclient-jackson3/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/apache-httpclient-jackson3/src/main/java/org/openapitools/client/ApiClient.java
@@ -22,6 +22,7 @@ import tools.jackson.core.type.TypeReference;
 import tools.jackson.core.JacksonException;
 import org.openapitools.jackson.nullable.JsonNullableJackson3Module;
 
+import org.apache.hc.client5.http.config.Configurable;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.BasicCookieStore;
 import org.apache.hc.client5.http.cookie.Cookie;
@@ -530,12 +531,17 @@ public class ApiClient extends JavaTimeFormatter {
    * Set the connect timeout (in milliseconds).
    * A value of 0 means the HTTP client's default connect timeout is used,
    * otherwise values must be between 1 and {@link Integer#MAX_VALUE}.
-   * The timeout is applied to each request via its request configuration
-   * and takes precedence over the defaults of the underlying HTTP client.
+   * The timeout is applied to each request via its request configuration;
+   * other request configuration defaults of the underlying HTTP client
+   * are preserved.
    * @param connectionTimeout Connection timeout in milliseconds
    * @return API client
+   * @throws IllegalArgumentException if connectionTimeout is negative
    */
   public ApiClient setConnectTimeout(int connectionTimeout) {
+    if (connectionTimeout < 0) {
+      throw new IllegalArgumentException("connectionTimeout must not be negative");
+    }
     this.connectionTimeout = connectionTimeout;
     return this;
   }
@@ -553,12 +559,17 @@ public class ApiClient extends JavaTimeFormatter {
    * while waiting for data after the connection is established.
    * A value of 0 means the HTTP client's default response timeout is used,
    * otherwise values must be between 1 and {@link Integer#MAX_VALUE}.
-   * The timeout is applied to each request via its request configuration
-   * and takes precedence over the defaults of the underlying HTTP client.
+   * The timeout is applied to each request via its request configuration;
+   * other request configuration defaults of the underlying HTTP client
+   * are preserved.
    * @param readTimeout Read timeout in milliseconds
    * @return API client
+   * @throws IllegalArgumentException if readTimeout is negative
    */
   public ApiClient setReadTimeout(int readTimeout) {
+    if (readTimeout < 0) {
+      throw new IllegalArgumentException("readTimeout must not be negative");
+    }
     this.readTimeout = readTimeout;
     return this;
   }
@@ -1144,7 +1155,10 @@ public class ApiClient extends JavaTimeFormatter {
     context.setCookieStore(store);
 
     if (connectionTimeout > 0 || readTimeout > 0) {
-      RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
+      // start from the default request configuration of the underlying HTTP client, if
+      // accessible, so that only the configured timeouts are overridden
+      RequestConfig defaultConfig = httpClient instanceof Configurable ? ((Configurable) httpClient).getConfig() : null;
+      RequestConfig.Builder requestConfigBuilder = defaultConfig == null ? RequestConfig.custom() : RequestConfig.copy(defaultConfig);
       if (connectionTimeout > 0) {
         requestConfigBuilder.setConnectTimeout(Timeout.ofMilliseconds(connectionTimeout));
       }

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.openapitools.jackson.nullable.JsonNullableModule;
 
+import org.apache.hc.client5.http.config.Configurable;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.BasicCookieStore;
 import org.apache.hc.client5.http.cookie.Cookie;
@@ -528,12 +529,17 @@ public class ApiClient extends JavaTimeFormatter {
    * Set the connect timeout (in milliseconds).
    * A value of 0 means the HTTP client's default connect timeout is used,
    * otherwise values must be between 1 and {@link Integer#MAX_VALUE}.
-   * The timeout is applied to each request via its request configuration
-   * and takes precedence over the defaults of the underlying HTTP client.
+   * The timeout is applied to each request via its request configuration;
+   * other request configuration defaults of the underlying HTTP client
+   * are preserved.
    * @param connectionTimeout Connection timeout in milliseconds
    * @return API client
+   * @throws IllegalArgumentException if connectionTimeout is negative
    */
   public ApiClient setConnectTimeout(int connectionTimeout) {
+    if (connectionTimeout < 0) {
+      throw new IllegalArgumentException("connectionTimeout must not be negative");
+    }
     this.connectionTimeout = connectionTimeout;
     return this;
   }
@@ -551,12 +557,17 @@ public class ApiClient extends JavaTimeFormatter {
    * while waiting for data after the connection is established.
    * A value of 0 means the HTTP client's default response timeout is used,
    * otherwise values must be between 1 and {@link Integer#MAX_VALUE}.
-   * The timeout is applied to each request via its request configuration
-   * and takes precedence over the defaults of the underlying HTTP client.
+   * The timeout is applied to each request via its request configuration;
+   * other request configuration defaults of the underlying HTTP client
+   * are preserved.
    * @param readTimeout Read timeout in milliseconds
    * @return API client
+   * @throws IllegalArgumentException if readTimeout is negative
    */
   public ApiClient setReadTimeout(int readTimeout) {
+    if (readTimeout < 0) {
+      throw new IllegalArgumentException("readTimeout must not be negative");
+    }
     this.readTimeout = readTimeout;
     return this;
   }
@@ -1138,7 +1149,10 @@ public class ApiClient extends JavaTimeFormatter {
     context.setCookieStore(store);
 
     if (connectionTimeout > 0 || readTimeout > 0) {
-      RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
+      // start from the default request configuration of the underlying HTTP client, if
+      // accessible, so that only the configured timeouts are overridden
+      RequestConfig defaultConfig = httpClient instanceof Configurable ? ((Configurable) httpClient).getConfig() : null;
+      RequestConfig.Builder requestConfigBuilder = defaultConfig == null ? RequestConfig.custom() : RequestConfig.copy(defaultConfig);
       if (connectionTimeout > 0) {
         requestConfigBuilder.setConnectTimeout(Timeout.ofMilliseconds(connectionTimeout));
       }

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.openapitools.jackson.nullable.JsonNullableModule;
 
+import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.BasicCookieStore;
 import org.apache.hc.client5.http.cookie.Cookie;
 import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
@@ -42,6 +43,7 @@ import org.apache.hc.core5.http.io.entity.FileEntity;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
+import org.apache.hc.core5.util.Timeout;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -140,6 +142,7 @@ public class ApiClient extends JavaTimeFormatter {
   protected Map<String, String> serverVariables = null;
   protected boolean debugging = false;
   protected int connectionTimeout = 0;
+  protected int readTimeout = 0;
 
   protected CloseableHttpClient httpClient;
   protected ObjectMapper objectMapper;
@@ -523,15 +526,40 @@ public class ApiClient extends JavaTimeFormatter {
 
   /**
    * Set the connect timeout (in milliseconds).
-   * A value of 0 means no timeout, otherwise values must be between 1 and
-   * {@link Integer#MAX_VALUE}.
+   * A value of 0 means the HTTP client's default connect timeout is used,
+   * otherwise values must be between 1 and {@link Integer#MAX_VALUE}.
+   * The timeout is applied to each request via its request configuration
+   * and takes precedence over the defaults of the underlying HTTP client.
    * @param connectionTimeout Connection timeout in milliseconds
    * @return API client
    */
-   public ApiClient setConnectTimeout(int connectionTimeout) {
-     this.connectionTimeout = connectionTimeout;
-     return this;
-   }
+  public ApiClient setConnectTimeout(int connectionTimeout) {
+    this.connectionTimeout = connectionTimeout;
+    return this;
+  }
+
+  /**
+   * Read timeout (in milliseconds).
+   * @return Read timeout
+   */
+  public int getReadTimeout() {
+    return readTimeout;
+  }
+
+  /**
+   * Set the read timeout (in milliseconds), i.e. the response timeout
+   * while waiting for data after the connection is established.
+   * A value of 0 means the HTTP client's default response timeout is used,
+   * otherwise values must be between 1 and {@link Integer#MAX_VALUE}.
+   * The timeout is applied to each request via its request configuration
+   * and takes precedence over the defaults of the underlying HTTP client.
+   * @param readTimeout Read timeout in milliseconds
+   * @return API client
+   */
+  public ApiClient setReadTimeout(int readTimeout) {
+    this.readTimeout = readTimeout;
+    return this;
+  }
 
   /**
    * Get the date format used to parse/format date parameters.
@@ -1108,6 +1136,17 @@ public class ApiClient extends JavaTimeFormatter {
 
     HttpClientContext context = HttpClientContext.create();
     context.setCookieStore(store);
+
+    if (connectionTimeout > 0 || readTimeout > 0) {
+      RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
+      if (connectionTimeout > 0) {
+        requestConfigBuilder.setConnectTimeout(Timeout.ofMilliseconds(connectionTimeout));
+      }
+      if (readTimeout > 0) {
+        requestConfigBuilder.setResponseTimeout(Timeout.ofMilliseconds(readTimeout));
+      }
+      context.setRequestConfig(requestConfigBuilder.build());
+    }
 
     ContentType contentTypeObj = getContentType(contentType);
     if (body != null || !formParams.isEmpty()) {

--- a/samples/client/petstore/java/apache-httpclient/src/test/java/org/openapitools/client/ApiClientTest.java
+++ b/samples/client/petstore/java/apache-httpclient/src/test/java/org/openapitools/client/ApiClientTest.java
@@ -77,12 +77,12 @@ public class ApiClientTest {
         // start from the custom client's defaults, so the request against a socket that
         // never responds must still fail with the client's 500 ms response timeout
         // instead of waiting forever.
-        CloseableHttpClient customClient = HttpClients.custom()
-            .setDefaultRequestConfig(RequestConfig.custom()
-                .setResponseTimeout(Timeout.ofMilliseconds(500))
-                .build())
-            .build();
-        try (ServerSocket serverSocket = new ServerSocket(0)) {
+        try (CloseableHttpClient customClient = HttpClients.custom()
+                .setDefaultRequestConfig(RequestConfig.custom()
+                    .setResponseTimeout(Timeout.ofMilliseconds(500))
+                    .build())
+                .build();
+             ServerSocket serverSocket = new ServerSocket(0)) {
             ApiClient customApiClient = new ApiClient(customClient);
             customApiClient.setBasePath("http://localhost:" + serverSocket.getLocalPort());
             customApiClient.setConnectTimeout(5000);

--- a/samples/client/petstore/java/apache-httpclient/src/test/java/org/openapitools/client/ApiClientTest.java
+++ b/samples/client/petstore/java/apache-httpclient/src/test/java/org/openapitools/client/ApiClientTest.java
@@ -1,0 +1,62 @@
+package org.openapitools.client;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.time.Duration;
+
+import org.junit.jupiter.api.*;
+import org.openapitools.client.api.PetApi;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ApiClientTest {
+    ApiClient apiClient = null;
+
+    @BeforeEach
+    public void setup() {
+        apiClient = new ApiClient();
+    }
+
+    @Test
+    public void testConnectTimeoutRoundTrip() {
+        assertEquals(0, apiClient.getConnectTimeout());
+        apiClient.setConnectTimeout(15000);
+        assertEquals(15000, apiClient.getConnectTimeout());
+    }
+
+    @Test
+    public void testReadTimeoutRoundTrip() {
+        assertEquals(0, apiClient.getReadTimeout());
+        apiClient.setReadTimeout(15000);
+        assertEquals(15000, apiClient.getReadTimeout());
+    }
+
+    @Test
+    public void testConnectTimeoutIsApplied() {
+        // 192.0.2.1 (RFC 5737 TEST-NET-1) is non-routable: connecting blocks until the
+        // connect timeout fires. If the configured timeout is not applied to the request,
+        // Apache HttpClient's own default (3 minutes) is used instead and the assertion
+        // aborts the test after 30 seconds.
+        apiClient.setBasePath("http://192.0.2.1:81");
+        apiClient.setConnectTimeout(500);
+        PetApi petApi = new PetApi(apiClient);
+        assertTimeoutPreemptively(Duration.ofSeconds(30), () ->
+            assertThrows(ApiException.class, () -> petApi.getPetById(1L)));
+    }
+
+    @Test
+    public void testReadTimeoutIsApplied() throws IOException {
+        // A server socket that is never accepted from still completes the TCP handshake
+        // (via the OS backlog), so the request is sent and then blocks waiting for the
+        // response. If the configured timeout is not applied to the request, Apache
+        // HttpClient waits forever by default and the assertion aborts the test after
+        // 30 seconds.
+        try (ServerSocket serverSocket = new ServerSocket(0)) {
+            apiClient.setBasePath("http://localhost:" + serverSocket.getLocalPort());
+            apiClient.setReadTimeout(500);
+            PetApi petApi = new PetApi(apiClient);
+            assertTimeoutPreemptively(Duration.ofSeconds(30), () ->
+                assertThrows(ApiException.class, () -> petApi.getPetById(1L)));
+        }
+    }
+}

--- a/samples/client/petstore/java/apache-httpclient/src/test/java/org/openapitools/client/ApiClientTest.java
+++ b/samples/client/petstore/java/apache-httpclient/src/test/java/org/openapitools/client/ApiClientTest.java
@@ -4,6 +4,10 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.time.Duration;
 
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.util.Timeout;
 import org.junit.jupiter.api.*;
 import org.openapitools.client.api.PetApi;
 
@@ -32,6 +36,12 @@ public class ApiClientTest {
     }
 
     @Test
+    public void testNegativeTimeoutsAreRejected() {
+        assertThrows(IllegalArgumentException.class, () -> apiClient.setConnectTimeout(-1));
+        assertThrows(IllegalArgumentException.class, () -> apiClient.setReadTimeout(-1));
+    }
+
+    @Test
     public void testConnectTimeoutIsApplied() {
         // 192.0.2.1 (RFC 5737 TEST-NET-1) is non-routable: connecting blocks until the
         // connect timeout fires. If the configured timeout is not applied to the request,
@@ -55,6 +65,28 @@ public class ApiClientTest {
             apiClient.setBasePath("http://localhost:" + serverSocket.getLocalPort());
             apiClient.setReadTimeout(500);
             PetApi petApi = new PetApi(apiClient);
+            assertTimeoutPreemptively(Duration.ofSeconds(30), () ->
+                assertThrows(ApiException.class, () -> petApi.getPetById(1L)));
+        }
+    }
+
+    @Test
+    public void testCustomClientRequestConfigDefaultsArePreserved() throws IOException {
+        // A custom client is supplied with a default response timeout, while only the
+        // connect timeout is set on the ApiClient. The per-request configuration must
+        // start from the custom client's defaults, so the request against a socket that
+        // never responds must still fail with the client's 500 ms response timeout
+        // instead of waiting forever.
+        CloseableHttpClient customClient = HttpClients.custom()
+            .setDefaultRequestConfig(RequestConfig.custom()
+                .setResponseTimeout(Timeout.ofMilliseconds(500))
+                .build())
+            .build();
+        try (ServerSocket serverSocket = new ServerSocket(0)) {
+            ApiClient customApiClient = new ApiClient(customClient);
+            customApiClient.setBasePath("http://localhost:" + serverSocket.getLocalPort());
+            customApiClient.setConnectTimeout(5000);
+            PetApi petApi = new PetApi(customApiClient);
             assertTimeoutPreemptively(Duration.ofSeconds(30), () ->
                 assertThrows(ApiException.class, () -> petApi.getPetById(1L)));
         }


### PR DESCRIPTION
Fixes #24269.

For the Java client with `library=apache-httpclient`, `ApiClient.setConnectTimeout(int)` stored the value in a `connectionTimeout` field that was never read again, so the setter was a silent no-op: the client fell back to Apache HttpClient 5's own defaults (3-minute connect timeout, unbounded response wait).

### Changes

- `invokeAPI()` now builds a per-request `RequestConfig` from the configured timeouts and sets it on the `HttpClientContext`, so `setConnectTimeout(ms)` actually bounds the TCP connect time, consistent with the other Java libraries (okhttp-gson, native).
- Added symmetric `getReadTimeout()`/`setReadTimeout(ms)` mapped to the response timeout, as suggested in the issue (mirrors the okhttp-gson naming).
- A value of `0` (the default) leaves the underlying client's configuration untouched.

The per-request `RequestConfig` approach was chosen over rebuilding the client with a `PoolingHttpClientConnectionManager`/`ConnectionConfig` because:

- `ConnectionConfig` only exists since httpclient5 5.2, while the Gradle template still ships 5.1.3 (`RequestConfig#setConnectTimeout(Timeout)` exists since 5.0 and is honored in all 5.x versions, taking precedence over connection-manager defaults in 5.3+);
- it preserves a user-supplied custom `CloseableHttpClient` (constructor or `setHttpClient`) instead of silently discarding it.

### Tests

Added `ApiClientTest` to the `apache-httpclient` petstore sample:

- getter/setter round-trips for both timeouts;
- a regression test that a request against a socket that accepts but never responds fails after the configured 500 ms read timeout (verified: 0.52 s elapsed) instead of hanging forever;
- a regression test that a connect to a non-routable TEST-NET-1 address fails within bounds instead of taking Apache's 3-minute default.

All 136 test classes in the sample pass; the `echo_api` and `jackson3` samples were regenerated (`./bin/generate-samples.sh bin/configs/java-apache-httpclient*.yaml`) and compile.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples: `./bin/generate-samples.sh bin/configs/java-apache-httpclient*.yaml` (only the apache-httpclient templates changed; no doc changes, so `export_docs_generators.sh` produces no diff).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @martin-mfg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies per-request connect and read timeouts in the Java `apache-httpclient` client to prevent hangs and make `setConnectTimeout` effective. Preserves defaults from a custom `CloseableHttpClient`. Fixes #24269.

- **Bug Fixes**
  - Applies `setConnectTimeout(ms)` per request to bound TCP connect time.
  - Builds per-request `RequestConfig` from the underlying client's defaults (via `Configurable`); 0 uses client defaults.
  - Rejects negative values in `setConnectTimeout()`/`setReadTimeout()`.

- **New Features**
  - Added `getReadTimeout()`/`setReadTimeout(ms)` to control response wait time.
  - Works with httpclient5 5.1.x+; per-request config is compatible across versions.

<sup>Written for commit b3fa16117828e84e1162044bd61fd6aeb24de74c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

