### PR TITLE
Add features missing from #24286

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
@@ -38,10 +38,10 @@ class {{{classname}}} {
   {{/required}}
   {{^required}}
     {{#vendorExtensions.x-is-optional}}
-  {{{datatypeWithEnum}}} {{{name}}};
+  {{#useFinalProperties}}final {{/useFinalProperties}}{{{datatypeWithEnum}}} {{{name}}};
     {{/vendorExtensions.x-is-optional}}
     {{^vendorExtensions.x-is-optional}}
-  {{{datatypeWithEnum}}}{{#isNullable}}?{{/isNullable}}{{^isNullable}}{{^defaultValue}}?{{/defaultValue}}{{/isNullable}} {{{name}}};
+  {{#useFinalProperties}}final {{/useFinalProperties}}{{{datatypeWithEnum}}}{{#isNullable}}?{{/isNullable}}{{^isNullable}}{{^defaultValue}}?{{/defaultValue}}{{/isNullable}} {{{name}}};
     {{/vendorExtensions.x-is-optional}}
   {{/required}}
 
@@ -160,7 +160,7 @@ class {{{classname}}} {
   {{/vars}}
   }) => {{{classname}}}(
   {{#vars}}
-    {{{name}}}: {{#isNullable}}{{{name}}}SetToNull ? null : {{/isNullable}}{{{name}}} ?? this.{{{name}}},
+    {{{name}}}: {{{name}}} ?? this.{{{name}}},
   {{/vars}}
   );
 

--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
@@ -160,7 +160,7 @@ class {{{classname}}} {
   {{/vars}}
   }) => {{{classname}}}(
   {{#vars}}
-    {{{name}}}: {{{name}}} ?? this.{{{name}}},
+    {{{name}}}: {{#isNullable}}{{{name}}}SetToNull ? null : {{/isNullable}}{{{name}}} ?? this.{{{name}}},
   {{/vars}}
   );
 

--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
@@ -155,11 +155,12 @@ class {{{classname}}} {
   /// properties have changed.
   {{{classname}}} copyWith({
   {{#vars}}
-    final {{{datatypeWithEnum}}}? {{{name}}},
+    {{{datatypeWithEnum}}}? {{{name}}},{{#isNullable}}
+    bool {{{name}}}SetToNull = false,{{/isNullable}}
   {{/vars}}
   }) => {{{classname}}}(
   {{#vars}}
-    {{{name}}}: {{{name}}} ?? this.{{{name}}},
+    {{{name}}}: {{#isNullable}}{{{name}}}SetToNull ? null : {{/isNullable}}{{{name}}} ?? this.{{{name}}},
   {{/vars}}
   );
 


### PR DESCRIPTION
Add a couple of missing features that weren't merged in #24286:

1. When class properties aren't required, the `final` keyword wasn't added properly.
2. Addressed [this comment](https://github.com/OpenAPITools/openapi-generator/pull/24286#discussion_r3572377003) to allow nullifying certain class properties when using `copyWith()`.

The Petstore samples didn't change at all, so this is a 1-file PR :)

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12) @ahmednfwela (2021/08)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Dart model generation to mark non-required properties as `final` when `useFinalProperties` is enabled. In `copyWith()`, adds a `fieldNameSetToNull` flag for nullable fields (default false) that, when true, sets the field to null.

<sup>Written for commit 0f00e12935cdeede0406fd88685766d43b52b746. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

