### PR TITLE
fix(examples-utils): improve logging for non-application/json media types in API response examples

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ExamplesUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ExamplesUtils.java
@@ -14,7 +14,10 @@ import java.util.*;
 import static org.openapitools.codegen.utils.OnceLogger.once;
 
 public class ExamplesUtils {
+
     private static final Logger LOGGER = LoggerFactory.getLogger(ExamplesUtils.class);
+
+    private static final String APPLICATION_JSON = "application/json";
 
     /**
      * Return examples of API response.
@@ -36,20 +39,25 @@ public class ExamplesUtils {
         if (content == null || content.isEmpty())
             return Collections.emptyMap();
 
-        if (content.containsKey("application/json")) {
-            Map<String, Example> examples = content.get("application/json").getExamples();
+        if (content.containsKey(APPLICATION_JSON)) {
+            Map<String, Example> examples = content.get(APPLICATION_JSON).getExamples();
             if (content.size() > 1 && examples != null && !examples.isEmpty()) {
-                once(LOGGER).warn("More than one content media type found in response. Only response examples of the application/json will be taken for codegen.");
+                once(LOGGER).info("More than one content media type found in response. Only response examples of the application/json will be taken for codegen.");
             }
 
             return examples;
         }
 
-        once(LOGGER).warn("No application/json content media type found in response. Response examples can currently only be generated for application/json media type.");
+        if (containsContextMediaTypeWithExamples(content)) {
+            once(LOGGER).info("Found one or more content media type(s) with examples in response, but none was application/json. Examples can currently only be generated for application/json media type.");
+        }
 
         return Collections.emptyMap();
     }
 
+    private static boolean containsContextMediaTypeWithExamples(Content content) {
+        return content.values().stream().anyMatch(mediaType -> mediaType.getExamples() != null && !mediaType.getExamples().isEmpty());
+    }
 
     /**
      * Return actual examples objects of API response with values and processed from references (unaliased)


### PR DESCRIPTION
Changes the logging condition for when `ExamplesUtils` is unable to find `application/json` media type examples.

Instead of always logging that no examples can be found within the resolved `Content`, it instead only logs if it can find examples within a media type that is not `application/json`. I.e., there are examples defined, but the media type is currently not supported with regard to generation of examples. 

The logging level of this message has also been changed from `warn` to `info`, since it is not something faulty on the client's end.

I would also be fine with removing it entirely, since for the scenario "I have an example defined but it is not visible in the generated code" I am doubtful that this log would aid a user in the debugging process.

Fixes https://github.com/OpenAPITools/openapi-generator/issues/24364

@martin-mfg who wrote this class and the changed log message

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves `ExamplesUtils` logging for response examples: only logs when examples exist on non-`application/json` media types and downgrades related messages to info. This removes misleading warnings and clarifies that example generation currently supports only `application/json`.

- **Bug Fixes**
  - Log only when examples exist on non-`application/json` content; stay silent otherwise.
  - Downgrade warnings to info, including the multi-content-type notice; add small helpers (`APPLICATION_JSON` constant and example detector).

<sup>Written for commit 992108ee873f497a10aaee76c582166bdfeb57a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

