### PR TITLE
[python] serialize booleans as lowercase in all parameter styles

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -646,10 +646,15 @@ https://github.com/OpenAPITools/openapi-generator/blob/c84b949df1a9ec04ba75989cb
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:
+            if isinstance(v, bool):
+                v = str(v).lower()
             if k in collection_formats:
                 collection_format = collection_formats[k]
                 if collection_format == 'multi':
-                    new_params.extend((k, value) for value in v)
+                    new_params.extend(
+                        (k, str(value).lower() if isinstance(value, bool) else value)
+                        for value in v
+                    )
                 else:
                     if collection_format == 'ssv':
                         delimiter = ' '
@@ -660,7 +665,9 @@ https://github.com/OpenAPITools/openapi-generator/blob/c84b949df1a9ec04ba75989cb
                     else:  # csv is the default
                         delimiter = ','
                     new_params.append(
-                        (k, delimiter.join(str(value) for value in v)))
+                        (k, delimiter.join(
+                            str(value).lower() if isinstance(value, bool) else str(value)
+                            for value in v)))
             else:
                 new_params.append((k, v))
         return new_params
@@ -686,7 +693,10 @@ https://github.com/OpenAPITools/openapi-generator/blob/c84b949df1a9ec04ba75989cb
             if k in collection_formats:
                 collection_format = collection_formats[k]
                 if collection_format == 'multi':
-                    new_params.extend((k, quote(str(value))) for value in v)
+                    new_params.extend(
+                        (k, quote(str(value).lower() if isinstance(value, bool) else str(value)))
+                        for value in v
+                    )
                 else:
                     if collection_format == 'ssv':
                         delimiter = ' '
@@ -697,7 +707,9 @@ https://github.com/OpenAPITools/openapi-generator/blob/c84b949df1a9ec04ba75989cb
                     else:  # csv is the default
                         delimiter = ','
                     new_params.append(
-                        (k, delimiter.join(quote(str(value)) for value in v))
+                        (k, delimiter.join(
+                            quote(str(value).lower() if isinstance(value, bool) else str(value))
+                            for value in v))
                     )
             else:
                 new_params.append((k, quote(str(v))))

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
@@ -489,10 +489,15 @@ class ApiClient:
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:
+            if isinstance(v, bool):
+                v = str(v).lower()
             if k in collection_formats:
                 collection_format = collection_formats[k]
                 if collection_format == 'multi':
-                    new_params.extend((k, value) for value in v)
+                    new_params.extend(
+                        (k, str(value).lower() if isinstance(value, bool) else value)
+                        for value in v
+                    )
                 else:
                     if collection_format == 'ssv':
                         delimiter = ' '
@@ -503,7 +508,9 @@ class ApiClient:
                     else:  # csv is the default
                         delimiter = ','
                     new_params.append(
-                        (k, delimiter.join(str(value) for value in v)))
+                        (k, delimiter.join(
+                            str(value).lower() if isinstance(value, bool) else str(value)
+                            for value in v)))
             else:
                 new_params.append((k, v))
         return new_params
@@ -529,7 +536,10 @@ class ApiClient:
             if k in collection_formats:
                 collection_format = collection_formats[k]
                 if collection_format == 'multi':
-                    new_params.extend((k, quote(str(value))) for value in v)
+                    new_params.extend(
+                        (k, quote(str(value).lower() if isinstance(value, bool) else str(value)))
+                        for value in v
+                    )
                 else:
                     if collection_format == 'ssv':
                         delimiter = ' '
@@ -540,7 +550,9 @@ class ApiClient:
                     else:  # csv is the default
                         delimiter = ','
                     new_params.append(
-                        (k, delimiter.join(quote(str(value)) for value in v))
+                        (k, delimiter.join(
+                            quote(str(value).lower() if isinstance(value, bool) else str(value))
+                            for value in v))
                     )
             else:
                 new_params.append((k, quote(str(v))))

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -489,10 +489,15 @@ class ApiClient:
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:
+            if isinstance(v, bool):
+                v = str(v).lower()
             if k in collection_formats:
                 collection_format = collection_formats[k]
                 if collection_format == 'multi':
-                    new_params.extend((k, value) for value in v)
+                    new_params.extend(
+                        (k, str(value).lower() if isinstance(value, bool) else value)
+                        for value in v
+                    )
                 else:
                     if collection_format == 'ssv':
                         delimiter = ' '
@@ -503,7 +508,9 @@ class ApiClient:
                     else:  # csv is the default
                         delimiter = ','
                     new_params.append(
-                        (k, delimiter.join(str(value) for value in v)))
+                        (k, delimiter.join(
+                            str(value).lower() if isinstance(value, bool) else str(value)
+                            for value in v)))
             else:
                 new_params.append((k, v))
         return new_params
@@ -529,7 +536,10 @@ class ApiClient:
             if k in collection_formats:
                 collection_format = collection_formats[k]
                 if collection_format == 'multi':
-                    new_params.extend((k, quote(str(value))) for value in v)
+                    new_params.extend(
+                        (k, quote(str(value).lower() if isinstance(value, bool) else str(value)))
+                        for value in v
+                    )
                 else:
                     if collection_format == 'ssv':
                         delimiter = ' '
@@ -540,7 +550,9 @@ class ApiClient:
                     else:  # csv is the default
                         delimiter = ','
                     new_params.append(
-                        (k, delimiter.join(quote(str(value)) for value in v))
+                        (k, delimiter.join(
+                            quote(str(value).lower() if isinstance(value, bool) else str(value))
+                            for value in v))
                     )
             else:
                 new_params.append((k, quote(str(v))))

--- a/samples/client/echo_api/python/tests/test_manual.py
+++ b/samples/client/echo_api/python/tests/test_manual.py
@@ -61,7 +61,7 @@ class TestManual(unittest.TestCase):
         e = EchoServerResponseParser(api_response)
         expected_header = dict(
             integer_header="123",
-            boolean_header="True",
+            boolean_header="true",
             string_header="string_value",
             enum_nonref_string_header="success",
             enum_ref_string_header="failure",

--- a/samples/client/others/python-legacy-model-dictionaries/legacy_model_dict_client/api_client.py
+++ b/samples/client/others/python-legacy-model-dictionaries/legacy_model_dict_client/api_client.py
@@ -597,10 +597,15 @@ class ApiClient:
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:
+            if isinstance(v, bool):
+                v = str(v).lower()
             if k in collection_formats:
                 collection_format = collection_formats[k]
                 if collection_format == 'multi':
-                    new_params.extend((k, value) for value in v)
+                    new_params.extend(
+                        (k, str(value).lower() if isinstance(value, bool) else value)
+                        for value in v
+                    )
                 else:
                     if collection_format == 'ssv':
                         delimiter = ' '
@@ -611,7 +616,9 @@ class ApiClient:
                     else:  # csv is the default
                         delimiter = ','
                     new_params.append(
-                        (k, delimiter.join(str(value) for value in v)))
+                        (k, delimiter.join(
+                            str(value).lower() if isinstance(value, bool) else str(value)
+                            for value in v)))
             else:
                 new_params.append((k, v))
         return new_params
@@ -637,7 +644,10 @@ class ApiClient:
             if k in collection_formats:
                 collection_format = collection_formats[k]
                 if collection_format == 'multi':
-                    new_params.extend((k, quote(str(value))) for value in v)
+                    new_params.extend(
+                        (k, quote(str(value).lower() if isinstance(value, bool) else str(value)))
+                        for value in v
+                    )
                 else:
                     if collection_format == 'ssv':
                         delimiter = ' '
@@ -648,7 +658,9 @@ class ApiClient:
                     else:  # csv is the default
                         delimiter = ','
                     new_params.append(
-                        (k, delimiter.join(quote(str(value)) for value in v))
+                        (k, delimiter.join(
+                            quote(str(value).lower() if isinstance(value, bool) else str(value))
+                            for value in v))
                     )
             else:
                 new_params.append((k, quote(str(v))))

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -488,10 +488,15 @@ class ApiClient:
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:
+            if isinstance(v, bool):
+                v = str(v).lower()
             if k in collection_formats:
                 collection_format = collection_formats[k]
                 if collection_format == 'multi':
-                    new_params.extend((k, value) for value in v)
+                    new_params.extend(
+                        (k, str(value).lower() if isinstance(value, bool) else value)
+                        for value in v
+                    )
                 else:
                     if collection_format == 'ssv':
                         delimiter = ' '
@@ -502,7 +507,9 @@ class ApiClient:
                     else:  # csv is the default
                         delimiter = ','
                     new_params.append(
-                        (k, delimiter.join(str(value) for value in v)))
+                        (k, delimiter.join(
+                            str(value).lower() if isinstance(value, bool) else str(value)
+                            for value in v)))
             else:
                 new_params.append((k, v))
         return new_params
@@ -528,7 +535,10 @@ class ApiClient:
             if k in collection_formats:
                 collection_format = collection_formats[k]
                 if collection_format == 'multi':
-                    new_params.extend((k, quote(str(value))) for value in v)
+                    new_params.extend(
+                        (k, quote(str(value).lower() if isinstance(value, bool) else str(value)))
+                        for value in v
+                    )
                 else:
                     if collection_format == 'ssv':
                         delimiter = ' '
@@ -539,7 +549,9 @@ class ApiClient:
                     else:  # csv is the default
                         delimiter = ','
                     new_params.append(
-                        (k, delimiter.join(quote(str(value)) for value in v))
+                        (k, delimiter.join(
+                            quote(str(value).lower() if isinstance(value, bool) else str(value))
+                            for value in v))
                     )
             else:
                 new_params.append((k, quote(str(v))))

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/api_client.py
@@ -491,10 +491,15 @@ class ApiClient:
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:
+            if isinstance(v, bool):
+                v = str(v).lower()
             if k in collection_formats:
                 collection_format = collection_formats[k]
                 if collection_format == 'multi':
-                    new_params.extend((k, value) for value in v)
+                    new_params.extend(
+                        (k, str(value).lower() if isinstance(value, bool) else value)
+                        for value in v
+                    )
                 else:
                     if collection_format == 'ssv':
                         delimiter = ' '
@@ -505,7 +510,9 @@ class ApiClient:
                     else:  # csv is the default
                         delimiter = ','
                     new_params.append(
-                        (k, delimiter.join(str(value) for value in v)))
+                        (k, delimiter.join(
+                            str(value).lower() if isinstance(value, bool) else str(value)
+                            for value in v)))
             else:
                 new_params.append((k, v))
         return new_params
@@ -531,7 +538,10 @@ class ApiClient:
             if k in collection_formats:
                 collection_format = collection_formats[k]
                 if collection_format == 'multi':
-                    new_params.extend((k, quote(str(value))) for value in v)
+                    new_params.extend(
+                        (k, quote(str(value).lower() if isinstance(value, bool) else str(value)))
+                        for value in v
+                    )
                 else:
                     if collection_format == 'ssv':
                         delimiter = ' '
@@ -542,7 +552,9 @@ class ApiClient:
                     else:  # csv is the default
                         delimiter = ','
                     new_params.append(
-                        (k, delimiter.join(quote(str(value)) for value in v))
+                        (k, delimiter.join(
+                            quote(str(value).lower() if isinstance(value, bool) else str(value))
+                            for value in v))
                     )
             else:
                 new_params.append((k, quote(str(v))))

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/api_client.py
@@ -491,10 +491,15 @@ class ApiClient:
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:
+            if isinstance(v, bool):
+                v = str(v).lower()
             if k in collection_formats:
                 collection_format = collection_formats[k]
                 if collection_format == 'multi':
-                    new_params.extend((k, value) for value in v)
+                    new_params.extend(
+                        (k, str(value).lower() if isinstance(value, bool) else value)
+                        for value in v
+                    )
                 else:
                     if collection_format == 'ssv':
                         delimiter = ' '
@@ -505,7 +510,9 @@ class ApiClient:
                     else:  # csv is the default
                         delimiter = ','
                     new_params.append(
-                        (k, delimiter.join(str(value) for value in v)))
+                        (k, delimiter.join(
+                            str(value).lower() if isinstance(value, bool) else str(value)
+                            for value in v)))
             else:
                 new_params.append((k, v))
         return new_params
@@ -531,7 +538,10 @@ class ApiClient:
             if k in collection_formats:
                 collection_format = collection_formats[k]
                 if collection_format == 'multi':
-                    new_params.extend((k, quote(str(value))) for value in v)
+                    new_params.extend(
+                        (k, quote(str(value).lower() if isinstance(value, bool) else str(value)))
+                        for value in v
+                    )
                 else:
                     if collection_format == 'ssv':
                         delimiter = ' '
@@ -542,7 +552,9 @@ class ApiClient:
                     else:  # csv is the default
                         delimiter = ','
                     new_params.append(
-                        (k, delimiter.join(quote(str(value)) for value in v))
+                        (k, delimiter.join(
+                            quote(str(value).lower() if isinstance(value, bool) else str(value))
+                            for value in v))
                     )
             else:
                 new_params.append((k, quote(str(v))))

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api_client.py
@@ -488,10 +488,15 @@ class ApiClient:
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:
+            if isinstance(v, bool):
+                v = str(v).lower()
             if k in collection_formats:
                 collection_format = collection_formats[k]
                 if collection_format == 'multi':
-                    new_params.extend((k, value) for value in v)
+                    new_params.extend(
+                        (k, str(value).lower() if isinstance(value, bool) else value)
+                        for value in v
+                    )
                 else:
                     if collection_format == 'ssv':
                         delimiter = ' '
@@ -502,7 +507,9 @@ class ApiClient:
                     else:  # csv is the default
                         delimiter = ','
                     new_params.append(
-                        (k, delimiter.join(str(value) for value in v)))
+                        (k, delimiter.join(
+                            str(value).lower() if isinstance(value, bool) else str(value)
+                            for value in v)))
             else:
                 new_params.append((k, v))
         return new_params
@@ -528,7 +535,10 @@ class ApiClient:
             if k in collection_formats:
                 collection_format = collection_formats[k]
                 if collection_format == 'multi':
-                    new_params.extend((k, quote(str(value))) for value in v)
+                    new_params.extend(
+                        (k, quote(str(value).lower() if isinstance(value, bool) else str(value)))
+                        for value in v
+                    )
                 else:
                     if collection_format == 'ssv':
                         delimiter = ' '
@@ -539,7 +549,9 @@ class ApiClient:
                     else:  # csv is the default
                         delimiter = ','
                     new_params.append(
-                        (k, delimiter.join(quote(str(value)) for value in v))
+                        (k, delimiter.join(
+                            quote(str(value).lower() if isinstance(value, bool) else str(value))
+                            for value in v))
                     )
             else:
                 new_params.append((k, quote(str(v))))

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -488,10 +488,15 @@ class ApiClient:
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:
+            if isinstance(v, bool):
+                v = str(v).lower()
             if k in collection_formats:
                 collection_format = collection_formats[k]
                 if collection_format == 'multi':
-                    new_params.extend((k, value) for value in v)
+                    new_params.extend(
+                        (k, str(value).lower() if isinstance(value, bool) else value)
+                        for value in v
+                    )
                 else:
                     if collection_format == 'ssv':
                         delimiter = ' '
@@ -502,7 +507,9 @@ class ApiClient:
                     else:  # csv is the default
                         delimiter = ','
                     new_params.append(
-                        (k, delimiter.join(str(value) for value in v)))
+                        (k, delimiter.join(
+                            str(value).lower() if isinstance(value, bool) else str(value)
+                            for value in v)))
             else:
                 new_params.append((k, v))
         return new_params
@@ -528,7 +535,10 @@ class ApiClient:
             if k in collection_formats:
                 collection_format = collection_formats[k]
                 if collection_format == 'multi':
-                    new_params.extend((k, quote(str(value))) for value in v)
+                    new_params.extend(
+                        (k, quote(str(value).lower() if isinstance(value, bool) else str(value)))
+                        for value in v
+                    )
                 else:
                     if collection_format == 'ssv':
                         delimiter = ' '
@@ -539,7 +549,9 @@ class ApiClient:
                     else:  # csv is the default
                         delimiter = ','
                     new_params.append(
-                        (k, delimiter.join(quote(str(value)) for value in v))
+                        (k, delimiter.join(
+                            quote(str(value).lower() if isinstance(value, bool) else str(value))
+                            for value in v))
                     )
             else:
                 new_params.append((k, quote(str(v))))


### PR DESCRIPTION
Boolean parameters serialize as Python `True`/`False` in every place except a top-level query value, so a strict server rejects them.

`parameters_to_url_query` lowercased a scalar boolean query value, but booleans inside a collection went through `str()`:

```
?flags=True,False        # csv array
?multi=True&multi=False  # exploded array
```

Path, header and form parameters had no boolean handling at all:

```
/pets/True               # boolean path param
```

The fix lowercases booleans in `parameters_to_tuples` (covers path, header, form and the multi branch) and in the collection branches of `parameters_to_url_query`. After it:

```
/pets/true
?single=false&flags=true,false&multi=true&multi=false
```

and boolean headers serialize as `true`.

Verified against a generated client covering path / query (scalar, csv, exploded) / header booleans; petstore sample tests still pass.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran `./mvnw clean package` and regenerated the python samples.
- [x] Filed the PR against `master`.

/cc @cbornet @tomplus @krjakbrjak

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowercase boolean serialization across all Python client parameter styles to ensure servers receive true/false instead of True/False. Fixes strict servers rejecting mixed-case booleans.

- **Bug Fixes**
  - Lowercase bools in path, header, form, and query (scalar, csv, multi).
  - Implemented in `parameters_to_tuples` and collection handling in `parameters_to_url_query`.
  - Regenerated Python samples and updated echo_api header test to expect `true`.

<sup>Written for commit b2e9e746338c7195ed73d94517e919cd8367a536. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

