### PR TITLE
[VALIDATOR] fix: Update validation messages for 'nullable' attribute removal in OAS 3.1

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1949,8 +1949,9 @@ public class ModelUtils {
      * returns false (because the nullable attribute is defined in the referenced schema).
      * <p>
      * The 'nullable' attribute was introduced in OAS 3.0.
-     * The 'nullable' attribute is deprecated in OAS 3.1. In a OAS 3.1 document, the preferred way
-     * to specify nullable properties is to use the 'null' type.
+     * The 'nullable' attribute was removed in OAS 3.1 and is not a valid keyword there; it is ignored,
+     * so this method returns false for it in a 3.1 document. In an OAS 3.1 document, the way to specify
+     * nullable properties is to use the 'null' type (e.g. type: ['string', 'null']).
      *
      * @param schema the OAS schema.
      * @return true if the schema is nullable.

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
@@ -32,7 +32,7 @@ class OpenApiSchemaValidations extends GenericValidator<SchemaWrapper> {
             if (ruleConfiguration.isEnableNullableAttributeRecommendation()) {
                 rules.add(ValidationRule.warn(
                         "Schema uses the 'nullable' attribute.",
-                        "The 'nullable' attribute is deprecated in OpenAPI 3.1, and may no longer be supported in future releases. Consider migrating to the 'null' type.",
+                        "The 'nullable' attribute was removed in OpenAPI 3.1 and is IGNORED by the generator: the property will be treated as non-nullable. To make a property nullable in OpenAPI 3.1, add 'null' to its 'type' (e.g. type: ['string', 'null']).",
                         OpenApiSchemaValidations::checkNullableAttribute
                 ));
             }
@@ -109,7 +109,9 @@ class OpenApiSchemaValidations extends GenericValidator<SchemaWrapper> {
     /**
      * JSON Schema uses the 'nullable' attribute.
      * <p>
-     * The 'nullable' attribute is supported in OpenAPI Specification 3.0.x, but it is deprecated in OpenAPI 3.1 and above.
+     * The 'nullable' attribute is supported in OpenAPI Specification 3.0.x. It was removed in OpenAPI 3.1
+     * and above, where it is not a valid keyword: the generator ignores it and treats the property as
+     * non-nullable. Use the 'null' type instead (e.g. type: ['string', 'null']).
      *
      * @param schema An input schema, regardless of the type of schema
      * @return {@link ValidationRule.Pass} if the check succeeds, otherwise {@link ValidationRule.Fail}
@@ -123,14 +125,14 @@ class OpenApiSchemaValidations extends GenericValidator<SchemaWrapper> {
                 // ModelUtils.isNullable checks schema.getNullable(), but swagger-parser does not populate
                 // that field when parsing OAS 3.1 documents — 'nullable' is not a valid 3.1 keyword, so
                 // the parser stores it as a raw extension under the key "nullable" instead.
-                // We must check both paths to catch the deprecated usage in either case,
+                // We must check both paths to catch the ignored 'nullable' usage in either case,
                 // regardless of whether the value is true or false.
                 boolean hasNullableExtension = schema.getExtensions() != null
                         && schema.getExtensions().containsKey("nullable");
                 if (ModelUtils.isNullable(schema) || schema.getNullable() != null || hasNullableExtension) {
                     result = new ValidationRule.Fail();
                     result.setDetails(String.format(Locale.ROOT,
-                            "OAS document is version '%s'. Schema '%s' uses 'nullable' attribute, which has been deprecated in OAS 3.1.",
+                            "OAS document is version '%s'. Schema '%s' uses the 'nullable' attribute, which was removed in OAS 3.1 and is IGNORED: the property is treated as non-nullable. To make it nullable, add 'null' to its 'type' (e.g. type: ['string', 'null']).",
                             schemaWrapper.getOpenAPI().getOpenapi(), nameOf(schema)));
                     return result;
                 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/RuleConfiguration.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/RuleConfiguration.java
@@ -99,10 +99,10 @@ public class RuleConfiguration {
      * -- GETTER --
      * Gets whether the recommendation check for schemas containing the 'nullable' attribute.
      * <p>
-     * In OpenAPI 3.0.x, the "nullable" attribute is supported. However, because it is deprecated in 3.1
-     * and above, a warning is logged to prepare for OpenAPI 3.1 recommendations.
-     * In OpenAPI 3.1, the 'nullable' attribute is deprecated. Instead, the OpenAPI specification should
-     * use the 'null' type.
+     * In OpenAPI 3.0.x, the "nullable" attribute is supported and honored. It was removed in 3.1
+     * and above, where it is not a valid keyword: the generator ignores it and treats the property
+     * as non-nullable. A warning is logged so the 'nullable' usage can be migrated.
+     * In OpenAPI 3.1, use the 'null' type instead (e.g. type: ['string', 'null']).
      *
      * @return <code>true</code> if enabled, <code>false</code> if disabled
      * -- SETTER --


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies validation messaging for the removed `nullable` keyword in OpenAPI 3.1. Schemas using `nullable` now warn that it’s ignored and treated as non-nullable, with guidance to use the `null` type.

- **Bug Fixes**
  - Updated warning text in `org.openapitools.codegen.validations.oas.OpenApiSchemaValidations` to state `nullable` was removed in OAS 3.1 and is ignored; instructs to use `type: ['string', 'null']`.
  - Clarified Javadoc in `org.openapitools.codegen.utils.ModelUtils` and `org.openapitools.codegen.validations.oas.RuleConfiguration` to reflect OAS 3.1 behavior and migration path.

<sup>Written for commit 68b7eec1713a3a38e6ede46d45b63fc6170305c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

