### PR TITLE
feat(java-spring): operationId is extracted as a constant for Spring Boot api definitions

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
@@ -141,6 +141,7 @@ public interface {{classname}} {
 
     String PATH_{{#lambda.uppercase}}{{#lambda.snakecase}}{{{operationId}}}{{/lambda.snakecase}}{{/lambda.uppercase}} = "{{{path}}}";
     String OPERATION_{{#lambda.uppercase}}{{#lambda.snakecase}}{{{operationId}}}{{/lambda.snakecase}}{{/lambda.uppercase}} = "{{{operationId}}}";
+
     /**
      * {{httpMethod}} {{{path}}}{{#summary}} : {{.}}{{/summary}}
     {{#notes}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
@@ -140,6 +140,7 @@ public interface {{classname}} {
 {{#operation}}
 
     String PATH_{{#lambda.uppercase}}{{#lambda.snakecase}}{{{operationId}}}{{/lambda.snakecase}}{{/lambda.uppercase}} = "{{{path}}}";
+    String OPERATION_{{#lambda.uppercase}}{{#lambda.snakecase}}{{{operationId}}}{{/lambda.snakecase}}{{/lambda.uppercase}} = "{{{operationId}}}";
     /**
      * {{httpMethod}} {{{path}}}{{#summary}} : {{.}}{{/summary}}
     {{#notes}}
@@ -167,7 +168,7 @@ public interface {{classname}} {
     {{/virtualService}}
     {{#swagger2AnnotationLibrary}}
     @Operation(
-        operationId = "{{{operationId}}}",
+        operationId = {{classname}}.OPERATION_{{#lambda.uppercase}}{{#lambda.snakecase}}{{{operationId}}}{{/lambda.snakecase}}{{/lambda.uppercase}},
         {{#summary}}
         summary = "{{{.}}}",
         {{/summary}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -122,7 +122,7 @@ public class SpringCodegenTest {
                 .hasReturnType("ResponseEntity<Void>")
                 .assertMethodAnnotations()
                 .hasSize(2)
-                .containsWithNameAndAttributes("Operation", ImmutableMap.of("operationId", "\"getZebras\""))
+                .containsWithNameAndAttributes("Operation", ImmutableMap.of("operationId", "ZebrasApi.OPERATION_GET_ZEBRAS"))
                 .containsWithNameAndAttributes("RequestMapping", ImmutableMap.of(
                         "method", "RequestMethod.GET",
                         "value", "ZebrasApi.PATH_GET_ZEBRAS"
@@ -200,7 +200,7 @@ public class SpringCodegenTest {
                 .hasReturnType("ResponseEntity<Void>")
                 .assertMethodAnnotations()
                 .hasSize(2)
-                .containsWithNameAndAttributes("Operation", ImmutableMap.of("operationId", "\"getZebras\""))
+                .containsWithNameAndAttributes("Operation", ImmutableMap.of("operationId", "ZebrasApi.OPERATION_GET_ZEBRAS"))
                 .containsWithNameAndAttributes("RequestMapping", ImmutableMap.of(
                         "method", "RequestMethod.GET",
                         "value", "ZebrasApi.PATH_GET_ZEBRAS"
@@ -2328,11 +2328,11 @@ public class SpringCodegenTest {
         return new Object[][]{
                 {DocumentationProviderFeatures.DocumentationProvider.SPRINGDOC.name(), (Consumer<String>) outputPath -> {
                     assertFileContains(Paths.get(outputPath + "/src/main/java/org/openapitools/api/NoneApi.java"),
-                            "@Operation( operationId = \"getNone\", summary = \"No Tag\", responses = {");
+                            "@Operation( operationId = NoneApi.OPERATION_GET_NONE, summary = \"No Tag\", responses = {");
                     assertFileContains(Paths.get(outputPath + "/src/main/java/org/openapitools/api/SingleApi.java"),
-                            "@Operation( operationId = \"getSingleTag\", summary = \"Single Tag\", tags = { \"tag1\" }, responses = {");
+                            "@Operation( operationId = SingleApi.OPERATION_GET_SINGLE_TAG, summary = \"Single Tag\", tags = { \"tag1\" }, responses = {");
                     assertFileContains(Paths.get(outputPath + "/src/main/java/org/openapitools/api/MultipleApi.java"),
-                            "@Operation( operationId = \"getMultipleTags\", summary = \"Multiple Tags\", tags = { \"tag1\", \"tag2\" }, responses = {");
+                            "@Operation( operationId = MultipleApi.OPERATION_GET_MULTIPLE_TAGS, summary = \"Multiple Tags\", tags = { \"tag1\", \"tag2\" }, responses = {");
                 }}
         };
     }
@@ -2443,7 +2443,7 @@ public class SpringCodegenTest {
                 .containsWithName("Operation")
                 .containsWithNameAndAttributes("Operation",
                         ImmutableMap.of(
-                                "operationId", "\"updatePet\"",
+                                "operationId", "PetApi.OPERATION_UPDATE_PET",
                                 //"security", "{ @SecurityRequirement(name = \"petstore_auth\", scopes = { \"write:pets\", \"read:pets\" }) }",
                                 "externalDocs", "@ExternalDocumentation(description = \"API documentation for the updatePet operation\", url = \"http://petstore.swagger.io/v2/doc/updatePet\")"
                         )


### PR DESCRIPTION
- operationId is extracted as a constant for Spring Boot api definitions - similar to the PATH constant
- Update test expectations

### PR checklist
 
- [x ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @cachescrubber (2022/02) @welshm (2022/02) @MelleD (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02) @borsch (2022/02) @banlevente (2022/02) @Zomzog (2022/09) @martin-mfg (2023/08)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts operationId into String constants in the `java-spring` generator and references them from `@Operation(operationId=...)`. This removes repeated string literals and aligns with existing `PATH_*` constants.

- **New Features**
  - API interfaces now define `OPERATION_<OPERATION_ID>` and annotations reference `ClassName.OPERATION_<OPERATION_ID>`.

<sup>Written for commit e4c22281f61dd6da7b837cd703e5ced81b54c4a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator/pull/24479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



