### PR TITLE
fix(java): render enum default on allOf + $ref composed property (#24384)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1516,7 +1516,12 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                 if (!propertySchemas.isEmpty()) {
                     return toObjectDefaultValue(cp, schema.getDefault(), propertySchemas);
                 }
-                return null;
+                // No object properties resolved: the composition wraps a non-object, e.g. an `allOf`
+                // to an enum or scalar (`allOf: [{$ref: '#/.../CurrencyCode'}]` + sibling `default`).
+                // There is nothing to build via toObjectDefaultValue, so defer to the base behavior,
+                // which emits the raw default for later enum var-name / scalar conversion. Returning
+                // null here dropped the default and regressed enum defaults (see #24384).
+                return super.toDefaultValue(schema);
             }
             return null;
         }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -651,6 +651,26 @@ public class AbstractJavaCodegenTest {
     }
 
     @Test
+    public void toDefaultValueForComposedEnumWithDefaultTest() {
+        // A `$ref` to an enum schema combined with a sibling `default` is parsed as a composed (allOf)
+        // schema that wraps a non-object, so getComposedSchemaProperties resolves no properties. The raw
+        // enum default must still be preserved (for later enum var-name conversion, e.g. `CurrencyCode.EUR`)
+        // rather than dropped to null, which regressed the standard `allOf` + sibling-`default` idiom (see #24384).
+        codegen.setDateLibrary("java8");
+        codegen.setOpenAPI(new OpenAPI().components(new Components()
+                .addSchemas("CurrencyCode", new StringSchema()._enum(Arrays.asList("EUR", "USD")))));
+
+        Schema<?> composed = new ComposedSchema()
+                .addAllOfItem(new Schema<>().$ref("#/components/schemas/CurrencyCode"));
+        composed.setDefault("EUR");
+
+        CodegenProperty cp = codegen.fromProperty("currency", composed);
+        String rendered = codegen.toDefaultValue(cp, composed);
+
+        Assert.assertEquals(rendered, "EUR");
+    }
+
+    @Test
     public void dateDefaultValueIsIsoDate() {
         final OpenAPI openAPI = FLATTENED_SPEC.get("3_0/spring/date-time-parameter-types-for-testing");
         codegen.setOpenAPI(openAPI);


### PR DESCRIPTION
Fixes #24384

### Root cause
A property that references an **enum** via `allOf` + `$ref` with a sibling `default` (the standard OAS 3.0 idiom for attaching a `default` to a `$ref`) is parsed as a *composed* schema. `AbstractJavaCodegen.toDefaultValue()`'s composed-schema branch — added in #23971 to render **object** defaults — resolves the composition's effective properties via `getComposedSchemaProperties()` and, when that set is empty, returned `null`. For a composition wrapping an enum (or any non-object) there are no object properties, so the default was dropped. This is a regression between 7.23.0 and 7.24.0: previously this branch fell through to `super.toDefaultValue(...)`.

Runtime impact: deserializing a payload without the property now yields `null` from the getter instead of the declared enum default.

### Change
In the composed branch, when no object properties can be resolved, defer to `super.toDefaultValue(schema)` (the pre-#23971 behavior) so the raw default is emitted for later enum var-name conversion. Object compositions are unaffected and still go through `toObjectDefaultValue(...)`, so the #23795 fix is preserved.

For the reporter's spec the `spring`/`java` generators again emit `private CurrencyCode currency = CurrencyCode.EUR;` instead of `private @Nullable CurrencyCode currency;`.

### Test
Added `AbstractJavaCodegenTest#toDefaultValueForComposedEnumWithDefaultTest`, a sibling to the existing `toDefaultValueForComposedObjectWithDefaultTest`. It builds an `allOf` → enum `$ref` composed schema with a sibling `default` and asserts the rendered default is preserved. The test fails on current `master` (`expected [EUR] but found [null]`) and passes with this change.

Verification done: `./mvnw -pl modules/openapi-generator -am test -Dtest=AbstractJavaCodegenTest#...` — both the new enum test and the existing object test pass (2 run, 0 failures); confirmed the new test fails without the source change. No templates/samples touched, so no sample regeneration is required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression in Java generators where enum defaults on `allOf` + `$ref` properties were dropped. Restores proper field initialization so missing values use the declared enum default instead of null.

- **Bug Fixes**
  - In `AbstractJavaCodegen.toDefaultValue`, when a composed schema has no object properties, fall back to `super.toDefaultValue(...)` to preserve non-object defaults (enums/scalars).
  - Keeps object default rendering intact; only affects non-object compositions.
  - Adds a unit test for `allOf` + `$ref` enum with a sibling `default` to prevent regressions.

<sup>Written for commit ccded6354a8b7b2a65a5a1f79a80d658323fe2d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

