### PR TITLE
[scala-sttp4] Omit optional fields set to None instead of serializing null (circe)

### DIFF
--- a/modules/openapi-generator/src/main/resources/scala-sttp4/model.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp4/model.mustache
@@ -51,7 +51,7 @@ object {{classname}} {
   import io.circe.syntax._
   import io.circe.generic.semiauto._
 
-  implicit val encoder: Encoder[{{classname}}] = deriveEncoder
+  implicit val encoder: Encoder[{{classname}}] = deriveEncoder[{{classname}}].mapJson(_.dropNullValues)
   implicit val decoder: Decoder[{{classname}}] = deriveDecoder
 }
 {{/circe}}
@@ -180,7 +180,7 @@ object {{classname}} {
   import io.circe.{Encoder, Decoder}
   import io.circe.generic.semiauto._
 
-  implicit val encoder: Encoder[{{classname}}] = deriveEncoder
+  implicit val encoder: Encoder[{{classname}}] = deriveEncoder[{{classname}}].mapJson(_.dropNullValues)
   implicit val decoder: Decoder[{{classname}}] = deriveDecoder
 {{/vendorExtensions.x-use-discr}}
 {{#vendorExtensions.x-use-discr}}
@@ -198,7 +198,7 @@ object {{classname}} {
         case other => sys.error(s"Invalid {{classname}} discriminant: ${other}")
       }
     )  
-  implicit val encoder: Encoder[{{classname}}] = deriveConfiguredEncoder
+  implicit val encoder: Encoder[{{classname}}] = deriveConfiguredEncoder[{{classname}}].mapJson(_.dropNullValues)
   implicit val decoder: Decoder[{{classname}}] = deriveConfiguredDecoder
 {{/vendorExtensions.x-use-discr}}
 {{/vendorExtensions.x-hasWrappedOneOfMembers}}
@@ -326,7 +326,7 @@ object {{classname}} {
   import io.circe.syntax._
   import io.circe.generic.semiauto._
 
-  implicit val encoder: Encoder[{{classname}}] = deriveEncoder
+  implicit val encoder: Encoder[{{classname}}] = deriveEncoder[{{classname}}].mapJson(_.dropNullValues)
   implicit val decoder: Decoder[{{classname}}] = deriveDecoder
 }
 {{/circe}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/Sttp4CodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/Sttp4CodegenTest.java
@@ -333,4 +333,37 @@ public class Sttp4CodegenTest {
         assertFileContains(modelPath, "createdAt: OffsetDateTime");
         assertFileContains(modelPath, "updatedAt: Option[OffsetDateTime]");
     }
+
+    @Test
+    public void verifyOptionalFieldsOmittedWhenNone() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/scala/sttp4-optional-fields.yaml", null, new ParseOptions()).getOpenAPI();
+
+        ScalaSttp4ClientCodegen codegen = new ScalaSttp4ClientCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put("jsonLibrary", "circe");
+
+        ClientOptInput input = new ClientOptInput();
+        input.openAPI(openAPI);
+        input.config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.SUPPORTING_FILES, "false");
+        generator.opts(input).generate();
+
+        // Optional fields set to None must be omitted from the JSON (sttp3 parity),
+        // not serialized as null: strict servers reject explicit null for
+        // non-nullable optional properties.
+        Path petPath = Paths.get(outputPath + "/src/main/scala/org/openapitools/client/model/Pet.scala");
+        assertFileContains(petPath, "implicit val encoder: Encoder[Pet] = deriveEncoder[Pet].mapJson(_.dropNullValues)");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/scala/sttp4-optional-fields.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/scala/sttp4-optional-fields.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.3
+info:
+  title: Optional field test
+  version: 1.0.0
+paths:
+  /pets:
+    post:
+      operationId: createPet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        tag:
+          type: string

--- a/samples/client/petstore/scala-sttp4-circe/src/main/scala/org/openapitools/client/model/ApiResponse.scala
+++ b/samples/client/petstore/scala-sttp4-circe/src/main/scala/org/openapitools/client/model/ApiResponse.scala
@@ -26,6 +26,6 @@ object ApiResponse {
   import io.circe.syntax._
   import io.circe.generic.semiauto._
 
-  implicit val encoder: Encoder[ApiResponse] = deriveEncoder
+  implicit val encoder: Encoder[ApiResponse] = deriveEncoder[ApiResponse].mapJson(_.dropNullValues)
   implicit val decoder: Decoder[ApiResponse] = deriveDecoder
 }

--- a/samples/client/petstore/scala-sttp4-circe/src/main/scala/org/openapitools/client/model/Category.scala
+++ b/samples/client/petstore/scala-sttp4-circe/src/main/scala/org/openapitools/client/model/Category.scala
@@ -25,6 +25,6 @@ object Category {
   import io.circe.syntax._
   import io.circe.generic.semiauto._
 
-  implicit val encoder: Encoder[Category] = deriveEncoder
+  implicit val encoder: Encoder[Category] = deriveEncoder[Category].mapJson(_.dropNullValues)
   implicit val decoder: Decoder[Category] = deriveDecoder
 }

--- a/samples/client/petstore/scala-sttp4-circe/src/main/scala/org/openapitools/client/model/Order.scala
+++ b/samples/client/petstore/scala-sttp4-circe/src/main/scala/org/openapitools/client/model/Order.scala
@@ -31,7 +31,7 @@ object Order {
   import io.circe.syntax._
   import io.circe.generic.semiauto._
 
-  implicit val encoder: Encoder[Order] = deriveEncoder
+  implicit val encoder: Encoder[Order] = deriveEncoder[Order].mapJson(_.dropNullValues)
   implicit val decoder: Decoder[Order] = deriveDecoder
 }
 object OrderEnums {

--- a/samples/client/petstore/scala-sttp4-circe/src/main/scala/org/openapitools/client/model/Pet.scala
+++ b/samples/client/petstore/scala-sttp4-circe/src/main/scala/org/openapitools/client/model/Pet.scala
@@ -30,7 +30,7 @@ object Pet {
   import io.circe.syntax._
   import io.circe.generic.semiauto._
 
-  implicit val encoder: Encoder[Pet] = deriveEncoder
+  implicit val encoder: Encoder[Pet] = deriveEncoder[Pet].mapJson(_.dropNullValues)
   implicit val decoder: Decoder[Pet] = deriveDecoder
 }
 object PetEnums {

--- a/samples/client/petstore/scala-sttp4-circe/src/main/scala/org/openapitools/client/model/Tag.scala
+++ b/samples/client/petstore/scala-sttp4-circe/src/main/scala/org/openapitools/client/model/Tag.scala
@@ -25,6 +25,6 @@ object Tag {
   import io.circe.syntax._
   import io.circe.generic.semiauto._
 
-  implicit val encoder: Encoder[Tag] = deriveEncoder
+  implicit val encoder: Encoder[Tag] = deriveEncoder[Tag].mapJson(_.dropNullValues)
   implicit val decoder: Decoder[Tag] = deriveDecoder
 }

--- a/samples/client/petstore/scala-sttp4-circe/src/main/scala/org/openapitools/client/model/User.scala
+++ b/samples/client/petstore/scala-sttp4-circe/src/main/scala/org/openapitools/client/model/User.scala
@@ -32,6 +32,6 @@ object User {
   import io.circe.syntax._
   import io.circe.generic.semiauto._
 
-  implicit val encoder: Encoder[User] = deriveEncoder
+  implicit val encoder: Encoder[User] = deriveEncoder[User].mapJson(_.dropNullValues)
   implicit val decoder: Decoder[User] = deriveDecoder
 }


### PR DESCRIPTION
Fixes #24360.

The circe branch of the `scala-sttp4` generator uses plain `deriveEncoder`, which serializes `Option` `None` as JSON `null`:

```scala
implicit val encoder: Encoder[Pet] = deriveEncoder
// Pet("rex", None) => {"name":"rex","tag":null}
```

The `scala-sttp` (sttp3) generator **omits** absent optional fields — its hand-rolled encoders build fields via `t.tag.map(v => "tag" -> v.asJson)` — as do the json4s branch (json4s omits `None` by default) and `scala-sttp4-jsoniter` (`transientNone` defaults to true). So clients migrating sttp3 → sttp4 with circe silently start sending explicit `null`s, which strict servers (e.g. FastAPI/pydantic non-nullable optional fields) reject with 422.

**Fix:** append `.mapJson(_.dropNullValues)` to the generated circe encoders — plain models, inline oneOf members, and the discriminator-configured sealed-trait encoder — restoring sttp3 parity: `None` ⇒ field omitted. The wrapper-composition oneOf encoders delegate to member encoders and inherit the fix. Verified end-to-end: with this change `Pet(name = "rex", tag = None).asJson.noSpaces == {"name":"rex"}` and the regenerated `scala-sttp4-circe` petstore sample compiles.

**Known limitation (unchanged from scala-sttp):** `Option` cannot express an *explicit* JSON `null` for `nullable: true` properties; distinguishing null-vs-absent would require a tri-state type and is out of scope here.

**Tests:** `Sttp4CodegenTest#verifyOptionalFieldsOmittedWhenNone` with a new fixture (`sttp4-optional-fields.yaml`). Samples regenerated via `./bin/generate-samples.sh bin/configs/scala-sttp4*.yaml` — only the circe sample changes (json4s/jsoniter are unaffected, confirmed by zero-diff regeneration).

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Built the project and updated samples; changes committed.
- [x] Filed against `master`.
- [x] Scala technical committee: @clasnake @jimschubert @shijinkui @ramzimaalej @chameleon82 @Bouillie


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Omit optional fields set to None in `scala-sttp4` `circe` models by dropping null values during encoding. This restores `sttp3` behavior and prevents sending JSON nulls that strict servers reject.

- **Bug Fixes**
  - Appended `.mapJson(_.dropNullValues)` to all generated `circe` encoders (plain models, inline oneOf members, and discriminator-based sealed traits).
  - Added test `verifyOptionalFieldsOmittedWhenNone` with `sttp4-optional-fields.yaml`.
  - Regenerated `scala-sttp4-circe` petstore samples; other libraries (`json4s`, `scala-sttp4-jsoniter`) unchanged.

<sup>Written for commit 2a3769ccfd3a298e119a4e44edbb733670f790b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

