### PR TITLE
refactor: decouple schema naming from discriminator mapping introspection

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3404,36 +3404,16 @@ public class DefaultCodegen implements CodegenConfig {
                 CodegenProperty df = DiscriminatorUtils.discriminatorFound(openAPI, composedSchemaName, sc, discPropName, new TreeSet<String>());
                 String modelName = ModelUtils.getSimpleRef(ref);
                 if (df == null || !df.isString || !df.required) {
-                    String msgSuffix = "";
-                    if (df == null) {
-                        msgSuffix += discPropName + " is missing from the schema, define it as required and type string";
-                    } else {
-                        if (!df.isString) {
-                            msgSuffix += "invalid type for " + discPropName + ", set it to string";
-                        }
-                        if (!df.required) {
-                            String spacer = "";
-                            if (msgSuffix.length() != 0) {
-                                spacer = ". ";
-                            }
-                            msgSuffix += spacer + "invalid optional definition of " + discPropName + ", include it in required";
-                        }
-                    }
-                    once(LOGGER).warn("'{}' defines discriminator '{}', but the referenced schema '{}' is incorrect. {}",
-                            composedSchemaName, discPropName, modelName, msgSuffix);
+                    once(LOGGER).warn(getDiscriminatorSchemaError(df, discPropName, modelName, composedSchemaName));
                 }
-                MappedModel mm = new MappedModel(modelName, toModelName(modelName), modelName, false);
+                MappedModel mm = new MappedModel(modelName, modelName, modelName, false);
                 descendentSchemas.add(mm);
                 Schema cs = ModelUtils.getSchema(openAPI, modelName);
                 if (cs == null) { // cannot lookup the model based on the name
                     once(LOGGER).error("Failed to lookup the schema '{}' when processing oneOf/anyOf. Please check to ensure it's defined properly.", modelName);
                 } else {
-                    Map<String, Object> vendorExtensions = cs.getExtensions();
-                    if (vendorExtensions != null && !vendorExtensions.isEmpty() && vendorExtensions.containsKey(X_DISCRIMINATOR_VALUE)) {
-                        String xDiscriminatorValue = (String) vendorExtensions.get(X_DISCRIMINATOR_VALUE);
-                        mm = new MappedModel(xDiscriminatorValue, toModelName(modelName), modelName, true);
-                        descendentSchemas.add(mm);
-                    }
+                    discriminatorVendorExtensionValue(cs)
+                            .ifPresent(discriminatorValue -> descendentSchemas.add(new MappedModel(discriminatorValue, modelName, modelName, true)));
                 }
             }
         }
@@ -3483,13 +3463,9 @@ public class DefaultCodegen implements CodegenConfig {
             }
             currentSchemaName = queue.remove(0);
             Schema cs = schemas.get(currentSchemaName);
-            Map<String, Object> vendorExtensions = cs.getExtensions();
-            String mappingName =
-                    Optional.ofNullable(vendorExtensions)
-                            .map(ve -> ve.get(X_DISCRIMINATOR_VALUE))
-                            .map(discriminatorValue -> (String) discriminatorValue)
+            String mappingName = discriminatorVendorExtensionValue(cs)
                             .orElse(currentSchemaName);
-            MappedModel mm = new MappedModel(mappingName, toModelName(currentSchemaName), currentSchemaName, !mappingName.equals(currentSchemaName));
+            MappedModel mm = new MappedModel(mappingName, currentSchemaName, currentSchemaName, !mappingName.equals(currentSchemaName));
             descendentSchemas.add(mm);
         }
         return descendentSchemas;
@@ -3560,7 +3536,8 @@ public class DefaultCodegen implements CodegenConfig {
         boolean legacyUseCase = (this.getLegacyDiscriminatorBehavior() && uniqueDescendants.isEmpty());
         if (!this.getLegacyDiscriminatorBehavior() || legacyUseCase) {
             // for schemas that allOf inherit from this schema, add those descendants to this discriminator map
-            List<MappedModel> otherDescendants = getAllOfDescendants(schemaName);
+            List<MappedModel> otherDescendants =
+                    adjustModelNames(getAllOfDescendants(schemaName));
             for (MappedModel otherDescendant : otherDescendants) {
                 // add only if the mapping names are not the same and the model names are not the same
                 boolean matched = false;
@@ -3579,7 +3556,8 @@ public class DefaultCodegen implements CodegenConfig {
         }
         // if there are composed oneOf/anyOf schemas, add them to this discriminator
         if (ModelUtils.isComposedSchema(schema) && !this.getLegacyDiscriminatorBehavior()) {
-            List<MappedModel> otherDescendants = getOneOfAnyOfDescendants(schemaName, discriminatorPropertyName, schema);
+            List<MappedModel> otherDescendants =
+                    adjustModelNames(getOneOfAnyOfDescendants(schemaName, discriminatorPropertyName, schema));
             for (MappedModel otherDescendant : otherDescendants) {
                 // add only if the model names are not the same
                 if (uniqueDescendants.stream().map(MappedModel::getModelName).noneMatch(it -> it.equals(otherDescendant.getModelName()))) {
@@ -8819,5 +8797,17 @@ public class DefaultCodegen implements CodegenConfig {
                 operation.allParams.add(p);
             }
         }
+    }
+
+    /**
+     * Adjust the model name of the list of {@link MappedModel} to ensure that the names are consistent with the
+     * language specific model name expressed in the {@link CodegenConfig#toModelName(String)} method.
+     * @param mappedModels The {@link MappedModel}
+     * @return The {@link MappedModel} with the modelName adjusted to the language specific model name.
+     */
+    private List<MappedModel> adjustModelNames(List<MappedModel> mappedModels) {
+        return mappedModels.stream()
+                .peek(mappedModel -> mappedModel.setModelName(toModelName(mappedModel.getSchemaName())))
+                .collect(Collectors.toList());
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/DiscriminatorUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/DiscriminatorUtils.java
@@ -7,9 +7,11 @@ import org.jspecify.annotations.Nullable;
 import org.openapitools.codegen.CodegenProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.MessageFormatter;
 
 import java.util.*;
 
+import static org.openapitools.codegen.CodegenConstants.X_DISCRIMINATOR_VALUE;
 import static org.openapitools.codegen.utils.OnceLogger.once;
 
 public class DiscriminatorUtils {
@@ -24,7 +26,8 @@ public class DiscriminatorUtils {
             "'{}' defines discriminator '{}', but the referenced schema '{}' is missing {}";
     private static final String DEFINES_DISCRIMINATOR_BUT_ALTERNATIVE_HAS_OTHER_DEFINITION =
             "'{}' defines discriminator '{}', but the schema '{}' has a different {} definition than the prior schema's. Make sure the {} type and required values are the same";
-
+    private static final String DEFINES_DISCRIMINATOR_BUT_REFERENCE_IS_INCORRECT =
+            "'{}' defines discriminator '{}', but the referenced schema '{}' is incorrect. {}";
     /**
      * Recursively look in Schema sc for the discriminator discPropName
      * and return a CodegenProperty with the dataType and required params set
@@ -178,6 +181,39 @@ public class DiscriminatorUtils {
             }
         }
         return null;
+    }
+
+    /**
+     * Get the value of the vendor extension {@code x-discriminator-value} from the schema, if present.
+     * @param schema the schema to check for the vendor extension
+     * @return the value of the vendor extension, or an empty optional if not present
+     */
+    public static Optional<String> discriminatorVendorExtensionValue(Schema schema) {
+        return Optional.ofNullable(schema)
+                .map(Schema::getExtensions)
+                .map(vendorExtensions -> vendorExtensions.get(X_DISCRIMINATOR_VALUE))
+                .map(discriminatorValue -> (String) discriminatorValue);
+    }
+
+    public static String getDiscriminatorSchemaError(CodegenProperty codegenProperty, String discPropName,
+                                                     String modelName, String composedSchemaName) {
+        String msgSuffix = "";
+        if (codegenProperty == null) {
+            msgSuffix += discPropName + " is missing from the schema, define it as required and type string";
+        } else {
+            if (!codegenProperty.isString) {
+                msgSuffix += "invalid type for " + discPropName + ", set it to string";
+            }
+            if (!codegenProperty.required) {
+                String spacer = "";
+                if (!msgSuffix.isEmpty()) {
+                    spacer = ". ";
+                }
+                msgSuffix += spacer + "invalid optional definition of " + discPropName + ", include it in required";
+            }
+        }
+        return MessageFormatter.arrayFormat(DEFINES_DISCRIMINATOR_BUT_REFERENCE_IS_INCORRECT,
+                new Object[]{composedSchemaName, discPropName, modelName, msgSuffix}).getMessage();
     }
 
     /**


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Decouples the `toModelName` (e.g., adding a prefix or a suffix) `Codegen` functionality from the `getAllOfDescendants` and `getOneOfAnyOfDescendants` discriminator introspection methods. This is in preparation for these methods being moved to the `DiscriminatorUtils` class.

This is done so that the discriminator logic can later be clarified and optimized, since as of current there are several passes over the entire specification when searching for the discriminator mappings. A single walk along the path for each discriminator schema should be enough to gather all the necessary information for building the typing and the mapping for the discrimination.

There is also the [rather crude](https://github.com/Mattias-Sehlstedt/openapi-generator/blob/1a12bf72e2c927eb33e29b0c213c55e447022a20/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java#L3427) implementation of the specification analysis, where it should be preferable to utilize the `visitedSchemas` approach (walk the path recursively and keep a log of what schemas that have been visited to terminate loops).

This PR also breaks out the building of a larger error message when failing to interpret a discriminator, and it also creates a helper for repeated vendor extension introspection.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decouples schema naming from discriminator mapping introspection: descendant mappings now use raw schema names, and `toModelName` is applied once during discriminator creation. Centralizes `x-discriminator-value` lookups and discriminator error message building in `DiscriminatorUtils`; no behavior change expected.

- **Refactors**
  - `getAllOfDescendants`/`getOneOfAnyOfDescendants` now return schema-name-based `MappedModel`; `DefaultCodegen.adjustModelNames()` applies `toModelName` during `createDiscriminator`.
  - Added `DiscriminatorUtils.discriminatorVendorExtensionValue(...)` and `DiscriminatorUtils.getDiscriminatorSchemaError(...)`; replaced inline vendor extension access and warning assembly.

<sup>Written for commit 71064398b968f6826a779ea4eed318624c2aecd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

