### PR TITLE
build(deps): Generate Gradle Wrapper 8.14.5 instead of 8.7 and 8.14.3 (SECURITY)

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/gradle-wrapper.properties.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/gradle-wrapper.properties.mustache
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/modules/openapi-generator/src/main/resources/android/gradle-wrapper.properties.mustache
+++ b/modules/openapi-generator/src/main/resources/android/gradle-wrapper.properties.mustache
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
@@ -3,7 +3,7 @@ version '{{artifactVersion}}'
 {{^omitGradleWrapper}}
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 {{/omitGradleWrapper}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/gradle-wrapper.properties.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/gradle-wrapper.properties.mustache
@@ -4,7 +4,7 @@ distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-all.zip
 {{/jvm-volley}}
 {{^jvm-volley}}
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 {{/jvm-volley}}
 networkTimeout=10000
 validateDistributionUrl=true

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/gradle-wrapper.properties.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/gradle-wrapper.properties.mustache
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-{{#useSpringBoot4}}distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip{{/useSpringBoot4}}{{^useSpringBoot4}}distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip{{/useSpringBoot4}}
+{{#useSpringBoot4}}distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip{{/useSpringBoot4}}{{^useSpringBoot4}}distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip{{/useSpringBoot4}}
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/gradle-wrapper.properties.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/gradle-wrapper.properties.mustache
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-{{#useSpringBoot4}}distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip{{/useSpringBoot4}}{{^useSpringBoot4}}distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip{{/useSpringBoot4}}
+{{#useSpringBoot4}}distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip{{/useSpringBoot4}}{{^useSpringBoot4}}distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip{{/useSpringBoot4}}
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/gradle-wrapper.properties.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/gradle-wrapper.properties.mustache
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-{{#useSpringBoot4}}distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip{{/useSpringBoot4}}{{^useSpringBoot4}}distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip{{/useSpringBoot4}}
+{{#useSpringBoot4}}distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip{{/useSpringBoot4}}{{^useSpringBoot4}}distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip{{/useSpringBoot4}}
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/modules/openapi-generator/src/main/resources/kotlin-wiremock/gradle-wrapper.properties.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-wiremock/gradle-wrapper.properties.mustache
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/echo_api/java/apache-httpclient/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/echo_api/java/apache-httpclient/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/echo_api/java/feign-gson/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/echo_api/java/feign-gson/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/echo_api/java/native/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/echo_api/java/native/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/echo_api/java/okhttp-gson-user-defined-templates/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/echo_api/java/okhttp-gson-user-defined-templates/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/echo_api/java/okhttp-gson/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/echo_api/java/okhttp-gson/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/echo_api/java/restclient/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/echo_api/java/restclient/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/echo_api/java/resteasy/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/echo_api/java/resteasy/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/echo_api/java/resttemplate/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/echo_api/java/resttemplate/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/echo_api/kotlin-jvm-okhttp-multipart-json/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/echo_api/kotlin-jvm-okhttp-multipart-json/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/echo_api/kotlin-jvm-okhttp/build.gradle
+++ b/samples/client/echo_api/kotlin-jvm-okhttp/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/echo_api/kotlin-jvm-okhttp/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/echo_api/kotlin-jvm-okhttp/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/build.gradle
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/build.gradle
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/echo_api/kotlin-model-prefix-type-mappings/build.gradle
+++ b/samples/client/echo_api/kotlin-model-prefix-type-mappings/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/echo_api/kotlin-model-prefix-type-mappings/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/echo_api/kotlin-model-prefix-type-mappings/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/others/java/jersey2-oneOf-Mixed/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/others/java/jersey2-oneOf-Mixed/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/others/java/jersey2-oneOf-duplicates/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/others/java/jersey2-oneOf-duplicates/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/others/java/okhttp-gson-oneOf-array/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/others/java/okhttp-gson-oneOf-array/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/others/java/okhttp-gson-oneOf/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/others/java/okhttp-gson-oneOf/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/others/java/okhttp-gson-streaming/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/others/java/okhttp-gson-streaming/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/others/java/restclient-enum-in-multipart/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/others/java/restclient-enum-in-multipart/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/others/java/restclient-sealedInterface/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/others/java/restclient-sealedInterface/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/others/java/restclient-useAbstractionForFiles/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/others/java/restclient-useAbstractionForFiles/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/others/java/resttemplate-list-schema-validation/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/others/java/resttemplate-list-schema-validation/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/others/java/resttemplate-useAbstractionForFiles/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/others/java/resttemplate-useAbstractionForFiles/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/others/java/webclient-sealedInterface/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/others/java/webclient-sealedInterface/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/others/java/webclient-sealedInterface_3_1/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/others/java/webclient-sealedInterface_3_1/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/others/java/webclient-useAbstractionForFiles/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/others/java/webclient-useAbstractionForFiles/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/others/kotlin-integer-enum/build.gradle
+++ b/samples/client/others/kotlin-integer-enum/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/others/kotlin-integer-enum/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/others/kotlin-integer-enum/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/build.gradle
+++ b/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/others/kotlin-jvm-okhttp-parameter-tests/build.gradle
+++ b/samples/client/others/kotlin-jvm-okhttp-parameter-tests/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/others/kotlin-jvm-okhttp-parameter-tests/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/others/kotlin-jvm-okhttp-parameter-tests/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/others/kotlin-jvm-okhttp-path-comments/build.gradle
+++ b/samples/client/others/kotlin-jvm-okhttp-path-comments/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/others/kotlin-jvm-okhttp-path-comments/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/others/kotlin-jvm-okhttp-path-comments/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/others/kotlin-jvm-spring-3-restclient-nullable-return/build.gradle
+++ b/samples/client/others/kotlin-jvm-spring-3-restclient-nullable-return/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/others/kotlin-jvm-spring-3-restclient-nullable-return/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/others/kotlin-jvm-spring-3-restclient-nullable-return/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization-explicitApi/build.gradle
+++ b/samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization-explicitApi/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization-explicitApi/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization-explicitApi/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization-nonPublicApi/build.gradle
+++ b/samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization-nonPublicApi/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization-nonPublicApi/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization-nonPublicApi/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization/build.gradle
+++ b/samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/others/kotlin-oneOf-anyOf-kotlinx-serialization/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/others/kotlin-oneOf-discriminator-kotlinx-serialization/build.gradle
+++ b/samples/client/others/kotlin-oneOf-discriminator-kotlinx-serialization/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/others/kotlin-oneOf-discriminator-kotlinx-serialization/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/others/kotlin-oneOf-discriminator-kotlinx-serialization/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/android/httpclient/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/android/httpclient/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/client/petstore/android/volley/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/android/volley/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/client/petstore/java/apache-httpclient-jackson3/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/apache-httpclient-jackson3/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/apache-httpclient/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/apache-httpclient/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/feign-hc5/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/feign-hc5/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/feign-no-nullable/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/feign-no-nullable/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/feign/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/feign/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/google-api-client/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/google-api-client/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/jersey2-java8/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/jersey2-java8/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/jersey3-jackson3/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/jersey3-jackson3/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/jersey3-oneOf/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/jersey3-oneOf/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/jersey3/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/jersey3/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/native-async/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/native-async/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/native-jackson3-jspecify/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/native-jackson3-jspecify/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/native-jackson3/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/native-jackson3/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/native-jakarta/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/native-jakarta/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/native-useGzipFeature/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/native-useGzipFeature/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/native/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/native/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/native/test-regenerated-fixed/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/native/test-regenerated-fixed/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/native/test-regenerated-fixed2/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/native/test-regenerated-fixed2/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/native/test-regenerated-fixed3/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/native/test-regenerated-fixed3/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/native/test-regenerated/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/native/test-regenerated/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/okhttp-gson-3.1-duplicated-operationid/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/okhttp-gson-3.1-duplicated-operationid/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/okhttp-gson-3.1/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/okhttp-gson-3.1/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/okhttp-gson-swagger1/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/okhttp-gson-swagger2/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/okhttp-gson/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/okhttp-gson/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/rest-assured-jackson/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/rest-assured-jackson/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/rest-assured/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/rest-assured/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/restclient-nullable-arrays/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/restclient-nullable-arrays/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/restclient-springBoot4-jackson2/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson2/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/restclient-swagger2/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/restclient-swagger2/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/restclient/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/restclient/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/resteasy/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/resteasy/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/resttemplate-jakarta/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/resttemplate-jakarta/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson2/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson2/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson3-jspecify/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson3-jspecify/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson3/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson3/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/resttemplate-swagger1/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/resttemplate-swagger1/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/resttemplate-swagger2/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/resttemplate-swagger2/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/resttemplate-withXml/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/resttemplate-withXml/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/resttemplate/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/resttemplate/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/retrofit2-play26/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/retrofit2-play26/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/retrofit2/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/retrofit2/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/retrofit2rx2/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/retrofit2rx2/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/retrofit2rx3/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/retrofit2rx3/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/vertx-no-nullable/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/vertx-no-nullable/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/vertx-supportVertxFuture/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/vertx-supportVertxFuture/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/vertx/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/vertx/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/vertx5-supportVertxFuture/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/vertx5-supportVertxFuture/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/vertx5/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/vertx5/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/webclient-jakarta/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/webclient-jakarta/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/webclient-nullable-arrays/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/webclient-nullable-arrays/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/webclient-springBoot4-jackson3-jspecify/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/webclient-springBoot4-jackson3-jspecify/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/webclient-springBoot4-jackson3/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/webclient-springBoot4-jackson3/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/webclient-swagger2/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/webclient-swagger2/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/java/webclient/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/java/webclient/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-allOf-discriminator-kotlinx-serialization/build.gradle
+++ b/samples/client/petstore/kotlin-allOf-discriminator-kotlinx-serialization/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-allOf-discriminator-kotlinx-serialization/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-allOf-discriminator-kotlinx-serialization/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-allOf-discriminator/build.gradle
+++ b/samples/client/petstore/kotlin-allOf-discriminator/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-allOf-discriminator/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-allOf-discriminator/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-array-integer-enum/build.gradle
+++ b/samples/client/petstore/kotlin-array-integer-enum/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-array-integer-enum/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-array-integer-enum/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-array-nullable-items-multiplatform/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-array-nullable-items-multiplatform/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-array-nullable-items/build.gradle
+++ b/samples/client/petstore/kotlin-array-nullable-items/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-array-nullable-items/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-array-nullable-items/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/build.gradle
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-array-simple-string-multiplatform/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-array-simple-string-multiplatform/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-bigdecimal-default-multiplatform/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-bigdecimal-default-multiplatform/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/build.gradle
+++ b/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp4/build.gradle
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp4/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp4/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp4/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-default-values-jvm-retrofit2/build.gradle
+++ b/samples/client/petstore/kotlin-default-values-jvm-retrofit2/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-default-values-jvm-retrofit2/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-default-values-jvm-retrofit2/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-default-values-multiplatform/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-default-values-multiplatform/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-enum-default-value/build.gradle
+++ b/samples/client/petstore/kotlin-enum-default-value/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-enum-default-value/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-enum-default-value/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-enum-integers-multiplatform/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-enum-integers-multiplatform/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-explicit/build.gradle
+++ b/samples/client/petstore/kotlin-explicit/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-explicit/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-explicit/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-gson/build.gradle
+++ b/samples/client/petstore/kotlin-gson/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-gson/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-gson/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-jackson/build.gradle
+++ b/samples/client/petstore/kotlin-jackson/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-jackson/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-jackson/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-json-request-string/build.gradle
+++ b/samples/client/petstore/kotlin-json-request-string/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-json-request-string/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-json-request-string/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-jvm-jackson/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-jackson/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-jvm-jackson/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-jvm-jackson/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-jvm-retrofit2-coroutines/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-retrofit2-coroutines/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-jvm-retrofit2-coroutines/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-jvm-retrofit2-coroutines/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-jvm-vertx-gson/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-vertx-gson/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-jvm-vertx-gson/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-jvm-vertx-gson/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-jvm-vertx-moshi/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-vertx-moshi/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-jvm-vertx-moshi/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-jvm-vertx-moshi/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-kotlinx-datetime/build.gradle
+++ b/samples/client/petstore/kotlin-kotlinx-datetime/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-kotlinx-datetime/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-kotlinx-datetime/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/build.gradle
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-modelMutable/build.gradle
+++ b/samples/client/petstore/kotlin-modelMutable/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-modelMutable/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-modelMutable/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-moshi-codegen/build.gradle
+++ b/samples/client/petstore/kotlin-moshi-codegen/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-moshi-codegen/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-moshi-codegen/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-multiplatform-allOf-discriminator/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-multiplatform-allOf-discriminator/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-multiplatform/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-multiplatform/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-name-parameter-mappings/build.gradle
+++ b/samples/client/petstore/kotlin-name-parameter-mappings/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-name-parameter-mappings/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-name-parameter-mappings/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-nonpublic/build.gradle
+++ b/samples/client/petstore/kotlin-nonpublic/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-nonpublic/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-nonpublic/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-nullable/build.gradle
+++ b/samples/client/petstore/kotlin-nullable/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-nullable/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-nullable/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-retrofit2-jackson/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2-jackson/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-retrofit2-jackson/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-retrofit2-jackson/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-retrofit2-rx3/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-retrofit2-rx3/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-retrofit2/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-retrofit2/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-retrofit2/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-string/build.gradle
+++ b/samples/client/petstore/kotlin-string/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-string/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-string/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-threetenbp/build.gradle
+++ b/samples/client/petstore/kotlin-threetenbp/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-threetenbp/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-threetenbp/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin-uppercase-enum/build.gradle
+++ b/samples/client/petstore/kotlin-uppercase-enum/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin-uppercase-enum/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-uppercase-enum/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/client/petstore/kotlin/build.gradle
+++ b/samples/client/petstore/kotlin/build.gradle
@@ -2,7 +2,7 @@ group 'org.openapitools'
 version '1.0.0'
 
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '8.14.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/samples/client/petstore/kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/openapi3/client/petstore/java/jersey2-java8/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/server/echo_api/kotlin-wiremock/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/server/echo_api/kotlin-wiremock/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/server/petstore/kotlin-springboot-4/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/server/petstore/kotlin-springboot-4/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/server/petstore/kotlin-wiremock-responses/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/server/petstore/kotlin-wiremock-responses/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/server/petstore/kotlin-wiremock/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/server/petstore/kotlin-wiremock/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
It's not safe to use 8.x before 8.14.5 due to multiple vulnerabilities.

https://security.snyk.io/package/linux/chainguard:latest/gradle-8

Keeping wrapper 8.1.1 unchanged just in case there are some incompatibilities.

@cachescrubber (2022/02) @welshm (2022/02) @MelleD (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02) @borsch (2022/02) @banlevente (2022/02) @Zomzog (2022/09) @martin-mfg (2023/08) @KannaKim (2026/07)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Gradle wrappers to 8.14.5 across generator templates and samples to address vulnerabilities in earlier 8.x releases. Keep 8.1.1 for non–Spring Boot 4 Kotlin Spring and 7.6.2 for `jvm-volley` for compatibility.

- **Dependencies**
  - Bumped `distributionUrl` and `wrapper` gradleVersion from 8.7/8.14/8.14.3 to 8.14.5 across Java, Kotlin, and Android templates and samples.

<sup>Written for commit b6096f2ab48eb336f10d682108bbce4fa27cb176. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

