### PR TITLE
Better handling of cookie in python clients

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -841,7 +841,7 @@ https://github.com/OpenAPITools/openapi-generator/blob/c84b949df1a9ec04ba75989cb
             else:
                 headers['Cookie'] += "; "
             # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe='+/=')
+            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_{|}~%+/=")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -841,7 +841,7 @@ https://github.com/OpenAPITools/openapi-generator/blob/c84b949df1a9ec04ba75989cb
             else:
                 headers['Cookie'] += "; "
             # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_{|}~%+/=")
+            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_`{|}~%+/=")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -840,11 +840,8 @@ https://github.com/OpenAPITools/openapi-generator/blob/c84b949df1a9ec04ba75989cb
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces and special characters
-            cookie_value = str(auth_setting['value'])
-            if not re.match("^\".*\"$", cookie_value):
-                cookie_value = cookie_value.replace("\"", "\\\"")
-                cookie_value = f"\"{cookie_value}\""
+            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
+            cookie_value = quote(str(auth_setting['value']), safe='+/=')
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
@@ -684,7 +684,7 @@ class ApiClient:
             else:
                 headers['Cookie'] += "; "
             # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_{|}~%+/=")
+            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_`{|}~%+/=")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
@@ -683,11 +683,8 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces and special characters
-            cookie_value = str(auth_setting['value'])
-            if not re.match("^\".*\"$", cookie_value):
-                cookie_value = cookie_value.replace("\"", "\\\"")
-                cookie_value = f"\"{cookie_value}\""
+            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
+            cookie_value = quote(str(auth_setting['value']), safe='+/=')
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
@@ -684,7 +684,7 @@ class ApiClient:
             else:
                 headers['Cookie'] += "; "
             # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe='+/=')
+            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_{|}~%+/=")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -684,7 +684,7 @@ class ApiClient:
             else:
                 headers['Cookie'] += "; "
             # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_{|}~%+/=")
+            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_`{|}~%+/=")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -683,11 +683,8 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces and special characters
-            cookie_value = str(auth_setting['value'])
-            if not re.match("^\".*\"$", cookie_value):
-                cookie_value = cookie_value.replace("\"", "\\\"")
-                cookie_value = f"\"{cookie_value}\""
+            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
+            cookie_value = quote(str(auth_setting['value']), safe='+/=')
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -684,7 +684,7 @@ class ApiClient:
             else:
                 headers['Cookie'] += "; "
             # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe='+/=')
+            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_{|}~%+/=")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/client/others/python-legacy-model-dictionaries/legacy_model_dict_client/api_client.py
+++ b/samples/client/others/python-legacy-model-dictionaries/legacy_model_dict_client/api_client.py
@@ -792,7 +792,7 @@ class ApiClient:
             else:
                 headers['Cookie'] += "; "
             # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe='+/=')
+            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_{|}~%+/=")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/client/others/python-legacy-model-dictionaries/legacy_model_dict_client/api_client.py
+++ b/samples/client/others/python-legacy-model-dictionaries/legacy_model_dict_client/api_client.py
@@ -791,11 +791,8 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces and special characters
-            cookie_value = str(auth_setting['value'])
-            if not re.match("^\".*\"$", cookie_value):
-                cookie_value = cookie_value.replace("\"", "\\\"")
-                cookie_value = f"\"{cookie_value}\""
+            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
+            cookie_value = quote(str(auth_setting['value']), safe='+/=')
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/client/others/python-legacy-model-dictionaries/legacy_model_dict_client/api_client.py
+++ b/samples/client/others/python-legacy-model-dictionaries/legacy_model_dict_client/api_client.py
@@ -792,7 +792,7 @@ class ApiClient:
             else:
                 headers['Cookie'] += "; "
             # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_{|}~%+/=")
+            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_`{|}~%+/=")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -682,11 +682,8 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces and special characters
-            cookie_value = str(auth_setting['value'])
-            if not re.match("^\".*\"$", cookie_value):
-                cookie_value = cookie_value.replace("\"", "\\\"")
-                cookie_value = f"\"{cookie_value}\""
+            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
+            cookie_value = quote(str(auth_setting['value']), safe='+/=')
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -683,7 +683,7 @@ class ApiClient:
             else:
                 headers['Cookie'] += "; "
             # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_{|}~%+/=")
+            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_`{|}~%+/=")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -683,7 +683,7 @@ class ApiClient:
             else:
                 headers['Cookie'] += "; "
             # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe='+/=')
+            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_{|}~%+/=")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/api_client.py
@@ -686,7 +686,7 @@ class ApiClient:
             else:
                 headers['Cookie'] += "; "
             # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_{|}~%+/=")
+            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_`{|}~%+/=")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/api_client.py
@@ -685,11 +685,8 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces and special characters
-            cookie_value = str(auth_setting['value'])
-            if not re.match("^\".*\"$", cookie_value):
-                cookie_value = cookie_value.replace("\"", "\\\"")
-                cookie_value = f"\"{cookie_value}\""
+            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
+            cookie_value = quote(str(auth_setting['value']), safe='+/=')
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-httpx-sync/petstore_api/api_client.py
@@ -686,7 +686,7 @@ class ApiClient:
             else:
                 headers['Cookie'] += "; "
             # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe='+/=')
+            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_{|}~%+/=")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/api_client.py
@@ -686,7 +686,7 @@ class ApiClient:
             else:
                 headers['Cookie'] += "; "
             # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_{|}~%+/=")
+            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_`{|}~%+/=")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/api_client.py
@@ -685,11 +685,8 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces and special characters
-            cookie_value = str(auth_setting['value'])
-            if not re.match("^\".*\"$", cookie_value):
-                cookie_value = cookie_value.replace("\"", "\\\"")
-                cookie_value = f"\"{cookie_value}\""
+            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
+            cookie_value = quote(str(auth_setting['value']), safe='+/=')
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/api_client.py
@@ -686,7 +686,7 @@ class ApiClient:
             else:
                 headers['Cookie'] += "; "
             # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe='+/=')
+            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_{|}~%+/=")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api_client.py
@@ -682,11 +682,8 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces and special characters
-            cookie_value = str(auth_setting['value'])
-            if not re.match("^\".*\"$", cookie_value):
-                cookie_value = cookie_value.replace("\"", "\\\"")
-                cookie_value = f"\"{cookie_value}\""
+            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
+            cookie_value = quote(str(auth_setting['value']), safe='+/=')
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api_client.py
@@ -683,7 +683,7 @@ class ApiClient:
             else:
                 headers['Cookie'] += "; "
             # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_{|}~%+/=")
+            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_`{|}~%+/=")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api_client.py
@@ -683,7 +683,7 @@ class ApiClient:
             else:
                 headers['Cookie'] += "; "
             # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe='+/=')
+            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_{|}~%+/=")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -682,11 +682,8 @@ class ApiClient:
                 headers['Cookie'] = ""
             else:
                 headers['Cookie'] += "; "
-            # Account for cookie value containing spaces and special characters
-            cookie_value = str(auth_setting['value'])
-            if not re.match("^\".*\"$", cookie_value):
-                cookie_value = cookie_value.replace("\"", "\\\"")
-                cookie_value = f"\"{cookie_value}\""
+            # Account for cookie value containing spaces and special characters, excluding base64 delimiters
+            cookie_value = quote(str(auth_setting['value']), safe='+/=')
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -683,7 +683,7 @@ class ApiClient:
             else:
                 headers['Cookie'] += "; "
             # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_{|}~%+/=")
+            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_`{|}~%+/=")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -683,7 +683,7 @@ class ApiClient:
             else:
                 headers['Cookie'] += "; "
             # Account for cookie value containing spaces and special characters, excluding base64 delimiters
-            cookie_value = quote(str(auth_setting['value']), safe='+/=')
+            cookie_value = quote(str(auth_setting['value']), safe="!#$%&'()*+-./:<=>?@[]^_{|}~%+/=")
             headers['Cookie'] += f"{auth_setting['key']}={cookie_value}"
         elif auth_setting['in'] == 'header':
             if auth_setting['type'] != 'http-signature':


### PR DESCRIPTION
a follow up pr to https://github.com/OpenAPITools/openapi-generator/pull/24149

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve cookie handling in Python clients by percent-encoding cookie auth values while preserving RFC 6265–safe characters (including +/=) so base64 and other valid cookies aren’t broken. This prevents malformed Cookie headers when values contain spaces or special characters.

- **Bug Fixes**
  - Replace quote-wrapping with urllib.parse.quote(..., safe="!#$%&'()*+-./:<=>?@[]^_`{|}~%+/=") when building the Cookie header.
  - Update `python/api_client.mustache` and regenerate Python samples (`python`, `python-httpx`, `python-httpx-sync`, `python-aiohttp`, `python-lazyImports`, legacy).

<sup>Written for commit 00bf9237ada06e2ae20e87eaba92261a1f732335. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

