### PR TITLE
fix: Updates to take latest serde_valid in rust-server generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
@@ -91,7 +91,7 @@ validate = [{{^apiUsesByteArray}}"regex",{{/apiUsesByteArray}} "serde_valid", "s
 async-trait = "0.1.89"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
-swagger = { version = "7.0.0", features = ["serdejson", "server", "client"] }
+swagger = { version = "7.0.1", features = ["serdejson", "server", "client"] }
 headers = "0.4.1"
 log = "0.4.29"
 

--- a/modules/openapi-generator/src/main/resources/rust-server/validate.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/validate.mustache
@@ -54,7 +54,7 @@
 {{#isEnum}}
   {{#allowableValues}}
     {{#isString}}
-    #[cfg_attr(feature = "validate", validate(enumerate({{#enumVars}}{{{value}}}, {{/enumVars}})))]
+    #[cfg_attr(feature = "validate", validate(r#enum({{#enumVars}}{{{value}}}, {{/enumVars}})))]
     {{/isString}}
   {{/allowableValues}}
 {{/isEnum}}

--- a/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
@@ -45,7 +45,7 @@ validate = [ "serde_valid", "swagger/serdevalid"]
 async-trait = "0.1.89"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
-swagger = { version = "7.0.0", features = ["serdejson", "server", "client"] }
+swagger = { version = "7.0.1", features = ["serdejson", "server", "client"] }
 headers = "0.4.1"
 log = "0.4.29"
 

--- a/samples/server/petstore/rust-server/output/no-example-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/no-example-v3/Cargo.toml
@@ -41,7 +41,7 @@ validate = ["regex", "serde_valid", "swagger/serdevalid"]
 async-trait = "0.1.89"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
-swagger = { version = "7.0.0", features = ["serdejson", "server", "client"] }
+swagger = { version = "7.0.1", features = ["serdejson", "server", "client"] }
 headers = "0.4.1"
 log = "0.4.29"
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
@@ -44,7 +44,7 @@ validate = [ "serde_valid", "swagger/serdevalid"]
 async-trait = "0.1.89"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
-swagger = { version = "7.0.0", features = ["serdejson", "server", "client"] }
+swagger = { version = "7.0.1", features = ["serdejson", "server", "client"] }
 headers = "0.4.1"
 log = "0.4.29"
 

--- a/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
@@ -41,7 +41,7 @@ validate = ["regex", "serde_valid", "swagger/serdevalid"]
 async-trait = "0.1.89"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
-swagger = { version = "7.0.0", features = ["serdejson", "server", "client"] }
+swagger = { version = "7.0.1", features = ["serdejson", "server", "client"] }
 headers = "0.4.1"
 log = "0.4.29"
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
@@ -45,7 +45,7 @@ validate = [ "serde_valid", "swagger/serdevalid"]
 async-trait = "0.1.89"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
-swagger = { version = "7.0.0", features = ["serdejson", "server", "client"] }
+swagger = { version = "7.0.1", features = ["serdejson", "server", "client"] }
 headers = "0.4.1"
 log = "0.4.29"
 

--- a/samples/server/petstore/rust-server/output/ping-bearer-auth/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/ping-bearer-auth/Cargo.toml
@@ -41,7 +41,7 @@ validate = ["regex", "serde_valid", "swagger/serdevalid"]
 async-trait = "0.1.89"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
-swagger = { version = "7.0.0", features = ["serdejson", "server", "client"] }
+swagger = { version = "7.0.1", features = ["serdejson", "server", "client"] }
 headers = "0.4.1"
 log = "0.4.29"
 

--- a/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
@@ -41,7 +41,7 @@ validate = ["regex", "serde_valid", "swagger/serdevalid"]
 async-trait = "0.1.89"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
-swagger = { version = "7.0.0", features = ["serdejson", "server", "client"] }
+swagger = { version = "7.0.1", features = ["serdejson", "server", "client"] }
 headers = "0.4.1"
 log = "0.4.29"
 


### PR DESCRIPTION
Code changes required to take serde_valid. Note these changes are slightly academic as the rust-server has compile time enum verification so this isn't hit. 

I don't want to remove this case as there's a risk it's used in a future change. Therefore fixing here. 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Rust server generator to work with the latest `serde_valid`, fixing enum validation and bumping `swagger` to `7.0.1`. This keeps generated projects compiling when the `validate` feature is enabled.

- **Bug Fixes**
  - Switch enum validation attribute to `validate(r#enum(...))` in `validate.mustache` to match current `serde_valid`.

- **Dependencies**
  - Update `swagger` from `7.0.0` to `7.0.1` in `Cargo.mustache` and all sample `Cargo.toml` files.

<sup>Written for commit f2653bdb37cdee568308135667c4a826b753de45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

