### PR TITLE
[csharp][generichost] Update partial to create HttpClient

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/HostConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/HostConfiguration.mustache
@@ -134,8 +134,10 @@ namespace {{packageName}}.{{clientPackage}}
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAdd{{apiName}}HttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAdd{{apiName}}HttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -144,12 +146,17 @@ namespace {{packageName}}.{{clientPackage}}
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAdd{{apiName}}HttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAdd{{apiName}}HttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>{{nrt?}} userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -114,8 +114,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -124,12 +126,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/latest/ComposedEnum/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/latest/ComposedEnum/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -100,8 +100,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -110,12 +112,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/latest/HelloWorld/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/latest/HelloWorld/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -95,8 +95,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -105,12 +107,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -101,8 +101,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -111,12 +113,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -102,8 +102,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -112,12 +114,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -98,8 +98,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -108,12 +110,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/latest/Tags/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/latest/Tags/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -100,8 +100,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -110,12 +112,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -219,8 +219,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -229,12 +231,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -99,8 +99,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -109,12 +111,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -99,8 +99,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -109,12 +111,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -99,8 +99,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -109,12 +111,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -267,8 +267,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -277,12 +279,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder> userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -219,8 +219,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -229,12 +231,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -100,8 +100,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -110,12 +112,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -217,8 +217,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -227,12 +229,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder> userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -327,8 +327,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -337,12 +339,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net10/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net10/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -95,8 +95,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -105,12 +107,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -95,8 +95,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -105,12 +107,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder> userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -95,8 +95,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -105,12 +107,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder> userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -95,8 +95,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -105,12 +107,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder> userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -265,8 +265,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -275,12 +277,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder> userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -96,8 +96,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -106,12 +108,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder> userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -215,8 +215,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -225,12 +227,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder> userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -93,8 +93,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -103,12 +105,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder> userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -95,8 +95,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -105,12 +107,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder> userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -95,8 +95,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -105,12 +107,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder> userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -95,8 +95,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -105,12 +107,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder> userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -265,8 +265,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -275,12 +277,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder> userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -96,8 +96,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -106,12 +108,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder> userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -215,8 +215,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -225,12 +227,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder> userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -93,8 +93,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -103,12 +105,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder> userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -99,8 +99,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -109,12 +111,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -99,8 +99,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -109,12 +111,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -99,8 +99,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -109,12 +111,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -267,8 +267,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -277,12 +279,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder> userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -219,8 +219,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -229,12 +231,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -100,8 +100,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -110,12 +112,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -217,8 +217,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -227,12 +229,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder> userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -327,8 +327,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -337,12 +339,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -95,8 +95,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -105,12 +107,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -99,8 +99,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -109,12 +111,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -99,8 +99,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -109,12 +111,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -99,8 +99,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -109,12 +111,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -267,8 +267,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -277,12 +279,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder> userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -219,8 +219,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -229,12 +231,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -100,8 +100,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -110,12 +112,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -217,8 +217,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -227,12 +229,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder> userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -327,8 +327,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -337,12 +339,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -95,8 +95,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -105,12 +107,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder>? userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -215,8 +215,10 @@ namespace Org.OpenAPITools.Client
 
             foreach (IHttpClientBuilder instance in builders)
             {
-                OnAddApiHttpClientBuilder(instance);
-                builder?.Invoke(instance);
+                bool suppressDefault = false;
+                OnAddApiHttpClientBuilder(instance, builder, ref suppressDefault);
+                if (!suppressDefault)
+                    builder?.Invoke(instance);
             }
 
             HttpClientsAdded = true;
@@ -225,12 +227,17 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        /// Applies configuration to each HttpClient after registration.
-        /// Implement this partial method in a separate file to provide custom defaults;
-        /// the caller's <c>builder</c> action runs after.
+        /// Applies configuration to each HttpClient.
+        /// Implement this partial method to prepend configuration, invoke <paramref name="userBuilder"/> at the
+        /// desired position, and append further configuration. Set <paramref name="suppressDefault"/> to
+        /// <c>true</c> when you invoke <paramref name="userBuilder"/> yourself to prevent a second invocation,
+        /// or to ignore the user's builder entirely.
+        /// If this method is not implemented, <paramref name="userBuilder"/> is invoked automatically.
         /// </summary>
-        /// <param name="builder"></param>
-        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder);
+        /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+        /// <param name="userBuilder">The caller-supplied builder action, or <c>null</c> if none was provided.</param>
+        /// <param name="suppressDefault">Set to <c>true</c> to prevent the default invocation of <paramref name="userBuilder"/>.</param>
+        partial void OnAddApiHttpClientBuilder(IHttpClientBuilder builder, Action<IHttpClientBuilder> userBuilder, ref bool suppressDefault);
 
         /// <summary>
         /// Called at the end of the constructor after all JSON converters and services are registered.


### PR DESCRIPTION
Give library authors more control. They can prepend, append, or suppress the end user's HttpClient builder. This is improving something committed only yesterday so there should be no concern.


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
