### PR TITLE
refactor(enum-utils): add utility methods for simplified enum schema creation

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -515,6 +515,7 @@ public class CodegenConstants {
     public static final String X_NULLABLE = "x-nullable";
     public static final String X_ENUM_VARNAMES = "x-enum-varnames";
     public static final String X_ENUM_DESCRIPTIONS = "x-enum-descriptions";
+    public static final String X_ENUM_DEPRECATED = "x-enum-deprecated";
     public static final String X_PY_TYPING = "x-py-typing";
     public static final String X_PY_EXAMPLE = "x-py-example";
     public static final String X_PY_EXAMPLE_IMPORT = "x-py-example-import";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -27,9 +27,9 @@ import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityScheme;
-import io.swagger.v3.oas.models.security.SecurityScheme.Type;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import org.apache.commons.lang3.StringUtils;
+import org.openapitools.codegen.utils.EnumUtils;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1642,8 +1642,7 @@ public class OpenAPINormalizer {
      * @return Simplified schema
      */
     protected Schema simplifyComposedSchemaWithEnums(Schema schema, List<Object> subSchemas, String composedType) {
-        Map<Object, String> enumValues = new LinkedHashMap<>();
-        Map<Object, Boolean> deprecatedValues = new LinkedHashMap<>();
+        Map<Object, EnumUtils.EnumExtensions> enumExtensions = new LinkedHashMap<>();
 
         if(schema.getTypes() != null && schema.getTypes().size() > 1) {
             // we cannot handle enums with multiple types
@@ -1697,32 +1696,27 @@ public class OpenAPINormalizer {
                     }
                     description += subSchema.getDescription();
                 }
-                enumValues.put(subSchemaEnumValues.get(0), description);
-                deprecatedValues.put(subSchemaEnumValues.get(0), subSchemaDeprecated);
+                enumExtensions.put(subSchemaEnumValues.get(0), new EnumUtils.EnumExtensions(description, subSchemaDeprecated));
             } else {
                 for(Object e: subSchemaEnumValues) {
-                    enumValues.put(e, "");
-                    deprecatedValues.put(e, subSchemaDeprecated);
+                    enumExtensions.put(e, new EnumUtils.EnumExtensions("", subSchemaDeprecated));
                 }
             }
-
         }
 
-        return createSimplifiedEnumSchema(schema, enumValues, deprecatedValues, schemaType, composedType);
+        return createSimplifiedEnumSchema(schema, enumExtensions, schemaType, composedType);
     }
-
 
     /**
      * Creates a simplified enum schema from collected enum values.
      *
      * @param originalSchema Original schema to modify
-     * @param enumValues Collected enum values
-     * @param deprecatedValues Per-value deprecated flags (aligned with enumValues key order)
+     * @param enumExtensions Collected enum values
      * @param schemaType Consistent type across sub-schemas
      * @param composedType Type of composed schema being simplified
      * @return Simplified enum schema
      */
-    protected Schema createSimplifiedEnumSchema(Schema originalSchema, Map<Object, String> enumValues, Map<Object, Boolean> deprecatedValues, String schemaType, String composedType) {
+    protected Schema createSimplifiedEnumSchema(Schema originalSchema, Map<Object, EnumUtils.EnumExtensions> enumExtensions, String schemaType, String composedType) {
         // Clear the composed schema type
         if ("oneOf".equals(composedType)) {
             originalSchema.setOneOf(null);
@@ -1730,20 +1724,7 @@ public class OpenAPINormalizer {
             originalSchema.setAnyOf(null);
         }
 
-        if (ModelUtils.getType(originalSchema) == null && schemaType != null) {
-            //if type was specified in subschemas, keep it in the main schema
-            ModelUtils.setType(originalSchema, schemaType);
-        }
-
-        originalSchema.setEnum(new ArrayList<>(enumValues.keySet()));
-        if(enumValues.values().stream().anyMatch(e -> !e.isEmpty())) {
-            //set x-enum-descriptions only if there's at least one non-empty description
-            originalSchema.addExtension(X_ENUM_DESCRIPTIONS, new ArrayList<>(enumValues.values()));
-        }
-        if (deprecatedValues != null && deprecatedValues.values().stream().anyMatch(Boolean.TRUE::equals)) {
-            // preserve per-value deprecated flags from OAS 3.1 oneOf/anyOf + const sub-schemas
-            originalSchema.addExtension("x-enum-deprecated", new ArrayList<>(deprecatedValues.values()));
-        }
+        EnumUtils.createSimplifiedEnumSchema(originalSchema, enumExtensions, schemaType);
 
         LOGGER.debug("Simplified {} with enum sub-schemas to single enum: {}", composedType, originalSchema);
 
@@ -1835,7 +1816,7 @@ public class OpenAPINormalizer {
                     return schema;
                 }
                 Map<String, String> mappings = new TreeMap<>();
-                // is the discriminator qttribute qlready in this schema?
+                // is the discriminator attribute already in this schema?
                 // if yes, it will be deleted in references oneOf to avoid duplicates
                 boolean hasProperty = findProperty(schema, discriminator.getPropertyName(), false, new HashSet<>()) != null;
                 discriminator.setMapping(mappings);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/EnumUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/EnumUtils.java
@@ -1,0 +1,56 @@
+package org.openapitools.codegen.utils;
+
+import io.swagger.v3.oas.models.media.Schema;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.openapitools.codegen.CodegenConstants.X_ENUM_DEPRECATED;
+import static org.openapitools.codegen.CodegenConstants.X_ENUM_DESCRIPTIONS;
+
+public class EnumUtils {
+
+    public static Schema createSimplifiedEnumSchema(Schema originalSchema,
+                                                     Map<Object, EnumExtensions> enums,
+                                                     String schemaType) {
+        if (ModelUtils.getType(originalSchema) == null && schemaType != null) {
+            //if type was specified in subschemas, keep it in the main schema
+            ModelUtils.setType(originalSchema, schemaType);
+        }
+
+        originalSchema.setEnum(new ArrayList<>(enums.keySet()));
+        List<String> enumDescriptions = enums.values().stream().map(EnumExtensions::getDescription).collect(Collectors.toList());
+        List<Boolean> enumDeprecations = enums.values().stream().map(EnumExtensions::isDeprecated).collect(Collectors.toList());
+        if(enumDescriptions.stream().anyMatch(e -> !e.isEmpty())) {
+            //set x-enum-descriptions only if there's at least one non-empty description
+            originalSchema.addExtension(X_ENUM_DESCRIPTIONS, new ArrayList<>(enumDescriptions));
+        }
+        if (enumDeprecations.stream().anyMatch(Boolean.TRUE::equals)) {
+            // preserve per-value deprecated flags from OAS 3.1 oneOf/anyOf + const sub-schemas
+            originalSchema.addExtension(X_ENUM_DEPRECATED, new ArrayList<>(enumDeprecations));
+        }
+
+        return originalSchema;
+    }
+
+    public static class EnumExtensions {
+        private final String description;
+        private final boolean deprecated;
+
+        public EnumExtensions(String description, boolean deprecated) {
+            this.description = description;
+            this.deprecated = deprecated;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public boolean isDeprecated() {
+            return deprecated;
+        }
+    }
+
+}


### PR DESCRIPTION
Enum handling has over the years evolved with how they are constructed and interpreted. From just being a String value all the time, to adding better support for numbers, and later that they can be decorated better with both `description` and `deprecated`. They also support "defaults" for the cases where one might want to use an enum to express a limited value space, but to also capture that it might not be entirely static (i.e., it might happen that it is extended/shrunk, which is a breaking change).

It is now so complex that I would argue that they are also a suitable candidate for its own `Utils` class. This is inspired by [my comment](https://github.com/OpenAPITools/openapi-generator/pull/23869#issuecomment-5017250283) on a recent upgrade to the enum handling.

If this is considered helpful, then I can also investigate moving further enum logic that resides within the now quite large `OpenAPINormalizer` to the util class. Once all functionality has been moved, then it would be suitable to investigate creating a `CodegenEnum` class (as [mentioned](https://github.com/OpenAPITools/openapi-generator/pull/23869#issuecomment-4853451424) in the PR thread too) that more formally express and carry the different enum settings that the project supports (similar to what exists for the `Discriminator` now for example).


This is a minor breaking change to the `OpenAPINormalizer` since its method `createSimplifiedEnumSchema`
```diff
-protected Schema createSimplifiedEnumSchema(Schema originalSchema, Map<Object, String> enumValues, Map<Object, Boolean> deprecatedValues, String schemaType, String composedType) 
+protected Schema createSimplifiedEnumSchema(Schema originalSchema, Map<Object, EnumUtils.EnumExtensions> enumExtensions, String schemaType, String composedType)
```
will change slightly with `Map<Object, String> enumValues` becoming `Map<Object, EnumUtils.EnumExtensions> enumExtensions`.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces `EnumUtils` to centralize enum schema creation and refactors `OpenAPINormalizer` to use it. Adds `CodegenConstants.X_ENUM_DEPRECATED`; behavior stays the same.

- **Refactors**
  - Added `EnumUtils.createSimplifiedEnumSchema(...)` and `EnumExtensions` to handle descriptions and deprecations.
  - `OpenAPINormalizer#createSimplifiedEnumSchema` now delegates to `EnumUtils`.
  - Added `CodegenConstants.X_ENUM_DEPRECATED` for the `x-enum-deprecated` extension.

- **Migration**
  - Protected method signature change in `OpenAPINormalizer`:
    - From: `createSimplifiedEnumSchema(Schema, Map<Object, String>, Map<Object, Boolean>, String, String)`
    - To: `createSimplifiedEnumSchema(Schema, Map<Object, EnumUtils.EnumExtensions>, String, String)`
  - If you override or call this method, replace the two maps with a single `Map<Object, EnumUtils.EnumExtensions>` and build entries with `new EnumUtils.EnumExtensions(description, deprecated)`.

<sup>Written for commit 0e52d13841bda11855ca38d6949cf1ff020f5543. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

