### PR TITLE
[GRADLE-WRAPPER] Worker isolation log visiblity update & documentation fix

### DIFF
--- a/modules/openapi-generator-gradle-plugin/README.adoc
+++ b/modules/openapi-generator-gradle-plugin/README.adoc
@@ -462,7 +462,7 @@ file states is output.
 
 |workerIsolation
 |String / Provider<String>
-|`process`
+|`classloader`
 a|Controls how the code-generation work action is isolated from the Gradle daemon.
 
 `classloader` (default):: Runs generation inside the Gradle daemon JVM using a separate `ClassLoader`. Avoids the per-task JVM

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
@@ -1064,25 +1064,30 @@ abstract class GenerateTask : DefaultTask() {
 //   exits, and Gradle reuses the same worker daemon across tasks that share the same classpath,
 //   so startup cost is amortized — typically paid only once per parallel slot.
         val isolation = workerIsolation.getOrElse("classloader").lowercase()
+        val quietMode = quiet.getOrElse(false)
         val workQueue = when (isolation) {
             "process" -> {
-                val heapMsg = maxWorkerHeapSize.orNull?.let { " (maxHeapSize=$it)" } ?: ""
-                logger.lifecycle(
-                    "[openApiGenerate] Worker isolation: process$heapMsg " +
-                            "(isolated JVM per task, no Metaspace leak - " +
-                            "use workerIsolation = \"classloader\" to skip per-task JVM startup cost at the cost of increased Metaspace usage)"
-                )
+                if (!quietMode) {
+                    val heapMsg = maxWorkerHeapSize.orNull?.let { " (maxHeapSize=$it)" } ?: ""
+                    logger.lifecycle(
+                        "[openApiGenerate] Worker isolation: process$heapMsg " +
+                                "(isolated JVM per task, no Metaspace leak - " +
+                                "use workerIsolation = \"classloader\" to skip per-task JVM startup cost at the cost of increased Metaspace usage)"
+                    )
+                }
                 workerExecutor.processIsolation {
                     maxWorkerHeapSize.orNull?.let { forkOptions.maxHeapSize = it }
                 }
             }
 
             "classloader" -> {
-                logger.lifecycle(
-                    "[openApiGenerate] Worker isolation: classloader " +
-                            "(fast startup, but generator classes accumulate in Gradle daemon Metaspace - " +
-                            "consider workerIsolation = \"process\" if you hit metaspace pressure)"
-                )
+                if (!quietMode) {
+                    logger.lifecycle(
+                        "[openApiGenerate] Worker isolation: classloader " +
+                                "(fast startup, but generator classes accumulate in Gradle daemon Metaspace - " +
+                                "consider workerIsolation = \"process\" if you hit metaspace pressure)"
+                    )
+                }
                 workerExecutor.classLoaderIsolation()
             }
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
wrokerIsolation property status message always appears in the build output. This pollutes the log significantly in builds when a multiple standalone specs are to be processed. Our current projects generates over 130 individual open api specs. Similar to https://github.com/OpenAPITools/openapi-generator/issues/11211 where more such scenarios are described.

CC: @Picazsoo 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress worker isolation status logs when Gradle runs with `--quiet` to reduce build noise in projects with many specs. Update the Gradle plugin README to correctly document `classloader` as the default `workerIsolation`.

<sup>Written for commit 39d2e2bb714a88e0dfbb1c948ffe8a2dd2a2463e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

