### PR TITLE
docs: remove @josh-burton from Dart maintainers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1048,7 +1048,6 @@ Here is a list of template creators:
    * Dart (refactor): @joernahrens
    * Dart 2: @swipesight
    * Dart (Jaguar): @jaumard
-   * Dart (Dio): @josh-burton
    * Elixir: @niku
    * Elm: @eriktim
    * Eiffel: @jvelilla
@@ -1257,7 +1256,7 @@ If you want to join the committee, please kindly apply by sending an email to te
 | C#                    | @mandrean (2017/08) @shibayan (2020/02) @Blackclaws (2021/03) @lucamazzanti (2021/05) @iBicha (2023/07)                                                                                                                                          |
 | Clojure               |                                                                                                                                                                                                                                                       |
 | Crystal               | @cyangle (2021/01)                                                                                                                                                                                                                                    |
-| Dart                  | @jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12) @ahmednfwela (2021/08)                                                                                                        |
+| Dart                  | @jaumard (2018/09) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12) @ahmednfwela (2021/08)                                                                                                        |
 | Eiffel                | @jvelilla (2017/09)                                                                                                                                                                                                                                   |
 | Elixir                | @mrmstn (2018/12)                                                                                                                                                                                                                                     |
 | Elm                   | @eriktim (2018/09)                                                                                                                                                                                                                                    |


### PR DESCRIPTION
## Summary
- Removing myself (@josh-burton) as a Dart maintainer / template creator — I'm no longer active on this generator.
- Removes the entry from the Technical Committee "Dart" row (section 6.2) and the "Dart (Dio)" Template Creator credit (section 6.1).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `@josh-burton` from Dart maintainers and template creator credits in README. Updates the Technical Committee "Dart" row and removes the "Dart (Dio)" template creator entry to reflect current maintainers.

<sup>Written for commit 1556770504343b5fb94450c57221135d389348f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

