### PR TITLE
Update immutable to newer version (typescript-fetch)

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/package.mustache
@@ -25,7 +25,7 @@
 {{/packageAsSourceOnlyLibrary}}
   "devDependencies": {
 {{#sagasAndRecords}}
-    "immutable": "^4.3.8",
+    "immutable": "^4.3.9",
     "normalizr": "^3.6.1",
     "redux-saga": "^1.1.3",
     "redux-ts-simple": "^3.2.0",

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/package.json
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/package.json
@@ -15,7 +15,7 @@
     "build": "tsc && tsc -p tsconfig.esm.json"
   },
   "devDependencies": {
-    "immutable": "^4.3.8",
+    "immutable": "^4.3.9",
     "normalizr": "^3.6.1",
     "redux-saga": "^1.1.3",
     "redux-ts-simple": "^3.2.0",


### PR DESCRIPTION
to close https://github.com/OpenAPITools/openapi-generator/pull/24414
<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `immutable` to ^4.3.9 in the `typescript-fetch` sagas-and-records generator to pick up the latest bug fixes and keep samples in sync.

- **Dependencies**
  - Bump `immutable` from ^4.3.8 to ^4.3.9 in `modules/openapi-generator/src/main/resources/typescript-fetch/package.mustache`.
  - Update sample `samples/client/petstore/typescript-fetch/builds/sagas-and-records/package.json` to match.

<sup>Written for commit 8c11449d8661e95b327af93abcaef9b5aa6da387. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

