### PR TITLE
[jaxrs-spec][quarkus] Migrate the Jakarta path to Quarkus REST and fix file upload types

### DIFF
--- a/.github/workflows/samples-jaxrs.yaml
+++ b/.github/workflows/samples-jaxrs.yaml
@@ -38,7 +38,6 @@ jobs:
           - samples/server/petstore/jaxrs-spec-swagger-annotations
           - samples/server/petstore/jaxrs-spec-swagger-v3-annotations-jakarta
           - samples/server/petstore/jaxrs-spec-swagger-v3-annotations
-          - samples/server/petstore/jaxrs-spec/quarkus-security
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v5

--- a/.github/workflows/samples-jdk17.yaml
+++ b/.github/workflows/samples-jdk17.yaml
@@ -23,6 +23,7 @@ on:
       - samples/server/petstore/java-helidon-server/v3/mp/**
       - samples/server/petstore/java-helidon-server/v3/se/**
       - samples/server/petstore/jaxrs-spec-sealed/**
+      - samples/server/petstore/jaxrs-spec/quarkus-security/**
   pull_request:
     paths:
       # clients
@@ -46,6 +47,7 @@ on:
       - samples/server/petstore/java-helidon-server/v3/mp/**
       - samples/server/petstore/java-helidon-server/v3/se/**
       - samples/server/petstore/jaxrs-spec-sealed/**
+      - samples/server/petstore/jaxrs-spec/quarkus-security/**
 jobs:
   build:
     name: Build with JDK17
@@ -75,6 +77,7 @@ jobs:
           - samples/server/petstore/java-helidon-server/v3/mp/
           - samples/server/petstore/java-helidon-server/v3/se
           - samples/server/petstore/jaxrs-spec-sealed
+          - samples/server/petstore/jaxrs-spec/quarkus-security
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v5

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
@@ -393,6 +393,13 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
                 additionalProperties.put("hasResponseStatusAnnotations", true);
             }
         }
+
+        // The quarkus templates bind file form parameters to org.jboss.resteasy.reactive types, so the
+        // corresponding imports must only be emitted for API files that actually declare such a parameter.
+        // Always set explicitly so Mustache does not fall through to the global additionalProperties value.
+        objs.put("hasFileFormParams", objs.getOperations().getOperation().stream()
+                .flatMap(op -> op.formParams.stream())
+                .anyMatch(p -> p.isFile));
         return objs;
     }
 

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/libraries/quarkus/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/libraries/quarkus/api.mustache
@@ -37,6 +37,13 @@ import java.util.concurrent.CompletableFuture;
 {{/useMutiny}}
 {{/supportAsync}}
 
+{{#useJakartaEe}}
+{{#hasFileFormParams}}
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
+
+{{/hasFileFormParams}}
+{{/useJakartaEe}}
 import java.io.InputStream;
 import java.util.Map;
 import java.util.List;

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/libraries/quarkus/formParams.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/libraries/quarkus/formParams.mustache
@@ -1,0 +1,2 @@
+{{#isFormParam}}
+{{#isDeprecated}}@Deprecated {{/isDeprecated}}{{^isFile}}@FormParam(value = "{{baseName}}")  {{{dataType}}} {{paramName}}{{/isFile}}{{#isFile}}{{#useJakartaEe}}{{^isArray}}@RestForm(value = "{{baseName}}") FileUpload {{paramName}}{{/isArray}}{{#isArray}}@RestForm(value = "{{baseName}}") List<FileUpload> {{paramName}}{{/isArray}}{{/useJakartaEe}}{{^useJakartaEe}}@FormParam(value = "{{baseName}}") InputStream {{paramName}}InputStream{{/useJakartaEe}}{{/isFile}}{{/isFormParam}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/libraries/quarkus/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/libraries/quarkus/pom.mustache
@@ -18,19 +18,30 @@
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
+{{#useJakartaEe}}
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+{{/useJakartaEe}}
+{{^useJakartaEe}}
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+{{/useJakartaEe}}
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 {{#useJakartaEe}}
-    <quarkus-plugin.version>3.0.1.Final</quarkus-plugin.version>
-    <quarkus.platform.version>3.0.1.Final</quarkus.platform.version>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
 {{/useJakartaEe}}
 {{^useJakartaEe}}
     <quarkus-plugin.version>1.13.7.Final</quarkus-plugin.version>
     <quarkus.platform.version>1.13.7.Final</quarkus.platform.version>
 {{/useJakartaEe}}
+{{#useJakartaEe}}
+    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+{{/useJakartaEe}}
+{{^useJakartaEe}}
     <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
+{{/useJakartaEe}}
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
 {{#useJakartaEe}}
@@ -66,10 +77,25 @@
     </dependencies>
   </dependencyManagement>
   <dependencies>
+{{#useJakartaEe}}
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest</artifactId>
+    </dependency>
+{{#useBeanValidation}}
+    <!-- quarkus-rest does not pull in bean validation transitively, unlike quarkus-resteasy -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-hibernate-validator</artifactId>
+    </dependency>
+{{/useBeanValidation}}
+{{/useJakartaEe}}
+{{^useJakartaEe}}
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy</artifactId>
     </dependency>
+{{/useJakartaEe}}
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
@@ -2522,4 +2522,68 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
         assertFileContains(api, "import javax.validation.constraints.*;");
         assertFileContains(api, "@QueryParam(\"email\")", "@Email", "String email");
     }
+
+    /**
+     * On Quarkus REST a file form parameter is bound to the RESTEasy Reactive multipart type.
+     * {@code InputStream} is not a supported multipart type there.
+     */
+    @Test
+    public void testQuarkusJakartaBindsFileFormParamToFileUpload() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("jaxrs-spec")
+                .setLibrary(QUARKUS_LIBRARY)
+                .setAdditionalProperties(Map.of(USE_JAKARTA_EE, "true"))
+                .setInputSpec("src/test/resources/3_0/form-multipart-binary-array.yaml")
+                .setOutputDir(outputPath);
+
+        DefaultGenerator generator = new DefaultGenerator(false);
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        validateJavaSourceFiles(files);
+
+        Path api = Paths.get(outputPath + "/src/gen/java/org/openapitools/api/MultipartSingleApi.java");
+        assertFileContains(api, "import org.jboss.resteasy.reactive.RestForm;");
+        assertFileContains(api, "import org.jboss.resteasy.reactive.multipart.FileUpload;");
+        assertFileContains(api, "@RestForm(value = \"file\") FileUpload _file");
+        // an array of binary properties keeps its array dimension: several files may share one
+        // part name, which FileUpload supports and a scalar binding cannot express
+        assertFileContains(Paths.get(outputPath + "/src/gen/java/org/openapitools/api/MultipartArrayApi.java"),
+                "@RestForm(value = \"files\") List<FileUpload> files");
+        // the project targets Quarkus REST rather than RESTEasy Classic
+        assertFileContains(Paths.get(outputPath + "/pom.xml"), "<artifactId>quarkus-rest</artifactId>");
+    }
+
+    /**
+     * The javax path is pinned to Quarkus 1.13.7, which predates Quarkus REST, so it keeps
+     * RESTEasy Classic and its {@code InputStream} binding.
+     */
+    @Test
+    public void testQuarkusJavaxKeepsResteasyClassicFileBinding() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("jaxrs-spec")
+                .setLibrary(QUARKUS_LIBRARY)
+                .setInputSpec("src/test/resources/3_0/form-multipart-binary-array.yaml")
+                .setOutputDir(outputPath);
+
+        DefaultGenerator generator = new DefaultGenerator(false);
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        validateJavaSourceFiles(files);
+
+        Path api = Paths.get(outputPath + "/src/gen/java/org/openapitools/api/MultipartSingleApi.java");
+        assertFileContains(api, "@FormParam(value = \"file\") InputStream _fileInputStream");
+        assertFileNotContains(api, "import org.jboss.resteasy.reactive.multipart.FileUpload;");
+        // An array stays scalar here on purpose. @FormParam is a string-based annotation: injecting
+        // List<T> requires T to be constructible from a String, so List<InputStream> is rejected at
+        // deployment with RESTEASY003875. RESTEasy Classic has no portable multi-file binding.
+        assertFileNotContains(Paths.get(outputPath + "/src/gen/java/org/openapitools/api/MultipartArrayApi.java"),
+                "List<InputStream>");
+        assertFileContains(Paths.get(outputPath + "/pom.xml"), "<artifactId>quarkus-resteasy</artifactId>");
+    }
 }

--- a/samples/server/petstore/jaxrs-spec/quarkus-security/pom.xml
+++ b/samples/server/petstore/jaxrs-spec/quarkus-security/pom.xml
@@ -11,13 +11,13 @@
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>3.0.1.Final</quarkus-plugin.version>
-    <quarkus.platform.version>3.0.1.Final</quarkus.platform.version>
-    <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
+    <quarkus-plugin.version>3.27.4.1</quarkus-plugin.version>
+    <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
+    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
     <jakarta.ws.rs-version>3.1.0</jakarta.ws.rs-version>
@@ -38,7 +38,12 @@
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy</artifactId>
+      <artifactId>quarkus-rest</artifactId>
+    </dependency>
+    <!-- quarkus-rest does not pull in bean validation transitively, unlike quarkus-resteasy -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-hibernate-validator</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Proposal to solve #24454 

The `quarkus` library of `jaxrs-spec` generates for **RESTEasy Classic** (`quarkus-resteasy`) on a Quarkus version from 2021, while current Quarkus defaults to **Quarkus REST**. This migrates the `useJakartaEe=true` path and fixes the file upload binding that the old stack forced. 

## 1. Migrate to Quarkus REST

```diff
- <artifactId>quarkus-resteasy</artifactId>
+ <artifactId>quarkus-rest</artifactId>
```

`quarkus-rest` (formerly RESTEasy Reactive) is the default REST stack in current Quarkus. One knock-on: unlike `quarkus-resteasy`, it does **not** pull bean validation in transitively, so `quarkus-hibernate-validator` is now declared explicitly under `useBeanValidation`. Without it the generated `jakarta.validation` imports fail to compile.

## 2. BOM import and version upgrade

The migration cannot happen on the currently generated version, so two coupled changes are required:

```diff
- <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
- <quarkus.platform.version>3.0.1.Final</quarkus.platform.version>
+ <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+ <quarkus.platform.version>3.27.4.1</quarkus.platform.version>
```

- **BOM `quarkus-universe-bom` → `quarkus-bom`** — the universe BOM was discontinued after 3.0.1 and does not exist for later releases.
- **Platform `3.0.1.Final` → `3.27.4.1`** — `quarkus-rest` does not exist before 3.9 (it was `quarkus-resteasy-reactive` earlier). Per the [Quarkus release schedule](https://quarkus.io/releases/), **3.27 is the oldest LTS still under active support** (until 24 Sep 2026) - see question 4 in #24454.
- **Compiler release `1.8` → `17`**, since Quarkus 3.x requires it. The `quarkus-security` sample therefore moves out of the JDK 11 `samples-jaxrs` workflow into `samples-jdk17`.

## 3. File upload fixes

Two defects follow from the old stack, both fixed by the migration:

**Wrong type.** File form parameters were bound to `InputStream`, which is not a supported multipart type on Quarkus REST (the supported ones are `FileUpload`, `Path`, `File`, `byte[]`, `Buffer` — see the [Quarkus REST guide](https://quarkus.io/guides/rest#multipart)):

```diff
- public Response uploadFile(..., @FormParam(value = "file") InputStream _fileInputStream) {
+ public Response uploadFile(..., @RestForm(value = "file") FileUpload _file) {
```

**Dropped array dimension.** A `type: array` of `format: binary` properties was collapsed onto that scalar, so a multi-file upload got the same signature as a single-file one and only one file could ever be bound:

```diff
- public Response uploadMultiple(@FormParam(value = "files") InputStream filesInputStream) {
+ public Response uploadMultiple(@RestForm(value = "files") List<FileUpload> files) {
```

`List<FileUpload>` is the binding Quarkus REST provides for several files sharing one part name. 

The `org.jboss.resteasy.reactive` types are emitted from a new `libraries/quarkus/formParams.mustache` rather than the shared `spec/formParams.mustache`, to avoid changes to thorntail, helidon, openliberty and kumuluzee libraries.

### Scope: the javax path is deliberately untouched

`pom.mustache` forks on `useJakartaEe`, and the `false` branch is pinned to **Quarkus 1.13.7** — which predates Quarkus REST entirely. That path therefore keeps RESTEasy Classic, Java 8 and its `InputStream` binding.

| sample | `useJakartaEe` | platform | result |
|---|---|---|---|
| `jaxrs-spec/quarkus-security` | `true` | 3.0.1 → **3.27.4.1** | migrated to `quarkus-rest` |
| `jaxrs-spec-microprofile-openapi-annotations` | unset | 1.13.7 | unchanged |
| `jaxrs-spec-quarkus-mutiny` | unset | 1.13.7 | unchanged |

### Breaking change

Two, both on the `useJakartaEe=true` path:

- Generated signatures change: `InputStream _fileInputStream` → `FileUpload _file` (the parameter name loses its suffix too). Code implementing the generated interfaces will not compile until updated.
- The generated project now requires **JDK 17** to build, since Quarkus 3.x does.

### Testing

- 2 new tests in `JavaJAXRSSpecServerCodegenTest`, pinning both paths:
  - `testQuarkusJakartaBindsFileFormParamToFileUpload` — asserts the `@RestForm`/`FileUpload` imports, the scalar `FileUpload`, the array `List<FileUpload>`, and `quarkus-rest` in the generated `pom.xml`.
  - `testQuarkusJavaxKeepsResteasyClassicFileBinding` — asserts the javax path still emits `@FormParam`/`InputStream`, does *not* gain the RESTEasy Reactive import, does *not* turn the array into `List<InputStream>`, and keeps `quarkus-resteasy`.
- All three quarkus samples compile against their own poms, each on the JDK its workflow uses: `jaxrs-spec/quarkus-security` on Quarkus REST 3.27.4.1 with **JDK 17** (matching its new workflow), and both javax samples unchanged on 1.13.7 with **JDK 11**.

Note `jaxrs-spec-quarkus-mutiny` is not listed in `.github/workflows/samples-jaxrs.yaml`, so CI never compiles it — I compiled it locally.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.



