### PR TITLE
fix(python-fastapi): map binary response type file to bytes

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonFastAPIServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonFastAPIServerCodegen.java
@@ -101,6 +101,11 @@ public class PythonFastAPIServerCodegen extends AbstractPythonCodegen {
         languageSpecificPrimitives.add("Dict");
         typeMapping.put("array", "List");
         typeMapping.put("map", "Dict");
+        // Binary response body: map OAS file/binary to built-in bytes (not the invalid Py2 type `file`).
+        // Multipart upload fields remain UploadFile via overrideFileFormParamTyping (#23793).
+        // See https://github.com/OpenAPITools/openapi-generator/issues/20775
+        typeMapping.put("file", "bytes");
+        typeMapping.put("binary", "bytes");
 
         outputFolder = "generated-code" + File.separator + NAME;
         modelTemplateFiles.put("model.mustache", ".py");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonFastAPIServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonFastAPIServerCodegenTest.java
@@ -136,4 +136,23 @@ public class PythonFastAPIServerCodegenTest {
         assertFileContains(baseApi, "csv_file: UploadFile,");
         assertFileContains(baseApi, "image: Optional[UploadFile],");
     }
+
+    @Test(description = "binary response body is typed as bytes, not invalid file (#20775)")
+    public void testBinaryResponseUsesBytesNotFile() throws IOException {
+        final DefaultCodegen codegen = new PythonFastAPIServerCodegen();
+        final String outputPath = generateFiles(codegen, "src/test/resources/3_0/issue_20775.yaml");
+        final Path api = Paths.get(outputPath + "src/openapi_server/apis/resource_api.py");
+        final Path baseApi = Paths.get(outputPath + "src/openapi_server/apis/resource_api_base.py");
+
+        assertFileExists(api);
+        assertFileExists(baseApi);
+
+        assertFileContains(api, "-> bytes");
+        assertFileContains(api, "\"model\": bytes");
+        assertFileNotContains(api, "-> file");
+        assertFileNotContains(api, "\"model\": file");
+
+        assertFileContains(baseApi, "-> bytes");
+        assertFileNotContains(baseApi, "-> file");
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonFastapiCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonFastapiCodegenTest.java
@@ -89,4 +89,32 @@ public class PythonFastapiCodegenTest {
         TestUtils.assertFileContains(Paths.get(output + "/src/openapi_server/models/test_object.py"),
                 "raise ValueError(r\"must validate the regular expression /^[A-Z0-9_\\- ]+$/\")");
     }
+
+    @Test
+    public void testBinaryResponseUsesBytesNotFile() throws IOException {
+        // Regression for https://github.com/OpenAPITools/openapi-generator/issues/20775
+        // Repro: src/test/resources/3_0/issue_20775.yaml
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("python-fastapi")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"))
+                .setInputSpec("src/test/resources/3_0/issue_20775.yaml");
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        final String apiFile = output + "/src/openapi_server/apis/resource_api.py";
+        final String baseApiFile = output + "/src/openapi_server/apis/resource_api_base.py";
+
+        TestUtils.assertFileContains(Paths.get(apiFile), "-> bytes");
+        TestUtils.assertFileContains(Paths.get(apiFile), "\"model\": bytes");
+        TestUtils.assertFileNotContains(Paths.get(apiFile), "-> file");
+        TestUtils.assertFileNotContains(Paths.get(apiFile), "\"model\": file");
+
+        TestUtils.assertFileContains(Paths.get(baseApiFile), "-> bytes");
+        TestUtils.assertFileNotContains(Paths.get(baseApiFile), "-> file");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/issue_20775.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_20775.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.1
+info:
+  title: binary response typing
+  version: 1.0.0
+paths:
+  /resource:
+    get:
+      tags:
+        - resource
+      description: Binary response body (full or partial)
+      operationId: resourceInResponse
+      parameters:
+        - name: Range
+          in: header
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Full binary body
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        "206":
+          description: Partial binary body
+          headers:
+            Content-Range:
+              required: true
+              schema:
+                type: string
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary


### PR DESCRIPTION
### Description

Fixes invalid `-> file` / `"model": file` for binary (`application/octet-stream` + `format: binary`) response bodies in **python-fastapi** (#20775).

Python 3 has no built-in `file` type, so generated stubs raised `NameError` on import and broke IDE typing. This change maps OAS `file` / `binary` to built-in `bytes` in `PythonFastAPIServerCodegen` only (minimal scope). Multipart upload fields still use FastAPI `UploadFile` via the existing form-param override (#23793).

**What changed**
- `typeMapping.put("file", "bytes")` and `typeMapping.put("binary", "bytes")` in `PythonFastAPIServerCodegen`
- Regression sample: `modules/openapi-generator/src/test/resources/3_0/issue_20775.yaml` (200/206 + optional `Range`)
- Tests: `PythonFastapiCodegenTest` / `PythonFastAPIServerCodegenTest` assert `-> bytes` / `"model": bytes` and absence of bare `file`

**Verification**
```bash
./mvnw clean package -DskipTests
./bin/generate-samples.sh ./bin/configs/python*.yaml
./bin/utils/export_docs_generators.sh
mvn -pl modules/openapi-generator -am \
  -Dtest=PythonFastapiCodegenTest,PythonFastAPIServerCodegenTest \
  -Dsurefire.failIfNoSpecifiedTests=false test
```

No `samples/` diff: current python-fastapi petstore has no binary **response** endpoints (only multipart upload). Coverage is via `issue_20775.yaml` unit generation.

Related: #20775, #4372

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/python*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ```
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files.
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master.
  These must match the expectations made by your contribution.
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`.
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] @krjakbrjak (Python FastAPI)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Maps binary response bodies to `bytes` in `python-fastapi` server generation to replace the invalid Python `file` type. This prevents import errors and fixes typing for `application/octet-stream` responses.

- **Bug Fixes**
  - Map OAS `file` and `binary` to `bytes` in `PythonFastAPIServerCodegen`.
  - Multipart uploads remain `UploadFile` (unchanged).
  - Add regression spec `issue_20775.yaml` and tests asserting `-> bytes` and no `file`.
  - Fixes #20775; related to #4372.

<sup>Written for commit 24dd78a2e3e03699a81d847673ae2f4030b43844. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

