### PR TITLE
Update go dependencies to newer version

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-gin-server/go.mod.mustache
+++ b/modules/openapi-generator/src/main/resources/go-gin-server/go.mod.mustache
@@ -23,8 +23,8 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	golang.org/x/arch v0.3.0 // indirect
-	golang.org/x/crypto v0.45.0 // indirect
-	golang.org/x/net v0.23.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect

--- a/modules/openapi-generator/src/main/resources/go-gin-server/go.mod.mustache
+++ b/modules/openapi-generator/src/main/resources/go-gin-server/go.mod.mustache
@@ -1,6 +1,6 @@
 module {{gitHost}}/{{gitUserId}}/{{gitRepoId}}{{#isGoSubmodule}}/{{packageName}}{{/isGoSubmodule}}
 
-go 1.19
+go 1.25
 
 require github.com/gin-gonic/gin v1.9.1
 

--- a/samples/server/petstore/go-gin-api-server-interface-only/go.mod
+++ b/samples/server/petstore/go-gin-api-server-interface-only/go.mod
@@ -23,8 +23,8 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	golang.org/x/arch v0.3.0 // indirect
-	golang.org/x/crypto v0.45.0 // indirect
-	golang.org/x/net v0.23.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect

--- a/samples/server/petstore/go-gin-api-server-interface-only/go.mod
+++ b/samples/server/petstore/go-gin-api-server-interface-only/go.mod
@@ -1,6 +1,6 @@
 module github.com/GIT_USER_ID/GIT_REPO_ID
 
-go 1.19
+go 1.25
 
 require github.com/gin-gonic/gin v1.9.1
 

--- a/samples/server/petstore/go-gin-api-server/go.mod
+++ b/samples/server/petstore/go-gin-api-server/go.mod
@@ -23,8 +23,8 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	golang.org/x/arch v0.3.0 // indirect
-	golang.org/x/crypto v0.45.0 // indirect
-	golang.org/x/net v0.23.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect

--- a/samples/server/petstore/go-gin-api-server/go.mod
+++ b/samples/server/petstore/go-gin-api-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/GIT_USER_ID/GIT_REPO_ID
 
-go 1.19
+go 1.25
 
 require github.com/gin-gonic/gin v1.9.1
 


### PR DESCRIPTION
to close https://github.com/OpenAPITools/openapi-generator/pull/24440, https://github.com/OpenAPITools/openapi-generator/pull/24438


<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Go Gin server template and petstore samples to Go 1.25 and newer modules. This picks up security fixes and keeps generated servers compatible with current Go toolchains.

- **Dependencies**
  - `golang.org/x/crypto`: v0.45.0 → v0.52.0
  - `golang.org/x/net`: v0.23.0 → v0.55.0

<sup>Written for commit 9b8dba5a764b52a845bdee67fb3abcaef9447b72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



