### PR TITLE
[scala-sttp4-jsoniter] bump Scala to 3.3.8, sttp to 4.0.26, jsoniter-scala to 2.39.1

### DIFF
--- a/docs/generators/scala-sttp4-jsoniter.md
+++ b/docs/generators/scala-sttp4-jsoniter.md
@@ -23,7 +23,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |disallowAdditionalPropertiesIfNotPresent|If false, the 'additionalProperties' implementation (set to true by default) is compliant with the OAS and JSON schema specifications. If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.|<dl><dt>**false**</dt><dd>The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.</dd><dt>**true**</dt><dd>Keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.</dd></dl>|true|
 |ensureUniqueParams|Whether to ensure parameter names are unique in an operation (rename parameters that are not).| |true|
 |enumUnknownDefaultCase|If the server adds new enum cases, that are unknown by an old spec/client, the client will fail to parse the network response. With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the server sends an enum case that is not known by the client/spec, they can safely fallback to this case.|<dl><dt>**false**</dt><dd>No changes to the enums are made, this is the default option.</dd><dt>**true**</dt><dd>With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the enum case sent by the server is not known by the client/spec, can safely be decoded to this case.</dd></dl>|false|
-|jsoniterVersion|The version of jsoniter-scala library| |2.38.12|
+|jsoniterVersion|The version of jsoniter-scala library| |2.39.1|
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
 |mainPackage|Top-level package name, which defines 'apiPackage', 'modelPackage', 'invokerPackage'| |org.openapitools.client|
 |modelPackage|package for generated models| |null|
@@ -33,7 +33,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |null|
-|sttpClientVersion|The version of sttp client| |4.0.23|
+|sttpClientVersion|The version of sttp client| |4.0.26|
 
 ## IMPORT MAPPING
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaSttp4JsoniterClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaSttp4JsoniterClientCodegen.java
@@ -47,7 +47,7 @@ public class ScalaSttp4JsoniterClientCodegen extends AbstractScalaCodegen implem
     private static final StringProperty STTP_CLIENT_VERSION = new StringProperty("sttpClientVersion",
             "The version of " +
                     "sttp client",
-            "4.0.23");
+            "4.0.26");
     private static final BooleanProperty USE_SEPARATE_ERROR_CHANNEL = new BooleanProperty("separateErrorChannel",
             "Whether to return response as " +
                     "F[Either[ResponseError[ErrorType], ReturnType]]] or to flatten " +
@@ -56,7 +56,7 @@ public class ScalaSttp4JsoniterClientCodegen extends AbstractScalaCodegen implem
     private static final StringProperty JSONITER_VERSION = new StringProperty("jsoniterVersion",
             "The version of jsoniter-scala " +
                     "library",
-            "2.38.12");
+            "2.39.1");
 
     public static final String DEFAULT_PACKAGE_NAME = "org.openapitools.client";
     private static final PackageProperty PACKAGE_PROPERTY = new PackageProperty();

--- a/modules/openapi-generator/src/main/resources/scala-sttp4-jsoniter/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp4-jsoniter/build.sbt.mustache
@@ -2,7 +2,7 @@ version := "{{artifactVersion}}"
 name := "{{artifactId}}"
 organization := "{{groupId}}"
 
-scalaVersion := "3.3.7"
+scalaVersion := "3.3.8"
 
 libraryDependencies ++= Seq(
   "com.softwaremill.sttp.client4" %% "core"                          % "{{sttpClientVersion}}",

--- a/samples/client/petstore/scala-sttp4-jsoniter/build.sbt
+++ b/samples/client/petstore/scala-sttp4-jsoniter/build.sbt
@@ -2,14 +2,14 @@ version := "1.0.0"
 name := "openapi-client"
 organization := "org.openapitools"
 
-scalaVersion := "3.3.7"
+scalaVersion := "3.3.8"
 
 libraryDependencies ++= Seq(
-  "com.softwaremill.sttp.client4" %% "core"                          % "4.0.23",
-  "com.softwaremill.sttp.client4" %% "jsoniter"                      % "4.0.23",
-  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % "2.38.12",
-  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.38.12" % "compile-internal",
-  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-circe"  % "2.38.12"
+  "com.softwaremill.sttp.client4" %% "core"                          % "4.0.26",
+  "com.softwaremill.sttp.client4" %% "jsoniter"                      % "4.0.26",
+  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % "2.39.1",
+  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.39.1" % "compile-internal",
+  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-circe"  % "2.39.1"
 )
 
 scalacOptions := Seq(


### PR DESCRIPTION

- Scala 3.3.7 -> 3.3.8 (LTS line) in the generated build.sbt
- sttp client4 4.0.23 -> 4.0.26 (default of the sttpClientVersion option)
- jsoniter-scala 2.38.12 -> 2.39.1 (default of the jsoniterVersion option)

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `scala-sttp4-jsoniter` generator to Scala 3.3.8 and refreshes default versions for `sttp client4` and `jsoniter-scala`. Docs, `build.sbt` template, and Petstore sample are updated to match.

- **Dependencies**
  - Scala 3.3.7 → 3.3.8
  - `sttp client4` 4.0.23 → 4.0.26 (default `sttpClientVersion`)
  - `jsoniter-scala` 2.38.12 → 2.39.1 (default `jsoniterVersion`)

<sup>Written for commit c7f543864466626e1886eca9cb29c8383047b9a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

