### PR TITLE
fix(go-server): avoid AssertstringRequired for primitive-typed models

### DIFF
--- a/docs/generators/go-echo-server.md
+++ b/docs/generators/go-echo-server.md
@@ -45,15 +45,20 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>float32</li>
 <li>float64</li>
 <li>int</li>
+<li>int16</li>
 <li>int32</li>
 <li>int64</li>
+<li>int8</li>
 <li>interface{}</li>
 <li>map[string]interface{}</li>
 <li>rune</li>
 <li>string</li>
 <li>uint</li>
+<li>uint16</li>
 <li>uint32</li>
 <li>uint64</li>
+<li>uint8</li>
+<li>uintptr</li>
 </ul>
 
 ## RESERVED WORDS

--- a/docs/generators/go-gin-server.md
+++ b/docs/generators/go-gin-server.md
@@ -48,15 +48,20 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>float32</li>
 <li>float64</li>
 <li>int</li>
+<li>int16</li>
 <li>int32</li>
 <li>int64</li>
+<li>int8</li>
 <li>interface{}</li>
 <li>map[string]interface{}</li>
 <li>rune</li>
 <li>string</li>
 <li>uint</li>
+<li>uint16</li>
 <li>uint32</li>
 <li>uint64</li>
+<li>uint8</li>
+<li>uintptr</li>
 </ul>
 
 ## RESERVED WORDS

--- a/docs/generators/go-server.md
+++ b/docs/generators/go-server.md
@@ -52,15 +52,20 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>float32</li>
 <li>float64</li>
 <li>int</li>
+<li>int16</li>
 <li>int32</li>
 <li>int64</li>
+<li>int8</li>
 <li>interface{}</li>
 <li>map[string]interface{}</li>
 <li>rune</li>
 <li>string</li>
 <li>uint</li>
+<li>uint16</li>
 <li>uint32</li>
 <li>uint64</li>
+<li>uint8</li>
+<li>uintptr</li>
 </ul>
 
 ## RESERVED WORDS

--- a/docs/generators/go.md
+++ b/docs/generators/go.md
@@ -58,15 +58,20 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>float32</li>
 <li>float64</li>
 <li>int</li>
+<li>int16</li>
 <li>int32</li>
 <li>int64</li>
+<li>int8</li>
 <li>interface{}</li>
 <li>map[string]interface{}</li>
 <li>rune</li>
 <li>string</li>
 <li>uint</li>
+<li>uint16</li>
 <li>uint32</li>
 <li>uint64</li>
+<li>uint8</li>
+<li>uintptr</li>
 </ul>
 
 ## RESERVED WORDS

--- a/docs/generators/terraform-provider.md
+++ b/docs/generators/terraform-provider.md
@@ -47,15 +47,20 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>float32</li>
 <li>float64</li>
 <li>int</li>
+<li>int16</li>
 <li>int32</li>
 <li>int64</li>
+<li>int8</li>
 <li>interface{}</li>
 <li>map[string]interface{}</li>
 <li>rune</li>
 <li>string</li>
 <li>uint</li>
+<li>uint16</li>
 <li>uint32</li>
 <li>uint64</li>
+<li>uint8</li>
+<li>uintptr</li>
 </ul>
 
 ## RESERVED WORDS

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -98,11 +98,16 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
                         "string",
                         "bool",
                         "uint",
+                        "uint8",
+                        "uint16",
                         "uint32",
                         "uint64",
                         "int",
+                        "int8",
+                        "int16",
                         "int32",
                         "int64",
+                        "uintptr",
                         "float32",
                         "float64",
                         "complex64",
@@ -165,6 +170,34 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
                 .defaultValue("1.0.0"));
         cliOptions.add(new CliOption(CodegenConstants.HIDE_GENERATION_TIMESTAMP, CodegenConstants.HIDE_GENERATION_TIMESTAMP_DESC)
                 .defaultValue(Boolean.TRUE.toString()));
+    }
+
+    @Override
+    public CodegenProperty fromProperty(String name, Schema p, boolean required, boolean schemaIsFromAdditionalProperties) {
+        CodegenProperty property = super.fromProperty(name, p, required, schemaIsFromAdditionalProperties);
+        // A composed schema (e.g. a nullable oneOf enum) is classified as a model at the
+        // OpenAPI level even when Go flattens it to a primitive type such as *string.
+        // Correct the flags here so all Go generators rely on the same classification.
+        if (property != null && property.isModel
+                && (isGoPrimitiveType(property.baseType) || isGoPrimitiveType(property.dataType))) {
+            property.isModel = false;
+            property.isPrimitiveType = true;
+        }
+        return property;
+    }
+
+    /**
+     * Indicates whether the given Go type (a leading {@code *} for nullable pointer types
+     * is stripped first) is classified as a language-specific primitive type.
+     */
+    protected boolean isGoPrimitiveType(String goType) {
+        if (goType == null) {
+            return false;
+        }
+        if (goType.startsWith("*")) {
+            goType = goType.substring(1);
+        }
+        return languageSpecificPrimitives.contains(goType);
     }
 
     @Override

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/goserver/GoServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/goserver/GoServerCodegenTest.java
@@ -272,4 +272,23 @@ public class GoServerCodegenTest {
                 "if err := AssertMetaRequired(obj.Meta); err != nil {");
     }
 
+    @Test
+    public void verifyNoAssertstringRequiredForPrimitiveTypedModels() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = createDefaultCodegenConfigurator(output)
+                .setInputSpec("src/test/resources/3_0/go-server/assert-primitive-model.yaml");
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        java.nio.file.Path modelPath = Paths.get(output + "/go/model_thing.go");
+        TestUtils.assertFileExists(modelPath);
+        TestUtils.assertFileNotContains(modelPath, "AssertstringRequired");
+        TestUtils.assertFileNotContains(modelPath, "AssertstringConstraints");
+        TestUtils.assertFileContains(modelPath, "func AssertThingRequired(obj Thing) error {\n\treturn nil");
+    }
+
 }

--- a/modules/openapi-generator/src/test/resources/3_0/go-server/assert-primitive-model.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/go-server/assert-primitive-model.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.1
+info:
+  version: 1.0.0
+  title: composed nullable enum must not emit primitive Assert helpers
+paths:
+  /thing:
+    post:
+      operationId: createThing
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Thing'
+      responses:
+        '201':
+          description: created
+components:
+  schemas:
+    Mode:
+      type: string
+      enum: [On, Off]
+    Thing:
+      type: object
+      properties:
+        mode:
+          nullable: true
+          oneOf:
+            - $ref: '#/components/schemas/Mode'
+            - enum: [null]
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/Mode'
+            nullable: true


### PR DESCRIPTION
oneOf/nullable enums can flatten to *string while still flagged as models, so templates must not emit Assertstring* helpers that do not exist.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Go server codegen from emitting `Assertstring*` calls when composed schemas flatten to Go primitives (e.g., nullable `oneOf` enums), preventing bad references and compile errors. Primitive detection is centralized in `AbstractGoCodegen` so all Go generators treat these as primitives.

- **Bug Fixes**
  - Clear `isModel` and set `isPrimitiveType` in `AbstractGoCodegen.fromProperty` when the Go type (incl. pointer types) is primitive; applies to array items too.
  - Add missing Go builtins to `languageSpecificPrimitives`: `uint8`, `uint16`, `int8`, `int16`, `uintptr`, and update Go generator docs to list them.
  - Tests and sample spec verify no `AssertstringRequired/Constraints` generation and `AssertThingRequired` is a no-op.

<sup>Written for commit 2b5ed044a5e08c021193b38b44672c7dc4229aa0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

