### PR TITLE
fix(normalizer): prevent nullable state leaking across shared schema refs

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -23,6 +23,7 @@ import io.swagger.v3.core.util.AnnotationsUtils;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.SpecVersion;
 import io.swagger.v3.oas.models.callbacks.Callback;
 import io.swagger.v3.oas.models.headers.Header;
 import io.swagger.v3.oas.models.media.*;
@@ -2481,6 +2482,13 @@ public class ModelUtils {
         return false;
     }
 
+    /**
+     * Creates a deep copy of a schema.
+     *
+     * @param schema    schema to clone
+     * @param openapi31 true when cloning an OpenAPI 3.1 schema
+     * @return a deep copy of the schema
+     */
     public static Schema cloneSchema(Schema schema, boolean openapi31) {
         if (openapi31) {
             return AnnotationsUtils.clone(schema, openapi31);
@@ -2513,6 +2521,12 @@ public class ModelUtils {
         // if only one element left, simplify to just the element (schema)
         if (subSchemas.size() == 1) {
             Schema<?> subSchema = subSchemas.get(0);
+            // The parser may reuse a $ref schema instance in multiple locations. Clone the
+            // remaining $ref before applying parent metadata so those locations stay isolated.
+            if (subSchema.get$ref() != null) {
+                subSchema = cloneSchema(subSchema,
+                        openAPI != null && SpecVersion.V31.equals(openAPI.getSpecVersion()));
+            }
             // Preserve parent-level docs when nullable anyOf/oneOf collapses to a single child schema.
             if (subSchema.getDescription() == null && schema.getDescription() != null) {
                 subSchema.setDescription(schema.getDescription());

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/axios/TypeScriptAxiosClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/axios/TypeScriptAxiosClientCodegenTest.java
@@ -179,6 +179,27 @@ public class TypeScriptAxiosClientCodegenTest {
         TestUtils.assertFileContains(file, "'nicknames'?: Array<string>");
     }
 
+    @Test(description = "Nullable oneOf references do not make other uses of the referenced schema nullable")
+    public void testNullableReferenceDoesNotLeakIntoModelProperty() throws Exception {
+        final File output = Files.createTempDirectory("typescript_axios_nullable_reference_").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("typescript-axios")
+                .setInputSpec("src/test/resources/3_1/issue_23340.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        Path api = Paths.get(output + "/api.ts");
+        TestUtils.assertFileContains(api,
+                "export interface TitleGroupHierarchyLite {",
+                "'content_type': ContentType;");
+        TestUtils.assertFileNotContains(api, "'content_type': ContentType | null;");
+        TestUtils.assertFileContains(api, "search: async (contentType?: ContentType | null");
+    }
+
     @Test(description = "Verify multipart file arrays use repeated form fields")
     public void testMultipartFileArrayUsesRepeatedFormFields() throws Exception {
         final File output = Files.createTempDirectory("typescript_axios_multipart_file_array_").toFile();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -18,6 +18,7 @@
 package org.openapitools.codegen.utils;
 
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.SpecVersion;
 import io.swagger.v3.oas.models.media.*;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
@@ -553,6 +554,23 @@ public class ModelUtilsTest {
         assertTrue(schema.getReadOnly());
         assertNull(schema.getWriteOnly());
         assertEquals(schema.get$ref(), "#/components/schemas/IntegerRef");
+    }
+
+    @Test
+    public void simplifyOneOfWithOnlyOneNonNullSubSchemaDoesNotMutateSharedSchema() {
+        OpenAPI openAPI = new OpenAPI().specVersion(SpecVersion.V31);
+        Schema sharedRef = new Schema<>().$ref("#/components/schemas/ContentType");
+        Schema nullableParent = new ComposedSchema().oneOf(new ArrayList<>(Arrays.asList(
+                new Schema<>().type("null"),
+                sharedRef)));
+
+        Schema simplified = ModelUtils.simplifyOneOfAnyOfWithOnlyOneNonNullSubSchema(
+                openAPI, nullableParent, nullableParent.getOneOf());
+
+        assertNotSame(simplified, sharedRef);
+        assertEquals(simplified.get$ref(), sharedRef.get$ref());
+        assertTrue(simplified.getNullable());
+        assertNull(sharedRef.getNullable());
     }
 
     @Test

--- a/modules/openapi-generator/src/test/resources/3_1/issue_23340.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/issue_23340.yaml
@@ -1,0 +1,64 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "repro-23340", "version": "1.0.0" },
+  "paths": {
+    "/home": {
+      "get": {
+        "operationId": "getHome",
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["data"],
+                  "properties": { "data": { "$ref": "#/components/schemas/HomePage" } }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search": {
+      "get": {
+        "operationId": "search",
+        "parameters": [
+          {
+            "name": "content_type",
+            "in": "query",
+            "required": false,
+            "schema": { "oneOf": [ { "type": "null" }, { "$ref": "#/components/schemas/ContentType" } ] }
+          }
+        ],
+        "responses": { "200": { "description": "ok" } }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ContentType": { "type": "string", "enum": ["movie"] },
+      "TitleGroupLite": {
+        "type": "object",
+        "required": ["content_type"],
+        "properties": { "content_type": { "$ref": "#/components/schemas/ContentType" } }
+      },
+      "HomePage": {
+        "type": "object",
+        "required": ["latest_uploads"],
+        "properties": {
+          "latest_uploads": { "type": "array", "items": { "$ref": "#/components/schemas/TitleGroupLite" } }
+        }
+      },
+      "TitleGroupHierarchyLite": {
+        "type": "object",
+        "required": ["id", "content_type"],
+        "properties": {
+          "id": { "type": "integer", "format": "int32" },
+          "content_type": { "$ref": "#/components/schemas/ContentType" }
+        }
+      }
+    }
+  }
+}

--- a/samples/client/others/go/issue_20079_go_regex_wrongly_translated/model_import_code.go
+++ b/samples/client/others/go/issue_20079_go_regex_wrongly_translated/model_import_code.go
@@ -19,43 +19,43 @@ var _ MappedNullable = &ImportCode{}
 
 // ImportCode struct for ImportCode
 type ImportCode struct {
-	Code *string `json:"code,omitempty" validate:"regexp=^[0-9]{2,}$"`
+	Code *string `json:"code,omitempty" validate:"regexp=^[0-9]{2\\,}$"`
 	// Visa credit card  matches: 4123 6453 2222 1746  non-matches: 3124 5675 4400 4567, 4123-6453-2222-1746
-	CreditCard *string `json:"creditCard,omitempty" validate:"regexp=^4[0-9]{3}\\\\s[0-9]{4}\\\\s[0-9]{4}\\\\s[0-9]{4}$"`
+	CreditCard *string `json:"creditCard,omitempty" validate:"regexp=^4[0-9]{3}\\s[0-9]{4}\\s[0-9]{4}\\s[0-9]{4}$"`
 	// Some dates  matches: 31/04/1999, 15/12/4567  non-matches: 31/4/1999, 31/4/99, 1999/04/19, 42/67/25456
-	Date *string `json:"date,omitempty" validate:"regexp=^([0-2][0-9]|30|31)\\/(0[1-9]|1[0-2])\\/[0-9]{4}$"`
+	Date *string `json:"date,omitempty" validate:"regexp=^([0-2][0-9]|30|31)/(0[1-9]|1[0-2])/[0-9]{4}$"`
 	// Windows absolute path  matches: \\\\server\\share\\file  non-matches: \\directory\\directory2, /directory2
 	WindowsAbsolutePath *string `json:"windowsAbsolutePath,omitempty"`
 	// Email Address 1  matches: abc.123@def456.com, _123@abc.ca  non-matches: abc@dummy, ab*cd@efg.hijkl
-	Email1 *string `json:"email1,omitempty" validate:"regexp=^[[:word:]\\\\-.]+@[[:word:]\\\\-.]+\\\\.[[:alpha:]]{2,3}$"`
+	Email1 *string `json:"email1,omitempty" validate:"regexp=^[[:word:]\\-.]+@[[:word:]\\-.]+\\.[[:alpha:]]{2\\,3}$"`
 	// Email Address 2  matches: *@qrstuv@wxyz.12345.com, __1234^%@@abc.def.ghijkl  non-matches: abc.123.*&ca, ^%abcdefg123
-	Email2 *string `json:"email2,omitempty" validate:"regexp=^.+@.+\\\\..+$"`
+	Email2 *string `json:"email2,omitempty" validate:"regexp=^.+@.+\\..+$"`
 	// HTML Hexadecimal Color Code 1  matches: AB1234, CCCCCC, 12AF3B  non-matches: 123G45, 12-44-CC
 	HtmlHexadecimalColorCode1 *string `json:"htmlHexadecimalColorCode1,omitempty" validate:"regexp=^[A-F0-9]{6}$"`
 	// HTML Hexadecimal Color Code 2  matches: AB 11 00, CC 12 D3  non-matches: SS AB CD, AA BB CC DD, 1223AB
-	HtmlHexadecimalColorCode2 *string `json:"htmlHexadecimalColorCode2,omitempty" validate:"regexp=^[A-F0-9]{2}\\\\s[A-F0-9]{2}\\\\s[A-F0-9]{2}$"`
+	HtmlHexadecimalColorCode2 *string `json:"htmlHexadecimalColorCode2,omitempty" validate:"regexp=^[A-F0-9]{2}\\s[A-F0-9]{2}\\s[A-F0-9]{2}$"`
 	// IP Address  matches: 10.25.101.216  non-matches: 0.0.0, 256.89.457.02
-	IpAddress *string `json:"ipAddress,omitempty" validate:"regexp=^((2(5[0-5]|[0-4][0-9])|1([0-9][0-9])|([1-9][0-9])|[0-9])\\\\.){3}(2(5[0-5]|[0-4][0-9])|1([0-9][0-9])|([1-9][0-9])|[0-9])$"`
+	IpAddress *string `json:"ipAddress,omitempty" validate:"regexp=^((2(5[0-5]|[0-4][0-9])|1([0-9][0-9])|([1-9][0-9])|[0-9])\\.){3}(2(5[0-5]|[0-4][0-9])|1([0-9][0-9])|([1-9][0-9])|[0-9])$"`
 	// Java Comments  matches: Matches Java comments that are between /_* and *_/, or one line comments prefaced by //  non-matches: a=1
 	JavaComments *string `json:"javaComments,omitempty"`
 	//   matches: $1.00, -$97.65 non-matches: $1, 1.00$, $-75.17
-	Money *string `json:"money,omitempty" validate:"regexp=^(\\\\+|-)?\\\\$[0-9]*\\\\.[0-9]{2}$"`
+	Money *string `json:"money,omitempty" validate:"regexp=^(\\+|-)?\\$[0-9]*\\.[0-9]{2}$"`
 	// Positive, negative numbers, and decimal values  matches: +41, -412, 2, 7968412, 41, +41.1, -3.141592653 non-matches: ++41, 41.1.19, -+97.14
-	PositiveNegativeDecimalValue *string `json:"positiveNegativeDecimalValue,omitempty" validate:"regexp=^(\\\\+|-)?[0-9]+(\\\\.[0-9]+)?$"`
+	PositiveNegativeDecimalValue *string `json:"positiveNegativeDecimalValue,omitempty" validate:"regexp=^(\\+|-)?[0-9]+(\\.[0-9]+)?$"`
 	// Passwords 1  matches: abcd, 1234, A1b2C3d4, 1a2B3  non-matches: abc, *ab12, abcdefghijkl
-	Password1 *string `json:"password1,omitempty" validate:"regexp=^[[:alnum:]]{4,10}$"`
+	Password1 *string `json:"password1,omitempty" validate:"regexp=^[[:alnum:]]{4\\,10}$"`
 	// Passwords 2  matches: AB_cd, A1_b2c3, a123_  non-matches: *&^g, abc, 1bcd
-	Password2 *string `json:"password2,omitempty" validate:"regexp=^[a-zA-Z]\\\\w{3,7}$"`
+	Password2 *string `json:"password2,omitempty" validate:"regexp=^[a-zA-Z]\\w{3\\,7}$"`
 	// Phone Numbers  matches: 519-883-6898, 519 888 6898  non-matches: 888 6898, 5198886898, 519 883-6898
-	PhoneNumber *string `json:"phoneNumber,omitempty" validate:"regexp=^([2-9][0-9]{2}-[2-9][0-9]{2}-[0-9]{4})|([2-9][0-9]{2}\\\\s[2-9][0-9]{2}\\\\s[0-9]{4})$"`
+	PhoneNumber *string `json:"phoneNumber,omitempty" validate:"regexp=^([2-9][0-9]{2}-[2-9][0-9]{2}-[0-9]{4})|([2-9][0-9]{2}\\s[2-9][0-9]{2}\\s[0-9]{4})$"`
 	// Sentences 1  matches: Hello, how are you?  non-matches: i am fine
-	Sentence1 *string `json:"sentence1,omitempty" validate:"regexp=^[A-Z0-9].*(\\\\.|\\\\?|!)$"`
+	Sentence1 *string `json:"sentence1,omitempty" validate:"regexp=^[A-Z0-9].*(\\.|\\?|!)$"`
 	// Sentences 2  matches: Hello, how are you?n non-matches: i am fine
 	Sentence2 *string `json:"sentence2,omitempty" validate:"regexp=^[[:upper:]0-9].*[.?!]$"`
 	// Social Security Number  matches: 123-45-6789  non-matches: 123 45 6789, 123456789, 1234-56-7891
 	SocialSecurityNumber *string `json:"socialSecurityNumber,omitempty" validate:"regexp=^[0-9]{3}-[0-9]{2}-[0-9]{4}$"`
 	// URL  matches: http://www.sample.com, www.sample.com  non-matches: http://sample.com, http://www.sample.comm
-	Url *string `json:"url,omitempty" validate:"regexp=^(http:\\/\\/)?www\\\\.[a-zA-Z0-9]+\\\\.[a-zA-Z]{2,3}$"`
+	Url *string `json:"url,omitempty" validate:"regexp=^(http://)?www\\.[a-zA-Z0-9]+\\.[a-zA-Z]{2\\,3}$"`
 }
 
 // NewImportCode instantiates a new ImportCode object

--- a/samples/client/others/ruby-nextgen-qdrant/lib/qdrant/models/batch_payloads_inner.rb
+++ b/samples/client/others/ruby-nextgen-qdrant/lib/qdrant/models/batch_payloads_inner.rb
@@ -11,7 +11,7 @@ module Qdrant
     # anyOf wrapper. Returns the first candidate that validates.
     module BatchPayloadsInner
       CANDIDATES = [
-        'Hash',
+        'Hash<String, Object>',
       ].freeze
 
       def self.build(data)

--- a/samples/client/others/typescript-node/encode-decode/build/api/defaultApi.ts
+++ b/samples/client/others/typescript-node/encode-decode/build/api/defaultApi.ts
@@ -517,7 +517,7 @@ export class DefaultApi {
     /**
      * 
      */
-    public async testDecodeMapOfObjectsGet (options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.IncomingMessage; body: { [key: string]: ComplexObject | undefined | null; };  }> {
+    public async testDecodeMapOfObjectsGet (options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.IncomingMessage; body: { [key: string]: ComplexObject | undefined; };  }> {
         const localVarPath = this.basePath + '/test/decode/map-of/objects';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this._defaultHeaders);
@@ -559,13 +559,13 @@ export class DefaultApi {
                     localVarRequestOptions.form = localVarFormParams;
                 }
             }
-            return new Promise<{ response: http.IncomingMessage; body: { [key: string]: ComplexObject | undefined | null; };  }>((resolve, reject) => {
+            return new Promise<{ response: http.IncomingMessage; body: { [key: string]: ComplexObject | undefined; };  }>((resolve, reject) => {
                 localVarRequest(localVarRequestOptions, (error, response, body) => {
                     if (error) {
                         reject(error);
                     } else {
                         if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                            body = ObjectSerializer.deserialize(body, "{ [key: string]: ComplexObject | undefined | null; }");
+                            body = ObjectSerializer.deserialize(body, "{ [key: string]: ComplexObject | undefined; }");
                             resolve({ response: response, body: body });
                         } else {
                             reject(new HttpError(response, body, response.statusCode));
@@ -1487,7 +1487,7 @@ export class DefaultApi {
      * 
      * @param requestBody 
      */
-    public async testEncodeMapOfObjectsPost (requestBody: { [key: string]: ComplexObject | undefined | null; }, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.IncomingMessage; body?: any;  }> {
+    public async testEncodeMapOfObjectsPost (requestBody: { [key: string]: ComplexObject | undefined; }, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.IncomingMessage; body?: any;  }> {
         const localVarPath = this.basePath + '/test/encode/map-of/objects';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this._defaultHeaders);
@@ -1509,7 +1509,7 @@ export class DefaultApi {
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
-            body: ObjectSerializer.serialize(requestBody, "{ [key: string]: ComplexObject | undefined | null; }")
+            body: ObjectSerializer.serialize(requestBody, "{ [key: string]: ComplexObject | undefined; }")
         };
 
         let authenticationPromise = Promise.resolve();

--- a/samples/client/others/typescript/encode-decode/build/apis/DefaultApi.ts
+++ b/samples/client/others/typescript/encode-decode/build/apis/DefaultApi.ts
@@ -653,7 +653,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
     /**
      * @param requestBody 
      */
-    public async testEncodeMapOfObjectsPost(requestBody: { [key: string]: ComplexObject | null; }, _options?: Configuration): Promise<RequestContext> {
+    public async testEncodeMapOfObjectsPost(requestBody: { [key: string]: ComplexObject; }, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
 
         // verify required parameter 'requestBody' is not null or undefined
@@ -676,7 +676,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         ]);
         requestContext.setHeaderParam("Content-Type", contentType);
         const serializedBody = ObjectSerializer.stringify(
-            ObjectSerializer.serialize(requestBody, "{ [key: string]: ComplexObject | null; }", ""),
+            ObjectSerializer.serialize(requestBody, "{ [key: string]: ComplexObject; }", ""),
             contentType
         );
         requestContext.setBody(serializedBody);
@@ -1214,22 +1214,22 @@ export class DefaultApiResponseProcessor {
      * @params response Response returned by the server for a request to testDecodeMapOfObjectsGet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async testDecodeMapOfObjectsGetWithHttpInfo(response: ResponseContext): Promise<HttpInfo<{ [key: string]: ComplexObject | null; } >> {
+     public async testDecodeMapOfObjectsGetWithHttpInfo(response: ResponseContext): Promise<HttpInfo<{ [key: string]: ComplexObject; } >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const body: { [key: string]: ComplexObject | null; } = ObjectSerializer.deserialize(
+            const body: { [key: string]: ComplexObject; } = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
-                "{ [key: string]: ComplexObject | null; }", ""
-            ) as { [key: string]: ComplexObject | null; };
+                "{ [key: string]: ComplexObject; }", ""
+            ) as { [key: string]: ComplexObject; };
             return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: { [key: string]: ComplexObject | null; } = ObjectSerializer.deserialize(
+            const body: { [key: string]: ComplexObject; } = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
-                "{ [key: string]: ComplexObject | null; }", ""
-            ) as { [key: string]: ComplexObject | null; };
+                "{ [key: string]: ComplexObject; }", ""
+            ) as { [key: string]: ComplexObject; };
             return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 

--- a/samples/client/others/typescript/encode-decode/build/docs/DefaultApi.md
+++ b/samples/client/others/typescript/encode-decode/build/docs/DefaultApi.md
@@ -354,7 +354,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](README.md#documentation-for-api-endpoints) [[Back to Model list]](README.md#documentation-for-models) [[Back to README]](README.md)
 
 # **testDecodeMapOfObjectsGet**
-> { [key: string]: ComplexObject | null; } testDecodeMapOfObjectsGet()
+> { [key: string]: ComplexObject; } testDecodeMapOfObjectsGet()
 
 
 ### Example
@@ -379,7 +379,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-**{ [key: string]: ComplexObject | null; }**
+**{ [key: string]: ComplexObject; }**
 
 ### Authorization
 
@@ -1169,7 +1169,12 @@ const apiInstance = new DefaultApi(configuration);
 const request: DefaultApiTestEncodeMapOfObjectsPostRequest = {
   
   requestBody: {
-    "key": null,
+    "key": {
+      requiredProperty: "requiredProperty_example",
+      requiredNullableProperty: "requiredNullableProperty_example",
+      optionalProperty: "optionalProperty_example",
+      optionalNullableProperty: "optionalNullableProperty_example",
+    },
   },
 };
 
@@ -1182,7 +1187,7 @@ console.log('API called successfully. Returned data:', data);
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **requestBody** | **{ [key: string]: ComplexObject | null; }**|  |
+ **requestBody** | **{ [key: string]: ComplexObject; }**|  |
 
 
 ### Return type

--- a/samples/client/others/typescript/encode-decode/build/types/ObjectParamAPI.ts
+++ b/samples/client/others/typescript/encode-decode/build/types/ObjectParamAPI.ts
@@ -122,10 +122,10 @@ export interface DefaultApiTestEncodeMapOfMapsOfObjectsPostRequest {
 export interface DefaultApiTestEncodeMapOfObjectsPostRequest {
     /**
      * 
-     * @type { [key: string]: ComplexObject | null; }
+     * @type { [key: string]: ComplexObject; }
      * @memberof DefaultApitestEncodeMapOfObjectsPost
      */
-    requestBody: { [key: string]: ComplexObject | null; }
+    requestBody: { [key: string]: ComplexObject; }
 }
 
 export interface DefaultApiTestEncodeMapOfPrimitivePostRequest {
@@ -308,14 +308,14 @@ export class ObjectDefaultApi {
     /**
      * @param param the request object
      */
-    public testDecodeMapOfObjectsGetWithHttpInfo(param: DefaultApiTestDecodeMapOfObjectsGetRequest = {}, options?: ConfigurationOptions): Promise<HttpInfo<{ [key: string]: ComplexObject | null; }>> {
+    public testDecodeMapOfObjectsGetWithHttpInfo(param: DefaultApiTestDecodeMapOfObjectsGetRequest = {}, options?: ConfigurationOptions): Promise<HttpInfo<{ [key: string]: ComplexObject; }>> {
         return this.api.testDecodeMapOfObjectsGetWithHttpInfo( options).toPromise();
     }
 
     /**
      * @param param the request object
      */
-    public testDecodeMapOfObjectsGet(param: DefaultApiTestDecodeMapOfObjectsGetRequest = {}, options?: ConfigurationOptions): Promise<{ [key: string]: ComplexObject | null; }> {
+    public testDecodeMapOfObjectsGet(param: DefaultApiTestDecodeMapOfObjectsGetRequest = {}, options?: ConfigurationOptions): Promise<{ [key: string]: ComplexObject; }> {
         return this.api.testDecodeMapOfObjectsGet( options).toPromise();
     }
 

--- a/samples/client/others/typescript/encode-decode/build/types/ObservableAPI.ts
+++ b/samples/client/others/typescript/encode-decode/build/types/ObservableAPI.ts
@@ -220,7 +220,7 @@ export class ObservableDefaultApi {
 
     /**
      */
-    public testDecodeMapOfObjectsGetWithHttpInfo(_options?: ConfigurationOptions): Observable<HttpInfo<{ [key: string]: ComplexObject | null; }>> {
+    public testDecodeMapOfObjectsGetWithHttpInfo(_options?: ConfigurationOptions): Observable<HttpInfo<{ [key: string]: ComplexObject; }>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
         const requestContextPromise = this.requestFactory.testDecodeMapOfObjectsGet(_config);
@@ -242,8 +242,8 @@ export class ObservableDefaultApi {
 
     /**
      */
-    public testDecodeMapOfObjectsGet(_options?: ConfigurationOptions): Observable<{ [key: string]: ComplexObject | null; }> {
-        return this.testDecodeMapOfObjectsGetWithHttpInfo(_options).pipe(map((apiResponse: HttpInfo<{ [key: string]: ComplexObject | null; }>) => apiResponse.data));
+    public testDecodeMapOfObjectsGet(_options?: ConfigurationOptions): Observable<{ [key: string]: ComplexObject; }> {
+        return this.testDecodeMapOfObjectsGetWithHttpInfo(_options).pipe(map((apiResponse: HttpInfo<{ [key: string]: ComplexObject; }>) => apiResponse.data));
     }
 
     /**
@@ -683,7 +683,7 @@ export class ObservableDefaultApi {
     /**
      * @param requestBody
      */
-    public testEncodeMapOfObjectsPostWithHttpInfo(requestBody: { [key: string]: ComplexObject | null; }, _options?: ConfigurationOptions): Observable<HttpInfo<void>> {
+    public testEncodeMapOfObjectsPostWithHttpInfo(requestBody: { [key: string]: ComplexObject; }, _options?: ConfigurationOptions): Observable<HttpInfo<void>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
         const requestContextPromise = this.requestFactory.testEncodeMapOfObjectsPost(requestBody, _config);
@@ -706,7 +706,7 @@ export class ObservableDefaultApi {
     /**
      * @param requestBody
      */
-    public testEncodeMapOfObjectsPost(requestBody: { [key: string]: ComplexObject | null; }, _options?: ConfigurationOptions): Observable<void> {
+    public testEncodeMapOfObjectsPost(requestBody: { [key: string]: ComplexObject; }, _options?: ConfigurationOptions): Observable<void> {
         return this.testEncodeMapOfObjectsPostWithHttpInfo(requestBody, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 

--- a/samples/client/others/typescript/encode-decode/build/types/PromiseAPI.ts
+++ b/samples/client/others/typescript/encode-decode/build/types/PromiseAPI.ts
@@ -132,7 +132,7 @@ export class PromiseDefaultApi {
 
     /**
      */
-    public testDecodeMapOfObjectsGetWithHttpInfo(_options?: PromiseConfigurationOptions): Promise<HttpInfo<{ [key: string]: ComplexObject | null; }>> {
+    public testDecodeMapOfObjectsGetWithHttpInfo(_options?: PromiseConfigurationOptions): Promise<HttpInfo<{ [key: string]: ComplexObject; }>> {
         const observableOptions = wrapOptions(_options);
         const result = this.api.testDecodeMapOfObjectsGetWithHttpInfo(observableOptions);
         return result.toPromise();
@@ -140,7 +140,7 @@ export class PromiseDefaultApi {
 
     /**
      */
-    public testDecodeMapOfObjectsGet(_options?: PromiseConfigurationOptions): Promise<{ [key: string]: ComplexObject | null; }> {
+    public testDecodeMapOfObjectsGet(_options?: PromiseConfigurationOptions): Promise<{ [key: string]: ComplexObject; }> {
         const observableOptions = wrapOptions(_options);
         const result = this.api.testDecodeMapOfObjectsGet(observableOptions);
         return result.toPromise();
@@ -403,7 +403,7 @@ export class PromiseDefaultApi {
     /**
      * @param requestBody
      */
-    public testEncodeMapOfObjectsPostWithHttpInfo(requestBody: { [key: string]: ComplexObject | null; }, _options?: PromiseConfigurationOptions): Promise<HttpInfo<void>> {
+    public testEncodeMapOfObjectsPostWithHttpInfo(requestBody: { [key: string]: ComplexObject; }, _options?: PromiseConfigurationOptions): Promise<HttpInfo<void>> {
         const observableOptions = wrapOptions(_options);
         const result = this.api.testEncodeMapOfObjectsPostWithHttpInfo(requestBody, observableOptions);
         return result.toPromise();
@@ -412,7 +412,7 @@ export class PromiseDefaultApi {
     /**
      * @param requestBody
      */
-    public testEncodeMapOfObjectsPost(requestBody: { [key: string]: ComplexObject | null; }, _options?: PromiseConfigurationOptions): Promise<void> {
+    public testEncodeMapOfObjectsPost(requestBody: { [key: string]: ComplexObject; }, _options?: PromiseConfigurationOptions): Promise<void> {
         const observableOptions = wrapOptions(_options);
         const result = this.api.testEncodeMapOfObjectsPost(requestBody, observableOptions);
         return result.toPromise();

--- a/samples/client/petstore/java/okhttp-gson-3.1/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson-3.1/api/openapi.yaml
@@ -824,9 +824,7 @@ paths:
             application/json:
               schema:
                 items:
-                  allOf:
-                  - $ref: "#/components/schemas/myObject"
-                  nullable: true
+                  $ref: "#/components/schemas/myObject"
                 nullable: true
                 type: array
                 default: null


### PR DESCRIPTION
### Description

Fixes #23340.

When simplifying an OpenAPI 3.1 `oneOf`/`anyOf` containing `null` and a single `$ref`, the normalizer applied nullable metadata directly to the referenced schema instance.

Because the parser may reuse that schema instance elsewhere, the nullable state could leak into unrelated properties. For example, a required non-nullable `ContentType` property was generated as `ContentType | null`.

This change:

- Clones the remaining `$ref` schema before applying parent metadata.
- Keeps the nullable state local to the simplified `oneOf`/`anyOf`. 
- Adds a unit test confirming the shared schema is not mutated.
- Adds a TypeScript Axios regression test using a minimal OpenAPI 3.1 specification.
- Updates affected generated samples.
- Adds Javadoc to `cloneSchema` explaining its purpose, parameters, and return value.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04) @joscha (2024/10) @KannaKim (2026/07)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a normalization bug where `nullable` from `oneOf`/`anyOf` with `null` + `$ref` mutated a shared schema, causing unrelated properties to become nullable in generated clients.

- **Bug Fixes**
  - Clone the remaining `$ref` before applying parent metadata when simplifying `oneOf`/`anyOf` (OpenAPI 3.1), keeping `nullable` local to that union.
  - Add unit coverage in `ModelUtilsTest` and a `typescript-axios` regression test using `3_1/issue_23340.yaml` to ensure no nullability leak.
  - Document `cloneSchema` with Javadoc and update affected samples (Go, Ruby, TypeScript, Java petstore).

<sup>Written for commit 165edc1640f2742a58b250034c5bb3b466d29421. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

