### PR TITLE
refactor(enum-utils): move normalization logic for enum handling to EnumUtils

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -41,6 +41,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.openapitools.codegen.CodegenConstants.*;
+import static org.openapitools.codegen.utils.EnumUtils.ANY_OF;
+import static org.openapitools.codegen.utils.EnumUtils.ONE_OF;
 import static org.openapitools.codegen.utils.ModelUtils.simplifyOneOfAnyOfWithOnlyOneNonNullSubSchema;
 import static org.openapitools.codegen.utils.StringUtils.getUniqueString;
 
@@ -169,6 +171,8 @@ public class OpenAPINormalizer {
     final String LOOSE_NULL_DEFINITIONS = "LOOSE_NULL_DEFINITIONS";
 
     // ============= end of rules =============
+
+    private static final String ONE_OF_ANY_OF_ENUM_SIMPLIFIED = "Simplified {} with enum sub-schemas to single enum: {} since rule {} was enabled";
 
     /**
      * Factory constructor for OpenAPINormalizer.
@@ -1642,95 +1646,18 @@ public class OpenAPINormalizer {
      * @return Simplified schema
      */
     protected Schema simplifyComposedSchemaWithEnums(Schema schema, List<Object> subSchemas, String composedType) {
-        Map<Object, EnumUtils.EnumExtensions> enumExtensions = new LinkedHashMap<>();
-
-        if(schema.getTypes() != null && schema.getTypes().size() > 1) {
-            // we cannot handle enums with multiple types
-            return schema;
+        Schema enumSchema = EnumUtils.simplifyComposedSchemaWithEnums(schema, subSchemas, composedType, openAPI);
+        if (hasComposedSchemaWithEnumsBeenSimplified(schema, composedType)) {
+            LOGGER.debug(ONE_OF_ANY_OF_ENUM_SIMPLIFIED, composedType, enumSchema, SIMPLIFY_ONEOF_ANYOF_ENUM);
         }
-
-        if(subSchemas.size() < 2) {
-            //do not process if there's less than 2 sub-schemas. It will be normalized later, and this prevents
-            //named enum schemas from being converted to inline enum schemas
-            return schema;
-        }
-        String schemaType = ModelUtils.getType(schema);
-
-        for (Object item : subSchemas) {
-            if (!(item instanceof Schema)) {
-                return schema;
-            }
-
-            Schema subSchema = ModelUtils.getReferencedSchema(openAPI, (Schema) item);
-
-            // Check if this sub-schema has an enum or const value (OAS 3.1 uses const for single-value enums)
-            boolean definesEnum = ModelUtils.hasEnum(subSchema);
-            if (!definesEnum && subSchema.getConst() == null) {
-                return schema;
-            }
-            // If const is present but enum is not, treat const as a single enum value
-            List<Object> subSchemaEnumValues = definesEnum
-                    ? subSchema.getEnum()
-                    : Arrays.asList(subSchema.getConst());
-
-            // Ensure all sub-schemas have the same type (if type is specified)
-            if(subSchema.getTypes() != null && subSchema.getTypes().size() > 1) {
-                // we cannot handle enums with multiple types
-                return schema;
-            }
-            String subSchemaType = ModelUtils.getType(subSchema);
-            if (subSchemaType != null) {
-                if (schemaType == null) {
-                    schemaType = subSchemaType;
-                } else if (!schemaType.equals(subSchema.getType())) {
-                    return schema;
-                }
-            }
-            boolean subSchemaDeprecated = Boolean.TRUE.equals(subSchema.getDeprecated());
-            // Add all enum values from this sub-schema to our collection
-            if(subSchemaEnumValues.size() == 1) {
-                String description = subSchema.getTitle() == null ? "" : subSchema.getTitle();
-                if(subSchema.getDescription() != null) {
-                    if(!description.isEmpty()) {
-                        description += " - ";
-                    }
-                    description += subSchema.getDescription();
-                }
-                enumExtensions.put(subSchemaEnumValues.get(0), new EnumUtils.EnumExtensions(description, subSchemaDeprecated));
-            } else {
-                for(Object e: subSchemaEnumValues) {
-                    enumExtensions.put(e, new EnumUtils.EnumExtensions("", subSchemaDeprecated));
-                }
-            }
-        }
-
-        return createSimplifiedEnumSchema(schema, enumExtensions, schemaType, composedType);
+        return enumSchema;
     }
 
-    /**
-     * Creates a simplified enum schema from collected enum values.
-     *
-     * @param originalSchema Original schema to modify
-     * @param enumExtensions Collected enum values
-     * @param schemaType Consistent type across sub-schemas
-     * @param composedType Type of composed schema being simplified
-     * @return Simplified enum schema
-     */
-    protected Schema createSimplifiedEnumSchema(Schema originalSchema, Map<Object, EnumUtils.EnumExtensions> enumExtensions, String schemaType, String composedType) {
-        // Clear the composed schema type
-        if ("oneOf".equals(composedType)) {
-            originalSchema.setOneOf(null);
-        } else if ("anyOf".equals(composedType)) {
-            originalSchema.setAnyOf(null);
-        }
-
-        EnumUtils.createSimplifiedEnumSchema(originalSchema, enumExtensions, schemaType);
-
-        LOGGER.debug("Simplified {} with enum sub-schemas to single enum: {}", composedType, originalSchema);
-
-        return originalSchema;
+    private boolean hasComposedSchemaWithEnumsBeenSimplified(Schema schema, String composedType) {
+        boolean oneOfSimplified = ONE_OF.equals(composedType) && schema.getOneOf() == null;
+        boolean anyOfSimplified = ANY_OF.equals(composedType) && schema.getAnyOf() == null;
+        return oneOfSimplified || anyOfSimplified;
     }
-
 
     /**
      * If the schema is oneOf and the sub-schemas is null, set `nullable: true`

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/EnumUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/EnumUtils.java
@@ -1,10 +1,9 @@
 package org.openapitools.codegen.utils;
 
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.Schema;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.openapitools.codegen.CodegenConstants.X_ENUM_DEPRECATED;
@@ -12,30 +11,133 @@ import static org.openapitools.codegen.CodegenConstants.X_ENUM_DESCRIPTIONS;
 
 public class EnumUtils {
 
-    public static Schema createSimplifiedEnumSchema(Schema originalSchema,
-                                                     Map<Object, EnumExtensions> enums,
-                                                     String schemaType) {
-        if (ModelUtils.getType(originalSchema) == null && schemaType != null) {
-            //if type was specified in subschemas, keep it in the main schema
-            ModelUtils.setType(originalSchema, schemaType);
+    public static final String ONE_OF = "oneOf";
+    public static final String ANY_OF = "anyOf";
+
+    /**
+     * Simplifies a composed schema (oneOf/anyOf) where all sub-schemas are enums
+     * to a single enum schema containing all the values.
+     *
+     * @param schema       Schema to modify
+     * @param subSchemas   List of sub-schemas to check
+     * @param composedType Type of composed schema ("oneOf" or "anyOf")
+     * @param openAPI      The OpenAPI object to resolve references
+     * @return Simplified schema
+     */
+    public static Schema simplifyComposedSchemaWithEnums(Schema schema,
+                                                         List<Object> subSchemas,
+                                                         String composedType,
+                                                         OpenAPI openAPI) {
+        Map<Object, EnumExtensions> enumExtensions = new LinkedHashMap<>();
+
+        if (schema.getTypes() != null && schema.getTypes().size() > 1) {
+            // we cannot handle enums with multiple types
+            return schema;
         }
 
-        originalSchema.setEnum(new ArrayList<>(enums.keySet()));
+        if (subSchemas.size() < 2) {
+            //do not process if there's less than 2 sub-schemas. It will be normalized later, and this prevents
+            //named enum schemas from being converted to inline enum schemas
+            return schema;
+        }
+        String schemaType = ModelUtils.getType(schema);
+
+        for (Object item : subSchemas) {
+            if (!(item instanceof Schema)) {
+                return schema;
+            }
+
+            Schema subSchema = ModelUtils.getReferencedSchema(openAPI, (Schema) item);
+
+            // Check if this sub-schema has an enum or const value (OAS 3.1 uses const for single-value enums)
+            boolean definesEnum = ModelUtils.hasEnum(subSchema);
+            if (!definesEnum && subSchema.getConst() == null) {
+                return schema;
+            }
+            // If const is present but enum is not, treat const as a single enum value
+            List<Object> subSchemaEnumValues = definesEnum
+                    ? subSchema.getEnum()
+                    : Arrays.asList(subSchema.getConst());
+
+            // Ensure all sub-schemas have the same type (if type is specified)
+            if (subSchema.getTypes() != null && subSchema.getTypes().size() > 1) {
+                // we cannot handle enums with multiple types
+                return schema;
+            }
+            String subSchemaType = ModelUtils.getType(subSchema);
+            if (subSchemaType != null) {
+                if (schemaType == null) {
+                    schemaType = subSchemaType;
+                } else if (!schemaType.equals(subSchema.getType())) {
+                    return schema;
+                }
+            }
+            enumExtensions.putAll(getEnumExtensions(subSchema, subSchemaEnumValues));
+        }
+
+        // Clear the composed schema type since we were able to successfully process all subSchemas
+        if (ONE_OF.equals(composedType)) {
+            schema.setOneOf(null);
+        } else if (ANY_OF.equals(composedType)) {
+            schema.setAnyOf(null);
+        }
+        return createSimplifiedEnumSchema(schema, enumExtensions, schemaType);
+    }
+
+    private static Map<Object, EnumExtensions> getEnumExtensions(Schema schema,
+                                                                 List<Object> schemaEnumValues) {
+        Map<Object, EnumExtensions> enumExtensions = new LinkedHashMap<>();
+        boolean schemaDeprecated = Boolean.TRUE.equals(schema.getDeprecated());
+        // Add all enum values from this sub-schema to our collection
+        if (schemaEnumValues.size() == 1) {
+            String description = schema.getTitle() == null ? "" : schema.getTitle();
+            if (schema.getDescription() != null) {
+                if (!description.isEmpty()) {
+                    description += " - ";
+                }
+                description += schema.getDescription();
+            }
+            enumExtensions.put(schemaEnumValues.get(0), new EnumExtensions(description, schemaDeprecated));
+        } else {
+            for (Object enumValue : schemaEnumValues) {
+                enumExtensions.put(enumValue, new EnumExtensions("", schemaDeprecated));
+            }
+        }
+        return enumExtensions;
+    }
+
+    /**
+     * Creates a simplified enum schema from collected enum values.
+     *
+     * @param schema     schema to modify
+     * @param enums      Collected enum values
+     * @param schemaType Consistent type across sub-schemas
+     * @return Simplified enum schema
+     */
+    private static Schema createSimplifiedEnumSchema(Schema schema,
+                                                     Map<Object, EnumExtensions> enums,
+                                                     String schemaType) {
+        if (ModelUtils.getType(schema) == null && schemaType != null) {
+            //if type was specified in subschemas, keep it in the main schema
+            ModelUtils.setType(schema, schemaType);
+        }
+
+        schema.setEnum(new ArrayList<>(enums.keySet()));
         List<String> enumDescriptions = enums.values().stream().map(EnumExtensions::getDescription).collect(Collectors.toList());
         List<Boolean> enumDeprecations = enums.values().stream().map(EnumExtensions::isDeprecated).collect(Collectors.toList());
-        if(enumDescriptions.stream().anyMatch(e -> !e.isEmpty())) {
+        if (enumDescriptions.stream().anyMatch(e -> !e.isEmpty())) {
             //set x-enum-descriptions only if there's at least one non-empty description
-            originalSchema.addExtension(X_ENUM_DESCRIPTIONS, new ArrayList<>(enumDescriptions));
+            schema.addExtension(X_ENUM_DESCRIPTIONS, new ArrayList<>(enumDescriptions));
         }
         if (enumDeprecations.stream().anyMatch(Boolean.TRUE::equals)) {
             // preserve per-value deprecated flags from OAS 3.1 oneOf/anyOf + const sub-schemas
-            originalSchema.addExtension(X_ENUM_DEPRECATED, new ArrayList<>(enumDeprecations));
+            schema.addExtension(X_ENUM_DEPRECATED, new ArrayList<>(enumDeprecations));
         }
 
-        return originalSchema;
+        return schema;
     }
 
-    public static class EnumExtensions {
+    private static class EnumExtensions {
         private final String description;
         private final boolean deprecated;
 


### PR DESCRIPTION
This moves the remaining logic for enum processing in the `OpenAPINormalizer` to the `EnumUtils`.

This is done to centralize the logic for Enum processing, with the goal of being able to introduce a more explicit `CodegenEnum` model to carry the reoccurring Enum logic.

After this PR the `OpenAPI representation -> Normalized OpenAPI representation` step of the overall generator process
 ```
Specification -> 
OpenAPI representation -> 
Normalized OpenAPI representation -> 
Codegen models -> 
Code generated with mustache-templates
```
has been handled.

This should mean that we can now investigate `Normalized OpenAPI representation -> Codegen model`,  which is the step that would contain `CodegenEnum`.

----

Note that this intentionally removes the protected method `Schema createSimplifiedEnumSchema(...)` from the `OpenAPINormalizer`.

This is done since I do not believe it is a logical extension point for a user, and that it rather only is a helper for the main rule method (`Schema simplifyComposedSchemaWithEnums(...)`). Thus that it belongs entirely in the `Utils` class. This is also based around the reasoning that the Normalizer mainly has one protected method per rules, so that if the user wants to adjust a rule, then they mainly override the entire rule-method.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes enum normalization in `EnumUtils`, moving logic out of `OpenAPINormalizer`. Unifies `oneOf`/`anyOf` (including OAS 3.1 `const`) into a single enum while preserving type and enum metadata.

- **Refactors**
  - Added `EnumUtils.simplifyComposedSchemaWithEnums(schema, subSchemas, composedType, openAPI)` to resolve `$ref`s and merge enum/const sub-schemas, preserving `type`, `x-enum-descriptions`, and `x-enum-deprecated`.
  - `OpenAPINormalizer.simplifyComposedSchemaWithEnums(...)` now delegates to `EnumUtils` and logs a standardized debug message when simplification occurs.
  - Consolidated enum-building helpers inside `EnumUtils` (now private), and introduced `EnumUtils.ONE_OF`/`EnumUtils.ANY_OF` constants for consistency.

- **Migration**
  - Removed protected `OpenAPINormalizer.createSimplifiedEnumSchema(...)`. If you customized it, override `simplifyComposedSchemaWithEnums(...)` instead.

<sup>Written for commit 08617249abad3c6ea3f5ed43b99d9ddd52f13d53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

