### PR TITLE
fix(typescript-fetch): allow null for required nullable parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -118,10 +118,10 @@ export class {{classname}} extends runtime.BaseAPI {
     async {{nickname}}RequestOpts({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request{{/allParams.0}}): Promise<runtime.RequestOpts> {
         {{#allParams}}
         {{#required}}
-        if (requestParameters['{{paramName}}'] == null) {
+        if (requestParameters['{{paramName}}'] {{#isBodyParam}}{{#isNullable}}=== undefined{{/isNullable}}{{^isNullable}}== null{{/isNullable}}{{/isBodyParam}}{{^isBodyParam}}== null{{/isBodyParam}}) {
             throw new runtime.RequiredError(
                 '{{paramName}}',
-                'Required parameter "{{paramName}}" was null or undefined when calling {{nickname}}().'
+                'Required parameter "{{paramName}}" was {{#isBodyParam}}{{#isNullable}}undefined{{/isNullable}}{{^isNullable}}null or undefined{{/isNullable}}{{/isBodyParam}}{{^isBodyParam}}null or undefined{{/isBodyParam}} when calling {{nickname}}().'
             );
         }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -667,6 +667,27 @@ public class TypeScriptFetchClientCodegenTest {
         TestUtils.assertFileNotContains(modelPath, "json['required_property'] === undefined ? undefined : json['required_property'] === null ? null :");
     }
 
+    @Test(description = "Required nullable bodies should reject undefined but accept null (fix #23493)")
+    public void testRequiredNullableBodyRejectsOnlyUndefined() throws Exception {
+        File output = generate(
+            Collections.emptyMap(),
+            "src/test/resources/3_0/typescript-fetch/issue_23493.yaml"
+        );
+
+        Path apiPath = Paths.get(output + "/apis/DefaultApi.ts");
+        TestUtils.assertFileContains(apiPath,
+                "if (requestParameters['body'] === undefined)",
+                "Required parameter \"body\" was undefined when calling nullableBody().",
+                "body: boolean | null;",
+                "body: requestParameters['body'] as any");
+        TestUtils.assertFileContains(apiPath,
+                "if (requestParameters['body'] == null)",
+                "Required parameter \"body\" was null or undefined when calling nonNullableBody().");
+        TestUtils.assertFileContains(apiPath,
+                "if (requestParameters['requiredNullableQuery'] == null)",
+                "Required parameter \"requiredNullableQuery\" was null or undefined when calling nullableBody().");
+    }
+
     @Test(description = "Verify Omit uses the camelCase property name instead of the baseName for readOnly fields")
     public void testIssue23380_OmitUsesCorrectPropertyName() throws Exception {
         File output = generate(

--- a/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/issue_23493.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/issue_23493.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.1
+info:
+  title: Required nullable request body
+  version: 1.0.0
+paths:
+  /nullable:
+    post:
+      operationId: nullableBody
+      parameters:
+        - name: requiredNullableQuery
+          in: query
+          required: true
+          schema:
+            type: string
+            nullable: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: boolean
+              nullable: true
+      responses:
+        '200':
+          description: OK
+  /non-nullable:
+    post:
+      operationId: nonNullableBody
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: boolean
+      responses:
+        '200':
+          description: OK

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
@@ -589,10 +589,10 @@ export class FakeApi extends runtime.BaseAPI {
      * Creates request options for testBodyWithBinary without sending the request
      */
     async testBodyWithBinaryRequestOpts(requestParameters: TestBodyWithBinaryRequest): Promise<runtime.RequestOpts> {
-        if (requestParameters['body'] == null) {
+        if (requestParameters['body'] === undefined) {
             throw new runtime.RequiredError(
                 'body',
-                'Required parameter "body" was null or undefined when calling testBodyWithBinary().'
+                'Required parameter "body" was undefined when calling testBodyWithBinary().'
             );
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/kebab-case/apis/fake-api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/kebab-case/apis/fake-api.ts
@@ -589,10 +589,10 @@ export class FakeApi extends runtime.BaseAPI {
      * Creates request options for testBodyWithBinary without sending the request
      */
     async testBodyWithBinaryRequestOpts(requestParameters: TestBodyWithBinaryRequest): Promise<runtime.RequestOpts> {
-        if (requestParameters['body'] == null) {
+        if (requestParameters['body'] === undefined) {
             throw new runtime.RequiredError(
                 'body',
-                'Required parameter "body" was null or undefined when calling testBodyWithBinary().'
+                'Required parameter "body" was undefined when calling testBodyWithBinary().'
             );
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/FakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/FakeApi.ts
@@ -515,10 +515,10 @@ export class FakeApi extends runtime.BaseAPI {
      * Creates request options for testBodyWithBinary without sending the request
      */
     async testBodyWithBinaryRequestOpts(requestParameters: TestBodyWithBinaryRequest): Promise<runtime.RequestOpts> {
-        if (requestParameters['body'] == null) {
+        if (requestParameters['body'] === undefined) {
             throw new runtime.RequiredError(
                 'body',
-                'Required parameter "body" was null or undefined when calling testBodyWithBinary().'
+                'Required parameter "body" was undefined when calling testBodyWithBinary().'
             );
         }
 


### PR DESCRIPTION
### Description
Fixes #23493.

When a parameter was both required and nullable, `typescript-fetch` generated
a runtime guard using `== null`. This rejected both `null` and `undefined`,
even though `null` is valid according to the schema.

This change generates an undefined-only guard for required nullable
parameters:

```typescript
if (requestParameters['body'] === undefined) {
```


<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04) @joscha (2024/10)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow null for required nullable request bodies in the `typescript-fetch` generator by rejecting only undefined. Fixes #23493 and prevents valid null payloads from being blocked.

- **Bug Fixes**
  - Generate undefined-only guards for required nullable body params (e.g., if requestParameters['body'] === undefined) and update the error message to “undefined”.
  - Keep null-or-undefined guards for required non-nullable bodies and all non-body params.
  - Add regression test with `issue_23493.yaml`; update petstore samples accordingly.

<sup>Written for commit 68ca1c0f345ceb6d206c803a9520d8ed19e6a74e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

