### PR TITLE
[php-laravel] Use `baseName` instead of `paramName` for request lookup & validation keys

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-laravel/api_controller.mustache
+++ b/modules/openapi-generator/src/main/resources/php-laravel/api_controller.mustache
@@ -41,43 +41,43 @@ class {{controllerName}} extends Controller
         {{#allParams}}
         {{^isPathParam}}
         {{#isFile}}
-        ${{paramName}} = $request->file('{{paramName}}');
+        ${{paramName}} = $request->file('{{baseName}}');
         {{/isFile}}
         {{#isBoolean}}
-        ${{paramName}} = $request->boolean('{{paramName}}');
+        ${{paramName}} = $request->boolean('{{baseName}}');
         {{/isBoolean}}
         {{#isInteger}}
-        ${{paramName}} = $request->integer('{{paramName}}');
+        ${{paramName}} = $request->integer('{{baseName}}');
         {{/isInteger}}
         {{#isLong}}
-        ${{paramName}} = $request->integer('{{paramName}}');
+        ${{paramName}} = $request->integer('{{baseName}}');
         {{/isLong}}
         {{#isNumber}}
-        ${{paramName}} = $request->float('{{paramName}}');
+        ${{paramName}} = $request->float('{{baseName}}');
         {{/isNumber}}
         {{#isFloat}}
-        ${{paramName}} = $request->float('{{paramName}}');
+        ${{paramName}} = $request->float('{{baseName}}');
         {{/isFloat}}
         {{#isDouble}}
-        ${{paramName}} = $request->float('{{paramName}}');
+        ${{paramName}} = $request->float('{{baseName}}');
         {{/isDouble}}
         {{#isString}}
-        ${{paramName}} = $request->string('{{paramName}}')->value();
+        ${{paramName}} = $request->string('{{baseName}}')->value();
         {{/isString}}
         {{#isByteArray}}
-        ${{paramName}} = $request->string('{{paramName}}')->value();
+        ${{paramName}} = $request->string('{{baseName}}')->value();
         {{/isByteArray}}
         {{#isDateTime}}
-        ${{paramName}} = $request->date('{{paramName}}');
+        ${{paramName}} = $request->date('{{baseName}}');
         {{/isDateTime}}
         {{#isDate}}
-        ${{paramName}} = $request->date('{{paramName}}');
+        ${{paramName}} = $request->date('{{baseName}}');
         {{/isDate}}
         {{#isArray}}
-        ${{paramName}} = $request->get('{{paramName}}');
+        ${{paramName}} = $request->get('{{^isBodyParam}}{{baseName}}{{/isBodyParam}}{{#isBodyParam}}{{paramName}}{{/isBodyParam}}');
         {{/isArray}}
         {{#isMap}}
-        ${{paramName}} = $request->get('{{paramName}}');
+        ${{paramName}} = $request->get('{{^isBodyParam}}{{baseName}}{{/isBodyParam}}{{#isBodyParam}}{{paramName}}{{/isBodyParam}}');
         {{/isMap}}
         {{^isPrimitiveType}}
         {{^isContainer}}

--- a/modules/openapi-generator/src/main/resources/php-laravel/api_validation.mustache
+++ b/modules/openapi-generator/src/main/resources/php-laravel/api_validation.mustache
@@ -1,14 +1,14 @@
 $validator = Validator::make(
             array_merge(
                 [
-                    {{#pathParams}}'{{paramName}}' => ${{paramName}},{{/pathParams}}
+                    {{#pathParams}}'{{baseName}}' => ${{paramName}},{{/pathParams}}
                 ],
                 $request->all(),
             ),
             [
             {{#allParams}}
             {{^bodyParam}}
-                '{{paramName}}' => [
+                '{{baseName}}' => [
                 {{#isFile}}
                     'file',
                 {{/isFile}}

--- a/modules/openapi-generator/src/main/resources/php-laravel/api_validation.mustache
+++ b/modules/openapi-generator/src/main/resources/php-laravel/api_validation.mustache
@@ -1,9 +1,9 @@
 $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     {{#pathParams}}'{{baseName}}' => ${{paramName}},{{/pathParams}}
                 ],
-                $request->all(),
             ),
             [
             {{#allParams}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/laravel/PhpLaravelServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/laravel/PhpLaravelServerCodegenTest.java
@@ -1,0 +1,72 @@
+package org.openapitools.codegen.php.laravel;
+
+import org.openapitools.codegen.ClientOptInput;
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.TestUtils;
+import org.openapitools.codegen.config.CodegenConfigurator;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class PhpLaravelServerCodegenTest {
+
+    /**
+     * Parameters whose spec (wire) name is not already a valid camelCase PHP identifier must be read
+     * from the request and validated under the wire name ({@code baseName}), not under the sanitized
+     * PHP variable name ({@code paramName}). Otherwise the generated controller reads the wrong key
+     * and the value is always null.
+     */
+    @Test
+    public void shouldUseWireNameForRequestLookupsAndValidationKeys() throws Exception {
+        Map<String, Object> properties = new HashMap<>();
+
+        File output = Files.createTempDirectory("test").toFile();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("php-laravel")
+                .setAdditionalProperties(properties)
+                .setInputSpec("src/test/resources/3_0/php-laravel/petstore-with-fake-endpoints-models-for-testing.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(clientOptInput).generate();
+
+        TestUtils.ensureContainsFile(files, output, "Http/Controllers/FakeController.php");
+        TestUtils.ensureContainsFile(files, output, "Http/Controllers/StoreController.php");
+        TestUtils.ensureContainsFile(files, output, "Http/Controllers/UserController.php");
+
+        Path fakeController = files.stream().filter(f -> f.getName().equals("FakeController.php")).findFirst().orElseThrow().toPath();
+
+        // request accessors use the wire name (snake_case) while the local variable keeps the sanitized name
+        TestUtils.assertFileContains(fakeController, "$filterClientName = $request->string('filter_client_name')->value();");
+        TestUtils.assertFileContains(fakeController, "$filterUserIds = $request->get('filter_user_ids');");
+        TestUtils.assertFileContains(fakeController, "$clientId = $request->integer('client_id');");
+
+        // validation rule keys must match $request->all(), i.e. the wire name
+        TestUtils.assertFileContains(fakeController, "'filter_client_name' => [");
+        TestUtils.assertFileContains(fakeController, "'filter_user_ids' => [");
+        TestUtils.assertFileContains(fakeController, "'client_id' => [");
+
+        // the buggy behaviour (reading under the sanitized identifier) must not reappear
+        TestUtils.assertFileNotContains(fakeController, "$request->string('filterClientName')");
+        TestUtils.assertFileNotContains(fakeController, "$request->get('filterUserIds')");
+        TestUtils.assertFileNotContains(fakeController, "$request->integer('clientId')");
+
+        // path parameters: the merged validation key and the rule key both use the wire name
+        Path storeController = files.stream().filter(f -> f.getName().equals("StoreController.php")).findFirst().orElseThrow().toPath();
+        TestUtils.assertFileContains(storeController, "'order_id' => $orderId,");
+        TestUtils.assertFileContains(storeController, "'order_id' => [");
+
+        // body parameters are out of scope and must stay byte-identical: no wire-name substitution for the request body
+        Path userController = files.stream().filter(f -> f.getName().equals("UserController.php")).findFirst().orElseThrow().toPath();
+        TestUtils.assertFileContains(userController, "$user = $request->get('user');");
+
+        output.deleteOnExit();
+    }
+}

--- a/modules/openapi-generator/src/test/resources/3_0/php-laravel/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/php-laravel/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -995,6 +995,49 @@ paths:
               required:
                 - param
                 - param2
+  /fake/parameter-name-mapping:
+    get:
+      tags:
+        - fake
+      summary: test query parameter name sanitization
+      description: 'Query params whose spec names require PHP identifier sanitization (snake_case) must be read/validated under the wire name.'
+      operationId: getParameterNameMapping
+      parameters:
+        - name: filter_client_name
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: filter_user_ids
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: integer
+      responses:
+        '200':
+          description: successful operation
+    post:
+      tags:
+        - fake
+      summary: test form parameter name sanitization
+      description: 'Form param whose spec name requires PHP identifier sanitization (snake_case) must be read/validated under the wire name.'
+      operationId: postParameterNameMapping
+      responses:
+        '200':
+          description: successful operation
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                client_id:
+                  description: form field whose name requires sanitization
+                  type: integer
+              required:
+                - client_id
   /fake/additionalProperties-reference:
     post:
       tags:

--- a/samples/server/petstore/php-laravel-issue-21334/Http/Controllers/DefaultController.php
+++ b/samples/server/petstore/php-laravel-issue-21334/Http/Controllers/DefaultController.php
@@ -51,10 +51,10 @@ class DefaultController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
                 'paramCamelCase' => [

--- a/samples/server/petstore/php-laravel/Api/FakeApiInterface.php
+++ b/samples/server/petstore/php-laravel/Api/FakeApiInterface.php
@@ -125,6 +125,36 @@ interface FakeApiInterface {
 
 
     /**
+     * Operation getParameterNameMapping
+     *
+     * test query parameter name sanitization
+     * @param null | string $filterClientName
+     * @param null | int[] $filterUserIds
+     * @return \OpenAPI\Server\Model\NoContent200
+     */
+    public function getParameterNameMapping(
+            ?string $filterClientName,
+            ?array $filterUserIds,
+    ):
+        \OpenAPI\Server\Model\NoContent200
+    ;
+
+
+    /**
+     * Operation postParameterNameMapping
+     *
+     * test form parameter name sanitization
+     * @param int $clientId
+     * @return \OpenAPI\Server\Model\NoContent200
+     */
+    public function postParameterNameMapping(
+            int $clientId,
+    ):
+        \OpenAPI\Server\Model\NoContent200
+    ;
+
+
+    /**
      * Operation testAdditionalPropertiesReference
      *
      * test referenced additionalProperties

--- a/samples/server/petstore/php-laravel/Http/Controllers/AnotherFakeController.php
+++ b/samples/server/petstore/php-laravel/Http/Controllers/AnotherFakeController.php
@@ -51,10 +51,10 @@ class AnotherFakeController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],

--- a/samples/server/petstore/php-laravel/Http/Controllers/DefaultController.php
+++ b/samples/server/petstore/php-laravel/Http/Controllers/DefaultController.php
@@ -51,10 +51,10 @@ class DefaultController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],

--- a/samples/server/petstore/php-laravel/Http/Controllers/FakeClassnameTags123Controller.php
+++ b/samples/server/petstore/php-laravel/Http/Controllers/FakeClassnameTags123Controller.php
@@ -51,10 +51,10 @@ class FakeClassnameTags123Controller extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],

--- a/samples/server/petstore/php-laravel/Http/Controllers/FakeController.php
+++ b/samples/server/petstore/php-laravel/Http/Controllers/FakeController.php
@@ -51,10 +51,10 @@ class FakeController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],
@@ -85,10 +85,10 @@ class FakeController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],
@@ -119,10 +119,10 @@ class FakeController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],
@@ -159,10 +159,10 @@ class FakeController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],
@@ -195,10 +195,10 @@ class FakeController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],
@@ -231,10 +231,10 @@ class FakeController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],
@@ -267,10 +267,10 @@ class FakeController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],
@@ -303,10 +303,10 @@ class FakeController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],
@@ -339,10 +339,10 @@ class FakeController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
                 'filter_client_name' => [
@@ -383,10 +383,10 @@ class FakeController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
                 'client_id' => [
@@ -423,10 +423,10 @@ class FakeController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],
@@ -459,10 +459,10 @@ class FakeController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],
@@ -495,10 +495,10 @@ class FakeController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],
@@ -531,10 +531,10 @@ class FakeController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],
@@ -569,10 +569,10 @@ class FakeController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],
@@ -605,10 +605,10 @@ class FakeController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
                 'number' => [
@@ -725,10 +725,10 @@ class FakeController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
                 'required_string_group' => [
@@ -792,10 +792,10 @@ class FakeController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],
@@ -828,10 +828,10 @@ class FakeController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],
@@ -864,10 +864,10 @@ class FakeController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
                 'param' => [
@@ -910,10 +910,10 @@ class FakeController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],
@@ -946,10 +946,10 @@ class FakeController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
                 'pipe' => [
@@ -1020,10 +1020,10 @@ class FakeController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],

--- a/samples/server/petstore/php-laravel/Http/Controllers/FakeController.php
+++ b/samples/server/petstore/php-laravel/Http/Controllers/FakeController.php
@@ -134,9 +134,9 @@ class FakeController extends Controller
 
         $pet = $this->serde->deserialize($request->getContent(), from: 'json', to: \OpenAPI\Server\Model\Pet::class);
 
-        $query1 = $request->string('query1')->value();
+        $query1 = $request->string('query_1')->value();
 
-        $header1 = $request->string('header1')->value();
+        $header1 = $request->string('header_1')->value();
 
 
         $apiResult = $this->api->fakeHttpSignatureTest($pet, $query1, $header1);
@@ -322,6 +322,90 @@ class FakeController extends Controller
         $apiResult = $this->api->fakePropertyEnumIntegerSerialize($outerObjectWithEnumProperty);
 
         if ($apiResult instanceof \OpenAPI\Server\Model\OuterObjectWithEnumProperty) {
+            return response()->json($this->serde->serialize($apiResult, format: 'array'), 200);
+        }
+
+
+        // This shouldn't happen
+        return response()->abort(500);
+    }
+    /**
+     * Operation getParameterNameMapping
+     *
+     * test query parameter name sanitization.
+     *
+     */
+    public function getParameterNameMapping(Request $request): JsonResponse
+    {
+        $validator = Validator::make(
+            array_merge(
+                [
+                    
+                ],
+                $request->all(),
+            ),
+            [
+                'filter_client_name' => [
+                    'string',
+                ],
+                'filter_user_ids' => [
+                    'array',
+                ],
+            ],
+        );
+
+        if ($validator->fails()) {
+            return response()->json(['error' => 'Invalid input'], 400);
+        }
+
+        $filterClientName = $request->string('filter_client_name')->value();
+
+        $filterUserIds = $request->get('filter_user_ids');
+
+
+        $apiResult = $this->api->getParameterNameMapping($filterClientName, $filterUserIds);
+
+        if ($apiResult instanceof \OpenAPI\Server\Model\NoContent200) {
+            return response()->json($this->serde->serialize($apiResult, format: 'array'), 200);
+        }
+
+
+        // This shouldn't happen
+        return response()->abort(500);
+    }
+    /**
+     * Operation postParameterNameMapping
+     *
+     * test form parameter name sanitization.
+     *
+     */
+    public function postParameterNameMapping(Request $request): JsonResponse
+    {
+        $validator = Validator::make(
+            array_merge(
+                [
+                    
+                ],
+                $request->all(),
+            ),
+            [
+                'client_id' => [
+                    'required',
+                    'integer',
+                ],
+            ],
+        );
+
+        if ($validator->fails()) {
+            return response()->json(['error' => 'Invalid input'], 400);
+        }
+
+        $clientId = $request->integer('client_id');
+
+
+        $apiResult = $this->api->postParameterNameMapping($clientId);
+
+        if ($apiResult instanceof \OpenAPI\Server\Model\NoContent200) {
             return response()->json($this->serde->serialize($apiResult, format: 'array'), 200);
         }
 
@@ -537,7 +621,7 @@ class FakeController extends Controller
                     'gte:67.8',
                     'lte:123.4',
                 ],
-                'patternWithoutDelimiter' => [
+                'pattern_without_delimiter' => [
                     'required',
                     'regex:/^[A-Z].*/',
                     'string',
@@ -592,7 +676,7 @@ class FakeController extends Controller
 
         $double = $request->float('double');
 
-        $patternWithoutDelimiter = $request->string('patternWithoutDelimiter')->value();
+        $patternWithoutDelimiter = $request->string('pattern_without_delimiter')->value();
 
         $byte = $request->string('byte')->value();
 
@@ -647,25 +731,25 @@ class FakeController extends Controller
                 $request->all(),
             ),
             [
-                'requiredStringGroup' => [
+                'required_string_group' => [
                     'required',
                     'integer',
                 ],
-                'requiredBooleanGroup' => [
+                'required_boolean_group' => [
                     'required',
                     'boolean',
                 ],
-                'requiredInt64Group' => [
+                'required_int64_group' => [
                     'required',
                     'integer',
                 ],
-                'stringGroup' => [
+                'string_group' => [
                     'integer',
                 ],
-                'booleanGroup' => [
+                'boolean_group' => [
                     'boolean',
                 ],
-                'int64Group' => [
+                'int64_group' => [
                     'integer',
                 ],
             ],
@@ -675,17 +759,17 @@ class FakeController extends Controller
             return response()->json(['error' => 'Invalid input'], 400);
         }
 
-        $requiredStringGroup = $request->integer('requiredStringGroup');
+        $requiredStringGroup = $request->integer('required_string_group');
 
-        $requiredBooleanGroup = $request->boolean('requiredBooleanGroup');
+        $requiredBooleanGroup = $request->boolean('required_boolean_group');
 
-        $requiredInt64Group = $request->integer('requiredInt64Group');
+        $requiredInt64Group = $request->integer('required_int64_group');
 
-        $stringGroup = $request->integer('stringGroup');
+        $stringGroup = $request->integer('string_group');
 
-        $booleanGroup = $request->boolean('booleanGroup');
+        $booleanGroup = $request->boolean('boolean_group');
 
-        $int64Group = $request->integer('int64Group');
+        $int64Group = $request->integer('int64_group');
 
 
         $apiResult = $this->api->testGroupParameters($requiredStringGroup, $requiredBooleanGroup, $requiredInt64Group, $stringGroup, $booleanGroup, $int64Group);

--- a/samples/server/petstore/php-laravel/Http/Controllers/PetController.php
+++ b/samples/server/petstore/php-laravel/Http/Controllers/PetController.php
@@ -51,10 +51,10 @@ class PetController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],
@@ -91,10 +91,10 @@ class PetController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     'petId' => $petId,
                 ],
-                $request->all(),
             ),
             [
                 'petId' => [
@@ -139,10 +139,10 @@ class PetController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
                 'status' => [
@@ -185,10 +185,10 @@ class PetController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
                 'tags' => [
@@ -230,10 +230,10 @@ class PetController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     'petId' => $petId,
                 ],
-                $request->all(),
             ),
             [
                 'petId' => [
@@ -277,10 +277,10 @@ class PetController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],
@@ -325,10 +325,10 @@ class PetController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     'petId' => $petId,
                 ],
-                $request->all(),
             ),
             [
                 'petId' => [
@@ -378,10 +378,10 @@ class PetController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     'petId' => $petId,
                 ],
-                $request->all(),
             ),
             [
                 'petId' => [
@@ -427,10 +427,10 @@ class PetController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     'petId' => $petId,
                 ],
-                $request->all(),
             ),
             [
                 'petId' => [

--- a/samples/server/petstore/php-laravel/Http/Controllers/PetController.php
+++ b/samples/server/petstore/php-laravel/Http/Controllers/PetController.php
@@ -101,7 +101,7 @@ class PetController extends Controller
                     'required',
                     'integer',
                 ],
-                'apiKey' => [
+                'api_key' => [
                     'string',
                 ],
             ],
@@ -112,7 +112,7 @@ class PetController extends Controller
         }
 
 
-        $apiKey = $request->string('apiKey')->value();
+        $apiKey = $request->string('api_key')->value();
 
 
         $apiResult = $this->api->deletePet($petId, $apiKey);

--- a/samples/server/petstore/php-laravel/Http/Controllers/StoreController.php
+++ b/samples/server/petstore/php-laravel/Http/Controllers/StoreController.php
@@ -51,10 +51,10 @@ class StoreController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     'order_id' => $orderId,
                 ],
-                $request->all(),
             ),
             [
                 'order_id' => [
@@ -94,10 +94,10 @@ class StoreController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],
@@ -129,10 +129,10 @@ class StoreController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     'order_id' => $orderId,
                 ],
-                $request->all(),
             ),
             [
                 'order_id' => [
@@ -178,10 +178,10 @@ class StoreController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],

--- a/samples/server/petstore/php-laravel/Http/Controllers/StoreController.php
+++ b/samples/server/petstore/php-laravel/Http/Controllers/StoreController.php
@@ -52,12 +52,12 @@ class StoreController extends Controller
         $validator = Validator::make(
             array_merge(
                 [
-                    'orderId' => $orderId,
+                    'order_id' => $orderId,
                 ],
                 $request->all(),
             ),
             [
-                'orderId' => [
+                'order_id' => [
                     'required',
                     'string',
                 ],
@@ -130,12 +130,12 @@ class StoreController extends Controller
         $validator = Validator::make(
             array_merge(
                 [
-                    'orderId' => $orderId,
+                    'order_id' => $orderId,
                 ],
                 $request->all(),
             ),
             [
-                'orderId' => [
+                'order_id' => [
                     'required',
                     'gte:1',
                     'lte:5',

--- a/samples/server/petstore/php-laravel/Http/Controllers/UserController.php
+++ b/samples/server/petstore/php-laravel/Http/Controllers/UserController.php
@@ -51,10 +51,10 @@ class UserController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],
@@ -87,10 +87,10 @@ class UserController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],
@@ -123,10 +123,10 @@ class UserController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],
@@ -159,10 +159,10 @@ class UserController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     'username' => $username,
                 ],
-                $request->all(),
             ),
             [
                 'username' => [
@@ -202,10 +202,10 @@ class UserController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     'username' => $username,
                 ],
-                $request->all(),
             ),
             [
                 'username' => [
@@ -249,10 +249,10 @@ class UserController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
                 'username' => [
@@ -299,10 +299,10 @@ class UserController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     
                 ],
-                $request->all(),
             ),
             [
             ],
@@ -333,10 +333,10 @@ class UserController extends Controller
     {
         $validator = Validator::make(
             array_merge(
+                $request->all(),
                 [
                     'username' => $username,
                 ],
-                $request->all(),
             ),
             [
             ],

--- a/samples/server/petstore/php-laravel/routes.php
+++ b/samples/server/petstore/php-laravel/routes.php
@@ -91,6 +91,20 @@ Route::POST('/v2/fake/outer/string', [\OpenAPI\Server\Http\Controllers\FakeContr
 Route::POST('/v2/fake/property/enum-int', [\OpenAPI\Server\Http\Controllers\FakeController::class, 'fakePropertyEnumIntegerSerialize'])->name('fake.fake.property.enum.integer.serialize');
 
 /**
+ * GET getParameterNameMapping
+ * Summary: test query parameter name sanitization
+ * Notes: Query params whose spec names require PHP identifier sanitization (snake_case) must be read/validated under the wire name.
+ */
+Route::GET('/v2/fake/parameter-name-mapping', [\OpenAPI\Server\Http\Controllers\FakeController::class, 'getParameterNameMapping'])->name('fake.get.parameter.name.mapping');
+
+/**
+ * POST postParameterNameMapping
+ * Summary: test form parameter name sanitization
+ * Notes: Form param whose spec name requires PHP identifier sanitization (snake_case) must be read/validated under the wire name.
+ */
+Route::POST('/v2/fake/parameter-name-mapping', [\OpenAPI\Server\Http\Controllers\FakeController::class, 'postParameterNameMapping'])->name('fake.post.parameter.name.mapping');
+
+/**
  * POST testAdditionalPropertiesReference
  * Summary: test referenced additionalProperties
  * Notes: 


### PR DESCRIPTION

### Description

Hi there! Wanted to share one of the modifications we made to the php-laravel generator templates. This commit aims to fix a bug caused by case inconsistencies.

The php-laravel server templates read request values and build validation rules keyed by `paramName` — the *sanitized PHP identifier* — instead of `baseName`. Laravel does not convert casing though, so request variables do not get parsed correctly.

### Example

Given a query parameter `filter_name`:

**Before** (generated — broken)
```php
// In generated controller
$filterName = $request->string('filterName')->value(); // wire key is `filter_name` -> always null

Validator::make($request->all(), [
    'filterName' => ['string'],   // never matches the incoming `filter_name`
]);
```

**After** (generated — fixed)
```php
$filterName = $request->string('filter_name')->value();

$validator = Validator::make($request->all(), [
    'filter_name' => ['string'],
]);
```

This is mostly a problem for form-data requests. `application/json` is handled using Serde (de)serializer and is unaffected.
PR is against master since it does not affect the interface other than fixing the actual bug.
Route parameters are not affected since these are resolved positionally. Intentionally did not change these so the generated interface classes are unaffected.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples
- [x] If your PR is targeting a particular programming language, @mention the [technical committee]
@ybelenko @gijs-blanken 
