### PR TITLE
[python] fix null handling in generated models

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_generic.mustache
@@ -220,7 +220,7 @@ https://github.com/OpenAPITools/openapi-generator/blob/c84b949df1a9ec04ba75989cb
     @classmethod
     def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
         """Returns the discriminator value (object type) of the data"""
-        discriminator_value = obj[cls.__discriminator_property_name]
+        discriminator_value = obj.get(cls.__discriminator_property_name)
         if discriminator_value:
             return cls.__discriminator_value_class_map.get(discriminator_value)
         else:
@@ -336,10 +336,12 @@ https://github.com/OpenAPITools/openapi-generator/blob/c84b949df1a9ec04ba75989cb
         _items = []
         if self.{{{name}}}:
             for _item_{{{name}}} in self.{{{name}}}:
-                if _item_{{{name}}}:
+                if _item_{{{name}}} is not None:
                     _items.append(
-                         [{{#compatibleWithPythonLegacy}}_to_openapi_value(_inner_item){{/compatibleWithPythonLegacy}}{{^compatibleWithPythonLegacy}}_inner_item.to_dict(){{/compatibleWithPythonLegacy}} for _inner_item in _item_{{{name}}} if _inner_item is not None]
+                         [{{#compatibleWithPythonLegacy}}_to_openapi_value(_inner_item){{/compatibleWithPythonLegacy}}{{^compatibleWithPythonLegacy}}_inner_item.to_dict(){{/compatibleWithPythonLegacy}} if _inner_item is not None else None for _inner_item in _item_{{{name}}}]
                     )
+                else:
+                    _items.append(None)
             _dict[{{#lambda.pythonSingleQuotedStringLiteral}}{{{baseName}}}{{/lambda.pythonSingleQuotedStringLiteral}}] = _items
         {{/items.items.isPrimitiveType}}
         {{/items.isArray}}
@@ -349,10 +351,12 @@ https://github.com/OpenAPITools/openapi-generator/blob/c84b949df1a9ec04ba75989cb
         _items = []
         if self.{{{name}}}:
             for _item_{{{name}}} in self.{{{name}}}:
-                if _item_{{{name}}}:
+                if _item_{{{name}}} is not None:
                     _items.append(
-                         {_inner_key: {{#compatibleWithPythonLegacy}}_to_openapi_value(_inner_value){{/compatibleWithPythonLegacy}}{{^compatibleWithPythonLegacy}}_inner_value.to_dict(){{/compatibleWithPythonLegacy}} for _inner_key, _inner_value in _item_{{{name}}}.items()}
+                         {_inner_key: {{#compatibleWithPythonLegacy}}_to_openapi_value(_inner_value){{/compatibleWithPythonLegacy}}{{^compatibleWithPythonLegacy}}_inner_value.to_dict(){{/compatibleWithPythonLegacy}} if _inner_value is not None else None for _inner_key, _inner_value in _item_{{{name}}}.items()}
                     )
+                else:
+                    _items.append(None)
             _dict[{{#lambda.pythonSingleQuotedStringLiteral}}{{{baseName}}}{{/lambda.pythonSingleQuotedStringLiteral}}] = _items
         {{/items.items.isPrimitiveType}}
         {{/items.isMap}}
@@ -364,8 +368,7 @@ https://github.com/OpenAPITools/openapi-generator/blob/c84b949df1a9ec04ba75989cb
         _items = []
         if self.{{{name}}}:
             for _item_{{{name}}} in self.{{{name}}}:
-                if _item_{{{name}}}:
-                    _items.append({{#compatibleWithPythonLegacy}}_to_openapi_value(_item_{{{name}}}){{/compatibleWithPythonLegacy}}{{^compatibleWithPythonLegacy}}_item_{{{name}}}.to_dict(){{/compatibleWithPythonLegacy}})
+                _items.append({{#compatibleWithPythonLegacy}}_to_openapi_value(_item_{{{name}}}){{/compatibleWithPythonLegacy}}{{^compatibleWithPythonLegacy}}_item_{{{name}}}.to_dict(){{/compatibleWithPythonLegacy}} if _item_{{{name}}} is not None else None)
             _dict[{{#lambda.pythonSingleQuotedStringLiteral}}{{{baseName}}}{{/lambda.pythonSingleQuotedStringLiteral}}] = _items
         {{/items.isEnumOrRef}}
         {{/items.isPrimitiveType}}
@@ -381,8 +384,10 @@ https://github.com/OpenAPITools/openapi-generator/blob/c84b949df1a9ec04ba75989cb
             for _key_{{{name}}} in self.{{{name}}}:
                 if self.{{{name}}}[_key_{{{name}}}] is not None:
                     _field_dict_of_array[_key_{{{name}}}] = [
-                        {{#compatibleWithPythonLegacy}}_to_openapi_value(_item){{/compatibleWithPythonLegacy}}{{^compatibleWithPythonLegacy}}_item.to_dict(){{/compatibleWithPythonLegacy}} for _item in self.{{{name}}}[_key_{{{name}}}]
+                        {{#compatibleWithPythonLegacy}}_to_openapi_value(_item){{/compatibleWithPythonLegacy}}{{^compatibleWithPythonLegacy}}_item.to_dict(){{/compatibleWithPythonLegacy}} if _item is not None else None for _item in self.{{{name}}}[_key_{{{name}}}]
                     ]
+                else:
+                    _field_dict_of_array[_key_{{{name}}}] = None
             _dict[{{#lambda.pythonSingleQuotedStringLiteral}}{{{baseName}}}{{/lambda.pythonSingleQuotedStringLiteral}}] = _field_dict_of_array
         {{/items.items.isPrimitiveType}}
         {{/items.isArray}}
@@ -394,8 +399,10 @@ https://github.com/OpenAPITools/openapi-generator/blob/c84b949df1a9ec04ba75989cb
             for _key_{{{name}}}, _value_{{{name}}} in self.{{{name}}}.items():
                 if _value_{{{name}}} is not None:
                     _field_dict_of_dict[_key_{{{name}}}] = {
-                        _key: {{#compatibleWithPythonLegacy}}_to_openapi_value(_value){{/compatibleWithPythonLegacy}}{{^compatibleWithPythonLegacy}}_value.to_dict(){{/compatibleWithPythonLegacy}} for _key, _value in _value_{{{name}}}.items()
+                        _key: {{#compatibleWithPythonLegacy}}_to_openapi_value(_value){{/compatibleWithPythonLegacy}}{{^compatibleWithPythonLegacy}}_value.to_dict(){{/compatibleWithPythonLegacy}} if _value is not None else None for _key, _value in _value_{{{name}}}.items()
                     }
+                else:
+                    _field_dict_of_dict[_key_{{{name}}}] = None
             _dict[{{#lambda.pythonSingleQuotedStringLiteral}}{{{baseName}}}{{/lambda.pythonSingleQuotedStringLiteral}}] = _field_dict_of_dict
         {{/items.items.isPrimitiveType}}
         {{/items.isMap}}
@@ -407,8 +414,10 @@ https://github.com/OpenAPITools/openapi-generator/blob/c84b949df1a9ec04ba75989cb
         _field_dict = {}
         if self.{{{name}}}:
             for _key_{{{name}}} in self.{{{name}}}:
-                if self.{{{name}}}[_key_{{{name}}}]:
+                if self.{{{name}}}[_key_{{{name}}}] is not None:
                     _field_dict[_key_{{{name}}}] = {{#compatibleWithPythonLegacy}}_to_openapi_value(self.{{{name}}}[_key_{{{name}}}]){{/compatibleWithPythonLegacy}}{{^compatibleWithPythonLegacy}}self.{{{name}}}[_key_{{{name}}}].to_dict(){{/compatibleWithPythonLegacy}}
+                else:
+                    _field_dict[_key_{{{name}}}] = None
             _dict[{{#lambda.pythonSingleQuotedStringLiteral}}{{{baseName}}}{{/lambda.pythonSingleQuotedStringLiteral}}] = _field_dict
         {{/items.isEnumOrRef}}
         {{/items.isPrimitiveType}}
@@ -512,7 +521,7 @@ https://github.com/OpenAPITools/openapi-generator/blob/c84b949df1a9ec04ba75989cb
             {{/items.items.isPrimitiveType}}
             {{^items.items.isPrimitiveType}}
             {{{vendorExtensions.x-py-wire-name-literal}}}: [
-                    [{{{items.items.dataType}}}.from_dict(_inner_item) for _inner_item in _item]
+                    [{{{items.items.dataType}}}.from_dict(_inner_item) for _inner_item in _item] if _item is not None else None
                     for _item in obj[{{{vendorExtensions.x-py-wire-name-literal}}}]
                 ] if obj.get({{{vendorExtensions.x-py-wire-name-literal}}}) is not None else None{{^-last}},{{/-last}}
             {{/items.items.isPrimitiveType}}
@@ -523,7 +532,7 @@ https://github.com/OpenAPITools/openapi-generator/blob/c84b949df1a9ec04ba75989cb
             {{/items.items.isPrimitiveType}}
             {{^items.items.isPrimitiveType}}
             {{{vendorExtensions.x-py-wire-name-literal}}}: [
-                    {_inner_key: {{{items.items.dataType}}}.from_dict(_inner_value) for _inner_key, _inner_value in _item.items()}
+                    {_inner_key: {{{items.items.dataType}}}.from_dict(_inner_value) for _inner_key, _inner_value in _item.items()} if _item is not None else None
                     for _item in obj[{{{vendorExtensions.x-py-wire-name-literal}}}]
                 ] if obj.get({{{vendorExtensions.x-py-wire-name-literal}}}) is not None else None{{^-last}},{{/-last}}
             {{/items.items.isPrimitiveType}}
@@ -594,12 +603,12 @@ https://github.com/OpenAPITools/openapi-generator/blob/c84b949df1a9ec04ba75989cb
             {{{vendorExtensions.x-py-wire-name-literal}}}: {{{dataType}}}.from_dict(obj[{{{vendorExtensions.x-py-wire-name-literal}}}]) if obj.get({{{vendorExtensions.x-py-wire-name-literal}}}) is not None else None{{^-last}},{{/-last}}
             {{/isEnumOrRef}}
             {{#isEnumOrRef}}
-            {{{vendorExtensions.x-py-wire-name-literal}}}: obj.get({{{vendorExtensions.x-py-wire-name-literal}}}){{#defaultValue}} if obj.get({{{vendorExtensions.x-py-wire-name-literal}}}) is not None else {{{defaultValue}}}{{/defaultValue}}{{^-last}},{{/-last}}
+            {{{vendorExtensions.x-py-wire-name-literal}}}: obj.get({{{vendorExtensions.x-py-wire-name-literal}}}){{#defaultValue}} if {{#isNullable}}{{{vendorExtensions.x-py-wire-name-literal}}} in obj{{/isNullable}}{{^isNullable}}obj.get({{{vendorExtensions.x-py-wire-name-literal}}}) is not None{{/isNullable}} else {{{defaultValue}}}{{/defaultValue}}{{^-last}},{{/-last}}
             {{/isEnumOrRef}}
             {{/isPrimitiveType}}
             {{#isPrimitiveType}}
             {{#defaultValue}}
-            {{{vendorExtensions.x-py-wire-name-literal}}}: obj.get({{{vendorExtensions.x-py-wire-name-literal}}}) if obj.get({{{vendorExtensions.x-py-wire-name-literal}}}) is not None else {{{defaultValue}}}{{^-last}},{{/-last}}
+            {{{vendorExtensions.x-py-wire-name-literal}}}: obj.get({{{vendorExtensions.x-py-wire-name-literal}}}) if {{#isNullable}}{{{vendorExtensions.x-py-wire-name-literal}}} in obj{{/isNullable}}{{^isNullable}}obj.get({{{vendorExtensions.x-py-wire-name-literal}}}) is not None{{/isNullable}} else {{{defaultValue}}}{{^-last}},{{/-last}}
             {{/defaultValue}}
             {{^defaultValue}}
             {{{vendorExtensions.x-py-wire-name-literal}}}: obj.get({{{vendorExtensions.x-py-wire-name-literal}}}){{^-last}},{{/-last}}

--- a/modules/openapi-generator/src/main/resources/python/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_generic.mustache
@@ -336,12 +336,9 @@ https://github.com/OpenAPITools/openapi-generator/blob/c84b949df1a9ec04ba75989cb
         _items = []
         if self.{{{name}}}:
             for _item_{{{name}}} in self.{{{name}}}:
-                if _item_{{{name}}} is not None:
-                    _items.append(
-                         [{{#compatibleWithPythonLegacy}}_to_openapi_value(_inner_item){{/compatibleWithPythonLegacy}}{{^compatibleWithPythonLegacy}}_inner_item.to_dict(){{/compatibleWithPythonLegacy}} if _inner_item is not None else None for _inner_item in _item_{{{name}}}]
-                    )
-                else:
-                    _items.append(None)
+                _items.append(
+                     [{{#compatibleWithPythonLegacy}}_to_openapi_value(_inner_item){{/compatibleWithPythonLegacy}}{{^compatibleWithPythonLegacy}}_inner_item.to_dict(){{/compatibleWithPythonLegacy}} if _inner_item is not None else None for _inner_item in _item_{{{name}}}] if _item_{{{name}}} is not None else None
+                )
             _dict[{{#lambda.pythonSingleQuotedStringLiteral}}{{{baseName}}}{{/lambda.pythonSingleQuotedStringLiteral}}] = _items
         {{/items.items.isPrimitiveType}}
         {{/items.isArray}}
@@ -351,12 +348,9 @@ https://github.com/OpenAPITools/openapi-generator/blob/c84b949df1a9ec04ba75989cb
         _items = []
         if self.{{{name}}}:
             for _item_{{{name}}} in self.{{{name}}}:
-                if _item_{{{name}}} is not None:
-                    _items.append(
-                         {_inner_key: {{#compatibleWithPythonLegacy}}_to_openapi_value(_inner_value){{/compatibleWithPythonLegacy}}{{^compatibleWithPythonLegacy}}_inner_value.to_dict(){{/compatibleWithPythonLegacy}} if _inner_value is not None else None for _inner_key, _inner_value in _item_{{{name}}}.items()}
-                    )
-                else:
-                    _items.append(None)
+                _items.append(
+                     {_inner_key: {{#compatibleWithPythonLegacy}}_to_openapi_value(_inner_value){{/compatibleWithPythonLegacy}}{{^compatibleWithPythonLegacy}}_inner_value.to_dict(){{/compatibleWithPythonLegacy}} if _inner_value is not None else None for _inner_key, _inner_value in _item_{{{name}}}.items()} if _item_{{{name}}} is not None else None
+                )
             _dict[{{#lambda.pythonSingleQuotedStringLiteral}}{{{baseName}}}{{/lambda.pythonSingleQuotedStringLiteral}}] = _items
         {{/items.items.isPrimitiveType}}
         {{/items.isMap}}
@@ -382,12 +376,9 @@ https://github.com/OpenAPITools/openapi-generator/blob/c84b949df1a9ec04ba75989cb
         _field_dict_of_array = {}
         if self.{{{name}}}:
             for _key_{{{name}}} in self.{{{name}}}:
-                if self.{{{name}}}[_key_{{{name}}}] is not None:
-                    _field_dict_of_array[_key_{{{name}}}] = [
-                        {{#compatibleWithPythonLegacy}}_to_openapi_value(_item){{/compatibleWithPythonLegacy}}{{^compatibleWithPythonLegacy}}_item.to_dict(){{/compatibleWithPythonLegacy}} if _item is not None else None for _item in self.{{{name}}}[_key_{{{name}}}]
-                    ]
-                else:
-                    _field_dict_of_array[_key_{{{name}}}] = None
+                _field_dict_of_array[_key_{{{name}}}] = [
+                    {{#compatibleWithPythonLegacy}}_to_openapi_value(_item){{/compatibleWithPythonLegacy}}{{^compatibleWithPythonLegacy}}_item.to_dict(){{/compatibleWithPythonLegacy}} if _item is not None else None for _item in self.{{{name}}}[_key_{{{name}}}]
+                ] if self.{{{name}}}[_key_{{{name}}}] is not None else None
             _dict[{{#lambda.pythonSingleQuotedStringLiteral}}{{{baseName}}}{{/lambda.pythonSingleQuotedStringLiteral}}] = _field_dict_of_array
         {{/items.items.isPrimitiveType}}
         {{/items.isArray}}
@@ -397,12 +388,9 @@ https://github.com/OpenAPITools/openapi-generator/blob/c84b949df1a9ec04ba75989cb
         _field_dict_of_dict = {}
         if self.{{{name}}}:
             for _key_{{{name}}}, _value_{{{name}}} in self.{{{name}}}.items():
-                if _value_{{{name}}} is not None:
-                    _field_dict_of_dict[_key_{{{name}}}] = {
-                        _key: {{#compatibleWithPythonLegacy}}_to_openapi_value(_value){{/compatibleWithPythonLegacy}}{{^compatibleWithPythonLegacy}}_value.to_dict(){{/compatibleWithPythonLegacy}} if _value is not None else None for _key, _value in _value_{{{name}}}.items()
-                    }
-                else:
-                    _field_dict_of_dict[_key_{{{name}}}] = None
+                _field_dict_of_dict[_key_{{{name}}}] = {
+                    _key: {{#compatibleWithPythonLegacy}}_to_openapi_value(_value){{/compatibleWithPythonLegacy}}{{^compatibleWithPythonLegacy}}_value.to_dict(){{/compatibleWithPythonLegacy}} if _value is not None else None for _key, _value in _value_{{{name}}}.items()
+                } if _value_{{{name}}} is not None else None
             _dict[{{#lambda.pythonSingleQuotedStringLiteral}}{{{baseName}}}{{/lambda.pythonSingleQuotedStringLiteral}}] = _field_dict_of_dict
         {{/items.items.isPrimitiveType}}
         {{/items.isMap}}
@@ -414,10 +402,7 @@ https://github.com/OpenAPITools/openapi-generator/blob/c84b949df1a9ec04ba75989cb
         _field_dict = {}
         if self.{{{name}}}:
             for _key_{{{name}}} in self.{{{name}}}:
-                if self.{{{name}}}[_key_{{{name}}}] is not None:
-                    _field_dict[_key_{{{name}}}] = {{#compatibleWithPythonLegacy}}_to_openapi_value(self.{{{name}}}[_key_{{{name}}}]){{/compatibleWithPythonLegacy}}{{^compatibleWithPythonLegacy}}self.{{{name}}}[_key_{{{name}}}].to_dict(){{/compatibleWithPythonLegacy}}
-                else:
-                    _field_dict[_key_{{{name}}}] = None
+                _field_dict[_key_{{{name}}}] = {{#compatibleWithPythonLegacy}}_to_openapi_value(self.{{{name}}}[_key_{{{name}}}]){{/compatibleWithPythonLegacy}}{{^compatibleWithPythonLegacy}}self.{{{name}}}[_key_{{{name}}}].to_dict(){{/compatibleWithPythonLegacy}} if self.{{{name}}}[_key_{{{name}}}] is not None else None
             _dict[{{#lambda.pythonSingleQuotedStringLiteral}}{{{baseName}}}{{/lambda.pythonSingleQuotedStringLiteral}}] = _field_dict
         {{/items.isEnumOrRef}}
         {{/items.isPrimitiveType}}

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/pet.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/pet.py
@@ -94,8 +94,7 @@ class Pet(BaseModel):
         _items = []
         if self.tags:
             for _item_tags in self.tags:
-                if _item_tags:
-                    _items.append(_item_tags.to_dict())
+                _items.append(_item_tags.to_dict() if _item_tags is not None else None)
             _dict['tags'] = _items
         return _dict
 

--- a/samples/client/echo_api/python/openapi_client/models/pet.py
+++ b/samples/client/echo_api/python/openapi_client/models/pet.py
@@ -94,8 +94,7 @@ class Pet(BaseModel):
         _items = []
         if self.tags:
             for _item_tags in self.tags:
-                if _item_tags:
-                    _items.append(_item_tags.to_dict())
+                _items.append(_item_tags.to_dict() if _item_tags is not None else None)
             _dict['tags'] = _items
         return _dict
 

--- a/samples/client/others/python-legacy-model-dictionaries/legacy_model_dict_client/models/legacy_model.py
+++ b/samples/client/others/python-legacy-model-dictionaries/legacy_model_dict_client/models/legacy_model.py
@@ -334,54 +334,39 @@ class LegacyModel(BaseModel):
         _field_dict = {}
         if self.nested_map:
             for _key_nested_map in self.nested_map:
-                if self.nested_map[_key_nested_map] is not None:
-                    _field_dict[_key_nested_map] = _to_openapi_value(self.nested_map[_key_nested_map])
-                else:
-                    _field_dict[_key_nested_map] = None
+                _field_dict[_key_nested_map] = _to_openapi_value(self.nested_map[_key_nested_map]) if self.nested_map[_key_nested_map] is not None else None
             _dict['nestedMap'] = _field_dict
         # override the default output from pydantic by calling `to_dict()` of each item in nested_lists (list of list)
         _items = []
         if self.nested_lists:
             for _item_nested_lists in self.nested_lists:
-                if _item_nested_lists is not None:
-                    _items.append(
-                         [_to_openapi_value(_inner_item) if _inner_item is not None else None for _inner_item in _item_nested_lists]
-                    )
-                else:
-                    _items.append(None)
+                _items.append(
+                     [_to_openapi_value(_inner_item) if _inner_item is not None else None for _inner_item in _item_nested_lists] if _item_nested_lists is not None else None
+                )
             _dict['nestedLists'] = _items
         # override the default output from pydantic by calling `to_dict()` of each item in nested_maps (list of dict)
         _items = []
         if self.nested_maps:
             for _item_nested_maps in self.nested_maps:
-                if _item_nested_maps is not None:
-                    _items.append(
-                         {_inner_key: _to_openapi_value(_inner_value) if _inner_value is not None else None for _inner_key, _inner_value in _item_nested_maps.items()}
-                    )
-                else:
-                    _items.append(None)
+                _items.append(
+                     {_inner_key: _to_openapi_value(_inner_value) if _inner_value is not None else None for _inner_key, _inner_value in _item_nested_maps.items()} if _item_nested_maps is not None else None
+                )
             _dict['nestedMaps'] = _items
         # override the default output from pydantic by calling `to_dict()` of each value in map_of_lists (dict of array)
         _field_dict_of_array = {}
         if self.map_of_lists:
             for _key_map_of_lists in self.map_of_lists:
-                if self.map_of_lists[_key_map_of_lists] is not None:
-                    _field_dict_of_array[_key_map_of_lists] = [
-                        _to_openapi_value(_item) if _item is not None else None for _item in self.map_of_lists[_key_map_of_lists]
-                    ]
-                else:
-                    _field_dict_of_array[_key_map_of_lists] = None
+                _field_dict_of_array[_key_map_of_lists] = [
+                    _to_openapi_value(_item) if _item is not None else None for _item in self.map_of_lists[_key_map_of_lists]
+                ] if self.map_of_lists[_key_map_of_lists] is not None else None
             _dict['mapOfLists'] = _field_dict_of_array
         # override the default output from pydantic by calling `to_dict()` of each value in map_of_maps (dict of dict)
         _field_dict_of_dict = {}
         if self.map_of_maps:
             for _key_map_of_maps, _value_map_of_maps in self.map_of_maps.items():
-                if _value_map_of_maps is not None:
-                    _field_dict_of_dict[_key_map_of_maps] = {
-                        _key: _to_openapi_value(_value) if _value is not None else None for _key, _value in _value_map_of_maps.items()
-                    }
-                else:
-                    _field_dict_of_dict[_key_map_of_maps] = None
+                _field_dict_of_dict[_key_map_of_maps] = {
+                    _key: _to_openapi_value(_value) if _value is not None else None for _key, _value in _value_map_of_maps.items()
+                } if _value_map_of_maps is not None else None
             _dict['mapOfMaps'] = _field_dict_of_dict
         # set to None if nullable_value (nullable) is None
         # and model_fields_set contains the field

--- a/samples/client/others/python-legacy-model-dictionaries/legacy_model_dict_client/models/legacy_model.py
+++ b/samples/client/others/python-legacy-model-dictionaries/legacy_model_dict_client/models/legacy_model.py
@@ -328,33 +328,38 @@ class LegacyModel(BaseModel):
         _items = []
         if self.nested_list:
             for _item_nested_list in self.nested_list:
-                if _item_nested_list:
-                    _items.append(_to_openapi_value(_item_nested_list))
+                _items.append(_to_openapi_value(_item_nested_list) if _item_nested_list is not None else None)
             _dict['nestedList'] = _items
         # override the default output from pydantic by calling `to_dict()` of each value in nested_map (dict)
         _field_dict = {}
         if self.nested_map:
             for _key_nested_map in self.nested_map:
-                if self.nested_map[_key_nested_map]:
+                if self.nested_map[_key_nested_map] is not None:
                     _field_dict[_key_nested_map] = _to_openapi_value(self.nested_map[_key_nested_map])
+                else:
+                    _field_dict[_key_nested_map] = None
             _dict['nestedMap'] = _field_dict
         # override the default output from pydantic by calling `to_dict()` of each item in nested_lists (list of list)
         _items = []
         if self.nested_lists:
             for _item_nested_lists in self.nested_lists:
-                if _item_nested_lists:
+                if _item_nested_lists is not None:
                     _items.append(
-                         [_to_openapi_value(_inner_item) for _inner_item in _item_nested_lists if _inner_item is not None]
+                         [_to_openapi_value(_inner_item) if _inner_item is not None else None for _inner_item in _item_nested_lists]
                     )
+                else:
+                    _items.append(None)
             _dict['nestedLists'] = _items
         # override the default output from pydantic by calling `to_dict()` of each item in nested_maps (list of dict)
         _items = []
         if self.nested_maps:
             for _item_nested_maps in self.nested_maps:
-                if _item_nested_maps:
+                if _item_nested_maps is not None:
                     _items.append(
-                         {_inner_key: _to_openapi_value(_inner_value) for _inner_key, _inner_value in _item_nested_maps.items()}
+                         {_inner_key: _to_openapi_value(_inner_value) if _inner_value is not None else None for _inner_key, _inner_value in _item_nested_maps.items()}
                     )
+                else:
+                    _items.append(None)
             _dict['nestedMaps'] = _items
         # override the default output from pydantic by calling `to_dict()` of each value in map_of_lists (dict of array)
         _field_dict_of_array = {}
@@ -362,8 +367,10 @@ class LegacyModel(BaseModel):
             for _key_map_of_lists in self.map_of_lists:
                 if self.map_of_lists[_key_map_of_lists] is not None:
                     _field_dict_of_array[_key_map_of_lists] = [
-                        _to_openapi_value(_item) for _item in self.map_of_lists[_key_map_of_lists]
+                        _to_openapi_value(_item) if _item is not None else None for _item in self.map_of_lists[_key_map_of_lists]
                     ]
+                else:
+                    _field_dict_of_array[_key_map_of_lists] = None
             _dict['mapOfLists'] = _field_dict_of_array
         # override the default output from pydantic by calling `to_dict()` of each value in map_of_maps (dict of dict)
         _field_dict_of_dict = {}
@@ -371,8 +378,10 @@ class LegacyModel(BaseModel):
             for _key_map_of_maps, _value_map_of_maps in self.map_of_maps.items():
                 if _value_map_of_maps is not None:
                     _field_dict_of_dict[_key_map_of_maps] = {
-                        _key: _to_openapi_value(_value) for _key, _value in _value_map_of_maps.items()
+                        _key: _to_openapi_value(_value) if _value is not None else None for _key, _value in _value_map_of_maps.items()
                     }
+                else:
+                    _field_dict_of_dict[_key_map_of_maps] = None
             _dict['mapOfMaps'] = _field_dict_of_dict
         # set to None if nullable_value (nullable) is None
         # and model_fields_set contains the field
@@ -424,11 +433,11 @@ class LegacyModel(BaseModel):
             if obj.get("nestedMap") is not None
             else None,
             "nestedLists": [
-                    [NestedModel.from_dict(_inner_item) for _inner_item in _item]
+                    [NestedModel.from_dict(_inner_item) for _inner_item in _item] if _item is not None else None
                     for _item in obj["nestedLists"]
                 ] if obj.get("nestedLists") is not None else None,
             "nestedMaps": [
-                    {_inner_key: NestedModel.from_dict(_inner_value) for _inner_key, _inner_value in _item.items()}
+                    {_inner_key: NestedModel.from_dict(_inner_value) for _inner_key, _inner_value in _item.items()} if _item is not None else None
                     for _item in obj["nestedMaps"]
                 ] if obj.get("nestedMaps") is not None else None,
             "mapOfLists": {

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_class.py
@@ -76,12 +76,9 @@ class AdditionalPropertiesClass(BaseModel):
         _field_dict_of_dict = {}
         if self.map_of_map_non_primitive_property:
             for _key_map_of_map_non_primitive_property, _value_map_of_map_non_primitive_property in self.map_of_map_non_primitive_property.items():
-                if _value_map_of_map_non_primitive_property is not None:
-                    _field_dict_of_dict[_key_map_of_map_non_primitive_property] = {
-                        _key: _value.to_dict() if _value is not None else None for _key, _value in _value_map_of_map_non_primitive_property.items()
-                    }
-                else:
-                    _field_dict_of_dict[_key_map_of_map_non_primitive_property] = None
+                _field_dict_of_dict[_key_map_of_map_non_primitive_property] = {
+                    _key: _value.to_dict() if _value is not None else None for _key, _value in _value_map_of_map_non_primitive_property.items()
+                } if _value_map_of_map_non_primitive_property is not None else None
             _dict['map_of_map_non_primitive_property'] = _field_dict_of_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_class.py
@@ -78,8 +78,10 @@ class AdditionalPropertiesClass(BaseModel):
             for _key_map_of_map_non_primitive_property, _value_map_of_map_non_primitive_property in self.map_of_map_non_primitive_property.items():
                 if _value_map_of_map_non_primitive_property is not None:
                     _field_dict_of_dict[_key_map_of_map_non_primitive_property] = {
-                        _key: _value.to_dict() for _key, _value in _value_map_of_map_non_primitive_property.items()
+                        _key: _value.to_dict() if _value is not None else None for _key, _value in _value_map_of_map_non_primitive_property.items()
                     }
+                else:
+                    _field_dict_of_dict[_key_map_of_map_non_primitive_property] = None
             _dict['map_of_map_non_primitive_property'] = _field_dict_of_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
@@ -56,7 +56,7 @@ class Animal(BaseModel):
     @classmethod
     def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
         """Returns the discriminator value (object type) of the data"""
-        discriminator_value = obj[cls.__discriminator_property_name]
+        discriminator_value = obj.get(cls.__discriminator_property_name)
         if discriminator_value:
             return cls.__discriminator_value_class_map.get(discriminator_value)
         else:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_model.py
@@ -74,12 +74,9 @@ class ArrayOfArrayOfModel(BaseModel):
         _items = []
         if self.another_property:
             for _item_another_property in self.another_property:
-                if _item_another_property is not None:
-                    _items.append(
-                         [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_another_property]
-                    )
-                else:
-                    _items.append(None)
+                _items.append(
+                     [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_another_property] if _item_another_property is not None else None
+                )
             _dict['another_property'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_model.py
@@ -74,10 +74,12 @@ class ArrayOfArrayOfModel(BaseModel):
         _items = []
         if self.another_property:
             for _item_another_property in self.another_property:
-                if _item_another_property:
+                if _item_another_property is not None:
                     _items.append(
-                         [_inner_item.to_dict() for _inner_item in _item_another_property if _inner_item is not None]
+                         [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_another_property]
                     )
+                else:
+                    _items.append(None)
             _dict['another_property'] = _items
         return _dict
 
@@ -92,7 +94,7 @@ class ArrayOfArrayOfModel(BaseModel):
 
         _obj = cls.model_validate({
             "another_property": [
-                    [Tag.from_dict(_inner_item) for _inner_item in _item]
+                    [Tag.from_dict(_inner_item) for _inner_item in _item] if _item is not None else None
                     for _item in obj["another_property"]
                 ] if obj.get("another_property") is not None else None
         })

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_map_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_map_model.py
@@ -74,10 +74,12 @@ class ArrayOfMapModel(BaseModel):
         _items = []
         if self.array_of_map_property:
             for _item_array_of_map_property in self.array_of_map_property:
-                if _item_array_of_map_property:
+                if _item_array_of_map_property is not None:
                     _items.append(
-                         {_inner_key: _inner_value.to_dict() for _inner_key, _inner_value in _item_array_of_map_property.items()}
+                         {_inner_key: _inner_value.to_dict() if _inner_value is not None else None for _inner_key, _inner_value in _item_array_of_map_property.items()}
                     )
+                else:
+                    _items.append(None)
             _dict['array_of_map_property'] = _items
         return _dict
 
@@ -92,7 +94,7 @@ class ArrayOfMapModel(BaseModel):
 
         _obj = cls.model_validate({
             "array_of_map_property": [
-                    {_inner_key: Tag.from_dict(_inner_value) for _inner_key, _inner_value in _item.items()}
+                    {_inner_key: Tag.from_dict(_inner_value) for _inner_key, _inner_value in _item.items()} if _item is not None else None
                     for _item in obj["array_of_map_property"]
                 ] if obj.get("array_of_map_property") is not None else None
         })

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_map_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_map_model.py
@@ -74,12 +74,9 @@ class ArrayOfMapModel(BaseModel):
         _items = []
         if self.array_of_map_property:
             for _item_array_of_map_property in self.array_of_map_property:
-                if _item_array_of_map_property is not None:
-                    _items.append(
-                         {_inner_key: _inner_value.to_dict() if _inner_value is not None else None for _inner_key, _inner_value in _item_array_of_map_property.items()}
-                    )
-                else:
-                    _items.append(None)
+                _items.append(
+                     {_inner_key: _inner_value.to_dict() if _inner_value is not None else None for _inner_key, _inner_value in _item_array_of_map_property.items()} if _item_array_of_map_property is not None else None
+                )
             _dict['array_of_map_property'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_test.py
@@ -78,12 +78,9 @@ class ArrayTest(BaseModel):
         _items = []
         if self.array_array_of_model:
             for _item_array_array_of_model in self.array_array_of_model:
-                if _item_array_array_of_model is not None:
-                    _items.append(
-                         [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_array_array_of_model]
-                    )
-                else:
-                    _items.append(None)
+                _items.append(
+                     [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_array_array_of_model] if _item_array_array_of_model is not None else None
+                )
             _dict['array_array_of_model'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_test.py
@@ -78,10 +78,12 @@ class ArrayTest(BaseModel):
         _items = []
         if self.array_array_of_model:
             for _item_array_array_of_model in self.array_array_of_model:
-                if _item_array_array_of_model:
+                if _item_array_array_of_model is not None:
                     _items.append(
-                         [_inner_item.to_dict() for _inner_item in _item_array_array_of_model if _inner_item is not None]
+                         [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_array_array_of_model]
                     )
+                else:
+                    _items.append(None)
             _dict['array_array_of_model'] = _items
         return _dict
 
@@ -99,7 +101,7 @@ class ArrayTest(BaseModel):
             "array_of_nullable_float": obj.get("array_of_nullable_float"),
             "array_array_of_integer": obj.get("array_array_of_integer"),
             "array_array_of_model": [
-                    [ReadOnlyFirst.from_dict(_inner_item) for _inner_item in _item]
+                    [ReadOnlyFirst.from_dict(_inner_item) for _inner_item in _item] if _item is not None else None
                     for _item in obj["array_array_of_model"]
                 ] if obj.get("array_array_of_model") is not None else None
         })

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/base_discriminator.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/base_discriminator.py
@@ -55,7 +55,7 @@ class BaseDiscriminator(BaseModel):
     @classmethod
     def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
         """Returns the discriminator value (object type) of the data"""
-        discriminator_value = obj[cls.__discriminator_property_name]
+        discriminator_value = obj.get(cls.__discriminator_property_name)
         if discriminator_value:
             return cls.__discriminator_value_class_map.get(discriminator_value)
         else:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/circular_all_of_ref.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/circular_all_of_ref.py
@@ -74,8 +74,7 @@ class CircularAllOfRef(BaseModel):
         _items = []
         if self.second_circular_all_of_ref:
             for _item_second_circular_all_of_ref in self.second_circular_all_of_ref:
-                if _item_second_circular_all_of_ref:
-                    _items.append(_item_second_circular_all_of_ref.to_dict())
+                _items.append(_item_second_circular_all_of_ref.to_dict() if _item_second_circular_all_of_ref is not None else None)
             _dict['secondCircularAllOfRef'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature.py
@@ -56,7 +56,7 @@ class Creature(BaseModel):
     @classmethod
     def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
         """Returns the discriminator value (object type) of the data"""
-        discriminator_value = obj[cls.__discriminator_property_name]
+        discriminator_value = obj.get(cls.__discriminator_property_name)
         if discriminator_value:
             return cls.__discriminator_value_class_map.get(discriminator_value)
         else:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/discriminator_all_of_super.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/discriminator_all_of_super.py
@@ -54,7 +54,7 @@ class DiscriminatorAllOfSuper(BaseModel):
     @classmethod
     def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
         """Returns the discriminator value (object type) of the data"""
-        discriminator_value = obj[cls.__discriminator_property_name]
+        discriminator_value = obj.get(cls.__discriminator_property_name)
         if discriminator_value:
             return cls.__discriminator_value_class_map.get(discriminator_value)
         else:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file_schema_test_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file_schema_test_class.py
@@ -78,8 +78,7 @@ class FileSchemaTestClass(BaseModel):
         _items = []
         if self.files:
             for _item_files in self.files:
-                if _item_files:
-                    _items.append(_item_files.to_dict())
+                _items.append(_item_files.to_dict() if _item_files is not None else None)
             _dict['files'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/input_all_of.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/input_all_of.py
@@ -74,10 +74,7 @@ class InputAllOf(BaseModel):
         _field_dict = {}
         if self.some_data:
             for _key_some_data in self.some_data:
-                if self.some_data[_key_some_data] is not None:
-                    _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict()
-                else:
-                    _field_dict[_key_some_data] = None
+                _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict() if self.some_data[_key_some_data] is not None else None
             _dict['some_data'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/input_all_of.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/input_all_of.py
@@ -74,8 +74,10 @@ class InputAllOf(BaseModel):
         _field_dict = {}
         if self.some_data:
             for _key_some_data in self.some_data:
-                if self.some_data[_key_some_data]:
+                if self.some_data[_key_some_data] is not None:
                     _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict()
+                else:
+                    _field_dict[_key_some_data] = None
             _dict['some_data'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_of_array_of_model.py
@@ -74,12 +74,9 @@ class MapOfArrayOfModel(BaseModel):
         _field_dict_of_array = {}
         if self.shop_id_to_org_online_lip_map:
             for _key_shop_id_to_org_online_lip_map in self.shop_id_to_org_online_lip_map:
-                if self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map] is not None:
-                    _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = [
-                        _item.to_dict() if _item is not None else None for _item in self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map]
-                    ]
-                else:
-                    _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = None
+                _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = [
+                    _item.to_dict() if _item is not None else None for _item in self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map]
+                ] if self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map] is not None else None
             _dict['shopIdToOrgOnlineLipMap'] = _field_dict_of_array
         return _dict
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_of_array_of_model.py
@@ -76,8 +76,10 @@ class MapOfArrayOfModel(BaseModel):
             for _key_shop_id_to_org_online_lip_map in self.shop_id_to_org_online_lip_map:
                 if self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map] is not None:
                     _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = [
-                        _item.to_dict() for _item in self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map]
+                        _item.to_dict() if _item is not None else None for _item in self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map]
                     ]
+                else:
+                    _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = None
             _dict['shopIdToOrgOnlineLipMap'] = _field_dict_of_array
         return _dict
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -78,10 +78,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
         _field_dict = {}
         if self.map:
             for _key_map in self.map:
-                if self.map[_key_map] is not None:
-                    _field_dict[_key_map] = self.map[_key_map].to_dict()
-                else:
-                    _field_dict[_key_map] = None
+                _field_dict[_key_map] = self.map[_key_map].to_dict() if self.map[_key_map] is not None else None
             _dict['map'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -78,8 +78,10 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
         _field_dict = {}
         if self.map:
             for _key_map in self.map:
-                if self.map[_key_map]:
+                if self.map[_key_map] is not None:
                     _field_dict[_key_map] = self.map[_key_map].to_dict()
+                else:
+                    _field_dict[_key_map] = None
             _dict['map'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/multi_arrays.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/multi_arrays.py
@@ -76,15 +76,13 @@ class MultiArrays(BaseModel):
         _items = []
         if self.tags:
             for _item_tags in self.tags:
-                if _item_tags:
-                    _items.append(_item_tags.to_dict())
+                _items.append(_item_tags.to_dict() if _item_tags is not None else None)
             _dict['tags'] = _items
         # override the default output from pydantic by calling `to_dict()` of each item in files (list)
         _items = []
         if self.files:
             for _item_files in self.files:
-                if _item_files:
-                    _items.append(_item_files.to_dict())
+                _items.append(_item_files.to_dict() if _item_files is not None else None)
             _dict['files'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent.py
@@ -74,8 +74,10 @@ class Parent(BaseModel):
         _field_dict = {}
         if self.optional_dict:
             for _key_optional_dict in self.optional_dict:
-                if self.optional_dict[_key_optional_dict]:
+                if self.optional_dict[_key_optional_dict] is not None:
                     _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict()
+                else:
+                    _field_dict[_key_optional_dict] = None
             _dict['optionalDict'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent.py
@@ -74,10 +74,7 @@ class Parent(BaseModel):
         _field_dict = {}
         if self.optional_dict:
             for _key_optional_dict in self.optional_dict:
-                if self.optional_dict[_key_optional_dict] is not None:
-                    _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict()
-                else:
-                    _field_dict[_key_optional_dict] = None
+                _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict() if self.optional_dict[_key_optional_dict] is not None else None
             _dict['optionalDict'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent_with_optional_dict.py
@@ -74,8 +74,10 @@ class ParentWithOptionalDict(BaseModel):
         _field_dict = {}
         if self.optional_dict:
             for _key_optional_dict in self.optional_dict:
-                if self.optional_dict[_key_optional_dict]:
+                if self.optional_dict[_key_optional_dict] is not None:
                     _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict()
+                else:
+                    _field_dict[_key_optional_dict] = None
             _dict['optionalDict'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent_with_optional_dict.py
@@ -74,10 +74,7 @@ class ParentWithOptionalDict(BaseModel):
         _field_dict = {}
         if self.optional_dict:
             for _key_optional_dict in self.optional_dict:
-                if self.optional_dict[_key_optional_dict] is not None:
-                    _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict()
-                else:
-                    _field_dict[_key_optional_dict] = None
+                _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict() if self.optional_dict[_key_optional_dict] is not None else None
             _dict['optionalDict'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/pet.py
@@ -94,8 +94,7 @@ class Pet(BaseModel):
         _items = []
         if self.tags:
             for _item_tags in self.tags:
-                if _item_tags:
-                    _items.append(_item_tags.to_dict())
+                _items.append(_item_tags.to_dict() if _item_tags is not None else None)
             _dict['tags'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/property_map.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/property_map.py
@@ -74,10 +74,7 @@ class PropertyMap(BaseModel):
         _field_dict = {}
         if self.some_data:
             for _key_some_data in self.some_data:
-                if self.some_data[_key_some_data] is not None:
-                    _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict()
-                else:
-                    _field_dict[_key_some_data] = None
+                _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict() if self.some_data[_key_some_data] is not None else None
             _dict['some_data'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/property_map.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/property_map.py
@@ -74,8 +74,10 @@ class PropertyMap(BaseModel):
         _field_dict = {}
         if self.some_data:
             for _key_some_data in self.some_data:
-                if self.some_data[_key_some_data]:
+                if self.some_data[_key_some_data] is not None:
                     _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict()
+                else:
+                    _field_dict[_key_some_data] = None
             _dict['some_data'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/second_circular_all_of_ref.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/second_circular_all_of_ref.py
@@ -74,8 +74,7 @@ class SecondCircularAllOfRef(BaseModel):
         _items = []
         if self.circular_all_of_ref:
             for _item_circular_all_of_ref in self.circular_all_of_ref:
-                if _item_circular_all_of_ref:
-                    _items.append(_item_circular_all_of_ref.to_dict())
+                _items.append(_item_circular_all_of_ref.to_dict() if _item_circular_all_of_ref is not None else None)
             _dict['circularAllOfRef'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -76,8 +76,10 @@ class UnnamedDictWithAdditionalModelListProperties(BaseModel):
             for _key_dict_property in self.dict_property:
                 if self.dict_property[_key_dict_property] is not None:
                     _field_dict_of_array[_key_dict_property] = [
-                        _item.to_dict() for _item in self.dict_property[_key_dict_property]
+                        _item.to_dict() if _item is not None else None for _item in self.dict_property[_key_dict_property]
                     ]
+                else:
+                    _field_dict_of_array[_key_dict_property] = None
             _dict['dictProperty'] = _field_dict_of_array
         return _dict
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -74,12 +74,9 @@ class UnnamedDictWithAdditionalModelListProperties(BaseModel):
         _field_dict_of_array = {}
         if self.dict_property:
             for _key_dict_property in self.dict_property:
-                if self.dict_property[_key_dict_property] is not None:
-                    _field_dict_of_array[_key_dict_property] = [
-                        _item.to_dict() if _item is not None else None for _item in self.dict_property[_key_dict_property]
-                    ]
-                else:
-                    _field_dict_of_array[_key_dict_property] = None
+                _field_dict_of_array[_key_dict_property] = [
+                    _item.to_dict() if _item is not None else None for _item in self.dict_property[_key_dict_property]
+                ] if self.dict_property[_key_dict_property] is not None else None
             _dict['dictProperty'] = _field_dict_of_array
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/additional_properties_class.py
@@ -76,12 +76,9 @@ class AdditionalPropertiesClass(BaseModel):
         _field_dict_of_dict = {}
         if self.map_of_map_non_primitive_property:
             for _key_map_of_map_non_primitive_property, _value_map_of_map_non_primitive_property in self.map_of_map_non_primitive_property.items():
-                if _value_map_of_map_non_primitive_property is not None:
-                    _field_dict_of_dict[_key_map_of_map_non_primitive_property] = {
-                        _key: _value.to_dict() if _value is not None else None for _key, _value in _value_map_of_map_non_primitive_property.items()
-                    }
-                else:
-                    _field_dict_of_dict[_key_map_of_map_non_primitive_property] = None
+                _field_dict_of_dict[_key_map_of_map_non_primitive_property] = {
+                    _key: _value.to_dict() if _value is not None else None for _key, _value in _value_map_of_map_non_primitive_property.items()
+                } if _value_map_of_map_non_primitive_property is not None else None
             _dict['map_of_map_non_primitive_property'] = _field_dict_of_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/additional_properties_class.py
@@ -78,8 +78,10 @@ class AdditionalPropertiesClass(BaseModel):
             for _key_map_of_map_non_primitive_property, _value_map_of_map_non_primitive_property in self.map_of_map_non_primitive_property.items():
                 if _value_map_of_map_non_primitive_property is not None:
                     _field_dict_of_dict[_key_map_of_map_non_primitive_property] = {
-                        _key: _value.to_dict() for _key, _value in _value_map_of_map_non_primitive_property.items()
+                        _key: _value.to_dict() if _value is not None else None for _key, _value in _value_map_of_map_non_primitive_property.items()
                     }
+                else:
+                    _field_dict_of_dict[_key_map_of_map_non_primitive_property] = None
             _dict['map_of_map_non_primitive_property'] = _field_dict_of_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/animal.py
@@ -56,7 +56,7 @@ class Animal(BaseModel):
     @classmethod
     def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
         """Returns the discriminator value (object type) of the data"""
-        discriminator_value = obj[cls.__discriminator_property_name]
+        discriminator_value = obj.get(cls.__discriminator_property_name)
         if discriminator_value:
             return cls.__discriminator_value_class_map.get(discriminator_value)
         else:

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/array_of_array_of_model.py
@@ -74,12 +74,9 @@ class ArrayOfArrayOfModel(BaseModel):
         _items = []
         if self.another_property:
             for _item_another_property in self.another_property:
-                if _item_another_property is not None:
-                    _items.append(
-                         [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_another_property]
-                    )
-                else:
-                    _items.append(None)
+                _items.append(
+                     [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_another_property] if _item_another_property is not None else None
+                )
             _dict['another_property'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/array_of_array_of_model.py
@@ -74,10 +74,12 @@ class ArrayOfArrayOfModel(BaseModel):
         _items = []
         if self.another_property:
             for _item_another_property in self.another_property:
-                if _item_another_property:
+                if _item_another_property is not None:
                     _items.append(
-                         [_inner_item.to_dict() for _inner_item in _item_another_property if _inner_item is not None]
+                         [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_another_property]
                     )
+                else:
+                    _items.append(None)
             _dict['another_property'] = _items
         return _dict
 
@@ -92,7 +94,7 @@ class ArrayOfArrayOfModel(BaseModel):
 
         _obj = cls.model_validate({
             "another_property": [
-                    [Tag.from_dict(_inner_item) for _inner_item in _item]
+                    [Tag.from_dict(_inner_item) for _inner_item in _item] if _item is not None else None
                     for _item in obj["another_property"]
                 ] if obj.get("another_property") is not None else None
         })

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/array_of_map_model.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/array_of_map_model.py
@@ -74,10 +74,12 @@ class ArrayOfMapModel(BaseModel):
         _items = []
         if self.array_of_map_property:
             for _item_array_of_map_property in self.array_of_map_property:
-                if _item_array_of_map_property:
+                if _item_array_of_map_property is not None:
                     _items.append(
-                         {_inner_key: _inner_value.to_dict() for _inner_key, _inner_value in _item_array_of_map_property.items()}
+                         {_inner_key: _inner_value.to_dict() if _inner_value is not None else None for _inner_key, _inner_value in _item_array_of_map_property.items()}
                     )
+                else:
+                    _items.append(None)
             _dict['array_of_map_property'] = _items
         return _dict
 
@@ -92,7 +94,7 @@ class ArrayOfMapModel(BaseModel):
 
         _obj = cls.model_validate({
             "array_of_map_property": [
-                    {_inner_key: Tag.from_dict(_inner_value) for _inner_key, _inner_value in _item.items()}
+                    {_inner_key: Tag.from_dict(_inner_value) for _inner_key, _inner_value in _item.items()} if _item is not None else None
                     for _item in obj["array_of_map_property"]
                 ] if obj.get("array_of_map_property") is not None else None
         })

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/array_of_map_model.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/array_of_map_model.py
@@ -74,12 +74,9 @@ class ArrayOfMapModel(BaseModel):
         _items = []
         if self.array_of_map_property:
             for _item_array_of_map_property in self.array_of_map_property:
-                if _item_array_of_map_property is not None:
-                    _items.append(
-                         {_inner_key: _inner_value.to_dict() if _inner_value is not None else None for _inner_key, _inner_value in _item_array_of_map_property.items()}
-                    )
-                else:
-                    _items.append(None)
+                _items.append(
+                     {_inner_key: _inner_value.to_dict() if _inner_value is not None else None for _inner_key, _inner_value in _item_array_of_map_property.items()} if _item_array_of_map_property is not None else None
+                )
             _dict['array_of_map_property'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/array_test.py
@@ -78,12 +78,9 @@ class ArrayTest(BaseModel):
         _items = []
         if self.array_array_of_model:
             for _item_array_array_of_model in self.array_array_of_model:
-                if _item_array_array_of_model is not None:
-                    _items.append(
-                         [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_array_array_of_model]
-                    )
-                else:
-                    _items.append(None)
+                _items.append(
+                     [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_array_array_of_model] if _item_array_array_of_model is not None else None
+                )
             _dict['array_array_of_model'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/array_test.py
@@ -78,10 +78,12 @@ class ArrayTest(BaseModel):
         _items = []
         if self.array_array_of_model:
             for _item_array_array_of_model in self.array_array_of_model:
-                if _item_array_array_of_model:
+                if _item_array_array_of_model is not None:
                     _items.append(
-                         [_inner_item.to_dict() for _inner_item in _item_array_array_of_model if _inner_item is not None]
+                         [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_array_array_of_model]
                     )
+                else:
+                    _items.append(None)
             _dict['array_array_of_model'] = _items
         return _dict
 
@@ -99,7 +101,7 @@ class ArrayTest(BaseModel):
             "array_of_nullable_float": obj.get("array_of_nullable_float"),
             "array_array_of_integer": obj.get("array_array_of_integer"),
             "array_array_of_model": [
-                    [ReadOnlyFirst.from_dict(_inner_item) for _inner_item in _item]
+                    [ReadOnlyFirst.from_dict(_inner_item) for _inner_item in _item] if _item is not None else None
                     for _item in obj["array_array_of_model"]
                 ] if obj.get("array_array_of_model") is not None else None
         })

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/base_discriminator.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/base_discriminator.py
@@ -55,7 +55,7 @@ class BaseDiscriminator(BaseModel):
     @classmethod
     def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
         """Returns the discriminator value (object type) of the data"""
-        discriminator_value = obj[cls.__discriminator_property_name]
+        discriminator_value = obj.get(cls.__discriminator_property_name)
         if discriminator_value:
             return cls.__discriminator_value_class_map.get(discriminator_value)
         else:

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/circular_all_of_ref.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/circular_all_of_ref.py
@@ -74,8 +74,7 @@ class CircularAllOfRef(BaseModel):
         _items = []
         if self.second_circular_all_of_ref:
             for _item_second_circular_all_of_ref in self.second_circular_all_of_ref:
-                if _item_second_circular_all_of_ref:
-                    _items.append(_item_second_circular_all_of_ref.to_dict())
+                _items.append(_item_second_circular_all_of_ref.to_dict() if _item_second_circular_all_of_ref is not None else None)
             _dict['secondCircularAllOfRef'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/creature.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/creature.py
@@ -56,7 +56,7 @@ class Creature(BaseModel):
     @classmethod
     def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
         """Returns the discriminator value (object type) of the data"""
-        discriminator_value = obj[cls.__discriminator_property_name]
+        discriminator_value = obj.get(cls.__discriminator_property_name)
         if discriminator_value:
             return cls.__discriminator_value_class_map.get(discriminator_value)
         else:

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/discriminator_all_of_super.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/discriminator_all_of_super.py
@@ -54,7 +54,7 @@ class DiscriminatorAllOfSuper(BaseModel):
     @classmethod
     def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
         """Returns the discriminator value (object type) of the data"""
-        discriminator_value = obj[cls.__discriminator_property_name]
+        discriminator_value = obj.get(cls.__discriminator_property_name)
         if discriminator_value:
             return cls.__discriminator_value_class_map.get(discriminator_value)
         else:

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/file_schema_test_class.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/file_schema_test_class.py
@@ -78,8 +78,7 @@ class FileSchemaTestClass(BaseModel):
         _items = []
         if self.files:
             for _item_files in self.files:
-                if _item_files:
-                    _items.append(_item_files.to_dict())
+                _items.append(_item_files.to_dict() if _item_files is not None else None)
             _dict['files'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/input_all_of.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/input_all_of.py
@@ -74,10 +74,7 @@ class InputAllOf(BaseModel):
         _field_dict = {}
         if self.some_data:
             for _key_some_data in self.some_data:
-                if self.some_data[_key_some_data] is not None:
-                    _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict()
-                else:
-                    _field_dict[_key_some_data] = None
+                _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict() if self.some_data[_key_some_data] is not None else None
             _dict['some_data'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/input_all_of.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/input_all_of.py
@@ -74,8 +74,10 @@ class InputAllOf(BaseModel):
         _field_dict = {}
         if self.some_data:
             for _key_some_data in self.some_data:
-                if self.some_data[_key_some_data]:
+                if self.some_data[_key_some_data] is not None:
                     _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict()
+                else:
+                    _field_dict[_key_some_data] = None
             _dict['some_data'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/map_of_array_of_model.py
@@ -74,12 +74,9 @@ class MapOfArrayOfModel(BaseModel):
         _field_dict_of_array = {}
         if self.shop_id_to_org_online_lip_map:
             for _key_shop_id_to_org_online_lip_map in self.shop_id_to_org_online_lip_map:
-                if self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map] is not None:
-                    _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = [
-                        _item.to_dict() if _item is not None else None for _item in self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map]
-                    ]
-                else:
-                    _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = None
+                _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = [
+                    _item.to_dict() if _item is not None else None for _item in self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map]
+                ] if self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map] is not None else None
             _dict['shopIdToOrgOnlineLipMap'] = _field_dict_of_array
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/map_of_array_of_model.py
@@ -76,8 +76,10 @@ class MapOfArrayOfModel(BaseModel):
             for _key_shop_id_to_org_online_lip_map in self.shop_id_to_org_online_lip_map:
                 if self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map] is not None:
                     _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = [
-                        _item.to_dict() for _item in self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map]
+                        _item.to_dict() if _item is not None else None for _item in self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map]
                     ]
+                else:
+                    _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = None
             _dict['shopIdToOrgOnlineLipMap'] = _field_dict_of_array
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -78,10 +78,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
         _field_dict = {}
         if self.map:
             for _key_map in self.map:
-                if self.map[_key_map] is not None:
-                    _field_dict[_key_map] = self.map[_key_map].to_dict()
-                else:
-                    _field_dict[_key_map] = None
+                _field_dict[_key_map] = self.map[_key_map].to_dict() if self.map[_key_map] is not None else None
             _dict['map'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -78,8 +78,10 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
         _field_dict = {}
         if self.map:
             for _key_map in self.map:
-                if self.map[_key_map]:
+                if self.map[_key_map] is not None:
                     _field_dict[_key_map] = self.map[_key_map].to_dict()
+                else:
+                    _field_dict[_key_map] = None
             _dict['map'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/multi_arrays.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/multi_arrays.py
@@ -76,15 +76,13 @@ class MultiArrays(BaseModel):
         _items = []
         if self.tags:
             for _item_tags in self.tags:
-                if _item_tags:
-                    _items.append(_item_tags.to_dict())
+                _items.append(_item_tags.to_dict() if _item_tags is not None else None)
             _dict['tags'] = _items
         # override the default output from pydantic by calling `to_dict()` of each item in files (list)
         _items = []
         if self.files:
             for _item_files in self.files:
-                if _item_files:
-                    _items.append(_item_files.to_dict())
+                _items.append(_item_files.to_dict() if _item_files is not None else None)
             _dict['files'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/parent.py
@@ -74,8 +74,10 @@ class Parent(BaseModel):
         _field_dict = {}
         if self.optional_dict:
             for _key_optional_dict in self.optional_dict:
-                if self.optional_dict[_key_optional_dict]:
+                if self.optional_dict[_key_optional_dict] is not None:
                     _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict()
+                else:
+                    _field_dict[_key_optional_dict] = None
             _dict['optionalDict'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/parent.py
@@ -74,10 +74,7 @@ class Parent(BaseModel):
         _field_dict = {}
         if self.optional_dict:
             for _key_optional_dict in self.optional_dict:
-                if self.optional_dict[_key_optional_dict] is not None:
-                    _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict()
-                else:
-                    _field_dict[_key_optional_dict] = None
+                _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict() if self.optional_dict[_key_optional_dict] is not None else None
             _dict['optionalDict'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/parent_with_optional_dict.py
@@ -74,8 +74,10 @@ class ParentWithOptionalDict(BaseModel):
         _field_dict = {}
         if self.optional_dict:
             for _key_optional_dict in self.optional_dict:
-                if self.optional_dict[_key_optional_dict]:
+                if self.optional_dict[_key_optional_dict] is not None:
                     _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict()
+                else:
+                    _field_dict[_key_optional_dict] = None
             _dict['optionalDict'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/parent_with_optional_dict.py
@@ -74,10 +74,7 @@ class ParentWithOptionalDict(BaseModel):
         _field_dict = {}
         if self.optional_dict:
             for _key_optional_dict in self.optional_dict:
-                if self.optional_dict[_key_optional_dict] is not None:
-                    _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict()
-                else:
-                    _field_dict[_key_optional_dict] = None
+                _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict() if self.optional_dict[_key_optional_dict] is not None else None
             _dict['optionalDict'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/pet.py
@@ -94,8 +94,7 @@ class Pet(BaseModel):
         _items = []
         if self.tags:
             for _item_tags in self.tags:
-                if _item_tags:
-                    _items.append(_item_tags.to_dict())
+                _items.append(_item_tags.to_dict() if _item_tags is not None else None)
             _dict['tags'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/property_map.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/property_map.py
@@ -74,10 +74,7 @@ class PropertyMap(BaseModel):
         _field_dict = {}
         if self.some_data:
             for _key_some_data in self.some_data:
-                if self.some_data[_key_some_data] is not None:
-                    _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict()
-                else:
-                    _field_dict[_key_some_data] = None
+                _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict() if self.some_data[_key_some_data] is not None else None
             _dict['some_data'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/property_map.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/property_map.py
@@ -74,8 +74,10 @@ class PropertyMap(BaseModel):
         _field_dict = {}
         if self.some_data:
             for _key_some_data in self.some_data:
-                if self.some_data[_key_some_data]:
+                if self.some_data[_key_some_data] is not None:
                     _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict()
+                else:
+                    _field_dict[_key_some_data] = None
             _dict['some_data'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/second_circular_all_of_ref.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/second_circular_all_of_ref.py
@@ -74,8 +74,7 @@ class SecondCircularAllOfRef(BaseModel):
         _items = []
         if self.circular_all_of_ref:
             for _item_circular_all_of_ref in self.circular_all_of_ref:
-                if _item_circular_all_of_ref:
-                    _items.append(_item_circular_all_of_ref.to_dict())
+                _items.append(_item_circular_all_of_ref.to_dict() if _item_circular_all_of_ref is not None else None)
             _dict['circularAllOfRef'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -76,8 +76,10 @@ class UnnamedDictWithAdditionalModelListProperties(BaseModel):
             for _key_dict_property in self.dict_property:
                 if self.dict_property[_key_dict_property] is not None:
                     _field_dict_of_array[_key_dict_property] = [
-                        _item.to_dict() for _item in self.dict_property[_key_dict_property]
+                        _item.to_dict() if _item is not None else None for _item in self.dict_property[_key_dict_property]
                     ]
+                else:
+                    _field_dict_of_array[_key_dict_property] = None
             _dict['dictProperty'] = _field_dict_of_array
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -74,12 +74,9 @@ class UnnamedDictWithAdditionalModelListProperties(BaseModel):
         _field_dict_of_array = {}
         if self.dict_property:
             for _key_dict_property in self.dict_property:
-                if self.dict_property[_key_dict_property] is not None:
-                    _field_dict_of_array[_key_dict_property] = [
-                        _item.to_dict() if _item is not None else None for _item in self.dict_property[_key_dict_property]
-                    ]
-                else:
-                    _field_dict_of_array[_key_dict_property] = None
+                _field_dict_of_array[_key_dict_property] = [
+                    _item.to_dict() if _item is not None else None for _item in self.dict_property[_key_dict_property]
+                ] if self.dict_property[_key_dict_property] is not None else None
             _dict['dictProperty'] = _field_dict_of_array
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/additional_properties_class.py
@@ -76,12 +76,9 @@ class AdditionalPropertiesClass(BaseModel):
         _field_dict_of_dict = {}
         if self.map_of_map_non_primitive_property:
             for _key_map_of_map_non_primitive_property, _value_map_of_map_non_primitive_property in self.map_of_map_non_primitive_property.items():
-                if _value_map_of_map_non_primitive_property is not None:
-                    _field_dict_of_dict[_key_map_of_map_non_primitive_property] = {
-                        _key: _value.to_dict() if _value is not None else None for _key, _value in _value_map_of_map_non_primitive_property.items()
-                    }
-                else:
-                    _field_dict_of_dict[_key_map_of_map_non_primitive_property] = None
+                _field_dict_of_dict[_key_map_of_map_non_primitive_property] = {
+                    _key: _value.to_dict() if _value is not None else None for _key, _value in _value_map_of_map_non_primitive_property.items()
+                } if _value_map_of_map_non_primitive_property is not None else None
             _dict['map_of_map_non_primitive_property'] = _field_dict_of_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/additional_properties_class.py
@@ -78,8 +78,10 @@ class AdditionalPropertiesClass(BaseModel):
             for _key_map_of_map_non_primitive_property, _value_map_of_map_non_primitive_property in self.map_of_map_non_primitive_property.items():
                 if _value_map_of_map_non_primitive_property is not None:
                     _field_dict_of_dict[_key_map_of_map_non_primitive_property] = {
-                        _key: _value.to_dict() for _key, _value in _value_map_of_map_non_primitive_property.items()
+                        _key: _value.to_dict() if _value is not None else None for _key, _value in _value_map_of_map_non_primitive_property.items()
                     }
+                else:
+                    _field_dict_of_dict[_key_map_of_map_non_primitive_property] = None
             _dict['map_of_map_non_primitive_property'] = _field_dict_of_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/animal.py
@@ -56,7 +56,7 @@ class Animal(BaseModel):
     @classmethod
     def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
         """Returns the discriminator value (object type) of the data"""
-        discriminator_value = obj[cls.__discriminator_property_name]
+        discriminator_value = obj.get(cls.__discriminator_property_name)
         if discriminator_value:
             return cls.__discriminator_value_class_map.get(discriminator_value)
         else:

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/array_of_array_of_model.py
@@ -74,12 +74,9 @@ class ArrayOfArrayOfModel(BaseModel):
         _items = []
         if self.another_property:
             for _item_another_property in self.another_property:
-                if _item_another_property is not None:
-                    _items.append(
-                         [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_another_property]
-                    )
-                else:
-                    _items.append(None)
+                _items.append(
+                     [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_another_property] if _item_another_property is not None else None
+                )
             _dict['another_property'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/array_of_array_of_model.py
@@ -74,10 +74,12 @@ class ArrayOfArrayOfModel(BaseModel):
         _items = []
         if self.another_property:
             for _item_another_property in self.another_property:
-                if _item_another_property:
+                if _item_another_property is not None:
                     _items.append(
-                         [_inner_item.to_dict() for _inner_item in _item_another_property if _inner_item is not None]
+                         [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_another_property]
                     )
+                else:
+                    _items.append(None)
             _dict['another_property'] = _items
         return _dict
 
@@ -92,7 +94,7 @@ class ArrayOfArrayOfModel(BaseModel):
 
         _obj = cls.model_validate({
             "another_property": [
-                    [Tag.from_dict(_inner_item) for _inner_item in _item]
+                    [Tag.from_dict(_inner_item) for _inner_item in _item] if _item is not None else None
                     for _item in obj["another_property"]
                 ] if obj.get("another_property") is not None else None
         })

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/array_of_map_model.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/array_of_map_model.py
@@ -74,10 +74,12 @@ class ArrayOfMapModel(BaseModel):
         _items = []
         if self.array_of_map_property:
             for _item_array_of_map_property in self.array_of_map_property:
-                if _item_array_of_map_property:
+                if _item_array_of_map_property is not None:
                     _items.append(
-                         {_inner_key: _inner_value.to_dict() for _inner_key, _inner_value in _item_array_of_map_property.items()}
+                         {_inner_key: _inner_value.to_dict() if _inner_value is not None else None for _inner_key, _inner_value in _item_array_of_map_property.items()}
                     )
+                else:
+                    _items.append(None)
             _dict['array_of_map_property'] = _items
         return _dict
 
@@ -92,7 +94,7 @@ class ArrayOfMapModel(BaseModel):
 
         _obj = cls.model_validate({
             "array_of_map_property": [
-                    {_inner_key: Tag.from_dict(_inner_value) for _inner_key, _inner_value in _item.items()}
+                    {_inner_key: Tag.from_dict(_inner_value) for _inner_key, _inner_value in _item.items()} if _item is not None else None
                     for _item in obj["array_of_map_property"]
                 ] if obj.get("array_of_map_property") is not None else None
         })

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/array_of_map_model.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/array_of_map_model.py
@@ -74,12 +74,9 @@ class ArrayOfMapModel(BaseModel):
         _items = []
         if self.array_of_map_property:
             for _item_array_of_map_property in self.array_of_map_property:
-                if _item_array_of_map_property is not None:
-                    _items.append(
-                         {_inner_key: _inner_value.to_dict() if _inner_value is not None else None for _inner_key, _inner_value in _item_array_of_map_property.items()}
-                    )
-                else:
-                    _items.append(None)
+                _items.append(
+                     {_inner_key: _inner_value.to_dict() if _inner_value is not None else None for _inner_key, _inner_value in _item_array_of_map_property.items()} if _item_array_of_map_property is not None else None
+                )
             _dict['array_of_map_property'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/array_test.py
@@ -78,12 +78,9 @@ class ArrayTest(BaseModel):
         _items = []
         if self.array_array_of_model:
             for _item_array_array_of_model in self.array_array_of_model:
-                if _item_array_array_of_model is not None:
-                    _items.append(
-                         [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_array_array_of_model]
-                    )
-                else:
-                    _items.append(None)
+                _items.append(
+                     [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_array_array_of_model] if _item_array_array_of_model is not None else None
+                )
             _dict['array_array_of_model'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/array_test.py
@@ -78,10 +78,12 @@ class ArrayTest(BaseModel):
         _items = []
         if self.array_array_of_model:
             for _item_array_array_of_model in self.array_array_of_model:
-                if _item_array_array_of_model:
+                if _item_array_array_of_model is not None:
                     _items.append(
-                         [_inner_item.to_dict() for _inner_item in _item_array_array_of_model if _inner_item is not None]
+                         [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_array_array_of_model]
                     )
+                else:
+                    _items.append(None)
             _dict['array_array_of_model'] = _items
         return _dict
 
@@ -99,7 +101,7 @@ class ArrayTest(BaseModel):
             "array_of_nullable_float": obj.get("array_of_nullable_float"),
             "array_array_of_integer": obj.get("array_array_of_integer"),
             "array_array_of_model": [
-                    [ReadOnlyFirst.from_dict(_inner_item) for _inner_item in _item]
+                    [ReadOnlyFirst.from_dict(_inner_item) for _inner_item in _item] if _item is not None else None
                     for _item in obj["array_array_of_model"]
                 ] if obj.get("array_array_of_model") is not None else None
         })

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/base_discriminator.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/base_discriminator.py
@@ -55,7 +55,7 @@ class BaseDiscriminator(BaseModel):
     @classmethod
     def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
         """Returns the discriminator value (object type) of the data"""
-        discriminator_value = obj[cls.__discriminator_property_name]
+        discriminator_value = obj.get(cls.__discriminator_property_name)
         if discriminator_value:
             return cls.__discriminator_value_class_map.get(discriminator_value)
         else:

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/circular_all_of_ref.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/circular_all_of_ref.py
@@ -74,8 +74,7 @@ class CircularAllOfRef(BaseModel):
         _items = []
         if self.second_circular_all_of_ref:
             for _item_second_circular_all_of_ref in self.second_circular_all_of_ref:
-                if _item_second_circular_all_of_ref:
-                    _items.append(_item_second_circular_all_of_ref.to_dict())
+                _items.append(_item_second_circular_all_of_ref.to_dict() if _item_second_circular_all_of_ref is not None else None)
             _dict['secondCircularAllOfRef'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/creature.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/creature.py
@@ -56,7 +56,7 @@ class Creature(BaseModel):
     @classmethod
     def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
         """Returns the discriminator value (object type) of the data"""
-        discriminator_value = obj[cls.__discriminator_property_name]
+        discriminator_value = obj.get(cls.__discriminator_property_name)
         if discriminator_value:
             return cls.__discriminator_value_class_map.get(discriminator_value)
         else:

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/discriminator_all_of_super.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/discriminator_all_of_super.py
@@ -54,7 +54,7 @@ class DiscriminatorAllOfSuper(BaseModel):
     @classmethod
     def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
         """Returns the discriminator value (object type) of the data"""
-        discriminator_value = obj[cls.__discriminator_property_name]
+        discriminator_value = obj.get(cls.__discriminator_property_name)
         if discriminator_value:
             return cls.__discriminator_value_class_map.get(discriminator_value)
         else:

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/file_schema_test_class.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/file_schema_test_class.py
@@ -78,8 +78,7 @@ class FileSchemaTestClass(BaseModel):
         _items = []
         if self.files:
             for _item_files in self.files:
-                if _item_files:
-                    _items.append(_item_files.to_dict())
+                _items.append(_item_files.to_dict() if _item_files is not None else None)
             _dict['files'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/input_all_of.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/input_all_of.py
@@ -74,10 +74,7 @@ class InputAllOf(BaseModel):
         _field_dict = {}
         if self.some_data:
             for _key_some_data in self.some_data:
-                if self.some_data[_key_some_data] is not None:
-                    _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict()
-                else:
-                    _field_dict[_key_some_data] = None
+                _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict() if self.some_data[_key_some_data] is not None else None
             _dict['some_data'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/input_all_of.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/input_all_of.py
@@ -74,8 +74,10 @@ class InputAllOf(BaseModel):
         _field_dict = {}
         if self.some_data:
             for _key_some_data in self.some_data:
-                if self.some_data[_key_some_data]:
+                if self.some_data[_key_some_data] is not None:
                     _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict()
+                else:
+                    _field_dict[_key_some_data] = None
             _dict['some_data'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/map_of_array_of_model.py
@@ -74,12 +74,9 @@ class MapOfArrayOfModel(BaseModel):
         _field_dict_of_array = {}
         if self.shop_id_to_org_online_lip_map:
             for _key_shop_id_to_org_online_lip_map in self.shop_id_to_org_online_lip_map:
-                if self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map] is not None:
-                    _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = [
-                        _item.to_dict() if _item is not None else None for _item in self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map]
-                    ]
-                else:
-                    _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = None
+                _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = [
+                    _item.to_dict() if _item is not None else None for _item in self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map]
+                ] if self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map] is not None else None
             _dict['shopIdToOrgOnlineLipMap'] = _field_dict_of_array
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/map_of_array_of_model.py
@@ -76,8 +76,10 @@ class MapOfArrayOfModel(BaseModel):
             for _key_shop_id_to_org_online_lip_map in self.shop_id_to_org_online_lip_map:
                 if self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map] is not None:
                     _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = [
-                        _item.to_dict() for _item in self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map]
+                        _item.to_dict() if _item is not None else None for _item in self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map]
                     ]
+                else:
+                    _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = None
             _dict['shopIdToOrgOnlineLipMap'] = _field_dict_of_array
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -78,10 +78,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
         _field_dict = {}
         if self.map:
             for _key_map in self.map:
-                if self.map[_key_map] is not None:
-                    _field_dict[_key_map] = self.map[_key_map].to_dict()
-                else:
-                    _field_dict[_key_map] = None
+                _field_dict[_key_map] = self.map[_key_map].to_dict() if self.map[_key_map] is not None else None
             _dict['map'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -78,8 +78,10 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
         _field_dict = {}
         if self.map:
             for _key_map in self.map:
-                if self.map[_key_map]:
+                if self.map[_key_map] is not None:
                     _field_dict[_key_map] = self.map[_key_map].to_dict()
+                else:
+                    _field_dict[_key_map] = None
             _dict['map'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/multi_arrays.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/multi_arrays.py
@@ -76,15 +76,13 @@ class MultiArrays(BaseModel):
         _items = []
         if self.tags:
             for _item_tags in self.tags:
-                if _item_tags:
-                    _items.append(_item_tags.to_dict())
+                _items.append(_item_tags.to_dict() if _item_tags is not None else None)
             _dict['tags'] = _items
         # override the default output from pydantic by calling `to_dict()` of each item in files (list)
         _items = []
         if self.files:
             for _item_files in self.files:
-                if _item_files:
-                    _items.append(_item_files.to_dict())
+                _items.append(_item_files.to_dict() if _item_files is not None else None)
             _dict['files'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/parent.py
@@ -74,8 +74,10 @@ class Parent(BaseModel):
         _field_dict = {}
         if self.optional_dict:
             for _key_optional_dict in self.optional_dict:
-                if self.optional_dict[_key_optional_dict]:
+                if self.optional_dict[_key_optional_dict] is not None:
                     _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict()
+                else:
+                    _field_dict[_key_optional_dict] = None
             _dict['optionalDict'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/parent.py
@@ -74,10 +74,7 @@ class Parent(BaseModel):
         _field_dict = {}
         if self.optional_dict:
             for _key_optional_dict in self.optional_dict:
-                if self.optional_dict[_key_optional_dict] is not None:
-                    _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict()
-                else:
-                    _field_dict[_key_optional_dict] = None
+                _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict() if self.optional_dict[_key_optional_dict] is not None else None
             _dict['optionalDict'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/parent_with_optional_dict.py
@@ -74,8 +74,10 @@ class ParentWithOptionalDict(BaseModel):
         _field_dict = {}
         if self.optional_dict:
             for _key_optional_dict in self.optional_dict:
-                if self.optional_dict[_key_optional_dict]:
+                if self.optional_dict[_key_optional_dict] is not None:
                     _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict()
+                else:
+                    _field_dict[_key_optional_dict] = None
             _dict['optionalDict'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/parent_with_optional_dict.py
@@ -74,10 +74,7 @@ class ParentWithOptionalDict(BaseModel):
         _field_dict = {}
         if self.optional_dict:
             for _key_optional_dict in self.optional_dict:
-                if self.optional_dict[_key_optional_dict] is not None:
-                    _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict()
-                else:
-                    _field_dict[_key_optional_dict] = None
+                _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict() if self.optional_dict[_key_optional_dict] is not None else None
             _dict['optionalDict'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/pet.py
@@ -94,8 +94,7 @@ class Pet(BaseModel):
         _items = []
         if self.tags:
             for _item_tags in self.tags:
-                if _item_tags:
-                    _items.append(_item_tags.to_dict())
+                _items.append(_item_tags.to_dict() if _item_tags is not None else None)
             _dict['tags'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/property_map.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/property_map.py
@@ -74,10 +74,7 @@ class PropertyMap(BaseModel):
         _field_dict = {}
         if self.some_data:
             for _key_some_data in self.some_data:
-                if self.some_data[_key_some_data] is not None:
-                    _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict()
-                else:
-                    _field_dict[_key_some_data] = None
+                _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict() if self.some_data[_key_some_data] is not None else None
             _dict['some_data'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/property_map.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/property_map.py
@@ -74,8 +74,10 @@ class PropertyMap(BaseModel):
         _field_dict = {}
         if self.some_data:
             for _key_some_data in self.some_data:
-                if self.some_data[_key_some_data]:
+                if self.some_data[_key_some_data] is not None:
                     _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict()
+                else:
+                    _field_dict[_key_some_data] = None
             _dict['some_data'] = _field_dict
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/second_circular_all_of_ref.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/second_circular_all_of_ref.py
@@ -74,8 +74,7 @@ class SecondCircularAllOfRef(BaseModel):
         _items = []
         if self.circular_all_of_ref:
             for _item_circular_all_of_ref in self.circular_all_of_ref:
-                if _item_circular_all_of_ref:
-                    _items.append(_item_circular_all_of_ref.to_dict())
+                _items.append(_item_circular_all_of_ref.to_dict() if _item_circular_all_of_ref is not None else None)
             _dict['circularAllOfRef'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -76,8 +76,10 @@ class UnnamedDictWithAdditionalModelListProperties(BaseModel):
             for _key_dict_property in self.dict_property:
                 if self.dict_property[_key_dict_property] is not None:
                     _field_dict_of_array[_key_dict_property] = [
-                        _item.to_dict() for _item in self.dict_property[_key_dict_property]
+                        _item.to_dict() if _item is not None else None for _item in self.dict_property[_key_dict_property]
                     ]
+                else:
+                    _field_dict_of_array[_key_dict_property] = None
             _dict['dictProperty'] = _field_dict_of_array
         return _dict
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -74,12 +74,9 @@ class UnnamedDictWithAdditionalModelListProperties(BaseModel):
         _field_dict_of_array = {}
         if self.dict_property:
             for _key_dict_property in self.dict_property:
-                if self.dict_property[_key_dict_property] is not None:
-                    _field_dict_of_array[_key_dict_property] = [
-                        _item.to_dict() if _item is not None else None for _item in self.dict_property[_key_dict_property]
-                    ]
-                else:
-                    _field_dict_of_array[_key_dict_property] = None
+                _field_dict_of_array[_key_dict_property] = [
+                    _item.to_dict() if _item is not None else None for _item in self.dict_property[_key_dict_property]
+                ] if self.dict_property[_key_dict_property] is not None else None
             _dict['dictProperty'] = _field_dict_of_array
         return _dict
 

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/additional_properties_class.py
@@ -81,8 +81,10 @@ class AdditionalPropertiesClass(BaseModel):
             for _key_map_of_map_non_primitive_property, _value_map_of_map_non_primitive_property in self.map_of_map_non_primitive_property.items():
                 if _value_map_of_map_non_primitive_property is not None:
                     _field_dict_of_dict[_key_map_of_map_non_primitive_property] = {
-                        _key: _value.to_dict() for _key, _value in _value_map_of_map_non_primitive_property.items()
+                        _key: _value.to_dict() if _value is not None else None for _key, _value in _value_map_of_map_non_primitive_property.items()
                     }
+                else:
+                    _field_dict_of_dict[_key_map_of_map_non_primitive_property] = None
             _dict['map_of_map_non_primitive_property'] = _field_dict_of_dict
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/additional_properties_class.py
@@ -79,12 +79,9 @@ class AdditionalPropertiesClass(BaseModel):
         _field_dict_of_dict = {}
         if self.map_of_map_non_primitive_property:
             for _key_map_of_map_non_primitive_property, _value_map_of_map_non_primitive_property in self.map_of_map_non_primitive_property.items():
-                if _value_map_of_map_non_primitive_property is not None:
-                    _field_dict_of_dict[_key_map_of_map_non_primitive_property] = {
-                        _key: _value.to_dict() if _value is not None else None for _key, _value in _value_map_of_map_non_primitive_property.items()
-                    }
-                else:
-                    _field_dict_of_dict[_key_map_of_map_non_primitive_property] = None
+                _field_dict_of_dict[_key_map_of_map_non_primitive_property] = {
+                    _key: _value.to_dict() if _value is not None else None for _key, _value in _value_map_of_map_non_primitive_property.items()
+                } if _value_map_of_map_non_primitive_property is not None else None
             _dict['map_of_map_non_primitive_property'] = _field_dict_of_dict
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/animal.py
@@ -57,7 +57,7 @@ class Animal(BaseModel):
     @classmethod
     def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
         """Returns the discriminator value (object type) of the data"""
-        discriminator_value = obj[cls.__discriminator_property_name]
+        discriminator_value = obj.get(cls.__discriminator_property_name)
         if discriminator_value:
             return cls.__discriminator_value_class_map.get(discriminator_value)
         else:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/array_of_array_of_model.py
@@ -77,12 +77,9 @@ class ArrayOfArrayOfModel(BaseModel):
         _items = []
         if self.another_property:
             for _item_another_property in self.another_property:
-                if _item_another_property is not None:
-                    _items.append(
-                         [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_another_property]
-                    )
-                else:
-                    _items.append(None)
+                _items.append(
+                     [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_another_property] if _item_another_property is not None else None
+                )
             _dict['another_property'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/array_of_array_of_model.py
@@ -77,10 +77,12 @@ class ArrayOfArrayOfModel(BaseModel):
         _items = []
         if self.another_property:
             for _item_another_property in self.another_property:
-                if _item_another_property:
+                if _item_another_property is not None:
                     _items.append(
-                         [_inner_item.to_dict() for _inner_item in _item_another_property if _inner_item is not None]
+                         [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_another_property]
                     )
+                else:
+                    _items.append(None)
             _dict['another_property'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:
@@ -100,7 +102,7 @@ class ArrayOfArrayOfModel(BaseModel):
 
         _obj = cls.model_validate({
             "another_property": [
-                    [Tag.from_dict(_inner_item) for _inner_item in _item]
+                    [Tag.from_dict(_inner_item) for _inner_item in _item] if _item is not None else None
                     for _item in obj["another_property"]
                 ] if obj.get("another_property") is not None else None
         })

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/array_of_map_model.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/array_of_map_model.py
@@ -77,12 +77,9 @@ class ArrayOfMapModel(BaseModel):
         _items = []
         if self.array_of_map_property:
             for _item_array_of_map_property in self.array_of_map_property:
-                if _item_array_of_map_property is not None:
-                    _items.append(
-                         {_inner_key: _inner_value.to_dict() if _inner_value is not None else None for _inner_key, _inner_value in _item_array_of_map_property.items()}
-                    )
-                else:
-                    _items.append(None)
+                _items.append(
+                     {_inner_key: _inner_value.to_dict() if _inner_value is not None else None for _inner_key, _inner_value in _item_array_of_map_property.items()} if _item_array_of_map_property is not None else None
+                )
             _dict['array_of_map_property'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/array_of_map_model.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/array_of_map_model.py
@@ -77,10 +77,12 @@ class ArrayOfMapModel(BaseModel):
         _items = []
         if self.array_of_map_property:
             for _item_array_of_map_property in self.array_of_map_property:
-                if _item_array_of_map_property:
+                if _item_array_of_map_property is not None:
                     _items.append(
-                         {_inner_key: _inner_value.to_dict() for _inner_key, _inner_value in _item_array_of_map_property.items()}
+                         {_inner_key: _inner_value.to_dict() if _inner_value is not None else None for _inner_key, _inner_value in _item_array_of_map_property.items()}
                     )
+                else:
+                    _items.append(None)
             _dict['array_of_map_property'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:
@@ -100,7 +102,7 @@ class ArrayOfMapModel(BaseModel):
 
         _obj = cls.model_validate({
             "array_of_map_property": [
-                    {_inner_key: Tag.from_dict(_inner_value) for _inner_key, _inner_value in _item.items()}
+                    {_inner_key: Tag.from_dict(_inner_value) for _inner_key, _inner_value in _item.items()} if _item is not None else None
                     for _item in obj["array_of_map_property"]
                 ] if obj.get("array_of_map_property") is not None else None
         })

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/array_test.py
@@ -81,12 +81,9 @@ class ArrayTest(BaseModel):
         _items = []
         if self.array_array_of_model:
             for _item_array_array_of_model in self.array_array_of_model:
-                if _item_array_array_of_model is not None:
-                    _items.append(
-                         [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_array_array_of_model]
-                    )
-                else:
-                    _items.append(None)
+                _items.append(
+                     [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_array_array_of_model] if _item_array_array_of_model is not None else None
+                )
             _dict['array_array_of_model'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/array_test.py
@@ -81,10 +81,12 @@ class ArrayTest(BaseModel):
         _items = []
         if self.array_array_of_model:
             for _item_array_array_of_model in self.array_array_of_model:
-                if _item_array_array_of_model:
+                if _item_array_array_of_model is not None:
                     _items.append(
-                         [_inner_item.to_dict() for _inner_item in _item_array_array_of_model if _inner_item is not None]
+                         [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_array_array_of_model]
                     )
+                else:
+                    _items.append(None)
             _dict['array_array_of_model'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:
@@ -107,7 +109,7 @@ class ArrayTest(BaseModel):
             "array_of_nullable_float": obj.get("array_of_nullable_float"),
             "array_array_of_integer": obj.get("array_array_of_integer"),
             "array_array_of_model": [
-                    [ReadOnlyFirst.from_dict(_inner_item) for _inner_item in _item]
+                    [ReadOnlyFirst.from_dict(_inner_item) for _inner_item in _item] if _item is not None else None
                     for _item in obj["array_array_of_model"]
                 ] if obj.get("array_array_of_model") is not None else None
         })

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/base_discriminator.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/base_discriminator.py
@@ -56,7 +56,7 @@ class BaseDiscriminator(BaseModel):
     @classmethod
     def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
         """Returns the discriminator value (object type) of the data"""
-        discriminator_value = obj[cls.__discriminator_property_name]
+        discriminator_value = obj.get(cls.__discriminator_property_name)
         if discriminator_value:
             return cls.__discriminator_value_class_map.get(discriminator_value)
         else:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/circular_all_of_ref.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/circular_all_of_ref.py
@@ -77,8 +77,7 @@ class CircularAllOfRef(BaseModel):
         _items = []
         if self.second_circular_all_of_ref:
             for _item_second_circular_all_of_ref in self.second_circular_all_of_ref:
-                if _item_second_circular_all_of_ref:
-                    _items.append(_item_second_circular_all_of_ref.to_dict())
+                _items.append(_item_second_circular_all_of_ref.to_dict() if _item_second_circular_all_of_ref is not None else None)
             _dict['secondCircularAllOfRef'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/creature.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/creature.py
@@ -57,7 +57,7 @@ class Creature(BaseModel):
     @classmethod
     def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
         """Returns the discriminator value (object type) of the data"""
-        discriminator_value = obj[cls.__discriminator_property_name]
+        discriminator_value = obj.get(cls.__discriminator_property_name)
         if discriminator_value:
             return cls.__discriminator_value_class_map.get(discriminator_value)
         else:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/discriminator_all_of_super.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/discriminator_all_of_super.py
@@ -55,7 +55,7 @@ class DiscriminatorAllOfSuper(BaseModel):
     @classmethod
     def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
         """Returns the discriminator value (object type) of the data"""
-        discriminator_value = obj[cls.__discriminator_property_name]
+        discriminator_value = obj.get(cls.__discriminator_property_name)
         if discriminator_value:
             return cls.__discriminator_value_class_map.get(discriminator_value)
         else:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/file_schema_test_class.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/file_schema_test_class.py
@@ -81,8 +81,7 @@ class FileSchemaTestClass(BaseModel):
         _items = []
         if self.files:
             for _item_files in self.files:
-                if _item_files:
-                    _items.append(_item_files.to_dict())
+                _items.append(_item_files.to_dict() if _item_files is not None else None)
             _dict['files'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/input_all_of.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/input_all_of.py
@@ -77,10 +77,7 @@ class InputAllOf(BaseModel):
         _field_dict = {}
         if self.some_data:
             for _key_some_data in self.some_data:
-                if self.some_data[_key_some_data] is not None:
-                    _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict()
-                else:
-                    _field_dict[_key_some_data] = None
+                _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict() if self.some_data[_key_some_data] is not None else None
             _dict['some_data'] = _field_dict
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/input_all_of.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/input_all_of.py
@@ -77,8 +77,10 @@ class InputAllOf(BaseModel):
         _field_dict = {}
         if self.some_data:
             for _key_some_data in self.some_data:
-                if self.some_data[_key_some_data]:
+                if self.some_data[_key_some_data] is not None:
                     _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict()
+                else:
+                    _field_dict[_key_some_data] = None
             _dict['some_data'] = _field_dict
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/map_of_array_of_model.py
@@ -77,12 +77,9 @@ class MapOfArrayOfModel(BaseModel):
         _field_dict_of_array = {}
         if self.shop_id_to_org_online_lip_map:
             for _key_shop_id_to_org_online_lip_map in self.shop_id_to_org_online_lip_map:
-                if self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map] is not None:
-                    _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = [
-                        _item.to_dict() if _item is not None else None for _item in self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map]
-                    ]
-                else:
-                    _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = None
+                _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = [
+                    _item.to_dict() if _item is not None else None for _item in self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map]
+                ] if self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map] is not None else None
             _dict['shopIdToOrgOnlineLipMap'] = _field_dict_of_array
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/map_of_array_of_model.py
@@ -79,8 +79,10 @@ class MapOfArrayOfModel(BaseModel):
             for _key_shop_id_to_org_online_lip_map in self.shop_id_to_org_online_lip_map:
                 if self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map] is not None:
                     _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = [
-                        _item.to_dict() for _item in self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map]
+                        _item.to_dict() if _item is not None else None for _item in self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map]
                     ]
+                else:
+                    _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = None
             _dict['shopIdToOrgOnlineLipMap'] = _field_dict_of_array
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -81,8 +81,10 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
         _field_dict = {}
         if self.map:
             for _key_map in self.map:
-                if self.map[_key_map]:
+                if self.map[_key_map] is not None:
                     _field_dict[_key_map] = self.map[_key_map].to_dict()
+                else:
+                    _field_dict[_key_map] = None
             _dict['map'] = _field_dict
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -81,10 +81,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
         _field_dict = {}
         if self.map:
             for _key_map in self.map:
-                if self.map[_key_map] is not None:
-                    _field_dict[_key_map] = self.map[_key_map].to_dict()
-                else:
-                    _field_dict[_key_map] = None
+                _field_dict[_key_map] = self.map[_key_map].to_dict() if self.map[_key_map] is not None else None
             _dict['map'] = _field_dict
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/multi_arrays.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/multi_arrays.py
@@ -79,15 +79,13 @@ class MultiArrays(BaseModel):
         _items = []
         if self.tags:
             for _item_tags in self.tags:
-                if _item_tags:
-                    _items.append(_item_tags.to_dict())
+                _items.append(_item_tags.to_dict() if _item_tags is not None else None)
             _dict['tags'] = _items
         # override the default output from pydantic by calling `to_dict()` of each item in files (list)
         _items = []
         if self.files:
             for _item_files in self.files:
-                if _item_files:
-                    _items.append(_item_files.to_dict())
+                _items.append(_item_files.to_dict() if _item_files is not None else None)
             _dict['files'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/parent.py
@@ -77,8 +77,10 @@ class Parent(BaseModel):
         _field_dict = {}
         if self.optional_dict:
             for _key_optional_dict in self.optional_dict:
-                if self.optional_dict[_key_optional_dict]:
+                if self.optional_dict[_key_optional_dict] is not None:
                     _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict()
+                else:
+                    _field_dict[_key_optional_dict] = None
             _dict['optionalDict'] = _field_dict
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/parent.py
@@ -77,10 +77,7 @@ class Parent(BaseModel):
         _field_dict = {}
         if self.optional_dict:
             for _key_optional_dict in self.optional_dict:
-                if self.optional_dict[_key_optional_dict] is not None:
-                    _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict()
-                else:
-                    _field_dict[_key_optional_dict] = None
+                _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict() if self.optional_dict[_key_optional_dict] is not None else None
             _dict['optionalDict'] = _field_dict
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/parent_with_optional_dict.py
@@ -77,10 +77,7 @@ class ParentWithOptionalDict(BaseModel):
         _field_dict = {}
         if self.optional_dict:
             for _key_optional_dict in self.optional_dict:
-                if self.optional_dict[_key_optional_dict] is not None:
-                    _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict()
-                else:
-                    _field_dict[_key_optional_dict] = None
+                _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict() if self.optional_dict[_key_optional_dict] is not None else None
             _dict['optionalDict'] = _field_dict
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/parent_with_optional_dict.py
@@ -77,8 +77,10 @@ class ParentWithOptionalDict(BaseModel):
         _field_dict = {}
         if self.optional_dict:
             for _key_optional_dict in self.optional_dict:
-                if self.optional_dict[_key_optional_dict]:
+                if self.optional_dict[_key_optional_dict] is not None:
                     _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict()
+                else:
+                    _field_dict[_key_optional_dict] = None
             _dict['optionalDict'] = _field_dict
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/pet.py
@@ -97,8 +97,7 @@ class Pet(BaseModel):
         _items = []
         if self.tags:
             for _item_tags in self.tags:
-                if _item_tags:
-                    _items.append(_item_tags.to_dict())
+                _items.append(_item_tags.to_dict() if _item_tags is not None else None)
             _dict['tags'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/property_map.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/property_map.py
@@ -77,10 +77,7 @@ class PropertyMap(BaseModel):
         _field_dict = {}
         if self.some_data:
             for _key_some_data in self.some_data:
-                if self.some_data[_key_some_data] is not None:
-                    _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict()
-                else:
-                    _field_dict[_key_some_data] = None
+                _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict() if self.some_data[_key_some_data] is not None else None
             _dict['some_data'] = _field_dict
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/property_map.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/property_map.py
@@ -77,8 +77,10 @@ class PropertyMap(BaseModel):
         _field_dict = {}
         if self.some_data:
             for _key_some_data in self.some_data:
-                if self.some_data[_key_some_data]:
+                if self.some_data[_key_some_data] is not None:
                     _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict()
+                else:
+                    _field_dict[_key_some_data] = None
             _dict['some_data'] = _field_dict
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/second_circular_all_of_ref.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/second_circular_all_of_ref.py
@@ -77,8 +77,7 @@ class SecondCircularAllOfRef(BaseModel):
         _items = []
         if self.circular_all_of_ref:
             for _item_circular_all_of_ref in self.circular_all_of_ref:
-                if _item_circular_all_of_ref:
-                    _items.append(_item_circular_all_of_ref.to_dict())
+                _items.append(_item_circular_all_of_ref.to_dict() if _item_circular_all_of_ref is not None else None)
             _dict['circularAllOfRef'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -79,8 +79,10 @@ class UnnamedDictWithAdditionalModelListProperties(BaseModel):
             for _key_dict_property in self.dict_property:
                 if self.dict_property[_key_dict_property] is not None:
                     _field_dict_of_array[_key_dict_property] = [
-                        _item.to_dict() for _item in self.dict_property[_key_dict_property]
+                        _item.to_dict() if _item is not None else None for _item in self.dict_property[_key_dict_property]
                     ]
+                else:
+                    _field_dict_of_array[_key_dict_property] = None
             _dict['dictProperty'] = _field_dict_of_array
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -77,12 +77,9 @@ class UnnamedDictWithAdditionalModelListProperties(BaseModel):
         _field_dict_of_array = {}
         if self.dict_property:
             for _key_dict_property in self.dict_property:
-                if self.dict_property[_key_dict_property] is not None:
-                    _field_dict_of_array[_key_dict_property] = [
-                        _item.to_dict() if _item is not None else None for _item in self.dict_property[_key_dict_property]
-                    ]
-                else:
-                    _field_dict_of_array[_key_dict_property] = None
+                _field_dict_of_array[_key_dict_property] = [
+                    _item.to_dict() if _item is not None else None for _item in self.dict_property[_key_dict_property]
+                ] if self.dict_property[_key_dict_property] is not None else None
             _dict['dictProperty'] = _field_dict_of_array
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_class.py
@@ -81,8 +81,10 @@ class AdditionalPropertiesClass(BaseModel):
             for _key_map_of_map_non_primitive_property, _value_map_of_map_non_primitive_property in self.map_of_map_non_primitive_property.items():
                 if _value_map_of_map_non_primitive_property is not None:
                     _field_dict_of_dict[_key_map_of_map_non_primitive_property] = {
-                        _key: _value.to_dict() for _key, _value in _value_map_of_map_non_primitive_property.items()
+                        _key: _value.to_dict() if _value is not None else None for _key, _value in _value_map_of_map_non_primitive_property.items()
                     }
+                else:
+                    _field_dict_of_dict[_key_map_of_map_non_primitive_property] = None
             _dict['map_of_map_non_primitive_property'] = _field_dict_of_dict
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_class.py
@@ -79,12 +79,9 @@ class AdditionalPropertiesClass(BaseModel):
         _field_dict_of_dict = {}
         if self.map_of_map_non_primitive_property:
             for _key_map_of_map_non_primitive_property, _value_map_of_map_non_primitive_property in self.map_of_map_non_primitive_property.items():
-                if _value_map_of_map_non_primitive_property is not None:
-                    _field_dict_of_dict[_key_map_of_map_non_primitive_property] = {
-                        _key: _value.to_dict() if _value is not None else None for _key, _value in _value_map_of_map_non_primitive_property.items()
-                    }
-                else:
-                    _field_dict_of_dict[_key_map_of_map_non_primitive_property] = None
+                _field_dict_of_dict[_key_map_of_map_non_primitive_property] = {
+                    _key: _value.to_dict() if _value is not None else None for _key, _value in _value_map_of_map_non_primitive_property.items()
+                } if _value_map_of_map_non_primitive_property is not None else None
             _dict['map_of_map_non_primitive_property'] = _field_dict_of_dict
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
@@ -101,7 +101,7 @@ class Animal(BaseModel):
     @classmethod
     def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
         """Returns the discriminator value (object type) of the data"""
-        discriminator_value = obj[cls.__discriminator_property_name]
+        discriminator_value = obj.get(cls.__discriminator_property_name)
         if discriminator_value:
             return cls.__discriminator_value_class_map.get(discriminator_value)
         else:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_of_array_of_model.py
@@ -77,12 +77,9 @@ class ArrayOfArrayOfModel(BaseModel):
         _items = []
         if self.another_property:
             for _item_another_property in self.another_property:
-                if _item_another_property is not None:
-                    _items.append(
-                         [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_another_property]
-                    )
-                else:
-                    _items.append(None)
+                _items.append(
+                     [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_another_property] if _item_another_property is not None else None
+                )
             _dict['another_property'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_of_array_of_model.py
@@ -77,10 +77,12 @@ class ArrayOfArrayOfModel(BaseModel):
         _items = []
         if self.another_property:
             for _item_another_property in self.another_property:
-                if _item_another_property:
+                if _item_another_property is not None:
                     _items.append(
-                         [_inner_item.to_dict() for _inner_item in _item_another_property if _inner_item is not None]
+                         [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_another_property]
                     )
+                else:
+                    _items.append(None)
             _dict['another_property'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:
@@ -100,7 +102,7 @@ class ArrayOfArrayOfModel(BaseModel):
 
         _obj = cls.model_validate({
             "another_property": [
-                    [Tag.from_dict(_inner_item) for _inner_item in _item]
+                    [Tag.from_dict(_inner_item) for _inner_item in _item] if _item is not None else None
                     for _item in obj["another_property"]
                 ] if obj.get("another_property") is not None else None
         })

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_of_map_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_of_map_model.py
@@ -77,12 +77,9 @@ class ArrayOfMapModel(BaseModel):
         _items = []
         if self.array_of_map_property:
             for _item_array_of_map_property in self.array_of_map_property:
-                if _item_array_of_map_property is not None:
-                    _items.append(
-                         {_inner_key: _inner_value.to_dict() if _inner_value is not None else None for _inner_key, _inner_value in _item_array_of_map_property.items()}
-                    )
-                else:
-                    _items.append(None)
+                _items.append(
+                     {_inner_key: _inner_value.to_dict() if _inner_value is not None else None for _inner_key, _inner_value in _item_array_of_map_property.items()} if _item_array_of_map_property is not None else None
+                )
             _dict['array_of_map_property'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_of_map_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_of_map_model.py
@@ -77,10 +77,12 @@ class ArrayOfMapModel(BaseModel):
         _items = []
         if self.array_of_map_property:
             for _item_array_of_map_property in self.array_of_map_property:
-                if _item_array_of_map_property:
+                if _item_array_of_map_property is not None:
                     _items.append(
-                         {_inner_key: _inner_value.to_dict() for _inner_key, _inner_value in _item_array_of_map_property.items()}
+                         {_inner_key: _inner_value.to_dict() if _inner_value is not None else None for _inner_key, _inner_value in _item_array_of_map_property.items()}
                     )
+                else:
+                    _items.append(None)
             _dict['array_of_map_property'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:
@@ -100,7 +102,7 @@ class ArrayOfMapModel(BaseModel):
 
         _obj = cls.model_validate({
             "array_of_map_property": [
-                    {_inner_key: Tag.from_dict(_inner_value) for _inner_key, _inner_value in _item.items()}
+                    {_inner_key: Tag.from_dict(_inner_value) for _inner_key, _inner_value in _item.items()} if _item is not None else None
                     for _item in obj["array_of_map_property"]
                 ] if obj.get("array_of_map_property") is not None else None
         })

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_test.py
@@ -81,12 +81,9 @@ class ArrayTest(BaseModel):
         _items = []
         if self.array_array_of_model:
             for _item_array_array_of_model in self.array_array_of_model:
-                if _item_array_array_of_model is not None:
-                    _items.append(
-                         [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_array_array_of_model]
-                    )
-                else:
-                    _items.append(None)
+                _items.append(
+                     [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_array_array_of_model] if _item_array_array_of_model is not None else None
+                )
             _dict['array_array_of_model'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_test.py
@@ -81,10 +81,12 @@ class ArrayTest(BaseModel):
         _items = []
         if self.array_array_of_model:
             for _item_array_array_of_model in self.array_array_of_model:
-                if _item_array_array_of_model:
+                if _item_array_array_of_model is not None:
                     _items.append(
-                         [_inner_item.to_dict() for _inner_item in _item_array_array_of_model if _inner_item is not None]
+                         [_inner_item.to_dict() if _inner_item is not None else None for _inner_item in _item_array_array_of_model]
                     )
+                else:
+                    _items.append(None)
             _dict['array_array_of_model'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:
@@ -107,7 +109,7 @@ class ArrayTest(BaseModel):
             "array_of_nullable_float": obj.get("array_of_nullable_float"),
             "array_array_of_integer": obj.get("array_array_of_integer"),
             "array_array_of_model": [
-                    [ReadOnlyFirst.from_dict(_inner_item) for _inner_item in _item]
+                    [ReadOnlyFirst.from_dict(_inner_item) for _inner_item in _item] if _item is not None else None
                     for _item in obj["array_array_of_model"]
                 ] if obj.get("array_array_of_model") is not None else None
         })

--- a/samples/openapi3/client/petstore/python/petstore_api/models/base_discriminator.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/base_discriminator.py
@@ -56,7 +56,7 @@ class BaseDiscriminator(BaseModel):
     @classmethod
     def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
         """Returns the discriminator value (object type) of the data"""
-        discriminator_value = obj[cls.__discriminator_property_name]
+        discriminator_value = obj.get(cls.__discriminator_property_name)
         if discriminator_value:
             return cls.__discriminator_value_class_map.get(discriminator_value)
         else:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/circular_all_of_ref.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/circular_all_of_ref.py
@@ -77,8 +77,7 @@ class CircularAllOfRef(BaseModel):
         _items = []
         if self.second_circular_all_of_ref:
             for _item_second_circular_all_of_ref in self.second_circular_all_of_ref:
-                if _item_second_circular_all_of_ref:
-                    _items.append(_item_second_circular_all_of_ref.to_dict())
+                _items.append(_item_second_circular_all_of_ref.to_dict() if _item_second_circular_all_of_ref is not None else None)
             _dict['secondCircularAllOfRef'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/creature.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/creature.py
@@ -57,7 +57,7 @@ class Creature(BaseModel):
     @classmethod
     def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
         """Returns the discriminator value (object type) of the data"""
-        discriminator_value = obj[cls.__discriminator_property_name]
+        discriminator_value = obj.get(cls.__discriminator_property_name)
         if discriminator_value:
             return cls.__discriminator_value_class_map.get(discriminator_value)
         else:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/discriminator_all_of_super.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/discriminator_all_of_super.py
@@ -55,7 +55,7 @@ class DiscriminatorAllOfSuper(BaseModel):
     @classmethod
     def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
         """Returns the discriminator value (object type) of the data"""
-        discriminator_value = obj[cls.__discriminator_property_name]
+        discriminator_value = obj.get(cls.__discriminator_property_name)
         if discriminator_value:
             return cls.__discriminator_value_class_map.get(discriminator_value)
         else:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/file_schema_test_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/file_schema_test_class.py
@@ -81,8 +81,7 @@ class FileSchemaTestClass(BaseModel):
         _items = []
         if self.files:
             for _item_files in self.files:
-                if _item_files:
-                    _items.append(_item_files.to_dict())
+                _items.append(_item_files.to_dict() if _item_files is not None else None)
             _dict['files'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/input_all_of.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/input_all_of.py
@@ -77,10 +77,7 @@ class InputAllOf(BaseModel):
         _field_dict = {}
         if self.some_data:
             for _key_some_data in self.some_data:
-                if self.some_data[_key_some_data] is not None:
-                    _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict()
-                else:
-                    _field_dict[_key_some_data] = None
+                _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict() if self.some_data[_key_some_data] is not None else None
             _dict['some_data'] = _field_dict
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/input_all_of.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/input_all_of.py
@@ -77,8 +77,10 @@ class InputAllOf(BaseModel):
         _field_dict = {}
         if self.some_data:
             for _key_some_data in self.some_data:
-                if self.some_data[_key_some_data]:
+                if self.some_data[_key_some_data] is not None:
                     _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict()
+                else:
+                    _field_dict[_key_some_data] = None
             _dict['some_data'] = _field_dict
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/map_of_array_of_model.py
@@ -77,12 +77,9 @@ class MapOfArrayOfModel(BaseModel):
         _field_dict_of_array = {}
         if self.shop_id_to_org_online_lip_map:
             for _key_shop_id_to_org_online_lip_map in self.shop_id_to_org_online_lip_map:
-                if self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map] is not None:
-                    _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = [
-                        _item.to_dict() if _item is not None else None for _item in self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map]
-                    ]
-                else:
-                    _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = None
+                _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = [
+                    _item.to_dict() if _item is not None else None for _item in self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map]
+                ] if self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map] is not None else None
             _dict['shopIdToOrgOnlineLipMap'] = _field_dict_of_array
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/map_of_array_of_model.py
@@ -79,8 +79,10 @@ class MapOfArrayOfModel(BaseModel):
             for _key_shop_id_to_org_online_lip_map in self.shop_id_to_org_online_lip_map:
                 if self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map] is not None:
                     _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = [
-                        _item.to_dict() for _item in self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map]
+                        _item.to_dict() if _item is not None else None for _item in self.shop_id_to_org_online_lip_map[_key_shop_id_to_org_online_lip_map]
                     ]
+                else:
+                    _field_dict_of_array[_key_shop_id_to_org_online_lip_map] = None
             _dict['shopIdToOrgOnlineLipMap'] = _field_dict_of_array
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -81,8 +81,10 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
         _field_dict = {}
         if self.map:
             for _key_map in self.map:
-                if self.map[_key_map]:
+                if self.map[_key_map] is not None:
                     _field_dict[_key_map] = self.map[_key_map].to_dict()
+                else:
+                    _field_dict[_key_map] = None
             _dict['map'] = _field_dict
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -81,10 +81,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
         _field_dict = {}
         if self.map:
             for _key_map in self.map:
-                if self.map[_key_map] is not None:
-                    _field_dict[_key_map] = self.map[_key_map].to_dict()
-                else:
-                    _field_dict[_key_map] = None
+                _field_dict[_key_map] = self.map[_key_map].to_dict() if self.map[_key_map] is not None else None
             _dict['map'] = _field_dict
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/multi_arrays.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/multi_arrays.py
@@ -79,15 +79,13 @@ class MultiArrays(BaseModel):
         _items = []
         if self.tags:
             for _item_tags in self.tags:
-                if _item_tags:
-                    _items.append(_item_tags.to_dict())
+                _items.append(_item_tags.to_dict() if _item_tags is not None else None)
             _dict['tags'] = _items
         # override the default output from pydantic by calling `to_dict()` of each item in files (list)
         _items = []
         if self.files:
             for _item_files in self.files:
-                if _item_files:
-                    _items.append(_item_files.to_dict())
+                _items.append(_item_files.to_dict() if _item_files is not None else None)
             _dict['files'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/parent.py
@@ -77,8 +77,10 @@ class Parent(BaseModel):
         _field_dict = {}
         if self.optional_dict:
             for _key_optional_dict in self.optional_dict:
-                if self.optional_dict[_key_optional_dict]:
+                if self.optional_dict[_key_optional_dict] is not None:
                     _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict()
+                else:
+                    _field_dict[_key_optional_dict] = None
             _dict['optionalDict'] = _field_dict
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/parent.py
@@ -77,10 +77,7 @@ class Parent(BaseModel):
         _field_dict = {}
         if self.optional_dict:
             for _key_optional_dict in self.optional_dict:
-                if self.optional_dict[_key_optional_dict] is not None:
-                    _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict()
-                else:
-                    _field_dict[_key_optional_dict] = None
+                _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict() if self.optional_dict[_key_optional_dict] is not None else None
             _dict['optionalDict'] = _field_dict
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/parent_with_optional_dict.py
@@ -77,10 +77,7 @@ class ParentWithOptionalDict(BaseModel):
         _field_dict = {}
         if self.optional_dict:
             for _key_optional_dict in self.optional_dict:
-                if self.optional_dict[_key_optional_dict] is not None:
-                    _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict()
-                else:
-                    _field_dict[_key_optional_dict] = None
+                _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict() if self.optional_dict[_key_optional_dict] is not None else None
             _dict['optionalDict'] = _field_dict
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/parent_with_optional_dict.py
@@ -77,8 +77,10 @@ class ParentWithOptionalDict(BaseModel):
         _field_dict = {}
         if self.optional_dict:
             for _key_optional_dict in self.optional_dict:
-                if self.optional_dict[_key_optional_dict]:
+                if self.optional_dict[_key_optional_dict] is not None:
                     _field_dict[_key_optional_dict] = self.optional_dict[_key_optional_dict].to_dict()
+                else:
+                    _field_dict[_key_optional_dict] = None
             _dict['optionalDict'] = _field_dict
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/pet.py
@@ -97,8 +97,7 @@ class Pet(BaseModel):
         _items = []
         if self.tags:
             for _item_tags in self.tags:
-                if _item_tags:
-                    _items.append(_item_tags.to_dict())
+                _items.append(_item_tags.to_dict() if _item_tags is not None else None)
             _dict['tags'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/property_map.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/property_map.py
@@ -77,10 +77,7 @@ class PropertyMap(BaseModel):
         _field_dict = {}
         if self.some_data:
             for _key_some_data in self.some_data:
-                if self.some_data[_key_some_data] is not None:
-                    _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict()
-                else:
-                    _field_dict[_key_some_data] = None
+                _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict() if self.some_data[_key_some_data] is not None else None
             _dict['some_data'] = _field_dict
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/property_map.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/property_map.py
@@ -77,8 +77,10 @@ class PropertyMap(BaseModel):
         _field_dict = {}
         if self.some_data:
             for _key_some_data in self.some_data:
-                if self.some_data[_key_some_data]:
+                if self.some_data[_key_some_data] is not None:
                     _field_dict[_key_some_data] = self.some_data[_key_some_data].to_dict()
+                else:
+                    _field_dict[_key_some_data] = None
             _dict['some_data'] = _field_dict
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/second_circular_all_of_ref.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/second_circular_all_of_ref.py
@@ -77,8 +77,7 @@ class SecondCircularAllOfRef(BaseModel):
         _items = []
         if self.circular_all_of_ref:
             for _item_circular_all_of_ref in self.circular_all_of_ref:
-                if _item_circular_all_of_ref:
-                    _items.append(_item_circular_all_of_ref.to_dict())
+                _items.append(_item_circular_all_of_ref.to_dict() if _item_circular_all_of_ref is not None else None)
             _dict['circularAllOfRef'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -79,8 +79,10 @@ class UnnamedDictWithAdditionalModelListProperties(BaseModel):
             for _key_dict_property in self.dict_property:
                 if self.dict_property[_key_dict_property] is not None:
                     _field_dict_of_array[_key_dict_property] = [
-                        _item.to_dict() for _item in self.dict_property[_key_dict_property]
+                        _item.to_dict() if _item is not None else None for _item in self.dict_property[_key_dict_property]
                     ]
+                else:
+                    _field_dict_of_array[_key_dict_property] = None
             _dict['dictProperty'] = _field_dict_of_array
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -77,12 +77,9 @@ class UnnamedDictWithAdditionalModelListProperties(BaseModel):
         _field_dict_of_array = {}
         if self.dict_property:
             for _key_dict_property in self.dict_property:
-                if self.dict_property[_key_dict_property] is not None:
-                    _field_dict_of_array[_key_dict_property] = [
-                        _item.to_dict() if _item is not None else None for _item in self.dict_property[_key_dict_property]
-                    ]
-                else:
-                    _field_dict_of_array[_key_dict_property] = None
+                _field_dict_of_array[_key_dict_property] = [
+                    _item.to_dict() if _item is not None else None for _item in self.dict_property[_key_dict_property]
+                ] if self.dict_property[_key_dict_property] is not None else None
             _dict['dictProperty'] = _field_dict_of_array
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:


### PR DESCRIPTION
Fixes a few ways the `python` generator mishandles `null` when (de)serializing models.

### to_dict() drops null entries from containers

`to_dict()` rebuilds containers of models by hand and skipped falsy entries, so `None` items disappeared:

```python
Container(items=[item, None]).to_dict()          # -> {'items': [{...}]}          length changed!
Container(mapping={'a': None, 'b': item}).to_dict()  # -> {'mapping': {'b': {...}}}   key 'a' gone
```

A dropped element shifts every following index for the consumer, and a dropped map key is just lost. Now the `None` is kept as an explicit `null`. The list-of-list / list-of-dict `from_dict` comprehensions also crashed on a `null` inner container (`'NoneType' object has no attribute ...`); those are guarded too.

### from_dict() resurrects the default over an explicit null

For a nullable property with a default, `from_dict` used `obj.get(k) if obj.get(k) is not None else <default>`, so an explicit JSON `null` was indistinguishable from an absent key and got replaced by the default:

```python
# property: {type: string, nullable: true, default: "hello"}
Container.from_dict({"note": None}).note   # -> "hello"   (should be None)
```

This round-trips as silent data corruption (`from_json(x.to_json())` turns an intentional `None` back into the default). Changed to check key presence for nullable properties; non-nullable properties keep the old behavior.

### get_discriminator_value() raises KeyError instead of ValueError

When the discriminator property is missing from the payload, `obj[cls.__discriminator_property_name]` raised a bare `KeyError`, while the code a few lines below builds a descriptive `ValueError` for unmapped values. The rest of the deserialization stack catches `ValueError`, so the `KeyError` leaked out. Switched to `obj.get()`.

Verified list/map null preservation, nullable-default round-trips, and the discriminator path against generated clients; petstore sample tests still pass.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran `./mvnw clean package` and regenerated the python samples.
- [x] Filed the PR against `master`.

/cc @cbornet @tomplus @krjakbrjak

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix incorrect null handling in generated `python` models to preserve data shape during (de)serialization and align error behavior with the rest of the stack. Keeps explicit `None` values and avoids crashes with `null` inner containers.

- **Bug Fixes**
  - Preserve `None` entries in lists and dict values in `to_dict()`; use single conditional expressions for container items to keep mypy happy.
  - For nullable properties with defaults, `from_dict()` checks key presence so an explicit `null` isn’t replaced by the default; non-nullable behavior unchanged.
  - Guard `from_dict()` list-of-list and list-of-dict comprehensions so `null` inner containers don’t crash.
  - Use `obj.get()` in discriminator lookup so a missing discriminator raises a descriptive `ValueError` instead of a `KeyError`.

<sup>Written for commit 4040d87b749cc8b6b43f2cc07f1d025b7f9f1d01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

