### PR TITLE
refactor(enum): centralize enum variable keys in code generation

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -467,6 +467,19 @@ public class CodegenConstants {
     public static final String DEFAULT_TO_EMPTY_CONTAINER = "defaultToEmptyContainer";
     public static final String DEFAULT_TO_EMPTY_CONTAINER_DESC = "Initialize containers (array/set/map) to empty containers instead of null by default. Usage: https://github.com/OpenAPITools/openapi-generator/blob/master/docs/customization.md#default-values";
 
+    // The raw enum values from the OpenAPI specification
+    public static final String ENUM_VALUES = "values";
+    // The map that stores all enum values and their metadata (name, value, enumDescription...)
+    public static final String ENUM_VARS = "enumVars";
+    // The name of the enum, for example NAME("value") in Java
+    public static final String ENUM_NAME = "name";
+    // The on-the-line value, i.e., the one present in the "values"
+    public static final String ENUM_VALUE = "value";
+    // If the enum is typed as a string
+    public static final String ENUM_IS_STRING = "isString";
+    // The description that should be attached to an entry in "enumVars"
+    public static final String ENUM_DESCRIPTION = "enumDescription";
+
     // Vendor extensions
     public static final String X_INTERNAL = "x-internal";
     public static final String X_PARENT = "x-parent";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -857,12 +857,12 @@ public class DefaultCodegen implements CodegenConfig {
             // for enum model
             if (cm.isEnum && cm.allowableValues != null) {
                 Map<String, Object> allowableValues = cm.allowableValues;
-                List<Object> values = (List<Object>) allowableValues.get("values");
+                List<Object> values = (List<Object>) allowableValues.get(ENUM_VALUES);
                 List<Map<String, Object>> enumVars = buildEnumVars(values, cm.dataType);
                 postProcessEnumVars(enumVars);
                 // if "x-enum-varnames" or "x-enum-descriptions" defined, update varnames
                 updateEnumVarsWithExtensions(enumVars, cm.getVendorExtensions(), cm.dataType);
-                cm.allowableValues.put("enumVars", enumVars);
+                cm.allowableValues.put(ENUM_VARS, enumVars);
             }
 
             // update codegen property enum with proper naming convention
@@ -3160,7 +3160,7 @@ public class DefaultCodegen implements CodegenConfig {
             m.isEnum = true;
             // comment out below as allowableValues is not set in post processing model enum
             m.allowableValues = new HashMap<>();
-            m.allowableValues.put("values", schema.getEnum());
+            m.allowableValues.put(ENUM_VALUES, schema.getEnum());
         }
         if (!ModelUtils.isArraySchema(schema)) {
             m.dataType = getSchemaType(schema);
@@ -3293,7 +3293,7 @@ public class DefaultCodegen implements CodegenConfig {
                 return e.getKey();
             }
         }
-        Object values = var.allowableValues.get("values");
+        Object values = var.allowableValues.get(ENUM_VALUES);
         if (!(values instanceof List<?>)) {
             return var.defaultValue;
         }
@@ -3976,7 +3976,7 @@ public class DefaultCodegen implements CodegenConfig {
             property.isInnerEnum = true;
 
             Map<String, Object> allowableValues = new HashMap<>();
-            allowableValues.put("values", _enum);
+            allowableValues.put(ENUM_VALUES, _enum);
             if (!allowableValues.isEmpty()) {
                 property.allowableValues = allowableValues;
             }
@@ -3991,7 +3991,7 @@ public class DefaultCodegen implements CodegenConfig {
             property.isEnumRef = true;
 
             Map<String, Object> allowableValues = new HashMap<>();
-            allowableValues.put("values", _enum);
+            allowableValues.put(ENUM_VALUES, _enum);
             if (allowableValues.size() > 0) {
                 property.allowableValues = allowableValues;
             }
@@ -6734,7 +6734,7 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     /**
-     * Update codegen property's enum by adding "enumVars" (with name and value)
+     * Update codegen property's enum by adding {@value CodegenConstants#ENUM_VARS} (with name and value)
      *
      * @param var list of CodegenProperty
      */
@@ -6750,7 +6750,7 @@ public class DefaultCodegen implements CodegenConfig {
             return;
         }
 
-        List<Object> values = (List<Object>) allowableValues.get("values");
+        List<Object> values = (List<Object>) allowableValues.get(ENUM_VALUES);
         if (values == null) {
             return;
         }
@@ -6770,7 +6770,7 @@ public class DefaultCodegen implements CodegenConfig {
             extensions = referencedSchema.get().getExtensions();
         }
         updateEnumVarsWithExtensions(enumVars, extensions, dataType);
-        allowableValues.put("enumVars", enumVars);
+        allowableValues.put(ENUM_VARS, enumVars);
 
         // handle default value for enum, e.g. available => StatusEnum.AVAILABLE
         if (var.defaultValue != null) {
@@ -6778,8 +6778,8 @@ public class DefaultCodegen implements CodegenConfig {
 
             String enumName = null;
             for (Map<String, Object> enumVar : enumVars) {
-                if (enumDefaultValue.equals(enumVar.get("value"))) {
-                    enumName = (String) enumVar.get("name");
+                if (enumDefaultValue.equals(enumVar.get(ENUM_VALUE))) {
+                    enumName = (String) enumVar.get(ENUM_NAME);
                     break;
                 }
             }
@@ -6822,9 +6822,9 @@ public class DefaultCodegen implements CodegenConfig {
 
             final String finalEnumName = toEnumVarName(enumName, dataType);
 
-            enumVar.put("name", finalEnumName);
-            enumVar.put("value", toEnumValue(String.valueOf(value), dataType));
-            enumVar.put("isString", isDataTypeString(dataType));
+            enumVar.put(ENUM_NAME, finalEnumName);
+            enumVar.put(ENUM_VALUE, toEnumValue(String.valueOf(value), dataType));
+            enumVar.put(ENUM_IS_STRING, isDataTypeString(dataType));
             // TODO: add isNumeric
             enumVars.add(enumVar);
         }
@@ -6845,9 +6845,9 @@ public class DefaultCodegen implements CodegenConfig {
                     // https://github.com/OpenAPITools/openapi-generator/pull/11013
                     String.valueOf(11184809);
 
-            enumVar.put("name", toEnumVarName(enumName, dataType));
-            enumVar.put("value", toEnumValue(enumValue, dataType));
-            enumVar.put("isString", isDataTypeString(dataType));
+            enumVar.put(ENUM_NAME, toEnumVarName(enumName, dataType));
+            enumVar.put(ENUM_VALUE, toEnumValue(enumValue, dataType));
+            enumVar.put(ENUM_IS_STRING, isDataTypeString(dataType));
             // TODO: add isNumeric
             enumVars.add(enumVar);
         }
@@ -6858,19 +6858,19 @@ public class DefaultCodegen implements CodegenConfig {
     protected void postProcessEnumVars(List<Map<String, Object>> enumVars) {
         Collections.reverse(enumVars);
         enumVars.forEach(v -> {
-            String name = (String) v.get("name");
-            long count = enumVars.stream().filter(v1 -> v1.get("name").equals(name)).count();
+            String name = (String) v.get(ENUM_NAME);
+            long count = enumVars.stream().filter(v1 -> v1.get(ENUM_NAME).equals(name)).count();
             if (count > 1) {
                 String uniqueEnumName = getUniqueEnumName(name, enumVars);
-                LOGGER.debug("Changing duplicate enumeration name from {} to {}", v.get("name"), uniqueEnumName);
-                v.put("name", uniqueEnumName);
+                LOGGER.debug("Changing duplicate enumeration name from {} to {}", v.get(ENUM_NAME), uniqueEnumName);
+                v.put(ENUM_NAME, uniqueEnumName);
             }
         });
         Collections.reverse(enumVars);
     }
 
     private String getUniqueEnumName(String name, List<Map<String, Object>> enumVars) {
-        long count = enumVars.stream().filter(v -> v.get("name").equals(name)).count();
+        long count = enumVars.stream().filter(v -> v.get(ENUM_NAME).equals(name)).count();
         return count > 1
                 ? getUniqueEnumName(name + count, enumVars)
                 : name;
@@ -6885,8 +6885,8 @@ public class DefaultCodegen implements CodegenConfig {
      */
     protected void updateEnumVarsWithExtensions(List<Map<String, Object>> enumVars, Map<String, Object> vendorExtensions, String dataType) {
         if (vendorExtensions != null) {
-            updateEnumVarsWithExtensions(enumVars, vendorExtensions, X_ENUM_VARNAMES, "name", dataType);
-            updateEnumVarsWithExtensions(enumVars, vendorExtensions, X_ENUM_DESCRIPTIONS, "enumDescription", dataType);
+            updateEnumVarsWithExtensions(enumVars, vendorExtensions, X_ENUM_VARNAMES, ENUM_NAME, dataType);
+            updateEnumVarsWithExtensions(enumVars, vendorExtensions, X_ENUM_DESCRIPTIONS, ENUM_DESCRIPTION, dataType);
         }
     }
 
@@ -6929,7 +6929,7 @@ public class DefaultCodegen implements CodegenConfig {
             } else if (extensionValue instanceof Map) {
                 Map<String, String> valueMap = (Map<String, String>) extensionValue;
                 for (Map<String, Object> enumVar : enumVars) {
-                    String enumValue = (String) enumVar.get("value");
+                    String enumValue = (String) enumVar.get(ENUM_VALUE);
                     for (Map.Entry<String, String> entry : valueMap.entrySet()) {
                         if (toEnumValue(entry.getKey(), dataType).equals(enumValue)) {
                             enumVar.put(key, enumDataTypeMapping.apply(entry.getValue(), dataType));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -488,8 +488,8 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen {
             if (Boolean.TRUE.equals(this.zeroBasedEnums)) {
                 property.vendorExtensions.put(AbstractCSharpCodegen.zeroBasedEnumVendorExtension, true);
             } else if (!Boolean.FALSE.equals(this.zeroBasedEnums)) {
-                if (property.allowableValues.containsKey("values")) {
-                    final List<?> allowableValues = (List<?>) property.allowableValues.get("values");
+                if (property.allowableValues.containsKey(ENUM_VALUES)) {
+                    final List<?> allowableValues = (List<?>) property.allowableValues.get(ENUM_VALUES);
                     boolean isZeroBased = String.valueOf(allowableValues.get(0)).toLowerCase(Locale.ROOT).equals("unknown");
                     property.vendorExtensions.put(AbstractCSharpCodegen.zeroBasedEnumVendorExtension, isZeroBased);
                 }
@@ -587,8 +587,8 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen {
                 if (Boolean.TRUE.equals(this.zeroBasedEnums)) {
                     cm.vendorExtensions.put(AbstractCSharpCodegen.zeroBasedEnumVendorExtension, true);
                 } else if (!Boolean.FALSE.equals(this.zeroBasedEnums)) {
-                    if (cm.allowableValues.containsKey("values")) {
-                        final List<?> allowableValues = (List<?>) cm.allowableValues.get("values");
+                    if (cm.allowableValues.containsKey(ENUM_VALUES)) {
+                        final List<?> allowableValues = (List<?>) cm.allowableValues.get(ENUM_VALUES);
                         boolean isZeroBased = String.valueOf(allowableValues.get(0)).toLowerCase(Locale.ROOT).equals("unknown");
                         cm.vendorExtensions.put(AbstractCSharpCodegen.zeroBasedEnumVendorExtension, isZeroBased);
                     }
@@ -892,7 +892,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen {
         // this is inline with C# enums with string values
         if ("string?".equals(dataType)) {
             enumVars.forEach((enumVar) -> {
-                enumVar.put("isString", true);
+                enumVar.put(ENUM_IS_STRING, true);
             });
         }
 
@@ -905,7 +905,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen {
     }
 
     /**
-     * Update codegen property's enum by adding "enumVars" (with name and value)
+     * Update codegen property's enum by adding {@value CodegenConstants#ENUM_VARS} (with name and value)
      *
      * @param var list of CodegenProperty
      */
@@ -1912,7 +1912,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen {
         boolean hasAllowableValues = p.allowableValues != null && !p.allowableValues.isEmpty();
         if (hasAllowableValues) {
             //support examples for inline enums
-            final List<?> values = (List<?>) p.allowableValues.get("values");
+            final List<?> values = (List<?>) p.allowableValues.get(ENUM_VALUES);
             example = String.valueOf(values.get(0));
         } else if (p.defaultValue == null) {
             example = p.example;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Stream;
 
+import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.StringUtils.*;
 
@@ -860,9 +861,9 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
             List<Map<String, Object>> values = (List<Map<String, Object>>) extension;
             for (Map<String, Object> value : values) {
                 Map<String, Object> enumVar = new HashMap<>();
-                enumVar.put("name", toEnumVarName((String) value.get("identifier"), dataType));
-                enumVar.put("value", toEnumValue(value.get("numericValue").toString(), dataType));
-                enumVar.put("isString", isDataTypeString(dataType));
+                enumVar.put(ENUM_NAME, toEnumVarName((String) value.get("identifier"), dataType));
+                enumVar.put(ENUM_VALUE, toEnumValue(value.get("numericValue").toString(), dataType));
+                enumVar.put(ENUM_IS_STRING, isDataTypeString(dataType));
                 if (value.containsKey("description")) {
                     enumVar.put("description", value.get("description").toString());
                 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractFSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractFSharpCodegen.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.*;
 
+import static org.openapitools.codegen.CodegenConstants.ENUM_VARS;
 import static org.openapitools.codegen.CodegenConstants.X_ENUM_BYTE;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
@@ -449,7 +450,7 @@ public abstract class AbstractFSharpCodegen extends DefaultCodegen implements Co
 
                     // Since we iterate enumVars for modelInnerEnum and enumClass templates, and CodegenModel is missing some of CodegenProperty's properties,
                     // we can take advantage of Mustache's contextual lookup to add the same "properties" to the model's enumVars scope rather than CodegenProperty's scope.
-                    List<Map<String, String>> enumVars = (ArrayList<Map<String, String>>) model.allowableValues.get("enumVars");
+                    List<Map<String, String>> enumVars = (ArrayList<Map<String, String>>) model.allowableValues.get(ENUM_VARS);
                     List<Map<String, Object>> newEnumVars = new ArrayList<>();
                     for (Map<String, String> enumVar : enumVars) {
                         Map<String, Object> mixedVars = new HashMap<>(enumVar);
@@ -463,7 +464,7 @@ public abstract class AbstractFSharpCodegen extends DefaultCodegen implements Co
                     }
 
                     if (!newEnumVars.isEmpty()) {
-                        model.allowableValues.put("enumVars", newEnumVars);
+                        model.allowableValues.put(ENUM_VARS, newEnumVars);
                     }
                 }
             } else {
@@ -473,7 +474,7 @@ public abstract class AbstractFSharpCodegen extends DefaultCodegen implements Co
     }
 
     /**
-     * Update codegen property's enum by adding "enumVars" (with name and value)
+     * Update codegen property's enum by adding {@value CodegenConstants#ENUM_VARS} (with name and value)
      *
      * @param var list of CodegenProperty
      */

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -75,8 +75,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import static org.openapitools.codegen.CodegenConstants.USE_DEDUCTION_FOR_ONE_OF_INTERFACES;
-import static org.openapitools.codegen.CodegenConstants.X_IMPLEMENTS;
+import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.CamelizeOption.*;
 import static org.openapitools.codegen.utils.ModelUtils.getSchemaItems;
 import static org.openapitools.codegen.utils.OnceLogger.once;
@@ -1788,7 +1787,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         boolean hasAllowableValues = p.allowableValues != null && !p.allowableValues.isEmpty();
         if (hasAllowableValues) {
             //support examples for inline enums
-            final List<Object> values = (List<Object>) p.allowableValues.get("values");
+            final List<Object> values = (List<Object>) p.allowableValues.get(ENUM_VALUES);
             example = String.valueOf(values.get(0));
         } else if (p.defaultValue == null) {
             example = p.example;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -38,8 +38,7 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.openapitools.codegen.CodegenConstants.X_ENUM_DESCRIPTIONS;
-import static org.openapitools.codegen.CodegenConstants.X_ENUM_VARNAMES;
+import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.CamelizeOption.UPPERCASE_FIRST_CHAR;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
@@ -755,8 +754,8 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
     @Override
     protected void updateEnumVarsWithExtensions(List<Map<String, Object>> enumVars, Map<String, Object> vendorExtensions, String dataType) {
         if (vendorExtensions != null) {
-            updateEnumVarsWithExtensions(enumVars, vendorExtensions, X_ENUM_VARNAMES, "name", dataType, this::toEnumVarName);
-            updateEnumVarsWithExtensions(enumVars, vendorExtensions, X_ENUM_DESCRIPTIONS, "enumDescription", dataType);
+            updateEnumVarsWithExtensions(enumVars, vendorExtensions, X_ENUM_VARNAMES, ENUM_NAME, dataType, this::toEnumVarName);
+            updateEnumVarsWithExtensions(enumVars, vendorExtensions, X_ENUM_DESCRIPTIONS, ENUM_DESCRIPTION, dataType);
         }
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -1136,18 +1136,18 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
 
             // set enum type in extensions and update `name` in enumVars
             if (model.isEnum) {
-                for (Map<String, Object> enumVars : (List<Map<String, Object>>) model.getAllowableValues().get("enumVars")) {
-                    if ((Boolean) enumVars.get("isString")) {
+                for (Map<String, Object> enumVars : (List<Map<String, Object>>) model.getAllowableValues().get(ENUM_VARS)) {
+                    if ((Boolean) enumVars.get(ENUM_IS_STRING)) {
                         model.vendorExtensions.putIfAbsent(X_PY_ENUM_TYPE, "str");
                         // Do not overwrite the variable name if already set through x-enum-varnames
                         if (model.vendorExtensions.get(X_ENUM_VARNAMES) == null) {
-                            enumVars.put("name", toEnumVariableName((String) enumVars.get("value"), "str"));
+                            enumVars.put(ENUM_NAME, toEnumVariableName((String) enumVars.get(ENUM_VALUE), "str"));
                         }
                     } else {
                         model.vendorExtensions.putIfAbsent(X_PY_ENUM_TYPE, "int");
                         // Do not overwrite the variable name if already set through x-enum-varnames
                         if (model.vendorExtensions.get(X_ENUM_VARNAMES) == null) {
-                            enumVars.put("name", toEnumVariableName((String) enumVars.get("value"), "int"));
+                            enumVars.put(ENUM_NAME, toEnumVariableName((String) enumVars.get(ENUM_VALUE), "int"));
                         }
                     }
                 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonPydanticV1Codegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonPydanticV1Codegen.java
@@ -977,14 +977,14 @@ public abstract class AbstractPythonPydanticV1Codegen extends DefaultCodegen imp
 
             // set enum type in extensions and update `name` in enumVars
             if (model.isEnum) {
-                for (Map<String, Object> enumVars : (List<Map<String, Object>>) model.getAllowableValues().get("enumVars")) {
-                    if ((Boolean) enumVars.get("isString")) {
+                for (Map<String, Object> enumVars : (List<Map<String, Object>>) model.getAllowableValues().get(ENUM_VARS)) {
+                    if ((Boolean) enumVars.get(ENUM_IS_STRING)) {
                         model.vendorExtensions.putIfAbsent(X_PY_ENUM_TYPE, "str");
                         // update `name`, e.g.
-                        enumVars.put("name", toEnumVariableName((String) enumVars.get("value"), "str"));
+                        enumVars.put(ENUM_NAME, toEnumVariableName((String) enumVars.get(ENUM_VALUE), "str"));
                     } else {
                         model.vendorExtensions.putIfAbsent(X_PY_ENUM_TYPE, "int");
-                        enumVars.put("name", toEnumVariableName((String) enumVars.get("value"), "int"));
+                        enumVars.put(ENUM_NAME, toEnumVariableName((String) enumVars.get(ENUM_VALUE), "int"));
                     }
                 }
             }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppHttplibServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppHttplibServerCodegen.java
@@ -59,6 +59,8 @@ import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 
+import static org.openapitools.codegen.CodegenConstants.*;
+
 /**
  * C++ HTTP Library Server Code Generator.
  * This code generator creates C++ server stubs using the httplib library for handling HTTP requests.
@@ -1304,9 +1306,9 @@ public class CppHttplibServerCodegen extends AbstractCppCodegen {
                         var.vendorExtensions.put("isOptionalEnum", true);
                     } else {
                         // Required enum: Use first value which is always UNSPECIFIED (added by setEnumVendorExtensions)
-                        if (var.allowableValues != null && var.allowableValues.containsKey("values")) {
+                        if (var.allowableValues != null && var.allowableValues.containsKey(ENUM_VALUES)) {
                             @SuppressWarnings("unchecked")
-                            List<Object> values = (List<Object>) var.allowableValues.get("values");
+                            List<Object> values = (List<Object>) var.allowableValues.get(ENUM_VALUES);
                             if (values != null && !values.isEmpty()) {
                                 // First value is always safe (UNSPECIFIED) after setEnumVendorExtensions
                                 String enumIdentifier = values.get(0).toString();
@@ -2439,9 +2441,9 @@ public class CppHttplibServerCodegen extends AbstractCppCodegen {
             LOGGER.warn("No enum values found for variable {} in model {}", var.name, model.classname);
         }
 
-        var.vendorExtensions.put("values", convertedValues);
+        var.vendorExtensions.put(ENUM_VALUES, convertedValues);
         var._enum = convertedValues;  // Also set it on the var itself for Mustache access
-        var.allowableValues.put("values", convertedValues);  // Also update allowableValues for template
+        var.allowableValues.put(ENUM_VALUES, convertedValues);  // Also update allowableValues for template
 
         // Create enumCases for use in helper functions
         List<Map<String, String>> enumCases = new ArrayList<>();
@@ -2451,8 +2453,8 @@ public class CppHttplibServerCodegen extends AbstractCppCodegen {
                 String originalVal = enumValues.get(i);  // Original value (e.g., "200")
                 String convertedVal = convertedValues.get(i);  // Converted C++ identifier (e.g., "_200")
                 Map<String, String> caseMap = new HashMap<>();
-                caseMap.put("name", convertedVal);  // C++ enum identifier
-                caseMap.put("value", originalVal);  // Original JSON value
+                caseMap.put(ENUM_NAME, convertedVal);  // C++ enum identifier
+                caseMap.put(ENUM_VALUE, originalVal);  // Original JSON value
                 caseMap.put("enumName", shortEnumName);  // Use short name
                 enumCases.add(caseMap);
             }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CrystalClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CrystalClientCodegen.java
@@ -39,6 +39,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.*;
 
+import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
@@ -927,7 +928,7 @@ public class CrystalClientCodegen extends DefaultCodegen {
         } else if (codegenParameter.isPrimitiveType) { // primitive type
             if (codegenParameter.isEnum) {
                 // When inline enum, set example to first allowable value
-                List<Object> values = (List<Object>) codegenParameter.allowableValues.get("values");
+                List<Object> values = (List<Object>) codegenParameter.allowableValues.get(ENUM_VALUES);
                 codegenParameter.example = String.valueOf(values.get(0));
             }
             if (codegenParameter.isString || "String".equalsIgnoreCase(codegenParameter.baseType)) {
@@ -992,7 +993,7 @@ public class CrystalClientCodegen extends DefaultCodegen {
         } else if (codegenProperty.isPrimitiveType) { // primitive type
             if (codegenProperty.isEnum) {
                 // When inline enum, set example to first allowable value
-                List<Object> values = (List<Object>) codegenProperty.allowableValues.get("values");
+                List<Object> values = (List<Object>) codegenProperty.allowableValues.get(ENUM_VALUES);
                 codegenProperty.example = String.valueOf(values.get(0));
             }
             if (codegenProperty.isString || "String".equalsIgnoreCase(codegenProperty.baseType)) {
@@ -1061,8 +1062,8 @@ public class CrystalClientCodegen extends DefaultCodegen {
                 throw new RuntimeException("Invalid count when constructing example: " + count);
             }
         } else if (codegenModel.isEnum) {
-            List<Map<String, String>> enumVars = (List<Map<String, String>>) codegenModel.allowableValues.get("enumVars");
-            return moduleName + "::" + codegenModel.classname + "::" + enumVars.get(0).get("name");
+            List<Map<String, String>> enumVars = (List<Map<String, String>>) codegenModel.allowableValues.get(ENUM_VARS);
+            return moduleName + "::" + codegenModel.classname + "::" + enumVars.get(0).get(ENUM_NAME);
         } else if (codegenModel.oneOf != null && !codegenModel.oneOf.isEmpty()) {
             String subModel = (String) codegenModel.oneOf.toArray()[0];
             if (modelMaps.get(subModel) == null) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.*;
 
+import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 
@@ -593,7 +594,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
         }
 
         // The enum variables are stored by the shared enum post-processing as allowableValues["enumVars"].
-        Object enumVarsObject = model.allowableValues.get("enumVars");
+        Object enumVarsObject = model.allowableValues.get(ENUM_VARS);
         if (!(enumVarsObject instanceof List)) {
             return;
         }
@@ -606,9 +607,9 @@ public class GoClientCodegen extends AbstractGoCodegen {
 
         // Prefix only the fallback name so user-defined enum values keep their existing generated names.
         Map<String, Object> fallbackEnumVar = (Map<String, Object>) enumVars.get(enumVars.size() - 1);
-        Object fallbackName = fallbackEnumVar.get("name");
+        Object fallbackName = fallbackEnumVar.get(ENUM_NAME);
         if (fallbackName instanceof String) {
-            fallbackEnumVar.put("name", model.classname.toUpperCase(Locale.ROOT) + "_" + fallbackName);
+            fallbackEnumVar.put(ENUM_NAME, model.classname.toUpperCase(Locale.ROOT) + "_" + fallbackName);
         }
     }
 
@@ -800,7 +801,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
             }
         } else if (codegenModel.isEnum) {
             Map<String, Object> allowableValues = codegenModel.allowableValues;
-            List<Object> values = (List<Object>) allowableValues.get("values");
+            List<Object> values = (List<Object>) allowableValues.get(ENUM_VALUES);
             String example = String.valueOf(values.get(0));
             if (codegenModel.isString) {
                 example = "\"" + example + "\"";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellHttpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellHttpClientCodegen.java
@@ -41,6 +41,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static org.openapitools.codegen.CodegenConstants.ENUM_NAME;
+import static org.openapitools.codegen.CodegenConstants.ENUM_VARS;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.CamelizeOption.UPPERCASE_FIRST_CHAR;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
@@ -1410,8 +1412,8 @@ public class HaskellHttpClientCodegen extends DefaultCodegen implements CodegenC
         if (allowableValues == null) {
             return;
         }
-        for (Map<String, String> enumVar : (List<Map<String, String>>) allowableValues.get("enumVars")) {
-            enumVar.put("name", paramNameType + enumVar.get("name"));
+        for (Map<String, String> enumVar : (List<Map<String, String>>) allowableValues.get(ENUM_VARS)) {
+            enumVar.put(ENUM_NAME, paramNameType + enumVar.get(ENUM_NAME));
         }
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaCXFExtServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaCXFExtServerCodegen.java
@@ -47,6 +47,8 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
+import static org.openapitools.codegen.CodegenConstants.*;
+
 /**
  * An Apache CXF-based JAX-RS server with extended capabilities.
  *
@@ -656,20 +658,20 @@ public class JavaCXFExtServerCodegen extends JavaCXFServerCodegen implements CXF
 
     private boolean appendRandomEnum(StringBuilder buffer, CodegenOperation op, CodegenVariable var) {
         if (var != null && var.allowableValues != null) {
-            List<?> values = (List<?>) var.allowableValues.get("values");
+            List<?> values = (List<?>) var.allowableValues.get(ENUM_VALUES);
             int i = (int) (values.size() * Math.random());
             Object randomEnum = values.get(i);
             boolean usingEnumLiteral = false;
             String definingClass = (String) var.varVendorExtensions.get("x-defining-class");
             if (definingClass != null) {
                 @SuppressWarnings("unchecked")
-                List<Map<String, Object>> enumVars = (List<Map<String, Object>>) var.allowableValues.get("enumVars");
+                List<Map<String, Object>> enumVars = (List<Map<String, Object>>) var.allowableValues.get(ENUM_VARS);
                 if (enumVars != null) {
                     if (!loadTestDataFromFile) {
                         Map<String, Object> randomEnumVar = enumVars.get(i);
                         // NOTE: to disambiguate identically named inner enums, qualify enum name with defining class.
                         buffer.append(definingClass).append('.').append(var.enumName).append('.')
-                                .append(randomEnumVar.get("name"));
+                                .append(randomEnumVar.get(ENUM_NAME));
                         op.imports.add(definingClass);
                     }
                     usingEnumLiteral = true;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -1231,10 +1231,10 @@ public class JavaClientCodegen extends AbstractJavaCodegen
 
                         if (StringUtils.isNotEmpty(var.defaultValue)) { // has default value
                             String defaultValue = var.defaultValue.substring(var.defaultValue.lastIndexOf('.') + 1);
-                            for (Map<String, Object> enumVars : (List<Map<String, Object>>) var.getAllowableValues().get("enumVars")) {
-                                if (defaultValue.equals(enumVars.get("name"))) {
+                            for (Map<String, Object> enumVars : (List<Map<String, Object>>) var.getAllowableValues().get(ENUM_VARS)) {
+                                if (defaultValue.equals(enumVars.get(ENUM_NAME))) {
                                     // update default to use the string directly instead of enum string
-                                    var.defaultValue = (String) enumVars.get("value");
+                                    var.defaultValue = (String) enumVars.get(ENUM_VALUE);
                                 }
                             }
                         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonClientCodegen.java
@@ -40,7 +40,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 
-import static org.openapitools.codegen.CodegenConstants.SERIALIZATION_LIBRARY;
+import static org.openapitools.codegen.CodegenConstants.*;
 
 /**
  * <p>Mustache templates are located in {@code src/main/resources/java-helidon/common/} and {@code src/main/resources/java-helidon/client/}.
@@ -412,10 +412,10 @@ public class JavaHelidonClientCodegen extends JavaHelidonCommonCodegen {
 
                         if (StringUtils.isNotEmpty(var.defaultValue)) { // has default value
                             String defaultValue = var.defaultValue.substring(var.defaultValue.lastIndexOf('.') + 1);
-                            for (Map<String, Object> enumVars : (List<Map<String, Object>>) var.getAllowableValues().get("enumVars")) {
-                                if (defaultValue.equals(enumVars.get("name"))) {
+                            for (Map<String, Object> enumVars : (List<Map<String, Object>>) var.getAllowableValues().get(ENUM_VARS)) {
+                                if (defaultValue.equals(enumVars.get(ENUM_NAME))) {
                                     // update default to use the string directly instead of enum string
-                                    var.defaultValue = (String) enumVars.get("value");
+                                    var.defaultValue = (String) enumVars.get(ENUM_VALUE);
                                 }
                             }
                         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaMicronautAbstractCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaMicronautAbstractCodegen.java
@@ -25,6 +25,7 @@ import java.io.Writer;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
 import static org.openapitools.codegen.CodegenConstants.INVOKER_PACKAGE;
 
 /**
@@ -482,8 +483,8 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
                 if (models.containsKey(op.returnType)) {
                     CodegenModel m = models.get(op.returnType);
                     List<Object> allowableValues = null;
-                    if (m.allowableValues != null && m.allowableValues.containsKey("values")) {
-                        allowableValues = (List<Object>) m.allowableValues.get("values");
+                    if (m.allowableValues != null && m.allowableValues.containsKey(ENUM_VALUES)) {
+                        allowableValues = (List<Object>) m.allowableValues.get(ENUM_VALUES);
                     }
                     example = getExampleValue(m.defaultValue, null, m.classname, true,
                             allowableValues, null, null, m.requiredVars, false, false);
@@ -565,7 +566,7 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
     }
 
     protected String getParameterExampleValue(CodegenParameter p, boolean groovy) {
-        List<Object> allowableValues = p.allowableValues == null ? null : (List<Object>) p.allowableValues.get("values");
+        List<Object> allowableValues = p.allowableValues == null ? null : (List<Object>) p.allowableValues.get(ENUM_VALUES);
 
         return getExampleValue(p.defaultValue, p.example, p.dataType, p.isModel, allowableValues,
                 p.items == null ? null : p.items.dataType,
@@ -574,7 +575,7 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
     }
 
     protected String getPropertyExampleValue(CodegenProperty p, boolean groovy) {
-        List<Object> allowableValues = p.allowableValues == null ? null : (List<Object>) p.allowableValues.get("values");
+        List<Object> allowableValues = p.allowableValues == null ? null : (List<Object>) p.allowableValues.get(ENUM_VALUES);
 
         return getExampleValue(p.defaultValue, p.example, p.dataType, p.isModel, allowableValues,
                 p.items == null ? null : p.items.dataType,

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinServerCodegen.java
@@ -55,6 +55,7 @@ import org.openapitools.codegen.templating.mustache.LowercaseLambda;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
 import static org.openapitools.codegen.languages.KotlinServerCodegen.Constants.USE_TAGS;
 
 /**
@@ -479,9 +480,9 @@ public class KotlinServerCodegen extends AbstractKotlinCodegen implements BeanVa
                                         if (prop.getBaseName().equals(discriminatorPropBaseName) && prop.isEnum) {
                                             // If it's an enum with exactly one value, use that as the mapping name
                                             Map<String, Object> allowableValues = prop.getAllowableValues();
-                                            if (allowableValues != null && allowableValues.containsKey("values")) {
+                                            if (allowableValues != null && allowableValues.containsKey(ENUM_VALUES)) {
                                                 @SuppressWarnings("unchecked")
-                                                List<Object> values = (List<Object>) allowableValues.get("values");
+                                                List<Object> values = (List<Object>) allowableValues.get(ENUM_VALUES);
                                                 if (values != null && values.size() == 1) {
                                                     mappedModel.setMappingName(String.valueOf(values.get(0)));
                                                 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/MysqlSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/MysqlSchemaCodegen.java
@@ -31,6 +31,7 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
 /**
@@ -382,7 +383,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
 
         if (Boolean.TRUE.equals(isEnum)) {
             Map<String, Object> allowableValues = property.getAllowableValues();
-            List<Object> enumValues = (List<Object>) allowableValues.get("values");
+            List<Object> enumValues = (List<Object>) allowableValues.get(ENUM_VALUES);
             for (int i = 0; i < enumValues.size(); i++) {
                 if (i > ENUM_MAX_ELEMENTS - 1) {
                     LOGGER.warn(
@@ -473,7 +474,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
 
         if (Boolean.TRUE.equals(isEnum)) {
             Map<String, Object> allowableValues = property.getAllowableValues();
-            List<Object> enumValues = (List<Object>) allowableValues.get("values");
+            List<Object> enumValues = (List<Object>) allowableValues.get(ENUM_VALUES);
             for (int i = 0; i < enumValues.size(); i++) {
                 if (i > ENUM_MAX_ELEMENTS - 1) {
                     LOGGER.warn(
@@ -615,7 +616,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
 
         if (Boolean.TRUE.equals(isEnum)) {
             Map<String, Object> allowableValues = property.getAllowableValues();
-            List<Object> enumValues = (List<Object>) allowableValues.get("values");
+            List<Object> enumValues = (List<Object>) allowableValues.get(ENUM_VALUES);
             columnDefinition.put("colDataType", "ENUM");
             columnDefinition.put("colDataTypeArguments", columnDataTypeArguments);
             for (int i = 0; i < enumValues.size(); i++) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/NimClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/NimClientCodegen.java
@@ -37,6 +37,8 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.openapitools.codegen.CodegenConstants.ENUM_VALUE;
+import static org.openapitools.codegen.CodegenConstants.ENUM_VARS;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 
@@ -251,19 +253,19 @@ public class NimClientCodegen extends DefaultCodegen implements CodegenConfig {
      * without quotes so they serialize correctly: %(0) instead of %("0")
      */
     private void stripQuotesFromIntegerEnumValues(Map<String, Object> allowableValues) {
-        if (allowableValues == null || !allowableValues.containsKey("enumVars")) {
+        if (allowableValues == null || !allowableValues.containsKey(ENUM_VARS)) {
             return;
         }
 
         @SuppressWarnings("unchecked")
-        List<Map<String, Object>> enumVars = (List<Map<String, Object>>) allowableValues.get("enumVars");
+        List<Map<String, Object>> enumVars = (List<Map<String, Object>>) allowableValues.get(ENUM_VARS);
         for (Map<String, Object> enumVar : enumVars) {
-            Object value = enumVar.get("value");
+            Object value = enumVar.get(ENUM_VALUE);
             if (value instanceof String) {
                 String strValue = (String) value;
                 // Remove surrounding quotes if present
                 if (strValue.startsWith("\"") && strValue.endsWith("\"")) {
-                    enumVar.put("value", strValue.substring(1, strValue.length() - 1));
+                    enumVar.put(ENUM_VALUE, strValue.substring(1, strValue.length() - 1));
                 }
             }
         }
@@ -276,7 +278,7 @@ public class NimClientCodegen extends DefaultCodegen implements CodegenConfig {
         for (ModelMap mo : objs.getModels()) {
             CodegenModel cm = mo.getModel();
 
-            if (cm.isEnum && cm.allowableValues != null && cm.allowableValues.containsKey("enumVars")) {
+            if (cm.isEnum && cm.allowableValues != null && cm.allowableValues.containsKey(ENUM_VARS)) {
                 cm.vendorExtensions.put("x-is-top-level-enum", true);
 
                 // For integer enums, strip quotes from enum values

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/OCamlClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/OCamlClientCodegen.java
@@ -41,6 +41,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.capitalize;
+import static org.openapitools.codegen.CodegenConstants.ENUM_NAME;
+import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
 import static org.openapitools.codegen.utils.StringUtils.escape;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
@@ -804,7 +806,7 @@ public class OCamlClientCodegen extends DefaultCodegen implements CodegenConfig 
 
     private Map<String, Object> allowableValues(String valueString) {
         Map<String, Object> result = new HashMap<>();
-        result.put("values", buildEnumValues(valueString));
+        result.put(ENUM_VALUES, buildEnumValues(valueString));
         return result;
     }
 
@@ -814,7 +816,7 @@ public class OCamlClientCodegen extends DefaultCodegen implements CodegenConfig 
         for (String v : valueString.split(",")) {
             Map<String, Object> m = new HashMap<>();
             String value = v.isEmpty() ? "empty" : v;
-            m.put("name", value);
+            m.put(ENUM_NAME, value);
             m.put("camlEnumValueName", ocamlizeEnumValue(value));
             result.add(m);
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostgresqlSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostgresqlSchemaCodegen.java
@@ -33,6 +33,7 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
 /**
@@ -508,7 +509,7 @@ public class PostgresqlSchemaCodegen extends DefaultCodegen {
 
         if (Boolean.TRUE.equals(isEnum)) {
             Map<String, Object> allowableValues = property.getAllowableValues();
-            List<Object> enumValues = (List<Object>) allowableValues.get("values");
+            List<Object> enumValues = (List<Object>) allowableValues.get(ENUM_VALUES);
             String typeName = this.toTableName(model.getName())
                     + "_" + this.toColumnName(property.getName());
             postgresqlSchema.put("typeDefinition", typeDefinition);
@@ -632,7 +633,7 @@ public class PostgresqlSchemaCodegen extends DefaultCodegen {
 
         if (Boolean.TRUE.equals(isEnum)) {
             Map<String, Object> allowableValues = property.getAllowableValues();
-            List<Object> enumValues = (List<Object>) allowableValues.get("values");
+            List<Object> enumValues = (List<Object>) allowableValues.get(ENUM_VALUES);
             String typeName = this.toTableName(model.getName())
                     + "_" + this.toColumnName(property.getName());
             postgresqlSchema.put("typeDefinition", typeDefinition);
@@ -738,7 +739,7 @@ public class PostgresqlSchemaCodegen extends DefaultCodegen {
 
         if (Boolean.TRUE.equals(isEnum)) {
             Map<String, Object> allowableValues = property.getAllowableValues();
-            List<Object> enumValues = (List<Object>) allowableValues.get("values");
+            List<Object> enumValues = (List<Object>) allowableValues.get(ENUM_VALUES);
             String typeName = this.toTableName(model.getName())
                     + "_" + this.toColumnName(property.getName());
             postgresqlSchema.put("typeDefinition", typeDefinition);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PowerShellClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PowerShellClientCodegen.java
@@ -38,6 +38,7 @@ import java.io.File;
 import java.util.*;
 
 import static java.util.UUID.randomUUID;
+import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 
 /**
@@ -1368,7 +1369,7 @@ public class PowerShellClientCodegen extends DefaultCodegen implements CodegenCo
 
         example.append("\"");
 
-        List<Object> enumValues = (List<Object>) allowableValues.get("values");
+        List<Object> enumValues = (List<Object>) allowableValues.get(ENUM_VALUES);
         example.append(enumValues.get(0));
 
         example.append("\"");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
@@ -47,6 +47,7 @@ import java.util.stream.Collectors;
 
 import com.google.common.base.CaseFormat;
 
+import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.StringUtils.*;
 
 /**
@@ -565,18 +566,18 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
      * @param prefix          added prefix
      */
     public void addEnumValuesPrefix(Map<String, Object> allowableValues, String prefix) {
-        if (allowableValues.containsKey("enumVars")) {
-            List<Map<String, Object>> enumVars = (List<Map<String, Object>>) allowableValues.get("enumVars");
+        if (allowableValues.containsKey(ENUM_VARS)) {
+            List<Map<String, Object>> enumVars = (List<Map<String, Object>>) allowableValues.get(ENUM_VARS);
             prefix = CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, prefix);
             for (Map<String, Object> value : enumVars) {
-                String name = (String) value.get("name");
-                value.put("name", useSimplifiedEnumNames ? name : prefix + "_" + name);
-                value.put("value", useSimplifiedEnumNames ? name : "\"" + prefix + "_" + name + "\"");
+                String name = (String) value.get(ENUM_NAME);
+                value.put(ENUM_NAME, useSimplifiedEnumNames ? name : prefix + "_" + name);
+                value.put(ENUM_VALUE, useSimplifiedEnumNames ? name : "\"" + prefix + "_" + name + "\"");
             }
         }
 
-        if (allowableValues.containsKey("values")) {
-            List<Object> values = (List<Object>) allowableValues.get("values");
+        if (allowableValues.containsKey(ENUM_VALUES)) {
+            List<Object> values = (List<Object>) allowableValues.get(ENUM_VALUES);
             for (Object value : values) {
                 value = useSimplifiedEnumNames ? value : prefix + "_" + value;
             }
@@ -593,27 +594,27 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
         final String UNSPECIFIED = "UNSPECIFIED";
 
         if (startEnumsWithUnspecified) {
-            if (allowableValues.containsKey("enumVars")) {
-                List<Map<String, Object>> enumVars = (List<Map<String, Object>>) allowableValues.get("enumVars");
+            if (allowableValues.containsKey(ENUM_VARS)) {
+                List<Map<String, Object>> enumVars = (List<Map<String, Object>>) allowableValues.get(ENUM_VARS);
                 boolean unspecifiedPresent = enumVars.stream()
                         .anyMatch(e -> {
-                            return UNSPECIFIED.equals(e.get("name"));
+                            return UNSPECIFIED.equals(e.get(ENUM_NAME));
                         });
                 if (!unspecifiedPresent) {
                     HashMap<String, Object> unspecifiedEnum = new HashMap<String, Object>();
-                    unspecifiedEnum.put("name", UNSPECIFIED);
-                    unspecifiedEnum.put("isString", "false");
-                    unspecifiedEnum.put("value", "\"" + UNSPECIFIED + "\"");
+                    unspecifiedEnum.put(ENUM_NAME, UNSPECIFIED);
+                    unspecifiedEnum.put(ENUM_IS_STRING, "false");
+                    unspecifiedEnum.put(ENUM_VALUE, "\"" + UNSPECIFIED + "\"");
                     enumVars.add(0, unspecifiedEnum);
                 }
             }
 
-            if (allowableValues.containsKey("values")) {
-                List<String> values = (List<String>) allowableValues.get("values");
+            if (allowableValues.containsKey(ENUM_VALUES)) {
+                List<String> values = (List<String>) allowableValues.get(ENUM_VALUES);
                 if (!values.contains(UNSPECIFIED)) {
                     List<String> modifiableValues = new ArrayList<>(values);
                     modifiableValues.add(0, UNSPECIFIED);
-                    allowableValues.put("values", modifiableValues);
+                    allowableValues.put(ENUM_VALUES, modifiableValues);
                 }
             }
         }
@@ -701,8 +702,8 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
                 Map<String, Object> allowableValues = cm.getAllowableValues();
                 addUnspecifiedToAllowableValues(allowableValues);
                 addEnumValuesPrefix(allowableValues, cm.getClassname());
-                if (allowableValues.containsKey("enumVars")) {
-                    List<Map<String, Object>> enumVars = (List<Map<String, Object>>) allowableValues.get("enumVars");
+                if (allowableValues.containsKey(ENUM_VARS)) {
+                    List<Map<String, Object>> enumVars = (List<Map<String, Object>>) allowableValues.get(ENUM_VARS);
                     addEnumIndexes(enumVars);
                 }
             }
@@ -757,8 +758,8 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
                     addUnspecifiedToAllowableValues(enumProperty.allowableValues);
                     addEnumValuesPrefix(enumProperty.allowableValues, enumProperty.getEnumName());
 
-                    if (enumProperty.allowableValues.containsKey("enumVars")) {
-                        List<Map<String, Object>> enumVars = (List<Map<String, Object>>) enumProperty.allowableValues.get("enumVars");
+                    if (enumProperty.allowableValues.containsKey(ENUM_VARS)) {
+                        List<Map<String, Object>> enumVars = (List<Map<String, Object>>) enumProperty.allowableValues.get(ENUM_VARS);
                         addEnumIndexes(enumVars);
                     }
                     

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RClientCodegen.java
@@ -40,6 +40,7 @@ import java.io.Writer;
 import java.util.*;
 import java.util.regex.Pattern;
 
+import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
@@ -967,7 +968,7 @@ public class RClientCodegen extends DefaultCodegen implements CodegenConfig {
                     return "\"" + codegenProperty.example + "\"";
                 } else {
                     if (Boolean.TRUE.equals(codegenProperty.isEnum)) { // enum
-                        return "\"" + ((List<Object>) codegenProperty.allowableValues.get("values")).get(0) + "\"";
+                        return "\"" + ((List<Object>) codegenProperty.allowableValues.get(ENUM_VALUES)).get(0) + "\"";
                     } else {
                         return "\"" + codegenProperty.name + "_example\"";
                     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.*;
 
+import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
@@ -644,7 +645,7 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
         } else if (codegenParameter.isPrimitiveType) { // primitive type
             if (codegenParameter.isEnum) {
                 // When inline enum, set example to first allowable value
-                List<Object> values = (List<Object>) codegenParameter.allowableValues.get("values");
+                List<Object> values = (List<Object>) codegenParameter.allowableValues.get(ENUM_VALUES);
                 codegenParameter.example = String.valueOf(values.get(0));
             }
             if (codegenParameter.isString || "String".equalsIgnoreCase(codegenParameter.baseType)) {
@@ -714,7 +715,7 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
         } else if (codegenProperty.isPrimitiveType) { // primitive type
             if (codegenProperty.isEnum) {
                 // When inline enum, set example to first allowable value
-                List<Object> values = (List<Object>) codegenProperty.allowableValues.get("values");
+                List<Object> values = (List<Object>) codegenProperty.allowableValues.get(ENUM_VALUES);
                 codegenProperty.example = String.valueOf(values.get(0));
             }
             if (codegenProperty.isString || "String".equalsIgnoreCase(codegenProperty.baseType)) {
@@ -781,8 +782,8 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
                 throw new RuntimeException("Invalid count when constructing example: " + count);
             }
         } else if (codegenModel.isEnum) {
-            List<Map<String, String>> enumVars = (List<Map<String, String>>) codegenModel.allowableValues.get("enumVars");
-            return moduleName + "::" + codegenModel.classname + "::" + enumVars.get(0).get("name");
+            List<Map<String, String>> enumVars = (List<Map<String, String>>) codegenModel.allowableValues.get(ENUM_VARS);
+            return moduleName + "::" + codegenModel.classname + "::" + enumVars.get(0).get(ENUM_NAME);
         } else if (codegenModel.oneOf != null && !codegenModel.oneOf.isEmpty()) {
             String subModel = (String) codegenModel.oneOf.toArray()[0];
             if (modelMaps.containsKey(subModel)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -48,7 +48,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.openapitools.codegen.CodegenConstants.X_ONE_OF_NAME;
+import static org.openapitools.codegen.CodegenConstants.*;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
@@ -1653,7 +1653,7 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
                 // Add numeric discriminant values for enum variants
                 @SuppressWarnings("unchecked")
                 List<Map<String, Object>> enumVars =
-                    (List<Map<String, Object>>) model.allowableValues.get("enumVars");
+                    (List<Map<String, Object>>) model.allowableValues.get(ENUM_VARS);
 
                 if (enumVars != null) {
                     for (Map<String, Object> enumVar : enumVars) {
@@ -1768,8 +1768,8 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
         } else {
             param.vendorExtensions.put("x-format-string", param.getIsEnumOrRef() ? "{}" : "{:?}");
             // Check if this is a model-type enum (allowableValues with values list)
-            if (param.allowableValues != null && param.allowableValues.containsKey("values")) {
-                List<?> values = (List<?>) param.allowableValues.get("values");
+            if (param.allowableValues != null && param.allowableValues.containsKey(ENUM_VALUES)) {
+                List<?> values = (List<?>) param.allowableValues.get(ENUM_VALUES);
                 if (!values.isEmpty()) {
                     // Use the first enum value as the example.
                     String firstEnumValue = values.get(0).toString();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegenDeprecated.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegenDeprecated.java
@@ -48,6 +48,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
 import static org.openapitools.codegen.CodegenConstants.X_ONE_OF_NAME;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
@@ -1563,8 +1564,8 @@ public class RustServerCodegenDeprecated extends AbstractRustCodegen implements 
             else {
             param.vendorExtensions.put("x-format-string", "{:?}");
             // Check if this is a model-type enum (allowableValues with values list)
-            if (param.allowableValues != null && param.allowableValues.containsKey("values")) {
-                List<?> values = (List<?>) param.allowableValues.get("values");
+            if (param.allowableValues != null && param.allowableValues.containsKey(ENUM_VALUES)) {
+                List<?> values = (List<?>) param.allowableValues.get(ENUM_VALUES);
                 if (!values.isEmpty()) {
                     // Use the first enum value as the example.
                     String firstEnumValue = values.get(0).toString();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaLagomServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaLagomServerCodegen.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
+import static org.openapitools.codegen.CodegenConstants.ENUM_VALUES;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 
@@ -189,7 +190,7 @@ public class ScalaLagomServerCodegen extends AbstractScalaCodegen implements Cod
 
             for (CodegenProperty var : cm.vars) {
                 if (var.isEnum) {
-                    List<Object> enumValues = (List<Object>) var.allowableValues.get("values");
+                    List<Object> enumValues = (List<Object>) var.allowableValues.get(ENUM_VALUES);
 
                     for (final ListIterator<Object> i = enumValues.listIterator(); i.hasNext(); ) {
                         final String element = String.valueOf(i.next());

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -42,6 +42,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.nonNull;
+import static org.openapitools.codegen.CodegenConstants.ENUM_NAME;
+import static org.openapitools.codegen.CodegenConstants.ENUM_VARS;
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.StringUtils.*;
 
@@ -589,8 +591,8 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         } else if (var.dataType.equalsIgnoreCase("boolean")) {
             var.defaultValue = "false";
         } else {
-            if (var.allowableValues != null && var.allowableValues.get("enumVars") instanceof ArrayList && ((ArrayList) var.allowableValues.get("enumVars")).get(0) instanceof HashMap) {
-                var.defaultValue = var.dataTypeAlternate + "." + ((HashMap<String, String>) ((ArrayList) var.allowableValues.get("enumVars")).get(0)).get("name");
+            if (var.allowableValues != null && var.allowableValues.get(ENUM_VARS) instanceof ArrayList && ((ArrayList) var.allowableValues.get(ENUM_VARS)).get(0) instanceof HashMap) {
+                var.defaultValue = var.dataTypeAlternate + "." + ((HashMap<String, String>) ((ArrayList) var.allowableValues.get(ENUM_VARS)).get(0)).get(ENUM_NAME);
             }
         }
     }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Most if not all enum handling is currently managed with `allowableValues` and `Map` of `Maps` using specific "known" keys. Some languages also use different keys for the same concept.

I have here collected the keys used in the `DefaultCodegen` that are also reused in language `Codegens`. This with the goal that the enum handling can instead be captured in a more formal `CodegenEnum` class rather than exclusively being a `Map` of `Maps`.

The keys are currently defined in `CodegenConstants`, but the idea is of course that this should be owned by the `CodegenEnum` class.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized enum metadata keys by adding constants in `CodegenConstants` and replacing magic strings across core and language generators. This aligns enum handling, improves readability, and keeps outputs unchanged while paving the way for a `CodegenEnum` model.

- **Refactors**
  - Added `ENUM_VALUES`, `ENUM_VARS`, `ENUM_NAME`, `ENUM_VALUE`, `ENUM_IS_STRING`, `ENUM_DESCRIPTION` to `CodegenConstants`.
  - Replaced hard-coded enum keys in `DefaultCodegen` and language codegens (C#, Dart, F#, Java, PHP, Python, C++, Crystal, Go, Haskell, Kotlin, Nim, OCaml, MySQL/PostgreSQL schema, PowerShell, Protobuf, R, Ruby, Rust, Scala, TypeScript).
  - Standardized references to enum data and updated inline docs; behavior and outputs remain the same.

<sup>Written for commit 817838dcebba0e45fff64193b88033335d36f162. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

