### PR TITLE
python: simplify lazy-import type-checking guards

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/__init__api.mustache
+++ b/modules/openapi-generator/src/main/resources/python/__init__api.mustache
@@ -3,7 +3,9 @@
 {{^lazyImports}}
 {{>exports_api}}
 {{/lazyImports}}
-{{#lazyImports}}if __import__("typing").TYPE_CHECKING:
+{{#lazyImports}}import typing as _typing
+
+if _typing.TYPE_CHECKING:
     {{>exports_api}}
 else:
     from lazy_imports import LazyModule, as_package, load

--- a/modules/openapi-generator/src/main/resources/python/__init__model.mustache
+++ b/modules/openapi-generator/src/main/resources/python/__init__model.mustache
@@ -6,7 +6,9 @@
 {{^lazyImports}}
 {{>exports_model}}
 {{/lazyImports}}
-{{#lazyImports}}if __import__("typing").TYPE_CHECKING:
+{{#lazyImports}}import typing as _typing
+
+if _typing.TYPE_CHECKING:
     {{>exports_model}}
 else:
     from lazy_imports import LazyModule, as_package, load

--- a/modules/openapi-generator/src/main/resources/python/__init__package.mustache
+++ b/modules/openapi-generator/src/main/resources/python/__init__package.mustache
@@ -27,7 +27,9 @@ __all__ = [
 {{^lazyImports}}
 {{>exports_package}}
 {{/lazyImports}}
-{{#lazyImports}}if __import__("typing").TYPE_CHECKING:
+{{#lazyImports}}import typing as _typing
+
+if _typing.TYPE_CHECKING:
     {{>exports_package}}
 else:
     from lazy_imports import LazyModule, as_package, load

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/__init__.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/__init__.py
@@ -152,7 +152,9 @@ __all__ = [
     "WithNestedOneOf",
 ]
 
-if __import__("typing").TYPE_CHECKING:
+import typing as _typing
+
+if _typing.TYPE_CHECKING:
     # import apis into sdk package
     from petstore_api.api.another_fake_api import AnotherFakeApi as AnotherFakeApi
     from petstore_api.api.default_api import DefaultApi as DefaultApi

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api/__init__.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api/__init__.py
@@ -1,6 +1,8 @@
 # flake8: noqa
 
-if __import__("typing").TYPE_CHECKING:
+import typing as _typing
+
+if _typing.TYPE_CHECKING:
     # import apis into api package
     from petstore_api.api.another_fake_api import AnotherFakeApi
     from petstore_api.api.default_api import DefaultApi

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/__init__.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/models/__init__.py
@@ -12,7 +12,9 @@
     Do not edit the class manually.
 """  # noqa: E501
 
-if __import__("typing").TYPE_CHECKING:
+import typing as _typing
+
+if _typing.TYPE_CHECKING:
     # import models into model package
     from petstore_api.models.additional_properties_any_type import AdditionalPropertiesAnyType
     from petstore_api.models.additional_properties_class import AdditionalPropertiesClass


### PR DESCRIPTION
The lazy Python initializers use dynamic `__import__` to reach typing.TYPE_CHECKING, an idiom introduced alongside lazy-imports in c4a7c14c8.

Use a private standard-library typing module import instead. This keeps type-checking branches statically recognizable, avoids shadowing generated models named TYPE_CHECKING, and leaves clients without lazy imports unchanged.