### PR TITLE
fix(golang): use datatype only for enums instead of format

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -1054,26 +1054,4 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
     public GeneratorLanguage generatorLanguage() {
         return GeneratorLanguage.GO;
     }
-
-    @Override
-    public CodegenProperty fromProperty(String name, Schema p, boolean required) {
-        CodegenProperty property = super.fromProperty(name, p, required);
-
-        if (property.isEnum && "enum".equals(property.dataFormat)) {
-            property.dataFormat = property.baseType;
-        }
-        
-        return property;
-    }
-
-    @Override
-    public CodegenModel fromModel(String name, Schema model) {
-        CodegenModel codegenModel = super.fromModel(name, model);
-        
-        if (codegenModel.isEnum && "enum".equals(codegenModel.getFormat())) {
-            codegenModel.setFormat(codegenModel.dataType);
-        }
-        
-        return codegenModel;
-    }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -1054,4 +1054,26 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
     public GeneratorLanguage generatorLanguage() {
         return GeneratorLanguage.GO;
     }
+
+    @Override
+    public CodegenProperty fromProperty(String name, Schema p, boolean required) {
+        CodegenProperty property = super.fromProperty(name, p, required);
+
+        if (property.isEnum && "enum".equals(property.dataFormat)) {
+            property.dataFormat = property.baseType;
+        }
+        
+        return property;
+    }
+
+    @Override
+    public CodegenModel fromModel(String name, Schema model) {
+        CodegenModel codegenModel = super.fromModel(name, model);
+        
+        if (codegenModel.isEnum && "enum".equals(codegenModel.getFormat())) {
+            codegenModel.setFormat(codegenModel.dataType);
+        }
+        
+        return codegenModel;
+    }
 }

--- a/modules/openapi-generator/src/main/resources/go/model_enum.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_enum.mustache
@@ -1,5 +1,5 @@
 // {{{classname}}} {{{description}}}{{^description}}the model '{{{classname}}}'{{/description}}
-type {{{classname}}} {{{format}}}{{^format}}{{dataType}}{{/format}}
+type {{{classname}}} {{dataType}}
 
 // List of {{{name}}}
 const (
@@ -22,7 +22,7 @@ var Allowed{{{classname}}}EnumValues = []{{{classname}}}{
 }
 
 func (v *{{{classname}}}) UnmarshalJSON(src []byte) error {
-	var value {{{format}}}{{^format}}{{dataType}}{{/format}}
+	var value {{dataType}}
 	err := json.Unmarshal(src, &value)
 	if err != nil {
 		return err
@@ -52,7 +52,7 @@ func (v *{{{classname}}}) UnmarshalJSON(src []byte) error {
 
 // New{{{classname}}}FromValue returns a pointer to a valid {{{classname}}}
 // for the value passed as argument, or an error if the value passed is not allowed by the enum
-func New{{{classname}}}FromValue(v {{{format}}}{{^format}}{{dataType}}{{/format}}) (*{{{classname}}}, error) {
+func New{{{classname}}}FromValue(v {{dataType}}) (*{{{classname}}}, error) {
 	ev := {{{classname}}}(v)
 	if ev.IsValid() {
 		return &ev, nil


### PR DESCRIPTION
relates to #24336

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->

Detailed description and steps to reproduce can be found in the linked [GitHub issue](https://github.com/OpenAPITools/openapi-generator/issues/24336).

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@antihax @grokify @kemokemo @jirikuncar @ph4r5h4d @lwj5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Go enum generation when a schema sets format: "enum" by always using the base data type in generated enums. Prevents invalid types in both models and properties.

- **Bug Fixes**
  - Updated `go/model_enum.mustache` to use `{{dataType}}` for the enum type, the UnmarshalJSON value, and the NewXFromValue parameter, removing reliance on `{{format}}`.

<sup>Written for commit 3a44bf6b6fabfcd79adf9c733f842602bebd72fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

