### PR TITLE
[php-nextgen] Add Flag to Allow Ignoring Operation Servers

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/Configuration.mustache
@@ -115,6 +115,13 @@ class Configuration
     protected string $tempFolderPath;
 
     /**
+     * Ignore operation specific hosts
+     * 
+     * @var bool
+     */
+    protected bool $ignoreOperationHosts = false;
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -381,6 +388,29 @@ class Configuration
     public function getTempFolderPath(): string
     {
         return $this->tempFolderPath;
+    }
+
+    /**
+     * Sets the ignore operation specific hosts flag
+     *
+     * @param bool $ignoreOperationHosts Ignore operation specific hosts flag
+     *
+     * @return $this
+     */
+    public function setIgnoreOperationHosts(bool $ignoreOperationHosts): static
+    {
+        $this->ignoreOperationHosts = $ignoreOperationHosts;
+        return $this;
+    }
+
+    /**
+     * Gets the ignore operation specific hosts flag
+     *
+     * @return bool Ignore operation specific hosts flag
+     */
+    public function getIgnoreOperationHosts(): bool
+    {
+        return $this->ignoreOperationHosts;
     }
 
     /**

--- a/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
@@ -842,17 +842,21 @@ use {{invokerPackage}}\ObjectSerializer;
         );
 
         {{#servers.0}}
-        # Preserve the original behavior of server indexing.
-        if ($hostIndex === null) {
-            $hostIndex = $this->hostIndex;
-        }
+        if ($this->config->getIgnoreOperationHosts()) {
+            $operationHost = $this->config->getHost();
+        } else {
+            # Preserve the original behavior of server indexing.
+            if ($hostIndex === null) {
+                $hostIndex = $this->hostIndex;
+            }
 
-        $hostSettings = $this->getHostSettingsFor{{operationId}}();
+            $hostSettings = $this->getHostSettingsFor{{operationId}}();
 
-        if ($hostIndex < 0 || $hostIndex >= count($hostSettings)) {
-            throw new InvalidArgumentException("Invalid index {$hostIndex} when selecting the host. Must be less than ".count($hostSettings));
+            if ($hostIndex < 0 || $hostIndex >= count($hostSettings)) {
+                throw new InvalidArgumentException("Invalid index {$hostIndex} when selecting the host. Must be less than ".count($hostSettings));
+            }
+            $operationHost = Configuration::getHostString($hostSettings, $hostIndex, $variables);
         }
-        $operationHost = Configuration::getHostString($hostSettings, $hostIndex, $variables);
         {{/servers.0}}
         {{^servers.0}}
         $operationHost = $this->config->getHost();

--- a/samples/client/echo_api/php-nextgen-streaming/src/Configuration.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Configuration.php
@@ -124,6 +124,13 @@ class Configuration
     protected string $tempFolderPath;
 
     /**
+     * Ignore operation specific hosts
+     * 
+     * @var bool
+     */
+    protected bool $ignoreOperationHosts = false;
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -390,6 +397,29 @@ class Configuration
     public function getTempFolderPath(): string
     {
         return $this->tempFolderPath;
+    }
+
+    /**
+     * Sets the ignore operation specific hosts flag
+     *
+     * @param bool $ignoreOperationHosts Ignore operation specific hosts flag
+     *
+     * @return $this
+     */
+    public function setIgnoreOperationHosts(bool $ignoreOperationHosts): static
+    {
+        $this->ignoreOperationHosts = $ignoreOperationHosts;
+        return $this;
+    }
+
+    /**
+     * Gets the ignore operation specific hosts flag
+     *
+     * @return bool Ignore operation specific hosts flag
+     */
+    public function getIgnoreOperationHosts(): bool
+    {
+        return $this->ignoreOperationHosts;
     }
 
     /**

--- a/samples/client/echo_api/php-nextgen/src/Configuration.php
+++ b/samples/client/echo_api/php-nextgen/src/Configuration.php
@@ -124,6 +124,13 @@ class Configuration
     protected string $tempFolderPath;
 
     /**
+     * Ignore operation specific hosts
+     * 
+     * @var bool
+     */
+    protected bool $ignoreOperationHosts = false;
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -390,6 +397,29 @@ class Configuration
     public function getTempFolderPath(): string
     {
         return $this->tempFolderPath;
+    }
+
+    /**
+     * Sets the ignore operation specific hosts flag
+     *
+     * @param bool $ignoreOperationHosts Ignore operation specific hosts flag
+     *
+     * @return $this
+     */
+    public function setIgnoreOperationHosts(bool $ignoreOperationHosts): static
+    {
+        $this->ignoreOperationHosts = $ignoreOperationHosts;
+        return $this;
+    }
+
+    /**
+     * Gets the ignore operation specific hosts flag
+     *
+     * @return bool Ignore operation specific hosts flag
+     */
+    public function getIgnoreOperationHosts(): bool
+    {
+        return $this->ignoreOperationHosts;
     }
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
@@ -477,17 +477,21 @@ class PetApi
             $headers
         );
 
-        # Preserve the original behavior of server indexing.
-        if ($hostIndex === null) {
-            $hostIndex = $this->hostIndex;
-        }
+        if ($this->config->getIgnoreOperationHosts()) {
+            $operationHost = $this->config->getHost();
+        } else {
+            # Preserve the original behavior of server indexing.
+            if ($hostIndex === null) {
+                $hostIndex = $this->hostIndex;
+            }
 
-        $hostSettings = $this->getHostSettingsForaddPet();
+            $hostSettings = $this->getHostSettingsForaddPet();
 
-        if ($hostIndex < 0 || $hostIndex >= count($hostSettings)) {
-            throw new InvalidArgumentException("Invalid index {$hostIndex} when selecting the host. Must be less than ".count($hostSettings));
+            if ($hostIndex < 0 || $hostIndex >= count($hostSettings)) {
+                throw new InvalidArgumentException("Invalid index {$hostIndex} when selecting the host. Must be less than ".count($hostSettings));
+            }
+            $operationHost = Configuration::getHostString($hostSettings, $hostIndex, $variables);
         }
-        $operationHost = Configuration::getHostString($hostSettings, $hostIndex, $variables);
         $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'POST',
@@ -1870,17 +1874,21 @@ class PetApi
             $headers
         );
 
-        # Preserve the original behavior of server indexing.
-        if ($hostIndex === null) {
-            $hostIndex = $this->hostIndex;
-        }
+        if ($this->config->getIgnoreOperationHosts()) {
+            $operationHost = $this->config->getHost();
+        } else {
+            # Preserve the original behavior of server indexing.
+            if ($hostIndex === null) {
+                $hostIndex = $this->hostIndex;
+            }
 
-        $hostSettings = $this->getHostSettingsForupdatePet();
+            $hostSettings = $this->getHostSettingsForupdatePet();
 
-        if ($hostIndex < 0 || $hostIndex >= count($hostSettings)) {
-            throw new InvalidArgumentException("Invalid index {$hostIndex} when selecting the host. Must be less than ".count($hostSettings));
+            if ($hostIndex < 0 || $hostIndex >= count($hostSettings)) {
+                throw new InvalidArgumentException("Invalid index {$hostIndex} when selecting the host. Must be less than ".count($hostSettings));
+            }
+            $operationHost = Configuration::getHostString($hostSettings, $hostIndex, $variables);
         }
-        $operationHost = Configuration::getHostString($hostSettings, $hostIndex, $variables);
         $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'PUT',

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Configuration.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Configuration.php
@@ -123,6 +123,13 @@ class Configuration
     protected string $tempFolderPath;
 
     /**
+     * Ignore operation specific hosts
+     * 
+     * @var bool
+     */
+    protected bool $ignoreOperationHosts = false;
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -389,6 +396,29 @@ class Configuration
     public function getTempFolderPath(): string
     {
         return $this->tempFolderPath;
+    }
+
+    /**
+     * Sets the ignore operation specific hosts flag
+     *
+     * @param bool $ignoreOperationHosts Ignore operation specific hosts flag
+     *
+     * @return $this
+     */
+    public function setIgnoreOperationHosts(bool $ignoreOperationHosts): static
+    {
+        $this->ignoreOperationHosts = $ignoreOperationHosts;
+        return $this;
+    }
+
+    /**
+     * Gets the ignore operation specific hosts flag
+     *
+     * @return bool Ignore operation specific hosts flag
+     */
+    public function getIgnoreOperationHosts(): bool
+    {
+        return $this->ignoreOperationHosts;
     }
 
     /**


### PR DESCRIPTION
This PR adds a flag to the configuration object to allow for ignoring operation servers. Currently, if operation level host objects are defined, there is no way to ignore these or use a different base path at the SDK level, which many other languages support. The new `ignoreOperationHosts` flag allows the user to ignore any operation hosts defined and instead use the currently defined `$host`. This will default to the top level base path defined in the OpenAPI file, but can be configured to be any url by using `setIgnoreOperationHosts`.

2 things to note:
1. I used `hosts` terminology instead of `servers` since this SDK refers to them as hosts already, this means the flag name deviates slightly from other languages, but is consistent with how the rest of the Config refers to this value. It'd be super simple to switch to `servers` if we value cross language consistency more. Let me know and I'll update that.
2. I originally planned to use a ternary when setting `$operationHost` to do the flag check inline, but decided to guard the entire block to avoid the potential for an invalid `$hostIndex` error if the config was just going to ignore it anyway. I can do it inline if we want to be as minimally invasive as possible. Also open to making that change, again lmk.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), [@ybelenko](https://github.com/ybelenko) (2018/07), @renepardon (2018/12)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `ignoreOperationHosts` config flag to the PHP next-gen SDK so clients can skip operation-level hosts and always use the configured `$host`. Updates templates and samples; default behavior is unchanged.

- **New Features**
  - Added `ignoreOperationHosts` (default false) with `setIgnoreOperationHosts(bool)` and `getIgnoreOperationHosts()` in `Configuration`.
  - API templates now use `$config->getHost()` for `$operationHost` when the flag is true; otherwise, existing server indexing and validation are preserved.
  - Regenerated samples for echo and petstore to include the new config option.

<sup>Written for commit 7228d2e28881da4f6661055ce3c0afb3500f998b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

