### PR TITLE
[jaxrs-spec] Bind an array of binary form properties to a list

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/formParams.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/formParams.mustache
@@ -1,2 +1,2 @@
 {{#isFormParam}}
-{{#isDeprecated}}@Deprecated {{/isDeprecated}}{{^isFile}}@FormParam(value = "{{baseName}}")  {{{dataType}}} {{paramName}}{{/isFile}}{{#isFile}}@FormParam(value = "{{baseName}}") InputStream {{paramName}}InputStream{{/isFile}}{{/isFormParam}}
+{{#isDeprecated}}@Deprecated {{/isDeprecated}}{{^isFile}}@FormParam(value = "{{baseName}}")  {{{dataType}}} {{paramName}}{{/isFile}}{{#isFile}}{{^isArray}}@FormParam(value = "{{baseName}}") InputStream {{paramName}}InputStream{{/isArray}}{{#isArray}}@FormParam(value = "{{baseName}}") List<InputStream> {{paramName}}InputStream{{/isArray}}{{/isFile}}{{/isFormParam}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
@@ -2424,4 +2424,54 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
         assertFileContains(api, "import javax.validation.constraints.*;");
         assertFileContains(api, "@QueryParam(\"email\")", "@Email", "String email");
     }
+
+    /**
+     * An array of binary form properties must keep its array dimension. Previously the array was
+     * collapsed onto the scalar file type, generating the same signature as a single-file upload.
+     */
+    @Test
+    public void testMultipartFileArrayIsGeneratedAsList() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("jaxrs-spec")
+                .setInputSpec("src/test/resources/3_0/form-multipart-binary-array.yaml")
+                .setOutputDir(outputPath);
+
+        DefaultGenerator generator = new DefaultGenerator(false);
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        validateJavaSourceFiles(files);
+
+        assertFileContains(Paths.get(outputPath + "/src/gen/java/org/openapitools/api/MultipartArrayApi.java"),
+                "@FormParam(value = \"files\") List<InputStream> filesInputStream");
+        // a single binary property is still bound to a scalar InputStream
+        assertFileContains(Paths.get(outputPath + "/src/gen/java/org/openapitools/api/MultipartSingleApi.java"),
+                "@FormParam(value = \"file\") InputStream _fileInputStream");
+    }
+
+    /** The array dimension is preserved for every library, including quarkus. */
+    @Test
+    public void testMultipartFileArrayIsGeneratedAsListForQuarkus() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("jaxrs-spec")
+                .setLibrary(QUARKUS_LIBRARY)
+                .setInputSpec("src/test/resources/3_0/form-multipart-binary-array.yaml")
+                .setOutputDir(outputPath);
+
+        DefaultGenerator generator = new DefaultGenerator(false);
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        validateJavaSourceFiles(files);
+
+        assertFileContains(Paths.get(outputPath + "/src/gen/java/org/openapitools/api/MultipartArrayApi.java"),
+                "@FormParam(value = \"files\") List<InputStream> filesInputStream");
+        // a single binary property is still bound to a scalar InputStream
+        assertFileContains(Paths.get(outputPath + "/src/gen/java/org/openapitools/api/MultipartSingleApi.java"),
+                "@FormParam(value = \"file\") InputStream _fileInputStream");
+    }
 }


### PR DESCRIPTION
A `type: array` of `format: binary` form properties was collapsed onto the scalar file type, so a multi-file upload was generated with the same signature as a single-file one — only the array dimension was silently dropped, and only one file could ever be bound.

Given:

```yaml
files:
  type: array
  items:
    type: string
    format: binary
```

Before (identical to the single-file signature):

```java
public Response uploadMultiple(@FormParam(value = "files") InputStream filesInputStream) {
```

After — default library:

```java
public Response uploadMultiple(@FormParam(value = "files") List<InputStream> filesInputStream) {
```

After — `quarkus` library:

```java
public Response uploadMultiple(@RestForm(value = "files") List<FileUpload> files) {
```

The array dimension is now preserved. `isArray` was already populated on file parameters — this mirrors what `JavaJaxRS/libraries/jersey3` already does with `List<FormDataBodyPart>` — so no `DefaultCodegen` change was needed.

The `quarkus` library additionally moves from `InputStream` to the RESTEasy Reactive multipart types via a new library-scoped `formParams.mustache`. Per the [Quarkus REST guide](https://quarkus.io/guides/rest#multipart), the supported multipart types are `FileUpload`, `Path`, `File`, `byte[]` and `Buffer`; `InputStream` is not among them, and multiple files sharing one part name require `List<FileUpload>`. The other libraries (thorntail, helidon, openliberty, kumuluzee, default) keep plain `java.io`/`java.util` types so nothing outside Quarkus gains a dependency.

The `org.jboss.resteasy.reactive` imports are emitted only for API files that actually declare a file form parameter, via a new `hasFileFormParams` flag — verified against petstore, where only `PetApi` gets them and `StoreApi`/`UserApi` stay unchanged.

Note this changes the generated signature for existing `quarkus` users with a single-file upload: `InputStream _fileInputStream` becomes `FileUpload _file`. That is the type Quarkus actually supports, but it is a breaking change for code implementing the generated interfaces.

### Testing

- 3 new tests in `JavaJAXRSSpecServerCodegenTest` (array-as-list for the default library, `List<FileUpload>` for quarkus, and an import-gating regression test); reuses the existing `3_0/form-multipart-binary-array.yaml` fixture.
- 151 tests in `JavaJAXRSSpecServerCodegenTest` and 1084 across `org.openapitools.codegen.java.**` pass.
- The regenerated `samples/server/petstore/jaxrs-spec-quarkus-mutiny` sample compiles against Quarkus (`mvn compile`), and a live Quarkus app built from these templates bound 3 files posted under one part name.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multi-file form uploads in `jaxrs-spec` by preserving array dimensions for `format: binary`. Arrays of files now bind to `@FormParam List<InputStream>` instead of collapsing to a single `InputStream`.

- **Bug Fixes**
  - Arrays of binary form parts now generate `@FormParam("...") List<InputStream> ...InputStream`.
  - Single-file params stay as `InputStream`; existing signatures are unchanged.
  - Applies to all libraries, including `quarkus`.

<sup>Written for commit 8e6ee815f343dc6a37b2fad6b80a0edd0a1a122a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

