### PR TITLE
[java client][kotlin spring] Update jackson to 3.1.5

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/build.gradle.mustache
@@ -133,7 +133,7 @@ ext {
     {{/openApiNullable}}
     {{/useJackson3}}
     {{#useJackson3}}
-    jackson3_version = "3.1.0"
+    jackson3_version = "3.1.5"
     jackson_annotations_version = "2.21"
     {{#openApiNullable}}
     jackson_databind_nullable_version = "0.2.10"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/pom.mustache
@@ -401,7 +401,7 @@
         {{/openApiNullable}}
         {{/useJackson3}}
         {{#useJackson3}}
-        <jackson3-version>3.1.0</jackson3-version>
+        <jackson3-version>3.1.5</jackson3-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         {{#openApiNullable}}
         <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/build.gradle.mustache
@@ -105,7 +105,7 @@ ext {
     jackson_databind_version = "2.21.1"
     {{/useJackson3}}
     {{#useJackson3}}
-    jackson3_version = "3.1.0"
+    jackson3_version = "3.1.5"
     jackson_annotations_version = "2.21"
     {{/useJackson3}}
     {{#openApiNullable}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pom.mustache
@@ -450,7 +450,7 @@
         <jackson-databind-version>2.21.1</jackson-databind-version>
         {{/useJackson3}}
         {{#useJackson3}}
-        <jackson3-version>3.1.0</jackson3-version>
+        <jackson3-version>3.1.5</jackson3-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         {{/useJackson3}}
         <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/build.gradle.mustache
@@ -104,7 +104,7 @@ ext {
     swagger_annotations_version = "2.2.43"
     {{/swagger2AnnotationLibrary}}
     {{#useJackson3}}
-    jackson_version = "3.1.0"
+    jackson_version = "3.1.5"
     {{/useJackson3}}
     {{^useJackson3}}
     jackson_version = "2.21.1"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/pom.mustache
@@ -357,7 +357,7 @@
         {{#useSpringBoot4}}
         <spring-web-version>7.0.5</spring-web-version>
         {{#useJackson3}}
-        <jackson-version>3.1.0</jackson-version>
+        <jackson-version>3.1.5</jackson-version>
         {{/useJackson3}}
         {{^useJackson3}}
         <jackson-version>2.21.1</jackson-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
@@ -116,7 +116,7 @@ ext {
     swagger_annotations_version = "2.2.9"
     {{/swagger2AnnotationLibrary}}
     {{#useJackson3}}
-    jackson_version = "3.1.0"
+    jackson_version = "3.1.5"
     {{/useJackson3}}
     {{^useJackson3}}
     jackson_version = "2.21.1"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
@@ -381,7 +381,7 @@
         {{#useSpringBoot4}}
         <spring-web-version>7.0.5</spring-web-version>
         {{#useJackson3}}
-        <jackson-version>3.1.0</jackson-version>
+        <jackson-version>3.1.5</jackson-version>
         {{/useJackson3}}
         {{^useJackson3}}
         <jackson-version>2.21.1</jackson-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/build.gradle.mustache
@@ -150,7 +150,7 @@ ext {
     reactor_netty_version = "1.2.8"
     {{/useJakartaEe}}
     {{#useJackson3}}
-    jackson_version = "3.1.0"
+    jackson_version = "3.1.5"
     {{/useJackson3}}
     {{^useJackson3}}
     jackson_version = "2.21.1"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pom.mustache
@@ -191,7 +191,7 @@
         <swagger-annotations-version>2.2.43</swagger-annotations-version>
         {{/swagger2AnnotationLibrary}}
         {{#useJackson3}}
-        <jackson-version>3.1.0</jackson-version>
+        <jackson-version>3.1.5</jackson-version>
         {{/useJackson3}}
         {{^useJackson3}}
         <jackson-version>2.21.1</jackson-version>

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/pom-sb4.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/pom-sb4.mustache
@@ -12,7 +12,7 @@
         <swagger-annotations.version>1.6.6</swagger-annotations.version>{{/swagger1AnnotationLibrary}}{{#swagger2AnnotationLibrary}}
         <swagger-annotations.version>2.2.28</swagger-annotations.version>{{/swagger2AnnotationLibrary}}{{/springDocDocumentationProvider}}
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>{{#useJackson3}}
-        <jackson3.version>3.1.0</jackson3.version>{{/useJackson3}}
+        <jackson3.version>3.1.5</jackson3.version>{{/useJackson3}}
         <jakarta-annotation.version>3.0.0</jakarta-annotation.version>
         <kotlin-test-junit5.version>2.2.0</kotlin-test-junit5.version>
 

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradle-sb4-Kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/buildGradle-sb4-Kts.mustache
@@ -54,7 +54,7 @@ dependencies {
 
     implementation("com.google.code.findbugs:jsr305:3.0.2")
 {{#useJackson3}}
-    val jackson3Version = "3.1.0"
+    val jackson3Version = "3.1.5"
     implementation("tools.jackson.dataformat:jackson-dataformat-yaml:$jackson3Version")
     implementation("tools.jackson.dataformat:jackson-dataformat-xml:$jackson3Version")
     implementation("tools.jackson.module:jackson-module-kotlin:$jackson3Version")

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom-sb4.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom-sb4.mustache
@@ -18,7 +18,7 @@
         <swagger-annotations.version>2.2.28
         </swagger-annotations.version>{{/swagger2AnnotationLibrary}}{{/springDocDocumentationProvider}}
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>{{#useJackson3}}
-        <jackson3.version>3.1.0</jackson3.version>{{/useJackson3}}
+        <jackson3.version>3.1.5</jackson3.version>{{/useJackson3}}
         <jakarta-annotation.version>3.0.0</jakarta-annotation.version>
         <kotlin-test-junit5.version>2.2.0</kotlin-test-junit5.version>
 

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/buildGradle-sb4-Kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/buildGradle-sb4-Kts.mustache
@@ -54,7 +54,7 @@ dependencies {
 
     implementation("com.google.code.findbugs:jsr305:3.0.2")
 {{#useJackson3}}
-    val jackson3Version = "3.1.0"
+    val jackson3Version = "3.1.5"
     implementation("tools.jackson.dataformat:jackson-dataformat-yaml:$jackson3Version")
     implementation("tools.jackson.dataformat:jackson-dataformat-xml:$jackson3Version")
     implementation("tools.jackson.module:jackson-module-kotlin:$jackson3Version")

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/pom-sb4.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/pom-sb4.mustache
@@ -18,7 +18,7 @@
         <swagger-annotations.version>2.2.28
         </swagger-annotations.version>{{/swagger2AnnotationLibrary}}{{/springDocDocumentationProvider}}
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>{{#useJackson3}}
-        <jackson3.version>3.1.0</jackson3.version>{{/useJackson3}}
+        <jackson3.version>3.1.5</jackson3.version>{{/useJackson3}}
         <jakarta-annotation.version>3.0.0</jakarta-annotation.version>
         <kotlin-test-junit5.version>2.2.0</kotlin-test-junit5.version>
 

--- a/samples/client/petstore/java/apache-httpclient-jackson3/build.gradle
+++ b/samples/client/petstore/java/apache-httpclient-jackson3/build.gradle
@@ -118,7 +118,7 @@ if(hasProperty('target') && target == 'android') {
 
 ext {
     swagger_annotations_version = "1.6.6"
-    jackson3_version = "3.1.0"
+    jackson3_version = "3.1.5"
     jackson_annotations_version = "2.21"
     jackson_databind_nullable_version = "0.2.10"
     jakarta_annotation_version = "1.3.5"

--- a/samples/client/petstore/java/apache-httpclient-jackson3/pom.xml
+++ b/samples/client/petstore/java/apache-httpclient-jackson3/pom.xml
@@ -266,7 +266,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <httpclient-version>5.2.1</httpclient-version>
-        <jackson3-version>3.1.0</jackson3-version>
+        <jackson3-version>3.1.5</jackson3-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>

--- a/samples/client/petstore/java/jersey3-jackson3/build.gradle
+++ b/samples/client/petstore/java/jersey3-jackson3/build.gradle
@@ -99,7 +99,7 @@ if(hasProperty('target') && target == 'android') {
 
 ext {
     swagger_annotations_version = "1.6.5"
-    jackson3_version = "3.1.0"
+    jackson3_version = "3.1.5"
     jackson_annotations_version = "2.21"
     jackson_databind_nullable_version = "0.2.10"
     jakarta_annotation_version = "3.0.0"

--- a/samples/client/petstore/java/jersey3-jackson3/pom.xml
+++ b/samples/client/petstore/java/jersey3-jackson3/pom.xml
@@ -350,7 +350,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jersey-version>3.1.11</jersey-version>
-        <jackson3-version>3.1.0</jackson3-version>
+        <jackson3-version>3.1.5</jackson3-version>
         <jackson-annotations-version>2.21</jackson-annotations-version>
         <jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
         <jakarta-annotation-version>3.0.0</jakarta-annotation-version>

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/build.gradle
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/build.gradle
@@ -97,7 +97,7 @@ if(hasProperty('target') && target == 'android') {
 }
 
 ext {
-    jackson_version = "3.1.0"
+    jackson_version = "3.1.5"
     jackson_annotations_version = "2.21"
     spring_web_version = "7.0.5"
     jakarta_annotation_version = "3.0.0"

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/pom.xml
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3-jspecify/pom.xml
@@ -254,7 +254,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <spring-web-version>7.0.5</spring-web-version>
-        <jackson-version>3.1.0</jackson-version>
+        <jackson-version>3.1.5</jackson-version>
         <jakarta-annotation-version>3.0.0</jakarta-annotation-version>
 
         <jackson-annotations-version>2.21</jackson-annotations-version>

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3/build.gradle
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3/build.gradle
@@ -97,7 +97,7 @@ if(hasProperty('target') && target == 'android') {
 }
 
 ext {
-    jackson_version = "3.1.0"
+    jackson_version = "3.1.5"
     jackson_annotations_version = "2.21"
     spring_web_version = "7.0.5"
     jakarta_annotation_version = "3.0.0"

--- a/samples/client/petstore/java/restclient-springBoot4-jackson3/pom.xml
+++ b/samples/client/petstore/java/restclient-springBoot4-jackson3/pom.xml
@@ -254,7 +254,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <spring-web-version>7.0.5</spring-web-version>
-        <jackson-version>3.1.0</jackson-version>
+        <jackson-version>3.1.5</jackson-version>
         <jakarta-annotation-version>3.0.0</jakarta-annotation-version>
 
         <jackson-annotations-version>2.21</jackson-annotations-version>

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson3-jspecify/build.gradle
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson3-jspecify/build.gradle
@@ -97,7 +97,7 @@ if(hasProperty('target') && target == 'android') {
 }
 
 ext {
-    jackson_version = "3.1.0"
+    jackson_version = "3.1.5"
     jackson_annotations_version = "2.21"
     spring_web_version = "7.0.5"
     jakarta_annotation_version = "3.0.0"

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson3-jspecify/pom.xml
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson3-jspecify/pom.xml
@@ -267,7 +267,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <spring-web-version>7.0.5</spring-web-version>
-        <jackson-version>3.1.0</jackson-version>
+        <jackson-version>3.1.5</jackson-version>
         <jakarta-annotation-version>3.0.0</jakarta-annotation-version>
 
         <jackson-annotations-version>2.21</jackson-annotations-version>

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson3/build.gradle
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson3/build.gradle
@@ -97,7 +97,7 @@ if(hasProperty('target') && target == 'android') {
 }
 
 ext {
-    jackson_version = "3.1.0"
+    jackson_version = "3.1.5"
     jackson_annotations_version = "2.21"
     spring_web_version = "7.0.5"
     jakarta_annotation_version = "3.0.0"

--- a/samples/client/petstore/java/resttemplate-springBoot4-jackson3/pom.xml
+++ b/samples/client/petstore/java/resttemplate-springBoot4-jackson3/pom.xml
@@ -270,7 +270,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <spring-web-version>7.0.5</spring-web-version>
-        <jackson-version>3.1.0</jackson-version>
+        <jackson-version>3.1.5</jackson-version>
         <jakarta-annotation-version>3.0.0</jakarta-annotation-version>
 
         <jackson-annotations-version>2.21</jackson-annotations-version>

--- a/samples/client/petstore/java/webclient-springBoot4-jackson3-jspecify/build.gradle
+++ b/samples/client/petstore/java/webclient-springBoot4-jackson3-jspecify/build.gradle
@@ -117,7 +117,7 @@ ext {
     beanvalidation_version = "3.0.2"
     reactor_version = "3.5.12"
     reactor_netty_version = "1.2.8"
-    jackson_version = "3.1.0"
+    jackson_version = "3.1.5"
     jackson_annotations_version = "2.21"
     junit_version = "5.10.2"
 }

--- a/samples/client/petstore/java/webclient-springBoot4-jackson3-jspecify/pom.xml
+++ b/samples/client/petstore/java/webclient-springBoot4-jackson3-jspecify/pom.xml
@@ -112,7 +112,7 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jackson-version>3.1.0</jackson-version>
+        <jackson-version>3.1.5</jackson-version>
         <spring-boot-version>4.0.3</spring-boot-version>
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
         <reactor-version>3.5.12</reactor-version>

--- a/samples/client/petstore/java/webclient-springBoot4-jackson3/build.gradle
+++ b/samples/client/petstore/java/webclient-springBoot4-jackson3/build.gradle
@@ -117,7 +117,7 @@ ext {
     beanvalidation_version = "3.0.2"
     reactor_version = "3.5.12"
     reactor_netty_version = "1.2.8"
-    jackson_version = "3.1.0"
+    jackson_version = "3.1.5"
     jackson_annotations_version = "2.21"
     junit_version = "5.10.2"
 }

--- a/samples/client/petstore/java/webclient-springBoot4-jackson3/pom.xml
+++ b/samples/client/petstore/java/webclient-springBoot4-jackson3/pom.xml
@@ -120,7 +120,7 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jackson-version>3.1.0</jackson-version>
+        <jackson-version>3.1.5</jackson-version>
         <spring-boot-version>4.0.3</spring-boot-version>
         <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
         <reactor-version>3.5.12</reactor-version>

--- a/samples/server/petstore/kotlin-springboot-4/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-4/pom.xml
@@ -7,7 +7,7 @@
     <version>1.0.0</version>
     <properties>
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
-        <jackson3.version>3.1.0</jackson3.version>
+        <jackson3.version>3.1.5</jackson3.version>
         <jakarta-annotation.version>3.0.0</jakarta-annotation.version>
         <kotlin-test-junit5.version>2.2.0</kotlin-test-junit5.version>
 


### PR DESCRIPTION
to close https://github.com/OpenAPITools/openapi-generator/pull/24404

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Jackson 3 from 3.1.0 to 3.1.5 across Java/Kotlin templates and petstore samples to pick up the latest bug fixes.

- **Dependencies**
  - Java templates: `apache-httpclient`, `jersey3`, `restclient`, `resttemplate`, `webclient` (set Jackson 3 to 3.1.5).
  - Kotlin Spring templates: `spring-boot` (SB4), `spring-cloud`, `spring-declarative-http-interface` (set Jackson 3 to 3.1.5).
  - Petstore samples: updated all `tools.jackson.*` references to 3.1.5 in Java clients and the Kotlin Spring Boot 4 server.

<sup>Written for commit 3dde282c649d4e23b17adfb1318ff14e2e2cc49f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



