### PR TITLE
[scala-sttp4] Fix enum operation parameters: type import and wire-value toString

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaSttp4ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaSttp4ClientCodegen.java
@@ -75,8 +75,6 @@ public class ScalaSttp4ClientCodegen extends AbstractScalaCodegen implements Cod
     protected boolean renderJavadoc = true;
     protected boolean removeOAuthSecurities = true;
 
-    Map<String, ModelsMap> enumRefs = new HashMap<>();
-
     public ScalaSttp4ClientCodegen() {
         super();
         generatorMetadata = GeneratorMetadata.newBuilder(generatorMetadata)
@@ -507,7 +505,6 @@ public class ScalaSttp4ClientCodegen extends AbstractScalaCodegen implements Cod
     /**
      * Update/clean up model imports
      * <p>
-     * append '._" if the import is a Enum class, otherwise
      * remove model imports to avoid warnings for importing class in the same package in Scala
      *
      * @param models processed models to be further processed
@@ -515,8 +512,6 @@ public class ScalaSttp4ClientCodegen extends AbstractScalaCodegen implements Cod
     @SuppressWarnings("unchecked")
     private void postProcessUpdateImports(final Map<String, ModelsMap> models) {
         final String prefix = modelPackage() + ".";
-
-        enumRefs = getEnumRefs(models);
 
         for (String openAPIName : models.keySet()) {
             CodegenModel model = ModelUtils.getModelByName(openAPIName, models);
@@ -534,13 +529,11 @@ public class ScalaSttp4ClientCodegen extends AbstractScalaCodegen implements Cod
             Iterator<Map<String, String>> iterator = imports.iterator();
             while (iterator.hasNext()) {
                 String importPath = iterator.next().get("import");
-                Map<String, String> item = new HashMap<>();
-                if (importPath.startsWith(prefix)) {
-                    if (isEnumClass(importPath, enumRefs)) {
-                        item.put("import", importPath.concat("._"));
-                        newImports.add(item);
-                    }
-                } else {
+                // Same-package imports are dropped: sttp4 enums are sealed traits +
+                // case objects (not Enumeration), so unlike scala-sttp there is no
+                // `MyEnum._` wildcard needed to bring a type alias into scope.
+                if (!importPath.startsWith(prefix)) {
+                    Map<String, String> item = new HashMap<>();
                     item.put("import", importPath);
                     newImports.add(item);
                 }
@@ -548,37 +541,6 @@ public class ScalaSttp4ClientCodegen extends AbstractScalaCodegen implements Cod
             // reset imports
             objs.setImports(newImports);
         }
-    }
-
-    private Map<String, ModelsMap> getEnumRefs(final Map<String, ModelsMap> models) {
-        Map<String, ModelsMap> enums = new HashMap<>();
-        for (String key : models.keySet()) {
-            CodegenModel model = ModelUtils.getModelByName(key, models);
-            if (model.isEnum) {
-                ModelsMap objs = models.get(key);
-                enums.put(key, objs);
-            }
-        }
-        return enums;
-    }
-
-    private boolean isEnumClass(final String importPath, final Map<String, ModelsMap> enumModels) {
-        if (enumModels == null || enumModels.isEmpty()) {
-            return false;
-        }
-        for (ModelsMap objs : enumModels.values()) {
-            List<ModelMap> models = objs.getModels();
-            if (models == null || models.isEmpty()) {
-                continue;
-            }
-            for (final Map<String, Object> model : models) {
-                String enumImportPath = (String) model.get("importPath");
-                if (enumImportPath != null && enumImportPath.equals(importPath)) {
-                    return true;
-                }
-            }
-        }
-        return false;
     }
 
     @Override
@@ -618,11 +580,10 @@ public class ScalaSttp4ClientCodegen extends AbstractScalaCodegen implements Cod
             while (iterator.hasNext()) {
                 String importPath = iterator.next().get("import");
                 Map<String, String> item = new HashMap<>();
-                if (isEnumClass(importPath, enumRefs)) {
-                    item.put("import", importPath.concat("._"));
-                } else {
-                    item.put("import", importPath);
-                }
+                // sttp4 enums are sealed traits + case objects (not Enumeration):
+                // import the type itself, not `MyEnum._` wildcard members, which
+                // would not bring the type into scope.
+                item.put("import", importPath);
                 newImports.add(item);
             }
         }

--- a/modules/openapi-generator/src/main/resources/scala-sttp4/model.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp4/model.mustache
@@ -258,7 +258,7 @@ sealed trait {{classname}}
 object {{classname}} {
 {{#allowableValues}}
   {{#values}}
-  case object {{#fnEnumEntry}}{{.}}{{/fnEnumEntry}} extends {{classname}}
+  case object {{#fnEnumEntry}}{{.}}{{/fnEnumEntry}} extends {{classname}} { override def toString: String = "{{.}}" }
   {{/values}}
 {{/allowableValues}}
 
@@ -338,7 +338,7 @@ object {{classname}}Enums {
   sealed trait {{datatypeWithEnum}}
   object {{datatypeWithEnum}} {
 {{#_enum}}
-    case object {{#fnEnumEntry}}{{.}}{{/fnEnumEntry}} extends {{datatypeWithEnum}}
+    case object {{#fnEnumEntry}}{{.}}{{/fnEnumEntry}} extends {{datatypeWithEnum}} { override def toString: String = "{{.}}" }
 {{/_enum}}
 
 {{#circe}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/Sttp4CodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/Sttp4CodegenTest.java
@@ -56,6 +56,50 @@ public class Sttp4CodegenTest {
     }
 
     @Test
+    public void verifyEnumParameterImportAndWireValues() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/scala/sttp4-enum-param.yaml", null, new ParseOptions()).getOpenAPI();
+
+        ScalaSttp4ClientCodegen codegen = new ScalaSttp4ClientCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put("jsonLibrary", "circe");
+
+        ClientOptInput input = new ClientOptInput();
+        input.openAPI(openAPI);
+        input.config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.SUPPORTING_FILES, "false");
+        generator.opts(input).generate();
+
+        // Enums are sealed traits + case objects: the API must import the type itself,
+        // not Enumeration-style wildcard members (which would not bring the type into scope).
+        Path apiPath = Paths.get(outputPath + "/src/main/scala/org/openapitools/client/api/DefaultApi.scala");
+        assertFileContains(apiPath, "import org.openapitools.client.model.PetStatus\n");
+        assertFileNotContains(apiPath, "import org.openapitools.client.model.PetStatus._");
+
+        // Models live in the same package as the enum: no import is needed at all
+        // (sealed trait, not an Enumeration with a type alias inside the companion).
+        Path modelPath = Paths.get(outputPath + "/src/main/scala/org/openapitools/client/model/Pet.scala");
+        assertFileNotContains(modelPath, "import org.openapitools.client.model.PetStatus");
+
+        // Case objects carry their wire value as toString so path/query interpolation
+        // (uri"...${param}...") serializes the wire value, not the Scala identifier.
+        Path enumPath = Paths.get(outputPath + "/src/main/scala/org/openapitools/client/model/PetStatus.scala");
+        assertFileContains(enumPath, "case object Available extends PetStatus { override def toString: String = \"available\" }");
+        assertFileContains(enumPath, "case object SoldOut extends PetStatus { override def toString: String = \"sold-out\" }");
+    }
+
+    @Test
     public void verifyOneOfSupportWithCirce() throws IOException {
         File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
         output.deleteOnExit();

--- a/modules/openapi-generator/src/test/resources/3_0/scala/sttp4-enum-param.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/scala/sttp4-enum-param.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.3
+info:
+  title: Enum parameter test
+  version: 1.0.0
+paths:
+  /pets/{status}:
+    get:
+      operationId: getPetsByStatus
+      parameters:
+        - name: status
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/PetStatus'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    PetStatus:
+      type: string
+      enum:
+        - available
+        - pending
+        - sold-out
+    Pet:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        status:
+          $ref: '#/components/schemas/PetStatus'

--- a/samples/client/petstore/scala-sttp4-circe/src/main/scala/org/openapitools/client/model/Order.scala
+++ b/samples/client/petstore/scala-sttp4-circe/src/main/scala/org/openapitools/client/model/Order.scala
@@ -38,9 +38,9 @@ object OrderEnums {
 
   sealed trait Status
   object Status {
-    case object Placed extends Status
-    case object Approved extends Status
-    case object Delivered extends Status
+    case object Placed extends Status { override def toString: String = "placed" }
+    case object Approved extends Status { override def toString: String = "approved" }
+    case object Delivered extends Status { override def toString: String = "delivered" }
 
     import io.circe.{Encoder, Decoder}
 

--- a/samples/client/petstore/scala-sttp4-circe/src/main/scala/org/openapitools/client/model/Pet.scala
+++ b/samples/client/petstore/scala-sttp4-circe/src/main/scala/org/openapitools/client/model/Pet.scala
@@ -37,9 +37,9 @@ object PetEnums {
 
   sealed trait Status
   object Status {
-    case object Available extends Status
-    case object Pending extends Status
-    case object Sold extends Status
+    case object Available extends Status { override def toString: String = "available" }
+    case object Pending extends Status { override def toString: String = "pending" }
+    case object Sold extends Status { override def toString: String = "sold" }
 
     import io.circe.{Encoder, Decoder}
 

--- a/samples/client/petstore/scala-sttp4/src/main/scala/org/openapitools/client/model/Order.scala
+++ b/samples/client/petstore/scala-sttp4/src/main/scala/org/openapitools/client/model/Order.scala
@@ -30,9 +30,9 @@ object OrderEnums {
 
   sealed trait Status
   object Status {
-    case object Placed extends Status
-    case object Approved extends Status
-    case object Delivered extends Status
+    case object Placed extends Status { override def toString: String = "placed" }
+    case object Approved extends Status { override def toString: String = "approved" }
+    case object Delivered extends Status { override def toString: String = "delivered" }
 
     import org.json4s._
 

--- a/samples/client/petstore/scala-sttp4/src/main/scala/org/openapitools/client/model/Pet.scala
+++ b/samples/client/petstore/scala-sttp4/src/main/scala/org/openapitools/client/model/Pet.scala
@@ -29,9 +29,9 @@ object PetEnums {
 
   sealed trait Status
   object Status {
-    case object Available extends Status
-    case object Pending extends Status
-    case object Sold extends Status
+    case object Available extends Status { override def toString: String = "available" }
+    case object Pending extends Status { override def toString: String = "pending" }
+    case object Sold extends Status { override def toString: String = "sold" }
 
     import org.json4s._
 


### PR DESCRIPTION
Fixes #24347.

Enums used as operation parameters in the `scala-sttp4` generator are broken in two ways:

**1. Generated code does not compile.** The API imports enum types Enumeration-style (`import pkg.MyEnum._`), inherited from the sttp3 generator where `type MyEnum = Value` lives inside the companion. scala-sttp4 enums are sealed traits + case objects, so the wildcard import does not bring the *type* into scope:

```scala
import org.openapitools.client.model.PetStatus._   // does not import the trait
def getPetsByStatus(status: PetStatus): Request[...] // error: not found: type PetStatus
```

Fixed by importing the type itself. Same-package model imports need no import at all for sealed traits, so that special case is removed along with the now-unused `enumRefs` / `isEnumClass` / `getEnumRefs` helpers.

**2. Path/query interpolation serializes the Scala identifier, not the wire value.** `uri"$baseUrl/pets/${status}"` uses `toString`, so a request for `sold-out` goes out as `/pets/SoldOut`. Fixed by overriding `toString` on each enum case object with its wire value, matching the sttp3 generator's behavior (`Enumeration.Value("sold-out").toString` is the wire value there):

```scala
case object SoldOut extends PetStatus { override def toString: String = "sold-out" }
```

JSON codecs are unaffected — both circe and json4s map enum values explicitly (visible in the regenerated samples).

**Tests:** `Sttp4CodegenTest#verifyEnumParameterImportAndWireValues` with a new spec fixture (`sttp4-enum-param.yaml`): a string enum (including a hyphenated value) used as a path parameter and as a model property. Asserts the plain type import in the API, no wildcard import, no same-package import in models, and wire-value `toString` on case objects.

Also verified end-to-end against a real FastAPI-generated spec (enum path param + discriminated `oneOf` bodies): the generated client compiles and produces correct URLs, correct request bodies, and round-trips responses.

`scala-sttp4-jsoniter` is unaffected (separate codegen class and templates); its samples are unchanged by regeneration.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Built the project and updated samples: `./bin/generate-samples.sh bin/configs/scala-sttp4*.yaml` — sample changes are committed. No generator options changed, so no doc export changes.
- [x] Filed against `master`.
- [x] Scala technical committee: @clasnake @jimschubert @shijinkui @ramzimaalej @chameleon82 @Bouillie

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes enum parameters in `scala-sttp4` so generated clients compile and send wire values in URLs. APIs now import the enum type directly, and enum case objects stringify to their wire values.

- **Bug Fixes**
  - Import the enum type in APIs (no `MyEnum._` wildcard; no same-package model imports).
  - Enum case objects override `toString` with the wire value (path/query params serialize correctly, including nested `...Enums`).

- **Refactors**
  - Removed enum-specific import helpers and simplified import processing.
  - Added a focused test and spec fixture; regenerated `scala-sttp4` and `scala-sttp4-circe` samples. `scala-sttp4-jsoniter` unchanged.

<sup>Written for commit dcd86c8c5e1d96469699ed5b324b03a1f1d4b6cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

