### PR TITLE
[csharp][generichost] Make host configuration optional

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/IServiceCollectionExtensions.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/IServiceCollectionExtensions.mustache
@@ -15,27 +15,15 @@ namespace {{packageName}}.Extensions
     /// </summary>
     {{>visibility}} static class IServiceCollectionExtensions
     {
-        {{^hasAuthMethods}}
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
-        public static void Add{{apiName}}(this IServiceCollection services)
-        {
-            HostConfiguration config = new{{^net70OrLater}} HostConfiguration{{/net70OrLater}}(services);
-            Add{{apiName}}(services, config);
-        }
-
-        {{/hasAuthMethods}}
         /// <summary>
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void Add{{apiName}}(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void Add{{apiName}}(this IServiceCollection services, Action<HostConfiguration>{{#nrt}}?{{/nrt}} options = null)
         {
             HostConfiguration config = new{{^net70OrLater}} HostConfiguration{{/net70OrLater}}(services);
-            options(config);
+            options?.Invoke(config);
             Add{{apiName}}(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/latest/AnnotatedEnum/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -25,21 +25,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/latest/ComposedEnum/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/latest/ComposedEnum/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -25,21 +25,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/latest/HelloWorld/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/latest/HelloWorld/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -25,21 +25,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -25,21 +25,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/latest/NullTypes/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -25,21 +25,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -25,21 +25,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/latest/Tags/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/latest/Tags/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -27,10 +27,10 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/latest/UseDateTimeOffset/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -26,10 +26,10 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -25,21 +25,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -25,21 +25,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -25,21 +25,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -24,10 +24,10 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -26,10 +26,10 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -25,21 +25,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -24,10 +24,10 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -26,10 +26,10 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net10/UseDateTimeForDate/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net10/UseDateTimeForDate/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -25,21 +25,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -23,21 +23,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new HostConfiguration(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options = null)
         {
             HostConfiguration config = new HostConfiguration(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -23,21 +23,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new HostConfiguration(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options = null)
         {
             HostConfiguration config = new HostConfiguration(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -23,21 +23,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new HostConfiguration(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options = null)
         {
             HostConfiguration config = new HostConfiguration(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -24,10 +24,10 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options = null)
         {
             HostConfiguration config = new HostConfiguration(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -23,21 +23,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new HostConfiguration(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options = null)
         {
             HostConfiguration config = new HostConfiguration(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -24,10 +24,10 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options = null)
         {
             HostConfiguration config = new HostConfiguration(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -23,21 +23,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new HostConfiguration(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options = null)
         {
             HostConfiguration config = new HostConfiguration(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -23,21 +23,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new HostConfiguration(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options = null)
         {
             HostConfiguration config = new HostConfiguration(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -23,21 +23,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new HostConfiguration(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options = null)
         {
             HostConfiguration config = new HostConfiguration(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -23,21 +23,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new HostConfiguration(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options = null)
         {
             HostConfiguration config = new HostConfiguration(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -24,10 +24,10 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options = null)
         {
             HostConfiguration config = new HostConfiguration(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -23,21 +23,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new HostConfiguration(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options = null)
         {
             HostConfiguration config = new HostConfiguration(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -24,10 +24,10 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options = null)
         {
             HostConfiguration config = new HostConfiguration(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -23,21 +23,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new HostConfiguration(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options = null)
         {
             HostConfiguration config = new HostConfiguration(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -25,21 +25,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -25,21 +25,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -25,21 +25,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -24,10 +24,10 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -26,10 +26,10 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -25,21 +25,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -24,10 +24,10 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -26,10 +26,10 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -25,21 +25,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -25,21 +25,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -25,21 +25,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -25,21 +25,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -24,10 +24,10 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -26,10 +26,10 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -25,21 +25,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -24,10 +24,10 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -26,10 +26,10 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -25,21 +25,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi(this IServiceCollection services)
-        {
-            HostConfiguration config = new(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration>? options = null)
         {
             HostConfiguration config = new(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -24,10 +24,10 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options = null)
         {
             HostConfiguration config = new HostConfiguration(services);
-            options(config);
+            options?.Invoke(config);
             AddApi(services, config);
         }
 


### PR DESCRIPTION
Library authors can provide a default configuration using the partial method, so we can let this parameter be null.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `HostConfiguration` optional in generated `csharp` `generichost` service registration by updating `IServiceCollectionExtensions.Add{Api}` to accept an optional options callback and use defaults when none is provided. This simplifies the API surface and keeps existing calls working.

- **Refactors**
  - Consolidated to a single method: `Add{Api}(IServiceCollection services, Action<HostConfiguration>? options = null)`; invokes `options?.Invoke(config)`.
  - Removed the parameterless overload previously generated when no auth methods were present.
  - Applies nullable annotation when NRT is enabled; regenerated samples to match.

<sup>Written for commit b040be2e5a66ff3750d2c4098ee9b345d0e36078. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

