### PR TITLE
Fix Dart native nullable number deserialization (#20238)

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
@@ -361,9 +361,9 @@ class {{{classname}}} {
                 {{^vendorExtensions.x-is-optional}}
         {{{name}}}: {{#isNullable}}json[r'{{{baseName}}}'] == null
             ? {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}
-            : {{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}json[r'{{{baseName}}}'] == null
+            : {{/isNullable}}{{^isNullable}}{{^required}}json[r'{{{baseName}}}'] == null
             ? {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}
-            : {{/defaultValue}}{{/required}}{{/isNullable}}{{{datatypeWithEnum}}}.parse('${json[r'{{{baseName}}}']}'),
+            : {{/required}}{{/isNullable}}{{{datatypeWithEnum}}}.parse('${json[r'{{{baseName}}}']}'),
                 {{/vendorExtensions.x-is-optional}}
               {{/isNumber}}
               {{^isNumber}}

--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
@@ -361,7 +361,9 @@ class {{{classname}}} {
                 {{^vendorExtensions.x-is-optional}}
         {{{name}}}: {{#isNullable}}json[r'{{{baseName}}}'] == null
             ? {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}
-            : {{/isNullable}}{{{datatypeWithEnum}}}.parse('${json[r'{{{baseName}}}']}'),
+            : {{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}json[r'{{{baseName}}}'] == null
+            ? {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}
+            : {{/defaultValue}}{{/required}}{{/isNullable}}{{{datatypeWithEnum}}}.parse('${json[r'{{{baseName}}}']}'),
                 {{/vendorExtensions.x-is-optional}}
               {{/isNumber}}
               {{^isNumber}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartClientCodegenTest.java
@@ -170,6 +170,22 @@ public class DartClientCodegenTest {
                 "json[r'nickname'] != null");
     }
 
+    @Test(description = "Optional numeric fields should guard against null values before parsing")
+    public void testOptionalNumericFieldsGuardAgainstNull() throws Exception {
+        List<File> files = generateDartNativeFromSpec(
+                "src/test/resources/3_0/dart/dart-native-deserialization-bugs.yaml");
+
+        File modelFile = files.stream()
+                .filter(f -> f.getName().equals("optional_number_model.dart"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("optional_number_model.dart not found in generated files"));
+
+        TestUtils.assertFileContains(modelFile.toPath(),
+                "problem: json[r'problem'] == null");
+        TestUtils.assertFileContains(modelFile.toPath(),
+                ": num.parse('${json[r'problem']}')");
+    }
+
     @Test(description = "Nullable nested arrays of complex types should preserve null entries")
     public void testNullableNestedComplexArraysPreserveNullEntries() throws Exception {
         List<File> files = generateDartNativeFromSpec(

--- a/modules/openapi-generator/src/test/resources/3_0/dart/dart-native-deserialization-bugs.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/dart/dart-native-deserialization-bugs.yaml
@@ -32,6 +32,11 @@ components:
         nickname:
           type: string
           nullable: true
+    OptionalNumberModel:
+      type: object
+      properties:
+        problem:
+          type: number
     ComplexNestedArrayNullableModel:
       type: object
       properties:

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/fake_big_decimal_map200_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/fake_big_decimal_map200_response.dart
@@ -67,7 +67,9 @@ class FakeBigDecimalMap200Response {
       }());
 
       return FakeBigDecimalMap200Response(
-        someId: num.parse('${json[r'someId']}'),
+        someId: json[r'someId'] == null
+            ? null
+            : num.parse('${json[r'someId']}'),
         someMap: mapCastOfType<String, num>(json, r'someMap') ?? const {},
       );
     }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/number_only.dart
@@ -61,7 +61,9 @@ class NumberOnly {
       }());
 
       return NumberOnly(
-        justNumber: num.parse('${json[r'JustNumber']}'),
+        justNumber: json[r'JustNumber'] == null
+            ? null
+            : num.parse('${json[r'JustNumber']}'),
       );
     }
     return null;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/object_with_deprecated_fields.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/object_with_deprecated_fields.dart
@@ -100,7 +100,9 @@ class ObjectWithDeprecatedFields {
 
       return ObjectWithDeprecatedFields(
         uuid: mapValueOfType<String>(json, r'uuid'),
-        id: num.parse('${json[r'id']}'),
+        id: json[r'id'] == null
+            ? null
+            : num.parse('${json[r'id']}'),
         deprecatedRef: DeprecatedObject.fromJson(json[r'deprecatedRef']),
         bars: json[r'bars'] is Iterable
             ? (json[r'bars'] as Iterable).cast<String>().toList(growable: false)

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_composite.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_composite.dart
@@ -93,7 +93,9 @@ class OuterComposite {
       }());
 
       return OuterComposite(
-        myNumber: num.parse('${json[r'my_number']}'),
+        myNumber: json[r'my_number'] == null
+            ? null
+            : num.parse('${json[r'my_number']}'),
         myString: mapValueOfType<String>(json, r'my_string'),
         myBoolean: mapValueOfType<bool>(json, r'my_boolean'),
       );


### PR DESCRIPTION
Fix Dart native serialization for optional number fields by guarding against null before calling num.parse(). Includes regression coverage in `dart-native-deserialization-bugs.yaml` and Dart client codegen tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Dart native model deserialization to guard optional numeric fields (including non-nullable) against null before parsing, preventing crashes when JSON contains null. Adds regression tests and updates samples accordingly.

- **Bug Fixes**
  - Add null check before `num.parse()` for non-required numeric fields in `dart2/serialization/native/native_class.mustache`, regardless of `nullable`.
  - Add spec fixture and codegen test to assert the null guard in generated `optional_number_model.dart`.

<sup>Written for commit b37508c41f6ac325be2fdafdd7dd1d5d972cc721. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

