### PR TITLE
feat: add support for translating @ to at_ in variable names for TypeScript clients

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -588,6 +588,10 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
             return nameMapping.get(name);
         }
 
+        // translate @ for properties (like @type) to at_.
+        // Otherwise an additional "type" property will leed to duplcates
+        name = name.replaceAll("^@", "at_");
+
         name = sanitizeName(name, "[^\\w$]");
 
         if ("_".equals(name)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -589,7 +589,7 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
         }
 
         // translate @ for properties (like @type) to at_.
-        // Otherwise an additional "type" property will leed to duplcates
+        // Otherwise an additional "type" property will lead to duplicates
         name = name.replaceAll("^@", "at_");
 
         name = sanitizeName(name, "[^\\w$]");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -128,6 +128,18 @@ public class TypeScriptFetchClientCodegenTest {
         codegen.processOpts();
         Assert.assertEquals(codegen.toVarName("valid_var"), "valid_var");
     }
+    
+    @Test
+    public void toVarNameWithAtSign() {
+        TypeScriptFetchClientCodegen codegen = new TypeScriptFetchClientCodegen();
+        codegen.processOpts();
+        Assert.assertEquals(codegen.toVarName("@id"), "atId");
+
+        codegen = new TypeScriptFetchClientCodegen();
+        codegen.additionalProperties().put(CodegenConstants.MODEL_PROPERTY_NAMING, "original");
+        codegen.processOpts();
+        Assert.assertEquals(codegen.toVarName("@id"), "at_id");
+    }
 
     @Test
     public void toEnumVarName() {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularClientCodegenTest.java
@@ -40,6 +40,18 @@ public class TypeScriptAngularClientCodegenTest {
     }
 
     @Test
+    public void toVarNameWithAtSign() {
+        TypeScriptAngularClientCodegen codegen = new TypeScriptAngularClientCodegen();
+        codegen.processOpts();
+        Assert.assertEquals(codegen.toVarName("@id"), "at_id");
+
+        codegen = new TypeScriptAngularClientCodegen();
+        codegen.additionalProperties().put(CodegenConstants.MODEL_PROPERTY_NAMING, "camelCase");
+        codegen.processOpts();
+        Assert.assertEquals(codegen.toVarName("@id"), "atId");
+    }
+
+    @Test
     public void toEnumVarName() {
         TypeScriptAngularClientCodegen codegen = new TypeScriptAngularClientCodegen();
         // unspecified option should default to PascalCase


### PR DESCRIPTION
I'm having the same issue as https://github.com/OpenAPITools/openapi-generator/pull/12171. This PR applies the same principe, but for TypeScript clients

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translate leading `@` in OpenAPI property names to `at_` for TypeScript clients to avoid collisions and duplicate `type` fields (e.g., `@type` becomes `atType`/`at_type`). Implemented in `AbstractTypeScriptClientCodegen`, so it applies to all TS client generators.

- **Bug Fixes**
  - Map leading `@` to `at_` in `toVarName` within `AbstractTypeScriptClientCodegen`.
  - Respect `MODEL_PROPERTY_NAMING` (e.g., camelCase vs original) when forming the final name.
  - Add tests for `typescript-fetch` and `typescript-angular` confirming `@id` => `atId`/`at_id`.

<sup>Written for commit c8f02db53a76cb59f14badc7d3f604f8c0bab4d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

