### PR TITLE
[typescript-axios] Update axios to 1.18.0 or later

### DIFF
--- a/docs/generators/typescript-axios.md
+++ b/docs/generators/typescript-axios.md
@@ -20,7 +20,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | ------ | ----------- | ------ | ------- |
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |apiPackage|package for generated api classes| |null|
-|axiosVersion|Use this property to override the axios version in package.json| |^1.16.0|
+|axiosVersion|Use this property to override the axios version in package.json| |^1.18.0|
 |disallowAdditionalPropertiesIfNotPresent|If false, the 'additionalProperties' implementation (set to true by default) is compliant with the OAS and JSON schema specifications. If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.|<dl><dt>**false**</dt><dd>The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.</dd><dt>**true**</dt><dd>Keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.</dd></dl>|true|
 |ensureUniqueParams|Whether to ensure parameter names are unique in an operation (rename parameters that are not).| |true|
 |enumNameSuffix|Suffix that will be appended to all enum names.| |Enum|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
@@ -54,7 +54,7 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
     public static final String IMPORT_FILE_EXTENSION_SWITCH_DESC = "File extension to use with relative imports. Set it to '.js' or '.mjs' when using [ESM](https://nodejs.org/api/esm.html).";
     public static final String USE_SQUARE_BRACKETS_IN_ARRAY_NAMES = "useSquareBracketsInArrayNames";
     public static final String AXIOS_VERSION = "axiosVersion";
-    public static final String DEFAULT_AXIOS_VERSION = "^1.16.0";
+    public static final String DEFAULT_AXIOS_VERSION = "^1.18.0";
     public static final String WITH_AWSV4_SIGNATURE = "withAWSV4Signature";
 
     @Getter @Setter

--- a/samples/client/echo_api/typescript-axios/build/package.json
+++ b/samples/client/echo_api/typescript-axios/build/package.json
@@ -22,7 +22,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "axios": "^1.16.0"
+    "axios": "^1.18.0"
   },
   "devDependencies": {
     "@types/node": "12.11.5 - 12.20.42",

--- a/samples/client/petstore/typescript-axios/builds/es6-target/package.json
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/package.json
@@ -24,7 +24,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "axios": "^1.16.0"
+    "axios": "^1.18.0"
   },
   "devDependencies": {
     "@types/node": "12.11.5 - 12.20.42",

--- a/samples/client/petstore/typescript-axios/builds/with-complex-headers/package.json
+++ b/samples/client/petstore/typescript-axios/builds/with-complex-headers/package.json
@@ -22,7 +22,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "axios": "^1.16.0"
+    "axios": "^1.18.0"
   },
   "devDependencies": {
     "@types/node": "12.11.5 - 12.20.42",

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/package.json
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/package.json
@@ -22,7 +22,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "axios": "^1.16.0"
+    "axios": "^1.18.0"
   },
   "devDependencies": {
     "@types/node": "12.11.5 - 12.20.42",

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/package.json
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/package.json
@@ -22,7 +22,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "axios": "^1.16.0"
+    "axios": "^1.18.0"
   },
   "devDependencies": {
     "@types/node": "12.11.5 - 12.20.42",


### PR DESCRIPTION
to close https://github.com/OpenAPITools/openapi-generator/pull/24424

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the TypeScript Axios generator default to `axios` ^1.18.0 and updated docs and sample packages to match. This ensures newly generated clients install `axios` 1.18+ and stay on a supported release.

<sup>Written for commit 77b6baeee5f7de1ea95268b5f579311c4a41d694. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



